### PR TITLE
Database: Fix namespace definition

### DIFF
--- a/components/ILIAS/Database/classes/Integrity/Association.php
+++ b/components/ILIAS/Database/classes/Integrity/Association.php
@@ -18,7 +18,7 @@
 
 declare(strict_types=1);
 
-namespace ILIAS\components\Database\Integrity;
+namespace ILIAS\Database\Integrity;
 
 class Association
 {

--- a/components/ILIAS/Database/classes/Integrity/Definition.php
+++ b/components/ILIAS/Database/classes/Integrity/Definition.php
@@ -18,7 +18,7 @@
 
 declare(strict_types=1);
 
-namespace ILIAS\components\Database\Integrity;
+namespace ILIAS\Database\Integrity;
 
 use InvalidArgumentException;
 

--- a/components/ILIAS/Database/classes/Integrity/Field.php
+++ b/components/ILIAS/Database/classes/Integrity/Field.php
@@ -18,7 +18,7 @@
 
 declare(strict_types=1);
 
-namespace ILIAS\components\Database\Integrity;
+namespace ILIAS\Database\Integrity;
 
 class Field
 {

--- a/components/ILIAS/Database/classes/Integrity/Ignore.php
+++ b/components/ILIAS/Database/classes/Integrity/Ignore.php
@@ -18,7 +18,7 @@
 
 declare(strict_types=1);
 
-namespace ILIAS\components\Database\Integrity;
+namespace ILIAS\Database\Integrity;
 
 class Ignore
 {

--- a/components/ILIAS/Database/classes/Integrity/Integrity.php
+++ b/components/ILIAS/Database/classes/Integrity/Integrity.php
@@ -18,7 +18,7 @@
 
 declare(strict_types=1);
 
-namespace ILIAS\components\Database\Integrity;
+namespace ILIAS\Database\Integrity;
 
 use ilDBInterface;
 

--- a/components/ILIAS/Database/classes/Integrity/Result.php
+++ b/components/ILIAS/Database/classes/Integrity/Result.php
@@ -18,7 +18,7 @@
 
 declare(strict_types=1);
 
-namespace ILIAS\components\Database\Integrity;
+namespace ILIAS\Database\Integrity;
 
 class Result
 {

--- a/components/ILIAS/Database/classes/PDO/FieldDefinition/ForeignKeyConstraints.php
+++ b/components/ILIAS/Database/classes/PDO/FieldDefinition/ForeignKeyConstraints.php
@@ -18,7 +18,7 @@
 
 declare(strict_types=1);
 
-namespace ILIAS\components\Database\PDO\FieldDefinition;
+namespace ILIAS\Database\PDO\FieldDefinition;
 
 enum ForeignKeyConstraints: string
 {

--- a/components/ILIAS/Database/classes/PDO/Manager/class.ilDBPdoManager.php
+++ b/components/ILIAS/Database/classes/PDO/Manager/class.ilDBPdoManager.php
@@ -18,7 +18,7 @@
 
 declare(strict_types=1);
 
-use ILIAS\Services\Database\PDO\FieldDefinition\ForeignKeyConstraints;
+use ILIAS\Database\PDO\FieldDefinition\ForeignKeyConstraints;
 
 /**
  * Class ilDBPdoManager

--- a/components/ILIAS/Database/classes/PDO/class.ilDBPdo.php
+++ b/components/ILIAS/Database/classes/PDO/class.ilDBPdo.php
@@ -18,8 +18,8 @@
 
 declare(strict_types=1);
 
-use ILIAS\components\Database\Integrity\Integrity;
-use ILIAS\components\Database\PDO\FieldDefinition\ForeignKeyConstraints;
+use ILIAS\Database\Integrity\Integrity;
+use ILIAS\Database\PDO\FieldDefinition\ForeignKeyConstraints;
 
 /**
  * Class pdoDB

--- a/components/ILIAS/Database/interfaces/interface.ilDBInterface.php
+++ b/components/ILIAS/Database/interfaces/interface.ilDBInterface.php
@@ -18,8 +18,8 @@
 
 declare(strict_types=1);
 
-use ILIAS\components\Database\Integrity\Integrity;
-use ILIAS\components\Database\PDO\FieldDefinition\ForeignKeyConstraints;
+use ILIAS\Database\Integrity\Integrity;
+use ILIAS\Database\PDO\FieldDefinition\ForeignKeyConstraints;
 
 /**
  * Interface ilDBInterface

--- a/components/ILIAS/Database/tests/Integrity/AssociationTest.php
+++ b/components/ILIAS/Database/tests/Integrity/AssociationTest.php
@@ -21,8 +21,8 @@ declare(strict_types=1);
 namespace ILIAS\Tests\Services\Database\Integrity;
 
 use PHPUnit\Framework\TestCase;
-use ILIAS\components\Database\Integrity\Association;
-use ILIAS\components\Database\Integrity\Field;
+use ILIAS\Database\Integrity\Association;
+use ILIAS\Database\Integrity\Field;
 
 class AssociationTest extends TestCase
 {

--- a/components/ILIAS/Database/tests/Integrity/DefinitionTest.php
+++ b/components/ILIAS/Database/tests/Integrity/DefinitionTest.php
@@ -21,10 +21,10 @@ declare(strict_types=1);
 namespace ILIAS\Tests\Services\Database\Integrity;
 
 use PHPUnit\Framework\TestCase;
-use ILIAS\components\Database\Integrity\Association;
-use ILIAS\components\Database\Integrity\Definition;
-use ILIAS\components\Database\Integrity\Field;
-use ILIAS\components\Database\Integrity\Ignore;
+use ILIAS\Database\Integrity\Association;
+use ILIAS\Database\Integrity\Definition;
+use ILIAS\Database\Integrity\Field;
+use ILIAS\Database\Integrity\Ignore;
 use InvalidArgumentException;
 
 class DefinitionTest extends TestCase
@@ -129,7 +129,7 @@ class DefinitionTest extends TestCase
         $association_two = 'funny string';
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Associations must be of type ILIAS\components\Database\Integrity\Association.');
+        $this->expectExceptionMessage('Associations must be of type ILIAS\Database\Integrity\Association.');
         $instance = new Definition([$association_one, $association_two]);
     }
 }

--- a/components/ILIAS/Database/tests/Integrity/FieldTest.php
+++ b/components/ILIAS/Database/tests/Integrity/FieldTest.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
 namespace ILIAS\Tests\Services\Database\Integrity;
 
 use PHPUnit\Framework\TestCase;
-use ILIAS\components\Database\Integrity\Field;
+use ILIAS\Database\Integrity\Field;
 
 class FieldTest extends TestCase
 {

--- a/components/ILIAS/Database/tests/Integrity/IgnoreTest.php
+++ b/components/ILIAS/Database/tests/Integrity/IgnoreTest.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
 namespace ILIAS\Tests\Services\Database\Integrity;
 
 use PHPUnit\Framework\TestCase;
-use ILIAS\components\Database\Integrity\Ignore;
+use ILIAS\Database\Integrity\Ignore;
 
 class IgnoreTest extends TestCase
 {

--- a/components/ILIAS/Database/tests/Integrity/IntegrityTest.php
+++ b/components/ILIAS/Database/tests/Integrity/IntegrityTest.php
@@ -21,11 +21,11 @@ declare(strict_types=1);
 namespace ILIAS\Tests\Services\Database\Integrity;
 
 use PHPUnit\Framework\TestCase;
-use ILIAS\components\Database\Integrity\Integrity;
-use ILIAS\components\Database\Integrity\Definition;
-use ILIAS\components\Database\Integrity\Result;
-use ILIAS\components\Database\Integrity\Association;
-use ILIAS\components\Database\Integrity\Field;
+use ILIAS\Database\Integrity\Integrity;
+use ILIAS\Database\Integrity\Definition;
+use ILIAS\Database\Integrity\Result;
+use ILIAS\Database\Integrity\Association;
+use ILIAS\Database\Integrity\Field;
 use ilDBInterface;
 use ilDBStatement;
 

--- a/components/ILIAS/Database/tests/Integrity/ResultTest.php
+++ b/components/ILIAS/Database/tests/Integrity/ResultTest.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
 namespace ILIAS\Tests\Services\Database\Integrity;
 
 use PHPUnit\Framework\TestCase;
-use ILIAS\components\Database\Integrity\Result;
+use ILIAS\Database\Integrity\Result;
 
 class ResultTest extends TestCase
 {


### PR DESCRIPTION
Hey @chfsx,

This PR builds on the changes from https://github.com/ILIAS-eLearning/ILIAS/pull/9810
I noticed there is still a small bug: the namespaces were not fully compatible (`ILIAS\Services\Database` != `ILIAS\components\Database`). Also, the definitions like `ILIAS\components\Database` didn’t fully follow the namespace rules.

With this PR, I have adjusted the namespaces to match the conventions.