### PR TITLE
fix typo in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,8 @@
 *.swo
 
 # Core Components and Components From Other Vendors
-/component/*
-!/component/ILIAS
+/components/*
+!/components/ILIAS
 
 # Generated Files
 /artifacts/*


### PR DESCRIPTION
Just a small correction for .gitignore: the `components` directory was typoed as `component`