### PR TITLE
Fix mantis #40823: Data too long for column 'resourceid' in table 'cp_dependency'

### DIFF
--- a/Modules/Scorm2004/classes/Setup/class.ilScorm2004DatabaseUpdateSteps.php
+++ b/Modules/Scorm2004/classes/Setup/class.ilScorm2004DatabaseUpdateSteps.php
@@ -32,4 +32,9 @@ class ilScorm2004DatabaseUpdateSteps implements ilDatabaseUpdateSteps
         $this->db->modifyTableColumn("cmi_interaction", "c_timestamp", array("type" => "text", "length" => 40, "notnull" => false, 'default' => null));
     }
 
+    public function step_2(): void
+    {
+        $this->db->modifyTableColumn("cp_dependency", "resourceid", array("type" => "text", "length" => 200, "notnull" => false, 'default' => null));
+    }
+
 }


### PR DESCRIPTION
Mantis: https://mantis.ilias.de/view.php?id=40823

Added new Scorm2004 DB Step: 
- Increasing max length of column 'resourceid' in table 'cp_dependency' to varchar(200)

PR for ILIAS 9 +10 + TRUNK
@qualitus-dahme FYI