### PR TITLE
[LTI] Fix: add doLTIAuthentication to safe commands

### DIFF
--- a/components/ILIAS/Init/classes/class.ilStartUpGUI.php
+++ b/components/ILIAS/Init/classes/class.ilStartUpGUI.php
@@ -147,7 +147,7 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
     {
         return [
             'doStandardAuthentication',
-            "doLTIAuthentication"
+            'doLTIAuthentication'
         ];
     }
 

--- a/components/ILIAS/Init/classes/class.ilStartUpGUI.php
+++ b/components/ILIAS/Init/classes/class.ilStartUpGUI.php
@@ -147,6 +147,7 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
     {
         return [
             'doStandardAuthentication',
+            "doLTIAuthentication"
         ];
     }
 


### PR DESCRIPTION
In version 10.1 of ILIAS, it was possible to execute a command in a POST request even if the request did not include a CSRF token. Change introduced in: https://github.com/surlabs/ILIAS/commit/a0696288b58df8d248261a0104f68960b5856b5d

Following the recent changes introduced in version 10.2, aimed at improving the robustness of request handling, any POST request must now include a CSRF token, or the command to be executed must be part of the list of secure commands. Due to the nature of LTI, it is necessary to include the LTI authentication command in the list of secure commands.