### PR TITLE
[FIX] Add `psr/http-message` as composer Dependency for ILIAS 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,8 @@
 		"sabre/dav": "4.6.0",
 		"seld/jsonlint": "^1.11",
 		"simplesamlphp/simplesamlphp": "^2.3.7",
-		"symfony/console" : "^6.4"
+		"symfony/console" : "^6.4",
+		"psr/http-message": "^2.0"
 	},
 	"require-dev": {
 		"captainhook/captainhook": "^5.24",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "73339ce2e2d59353fa4418e0a0802202",
+    "content-hash": "1a3cfcd49d0476b7477b42bd3a8c0716",
     "packages": [
         {
             "name": "brick/math",


### PR DESCRIPTION
Hi all,

I noticed that multiple interfaces from the `Psr\Http\Message` namespace, but mainly the `Psr\Http\Message\ServerRequestInterface` interface, are used by many ILIAS components. However, This interface is from the `psr/http-message` composer package, which is included as a transitive (not direct!) dependency.

Since ILIAS components primarily use this interface due to interactions with the `HTTP` and `UI` components, I feel responsible for this package and request it for ILIAS 11.

Kind regards,
@thibsy 