### PR TITLE
fix/43788-removed-aria-haspopup-on-the-control-element

### DIFF
--- a/components/ILIAS/Test/src/Results/Presentation/AttemptResultsTable.php
+++ b/components/ILIAS/Test/src/Results/Presentation/AttemptResultsTable.php
@@ -168,10 +168,14 @@ class AttemptResultsTable
         ];
 
         $pre = implode(URLBuilder::SEPARATOR, $this->getViewControlNamespace()) . URLBuilder::SEPARATOR;
-        $vc_sort = $ui_factory->viewControl()->sortation($options, $sortation)->withTargetURL(
+        $vc_sort = $ui_factory->viewControl()
+        ->sortation($options, $sortation)
+        ->withHasPopup(false)   // removed aria-haspopup 
+        ->withTargetURL(
             $target->buildURI()->__toString(),
             $pre . self::PARAM_SORT
         );
+
 
         return [
             $vc_mode,

--- a/components/ILIAS/UI/src/Component/ViewControl/Sortation.php
+++ b/components/ILIAS/UI/src/Component/ViewControl/Sortation.php
@@ -75,4 +75,10 @@ interface Sortation extends Component, JavaScriptBindable, Triggerer
      * Set the selected option.
      */
     public function withSelected(string $selected_option): self;
+
+
+
+     /** NEW: default true (backward compatible) */
+     public function withHasPopup(bool $has_popup): self;
+     public function hasPopup(): bool;
 }

--- a/components/ILIAS/UI/src/Implementation/Component/ViewControl/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/ViewControl/Renderer.php
@@ -161,6 +161,11 @@ class Renderer extends AbstractComponentRenderer
         $tpl->setVariable("ID", $id);
         $tpl->setVariable("ID_MENU", $id . '_ctrl');
 
+        /* NEW: control aria-haspopup via template block */
+        if ($component->hasPopup()) {
+            $tpl->touchBlock('has_popup');
+        }
+
         $options = $component->getOptions();
         $items = [];
 

--- a/components/ILIAS/UI/src/Implementation/Component/ViewControl/Sortation.php
+++ b/components/ILIAS/UI/src/Implementation/Component/ViewControl/Sortation.php
@@ -39,6 +39,9 @@ class Sortation implements C\ViewControl\Sortation
     protected string $parameter_name = "sortation";
     protected ?string $active = null;
 
+    /** NEW: default = true for BC */
+    private bool $has_popup = true;
+
     /**
      * @param array<string,string> $options
      */
@@ -152,4 +155,19 @@ class Sortation implements C\ViewControl\Sortation
     {
         return $this->selected;
     }
+
+
+     /** NEW */
+     public function withHasPopup(bool $has_popup): self
+     {
+         $clone = clone $this;
+         $clone->has_popup = $has_popup;
+         return $clone;
+     }
+ 
+     /** NEW */
+     public function hasPopup(): bool
+     {
+         return $this->has_popup;
+     }
 }

--- a/components/ILIAS/UI/src/templates/default/ViewControl/tpl.sortation.html
+++ b/components/ILIAS/UI/src/templates/default/ViewControl/tpl.sortation.html
@@ -1,5 +1,15 @@
 <div class="dropdown il-viewcontrol il-viewcontrol-sortation l-bar__element" id="{ID}">
-    <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown"<!-- BEGIN aria_label --> aria-label="{ARIA_LABEL}"<!-- END aria_label --> aria-haspopup="true" aria-expanded="false" aria-controls="{ID_MENU}"><span class="label">{LABEL}</span><span class="caret"></span></button>
+    <button class="btn btn-default dropdown-toggle"
+            type="button"
+            data-toggle="dropdown"
+            <!-- BEGIN aria_label --> aria-label="{ARIA_LABEL}"<!-- END aria_label -->
+            <!-- BEGIN has_popup --> aria-haspopup="true"<!-- END has_popup -->
+            aria-expanded="false"
+            aria-controls="{ID_MENU}">
+        <span class="label">{LABEL}</span>
+        <span class="caret"></span>
+    </button>
+
 
     <ul id="{ID_MENU}" class="dropdown-menu">
         <!-- BEGIN option -->


### PR DESCRIPTION
aria-haspopup on the control element “Sort test results” is unfavorable
it is noted for the area of the button for sorting test results that the aria-haspopup attribute on the control element is unfavorable, since according to the specification it may only be used for certain types (or roles) of inserted elements (menu, listbox, tree, grid or dialog). It should therefore be removed, as users may otherwise expect a different type of operation.
 
 https://mantis.ilias.de/view.php?id=43788