### PR TITLE
CLI Setup: Colored Migration Status

### DIFF
--- a/src/Setup/CLI/MigrateCommand.php
+++ b/src/Setup/CLI/MigrateCommand.php
@@ -153,7 +153,7 @@ class MigrateCommand extends Command
             $env = $this->prepareEnvironmentForMigration($env, $migration);
             $migration->prepare($env);
             $steps = $migration->getRemainingAmountOfSteps();
-            $status = $steps === 0 ? "[done]" : "[remaining steps: $steps]";
+            $status = $steps === 0 ? "[<fg=green>done</>]" : "[<fg=yellow>remaining steps: $steps</>]";
             $io->text($migration_key . ": " . $migration->getLabel() . " " . $status);
         }
         $io->inform('Run them by passing --run <migration_id>, e.g. --run ' . $migration_key);


### PR DESCRIPTION
Hello Richard,
I was wondering if you would mind adding this little tweak to the "setup migrate" that would add a little color and make it waaay easier to see if there are still migration that have to be done. Since the migrations all have different names and lengths of lines, it's otherwise much too easy to overlook some steps that still need to be done. I've been using it for almost half a year now and didn't have any issues.
If you deem it necessary for me to create a 'tweak' mantis ticket, just let me know.
If accepted, a cherry-pick to 10 and trunk would be also much appreciated.
Best regards
Alex
<img width="1528" height="770" alt="after" src="https://github.com/user-attachments/assets/c1c3ad8b-90a6-4eec-87f7-cac02c17e1dd" />
