### PR TITLE
Fix mantis #45858: Data too long for column 'c_timestamp' in table 'cmi_interaction'

### DIFF
--- a/components/ILIAS/Scorm2004/Scorm2004.php
+++ b/components/ILIAS/Scorm2004/Scorm2004.php
@@ -32,6 +32,12 @@ class Scorm2004 implements Component\Component
         array | \ArrayAccess &$pull,
         array | \ArrayAccess &$internal,
     ): void {
+
+        $contribute[\ILIAS\Setup\Agent::class] = static fn() =>
+            new \ilScorm2004SetupAgent(
+                $pull[\ILIAS\Refinery\Factory::class]
+            );
+
         $contribute[Component\Resource\PublicAsset::class] = fn() =>
             new Component\Resource\Endpoint($this, "storeScorm2004.php");
 

--- a/components/ILIAS/Scorm2004/classes/Setup/class.ilScorm2004DatabaseUpdateSteps.php
+++ b/components/ILIAS/Scorm2004/classes/Setup/class.ilScorm2004DatabaseUpdateSteps.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+class ilScorm2004DatabaseUpdateSteps implements ilDatabaseUpdateSteps
+{
+    protected ilDBInterface $db;
+
+    public function prepare(ilDBInterface $db): void
+    {
+        $this->db = $db;
+    }
+
+    public function step_1(): void
+    {
+        $this->db->modifyTableColumn("cmi_interaction", "c_timestamp", array("type" => "text", "length" => 40, "notnull" => false, 'default' => null));
+    }
+
+}

--- a/components/ILIAS/Scorm2004/classes/Setup/class.ilScorm2004SetupAgent.php
+++ b/components/ILIAS/Scorm2004/classes/Setup/class.ilScorm2004SetupAgent.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\Setup;
+
+class ilScorm2004SetupAgent extends Setup\Agent\NullAgent
+{
+    public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
+    {
+        return new ilDatabaseUpdateStepsExecutedObjective(new ilScorm2004DatabaseUpdateSteps());
+    }
+    public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
+    {
+        return new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilScorm2004DatabaseUpdateSteps());
+    }
+}


### PR DESCRIPTION
Mantis: https://mantis.ilias.de/view.php?id=45858

1. Added Scorm2004 Setup Agent
2. Added new Scorm2004 DB Step: 
- Increasing max length of column 'c_timestamp' in table 'cmi_interaction' to varchar(40)

PR for ILIAS 10 + TRUNK
@qualitus-dahme FYI