### PR TITLE
Fix 44557: Remove <a> empty anchor from message box to improve accessibility

### DIFF
--- a/components/ILIAS/UI/src/templates/default/MessageBox/tpl.messagebox.html
+++ b/components/ILIAS/UI/src/templates/default/MessageBox/tpl.messagebox.html
@@ -1,4 +1,4 @@
 <!-- BEGIN message_box -->
 <div class="alert <!-- BEGIN failure_class -->alert-danger<!-- END failure_class --><!-- BEGIN success_class -->alert-success<!-- END success_class --><!-- BEGIN info_class -->alert-info<!-- END info_class --><!-- BEGIN confirmation_class -->alert-warning<!-- END confirmation_class -->" role="{ROLE}">
-	<div class="ilAccHeadingHidden"><a name="il_message_focus">{ACC_TEXT}</a></div>{MESSAGE_TEXT}<!-- BEGIN buttons --><div>{BUTTONS}</div><!-- END buttons -->{LINK_LIST}</div>
+	<div class="ilAccHeadingHidden"><span id="il_message_focus" tabindex="-1">{ACC_TEXT}</span></div>{MESSAGE_TEXT}<!-- BEGIN buttons --><div>{BUTTONS}</div><!-- END buttons -->{LINK_LIST}</div>
 <!-- END message_box -->

--- a/components/ILIAS/UI/src/templates/default/MessageBox/tpl.messagebox.html
+++ b/components/ILIAS/UI/src/templates/default/MessageBox/tpl.messagebox.html
@@ -1,4 +1,4 @@
 <!-- BEGIN message_box -->
 <div class="alert <!-- BEGIN failure_class -->alert-danger<!-- END failure_class --><!-- BEGIN success_class -->alert-success<!-- END success_class --><!-- BEGIN info_class -->alert-info<!-- END info_class --><!-- BEGIN confirmation_class -->alert-warning<!-- END confirmation_class -->" role="{ROLE}">
-	<div class="ilAccHeadingHidden"><span id="il_message_focus" tabindex="-1">{ACC_TEXT}</span></div>{MESSAGE_TEXT}<!-- BEGIN buttons --><div>{BUTTONS}</div><!-- END buttons -->{LINK_LIST}</div>
+	<div class="ilAccHeadingHidden">{ACC_TEXT}</div>{MESSAGE_TEXT}<!-- BEGIN buttons --><div>{BUTTONS}</div><!-- END buttons -->{LINK_LIST}</div>
 <!-- END message_box -->

--- a/components/ILIAS/UI/tests/Component/MessageBox/MessageBoxTest.php
+++ b/components/ILIAS/UI/tests/Component/MessageBox/MessageBoxTest.php
@@ -177,8 +177,8 @@ class MessageBoxTest extends ILIAS_UI_TestBase
 
         $html = $this->normalizeHTML($r->render($g));
         $expected = "<div class=\"alert $css_classes\" role=\"$role_type\">" .
-                    "<div class=\"ilAccHeadingHidden\"><a name=\"il_message_focus\">" .
-                    $g->getType() . "_message</a></div>Lorem ipsum dolor sit amet.</div>";
+                    "<div class=\"ilAccHeadingHidden\"><span id=\"il_message_focus\" tabindex=\"-1\">" .
+                    $g->getType() . "_message</span></div>Lorem ipsum dolor sit amet.</div>";
         $this->assertHTMLEquals($expected, $html);
     }
 
@@ -199,8 +199,8 @@ class MessageBoxTest extends ILIAS_UI_TestBase
 
         $html = $this->normalizeHTML($r->render($g));
         $expected = "<div class=\"alert $css_classes\" role=\"$role_type\">" .
-                    "<div class=\"ilAccHeadingHidden\"><a name=\"il_message_focus\">" .
-                    $g->getType() . "_message</a></div>Lorem ipsum dolor sit amet." .
+                    "<div class=\"ilAccHeadingHidden\"><span id=\"il_message_focus\" tabindex=\"-1\">" .
+                    $g->getType() . "_message</span></div>Lorem ipsum dolor sit amet." .
                     "<div><button class=\"btn btn-default\"   data-action=\"#\" id=\"id_1\">Confirm</button>" .
                     "<button class=\"btn btn-default\"   data-action=\"#\" id=\"id_2\">Cancel</button></div></div>";
         $this->assertHTMLEquals($expected, $html);
@@ -226,8 +226,8 @@ class MessageBoxTest extends ILIAS_UI_TestBase
 
         $html = $this->normalizeHTML($r->render($g));
         $expected = "<div class=\"alert $css_classes\" role=\"$role_type\">" .
-                    "<div class=\"ilAccHeadingHidden\"><a name=\"il_message_focus\">" .
-                    $g->getType() . "_message</a></div>Lorem ipsum dolor sit amet." .
+                    "<div class=\"ilAccHeadingHidden\"><span id=\"il_message_focus\" tabindex=\"-1\">" .
+                    $g->getType() . "_message</span></div>Lorem ipsum dolor sit amet." .
                     "<ul><li><a href=\"#\" >Open Exercise Assignment</a></li>" .
                     "<li><a href=\"#\" >Open other screen</a></li></ul></div>";
         $this->assertHTMLEquals($expected, $html);
@@ -255,8 +255,8 @@ class MessageBoxTest extends ILIAS_UI_TestBase
 
         $html = $this->normalizeHTML($r->render($g));
         $expected = "<div class=\"alert $css_classes\" role=\"$role_type\">" .
-                    "<div class=\"ilAccHeadingHidden\"><a name=\"il_message_focus\">" .
-                    $g->getType() . "_message</a></div>Lorem ipsum dolor sit amet." .
+                    "<div class=\"ilAccHeadingHidden\"><span id=\"il_message_focus\" tabindex=\"-1\">" .
+                    $g->getType() . "_message</span></div>Lorem ipsum dolor sit amet." .
                     "<div><button class=\"btn btn-default\"   data-action=\"#\" id=\"id_1\">Confirm</button>" .
                     "<button class=\"btn btn-default\"   data-action=\"#\" id=\"id_2\">Cancel</button></div>" .
                     "<ul><li><a href=\"#\" >Open Exercise Assignment</a></li>" .

--- a/components/ILIAS/UI/tests/Component/MessageBox/MessageBoxTest.php
+++ b/components/ILIAS/UI/tests/Component/MessageBox/MessageBoxTest.php
@@ -177,8 +177,8 @@ class MessageBoxTest extends ILIAS_UI_TestBase
 
         $html = $this->normalizeHTML($r->render($g));
         $expected = "<div class=\"alert $css_classes\" role=\"$role_type\">" .
-                    "<div class=\"ilAccHeadingHidden\"><span id=\"il_message_focus\" tabindex=\"-1\">" .
-                    $g->getType() . "_message</span></div>Lorem ipsum dolor sit amet.</div>";
+                    "<div class=\"ilAccHeadingHidden\">" .
+                    $g->getType() . "_message</div>Lorem ipsum dolor sit amet.</div>";
         $this->assertHTMLEquals($expected, $html);
     }
 
@@ -199,8 +199,8 @@ class MessageBoxTest extends ILIAS_UI_TestBase
 
         $html = $this->normalizeHTML($r->render($g));
         $expected = "<div class=\"alert $css_classes\" role=\"$role_type\">" .
-                    "<div class=\"ilAccHeadingHidden\"><span id=\"il_message_focus\" tabindex=\"-1\">" .
-                    $g->getType() . "_message</span></div>Lorem ipsum dolor sit amet." .
+                    "<div class=\"ilAccHeadingHidden\">" .
+                    $g->getType() . "_message</div>Lorem ipsum dolor sit amet." .
                     "<div><button class=\"btn btn-default\"   data-action=\"#\" id=\"id_1\">Confirm</button>" .
                     "<button class=\"btn btn-default\"   data-action=\"#\" id=\"id_2\">Cancel</button></div></div>";
         $this->assertHTMLEquals($expected, $html);
@@ -226,8 +226,8 @@ class MessageBoxTest extends ILIAS_UI_TestBase
 
         $html = $this->normalizeHTML($r->render($g));
         $expected = "<div class=\"alert $css_classes\" role=\"$role_type\">" .
-                    "<div class=\"ilAccHeadingHidden\"><span id=\"il_message_focus\" tabindex=\"-1\">" .
-                    $g->getType() . "_message</span></div>Lorem ipsum dolor sit amet." .
+                    "<div class=\"ilAccHeadingHidden\">" .
+                    $g->getType() . "_message</div>Lorem ipsum dolor sit amet." .
                     "<ul><li><a href=\"#\" >Open Exercise Assignment</a></li>" .
                     "<li><a href=\"#\" >Open other screen</a></li></ul></div>";
         $this->assertHTMLEquals($expected, $html);
@@ -255,8 +255,8 @@ class MessageBoxTest extends ILIAS_UI_TestBase
 
         $html = $this->normalizeHTML($r->render($g));
         $expected = "<div class=\"alert $css_classes\" role=\"$role_type\">" .
-                    "<div class=\"ilAccHeadingHidden\"><span id=\"il_message_focus\" tabindex=\"-1\">" .
-                    $g->getType() . "_message</span></div>Lorem ipsum dolor sit amet." .
+                    "<div class=\"ilAccHeadingHidden\">" .
+                    $g->getType() . "_message</div>Lorem ipsum dolor sit amet." .
                     "<div><button class=\"btn btn-default\"   data-action=\"#\" id=\"id_1\">Confirm</button>" .
                     "<button class=\"btn btn-default\"   data-action=\"#\" id=\"id_2\">Cancel</button></div>" .
                     "<ul><li><a href=\"#\" >Open Exercise Assignment</a></li>" .


### PR DESCRIPTION
This PR addresses the accessibility issue [44557](https://mantis.ilias.de/view.php?id=44557) where a non-functional link in message boxes could confuse screen reader users.


~Replaces the outdated `<a>` name anchor with a modern `<span>` using an id and `tabindex="-1"`.~

EDIT: Removes the `<a>` anchor from around the accessibility text in the message box.

https://mantis.ilias.de/view.php?id=44557