### PR TITLE
UI: adjust tab dropdown expansion on click function in javascript.

### DIFF
--- a/components/ILIAS/JavaScript/resources/Basic.js
+++ b/components/ILIAS/JavaScript/resources/Basic.js
@@ -616,7 +616,11 @@ il.UICore = {
         dropdown.style.left = `${window.innerWidth - dropdownRight - 10}px`;
       }
     };
-    toggle.addEventListener('click', toggler);
+    toggle.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      toggler(e);
+    });
     toggle.addEventListener('keydown', (e) => {
       if (e.key === 'Enter') {
         e.preventDefault();


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45857

The event was triggered twice and therefore added 'open' and instantly removed 'open' as a class from the < li > tag.

**Before implementation**
<img width="1156" height="359" alt="ui_tab_dropdown_extension_old" src="https://github.com/user-attachments/assets/3a710e10-acd1-4221-8880-80b37dfa8eaa" />


**After implementation**
<img width="1156" height="359" alt="ui_tab_dropdown_extansion_new" src="https://github.com/user-attachments/assets/032095fa-00cd-4224-bf45-9df1c3c305e0" />
