### PR TITLE
[FIX] Add `psr/log` as npm Dependency for ILIAS 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,8 @@
 		"sabre/dav": "4.6.0",
 		"seld/jsonlint": "^1.11",
 		"simplesamlphp/simplesamlphp": "^2.3.7",
-		"symfony/console" : "^6.4"
+		"symfony/console" : "^6.4",
+		"psr/log": "^3.0.2"
 	},
 	"require-dev": {
 		"captainhook/captainhook": "^5.24",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "73339ce2e2d59353fa4418e0a0802202",
+    "content-hash": "c32e3be578e5f3fa048d5e10ce080b54",
     "packages": [
         {
             "name": "brick/math",


### PR DESCRIPTION
Hi @kergomard

I noticed that `ILIAS\Test\Logging\TestLogger` uses the `Psr\Log\LoggerInterface`. This interface is from the `psr/log` composer package, which is included as a transitive (not direct!) dependency.

Since this logger is yours, and its the only consumer of this interface, I wanted to (a) ask you if requiring this interface is really necessary and (b) if you could fill out the template for requesting this dependency explicitly.

Thx and kind regards,
@thibsy 