### PR TITLE
UI/DataTable: highlight rows

### DIFF
--- a/components/ILIAS/UI/src/Component/Table/Data.php
+++ b/components/ILIAS/UI/src/Component/Table/Data.php
@@ -25,6 +25,7 @@ use ILIAS\UI\Component\Input\Container\ViewControl\ViewControlInput;
 use Psr\Http\Message\ServerRequestInterface;
 use ILIAS\Data\Order;
 use ILIAS\Data\Range;
+use ILIAS\UI\URLBuilderToken;
 
 /**
  * This describes a Data Table.
@@ -72,4 +73,13 @@ interface Data extends Table
     public function withAdditionalViewControl(
         ViewControlInput $view_control
     ): self;
+
+    /**
+     * This is to show access to highlighted rows via GET-parameters;
+     * actually, highlighting rows will follow a (prompt-)action and
+     * the announcement of the relevant token will be part of adding
+     * this action to the table.
+     * @deprecated 11
+     */
+    public function withHighlightToken(URLBuilderToken $highlight_token): self;
 }

--- a/components/ILIAS/UI/src/Component/Table/DataRow.php
+++ b/components/ILIAS/UI/src/Component/Table/DataRow.php
@@ -20,9 +20,9 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\Component\Table;
 
-use  ILIAS\UI\Component\Table\Column\Column;
-use  ILIAS\UI\Component\Table\Action\Action;
-use  ILIAS\UI\Component\Component;
+use ILIAS\UI\Component\Table\Column\Column;
+use ILIAS\UI\Component\Table\Action\Action;
+use ILIAS\UI\Component\Component;
 
 interface DataRow extends Component
 {
@@ -32,6 +32,11 @@ interface DataRow extends Component
      * Refer to an Action by its id and disable it for this row/record only.
      */
     public function withDisabledAction(string $action_id, bool $disable = true): static;
+
+    /**
+     * Emphasize a row (visually) by marking it as 'highlighted'.
+     */
+    public function withHighlighted(bool $highlighted, bool $force = false): static;
 
     /**
      * @return array<string, Column>

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Data.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Data.php
@@ -33,6 +33,7 @@ use ILIAS\UI\Component\Input\ViewControl;
 use ILIAS\UI\Component\Input\Container\ViewControl as ViewControlContainer;
 use ILIAS\Data\Range;
 use ILIAS\Data\Order;
+use ILIAS\UI\URLBuilderToken;
 
 class Data extends AbstractTable implements T\Data
 {
@@ -51,6 +52,7 @@ class Data extends AbstractTable implements T\Data
     protected mixed $additional_parameters = null;
     protected mixed $additional_viewcontrol_data = null;
     protected ?ViewControlContainer\ViewControlInput $additional_view_control = null;
+    protected ?URLBuilderToken $highlight_token = null;
 
     /**
      * @param array<string, Column> $columns
@@ -201,6 +203,14 @@ class Data extends AbstractTable implements T\Data
         $clone = clone $this;
         $clone->additional_view_control = $view_control
             ->withDedicatedName(self::VIEWCONTROL_KEY_ADDITIONAL);
+        return $clone;
+    }
+
+    public function withHighlightToken(
+        URLBuilderToken $highlight_token
+    ): self {
+        $clone = clone $this;
+        $clone->highlight_token = $highlight_token;
         return $clone;
     }
 

--- a/components/ILIAS/UI/src/Implementation/Component/Table/DataRow.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/DataRow.php
@@ -47,7 +47,8 @@ class DataRow implements T\DataRow
         protected array $columns,
         protected array $actions,
         protected string $id,
-        protected array $record
+        protected array $record,
+        protected bool $highlighted = false
     ) {
     }
 
@@ -75,6 +76,7 @@ class DataRow implements T\DataRow
     {
         return $this->table_has_singleactions;
     }
+
     public function tableHasMultiActions(): bool
     {
         return $this->table_has_multiactions;
@@ -97,5 +99,22 @@ class DataRow implements T\DataRow
             return '';
         }
         return $this->columns[$col_id]->format($this->record[$col_id]);
+    }
+
+    public function withHighlighted(
+        bool $highlighted,
+        bool $force = false,
+    ): static {
+        $clone = clone $this;
+        $clone->highlighted = $force
+            ? $highlighted
+            : $highlighted || $this->highlighted;
+
+        return $clone;
+    }
+
+    public function isHighlighted(): bool
+    {
+        return $this->highlighted;
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Table/DataRowBuilder.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/DataRowBuilder.php
@@ -26,6 +26,8 @@ use ILIAS\UI\Component\Table\Action\Action;
 
 class DataRowBuilder extends RowBuilder implements T\DataRowBuilder
 {
+    protected array $highlighted_rows = [];
+
     /**
      * @param array<string, mixed> $record
      */
@@ -37,7 +39,15 @@ class DataRowBuilder extends RowBuilder implements T\DataRowBuilder
             $this->columns,
             $this->row_actions,
             $id,
-            $record
+            $record,
+            in_array($id, $this->highlighted_rows)
         );
+    }
+
+    public function withHighlightedRows(array $highlighted_rows): self
+    {
+        $clone = clone $this;
+        $clone->highlighted_rows = $highlighted_rows;
+        return $clone;
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Renderer.php
@@ -422,9 +422,12 @@ class Renderer extends AbstractComponentRenderer
         foreach ($rows as $row) {
             $row_contents = $default_renderer->render($row);
             $alternate = ($alternate === 'odd') ? 'even' : 'odd';
+            $highlighted = $row->isHighlighted() ? 'highlighted' : '';
+
             $tpl->setCurrentBlock('row');
             $tpl->setVariable('ALTERNATION', $alternate);
             $tpl->setVariable('CELLS', $row_contents);
+            $tpl->setVariable('HIGHLIGHTED', $highlighted);
             $tpl->parseCurrentBlock();
         }
     }

--- a/components/ILIAS/UI/src/examples/Table/Data/highlight_rows.php
+++ b/components/ILIAS/UI/src/examples/Table/Data/highlight_rows.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Table\Data;
+
+use ILIAS\UI\Component\Table\DataRetrieval;
+use ILIAS\UI\Component\Table\DataRowBuilder;
+use ILIAS\Data\Range;
+use ILIAS\Data\Order;
+use ILIAS\UI\URLBuilder;
+
+/**
+ * ---
+ * description: >
+ *   Data Table may highlight rows.
+ *
+ * expected output: >
+ *   Example showing a data table with a highlighted row.
+ *   Below the table is a button "Highlight some rows".
+ *   When clicked, the page reloads and two more columns are highlighted.
+ * ---
+ */
+function highlight_rows(): string
+{
+    global $DIC;
+
+    $factory = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+    $df = new \ILIAS\Data\Factory();
+    $refinery = $DIC['refinery'];
+
+    $request = $DIC->http()->request();
+    $query = $DIC->http()->wrapper()->query();
+
+    $here_uri = $df->uri($request->getUri()->__toString());
+    $url_builder = new URLBuilder($here_uri);
+
+    $namespace = ['dt', 'highlight'];
+    list($url_builder, $highlight_token) = $url_builder->acquireParameters(
+        $namespace,
+        'highlighted'
+    );
+
+    $records = [
+        ['col1' => 1, 'col2' => 'a'],
+        ['col1' => 2, 'col2' => 'b'],
+        ['col1' => 3, 'col2' => 'c'],
+        ['col1' => 4, 'col2' => 'd'],
+        ['col1' => 5, 'col2' => 'e'],
+    ];
+
+    $data_retrieval = new class ($records) implements DataRetrieval {
+        public function __construct(
+            protected array $records
+        ) {
+        }
+
+        public function getRows(
+            DataRowBuilder $row_builder,
+            array $visible_column_ids,
+            Range $range,
+            Order $order,
+            mixed $additional_viewcontrol_data,
+            mixed $filter_data,
+            mixed $additional_parameters
+        ): \Generator {
+            foreach ($this->records as $record) {
+                $row_id = (string) $record['col1'];
+                yield $row_builder->buildDataRow($row_id, $record)
+                    ->withHighlighted($row_id === '4');
+            }
+        }
+
+        public function getTotalRowCount(
+            mixed $additional_viewcontrol_data,
+            mixed $filter_data,
+            mixed $additional_parameters
+        ): ?int {
+            return count($this->records);
+        }
+    };
+
+    $table = $factory->table()->data(
+        $data_retrieval,
+        'Data Table with Highlighted Rows',
+        [
+            'col1' => $factory->table()->column()->number('Column 1')
+                ->withIsSortable(false),
+            'col2' => $factory->table()->column()->text('Column 2')
+                ->withIsSortable(false),
+        ],
+    )
+    ->withHighlightToken($highlight_token)
+    ->withRequest($request);
+
+    $button = $factory->button()->standard(
+        'Highlight some rows',
+        $url_builder
+            ->withParameter($highlight_token, ['1', '2'])
+            ->buildURI()
+            ->__toString()
+    );
+    return $renderer->render([
+        $table,
+        $button
+    ]);
+}

--- a/components/ILIAS/UI/src/examples/Table/Data/with_additional_viewcontrols.php
+++ b/components/ILIAS/UI/src/examples/Table/Data/with_additional_viewcontrols.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 declare(strict_types=1);
 
 namespace ILIAS\UI\examples\Table\Data;
@@ -72,10 +88,10 @@ function with_additional_viewcontrols()
             foreach ($records as $idx => $record) {
                 $row_id = (string) $record['usr_id'];
 
-                if (in_array('hide_login', $additional_viewcontrol_data[0])) {
+                if (in_array('hide_login', $additional_viewcontrol_data[0] ?? [])) {
                     $record['login'] = '-';
                 }
-                if (in_array('hide_mail', $additional_viewcontrol_data[0])) {
+                if (in_array('hide_mail', $additional_viewcontrol_data[0] ?? [])) {
                     $record['email'] = '-';
                 }
                 yield $row_builder->buildDataRow($row_id, $record);

--- a/components/ILIAS/UI/src/templates/default/Table/tpl.datatable.html
+++ b/components/ILIAS/UI/src/templates/default/Table/tpl.datatable.html
@@ -37,7 +37,7 @@
 
 			<tbody class="c-table-data__body" >
 				<!-- BEGIN row -->
-				<tr class="c-table-data__row {ALTERNATION}">
+				<tr class="c-table-data__row {ALTERNATION} {HIGHLIGHTED}">
 					{CELLS}
 				</tr>
 				<!-- END row -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,10 +29,6 @@
         "jsdom": "^26.1.0",
         "rollup": "^4.28.1",
         "sass": "^1.86.3"
-      },
-      "engines": {
-        "node": "^22.18 || ^24.0",
-        "npm": "^10.9.3 || ^11.3"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,10 @@
         "jsdom": "^26.1.0",
         "rollup": "^4.28.1",
         "sass": "^1.86.3"
+      },
+      "engines": {
+        "node": "^22.18 || ^24.0",
+        "npm": "^10.9.3 || ^11.3"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/templates/default/070-components/UI-framework/Table/_ui-component_table.scss
+++ b/templates/default/070-components/UI-framework/Table/_ui-component_table.scss
@@ -1,3 +1,4 @@
+@use "sass:color";
 @use "../../../010-settings/" as *;
 @use "../../../030-tools/_tool_buttons" as *;
 @use "../../../030-tools/_tool_browser-prefixes" as *;
@@ -145,12 +146,90 @@ $table-ordering__inset-row__shadow: inset 0px 0px 14px 2px #00000063;
     }
 }
 
+
 .c-table-data__cell {
-    background-color: $il-main-bg; // so sticky cells can cover up cells underneath them
     padding: $il-padding-large-vertical $il-padding-large-horizontal;
     border: 1px solid $il-main-border-color;
     &--multiaction {
         padding-bottom: $il-padding-large-vertical;
+    }
+}
+
+.c-table-data .c-table-data__row:not(.highlighted) {
+    .c-table-data__cell {
+        background-color: $il-main-bg; // so sticky cells can cover up cells underneath them
+    }
+}
+
+// Highlighted Rows
+$highlighted-color: $il-alert-info-bg;
+
+.c-table-data .c-table-data__row.highlighted {
+    background-color: $highlighted-color;
+    animation: highlight-callout 5s 1.2s ease-in-out, highlight-settle .6s .6s;
+    animation-fill-mode: both;
+    position: relative;
+    td:first-child::before {
+        position: absolute;
+        content: "";
+        left: -4px;
+        top: 0;
+        height: 100%;
+        width: 4px;
+        background-color: $il-info-color;
+    }
+}
+
+@keyframes highlight-callout {
+    0% {
+        background-color: color.change($highlighted-color, $alpha: 1);
+    }
+    5% {
+        background-color: color.change($highlighted-color, $alpha: 1);
+    }
+    10% {
+        background-color: color.change($highlighted-color, $alpha: 0);
+    }
+    15% {
+        background-color: color.change($highlighted-color, $alpha: 0);
+    }
+    20% {
+        background-color: color.change($highlighted-color, $alpha: 1);
+    }
+    25% {
+        background-color: color.change($highlighted-color, $alpha: 1);
+    }
+    30% {
+        background-color: color.change($highlighted-color, $alpha: 0);
+    }
+    35% {
+        background-color: color.change($highlighted-color, $alpha: 0);
+    }
+    40% {
+        background-color: color.change($highlighted-color, $alpha: 1);
+    }
+    45% {
+        background-color: color.change($highlighted-color, $alpha: 1);
+    }
+    100% {
+        background-color: color.change($highlighted-color, $alpha: 0);
+    }
+}
+@keyframes highlight-settle {
+    0% {
+        transform: translateX(-10px);
+        animation-timing-function: ease-in-out;
+    }
+    45% {
+        transform: translateX(-15px);
+        animation-timing-function: ease-in;
+    }
+    55% {
+        transform: translateX(-15px);
+        animation-timing-function: ease-in;
+    }
+    100% {
+        transform: translateX(0);
     }
 }
 
@@ -359,9 +438,12 @@ td.c-table-data__cell--number {
 }
 
 // Highlighted Columns
-td.c-table-data__cell--highlighted {
-    background-color: $il-main-dark-bg;
+.c-table-data .c-table-data__row :not(.highlighted) {
+    td.c-table-data__cell--highlighted {
+        background-color: $il-main-dark-bg;
+    }
 }
+
 // hover on larger screens only
 .c-table-data .c-table-data__row:hover td.c-table-data__cell--highlighted,
 .c-table-ordering:not(.dragInProgress) .c-table-data__row:hover td.c-table-data__cell--highlighted {

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -11971,7 +11971,6 @@ div.alert ul {
 }
 
 .c-table-data__cell {
-  background-color: white;
   padding: 6px 12px;
   border: 1px solid #dddddd;
 }
@@ -11979,6 +11978,78 @@ div.alert ul {
   padding-bottom: 6px;
 }
 
+.c-table-data .c-table-data__row:not(.highlighted) .c-table-data__cell {
+  background-color: white;
+}
+
+.c-table-data .c-table-data__row.highlighted {
+  background-color: rgb(221.841875, 236.45, 243.638125);
+  animation: highlight-callout 5s 1.2s ease-in-out, highlight-settle 0.6s 0.6s;
+  animation-fill-mode: both;
+  position: relative;
+}
+.c-table-data .c-table-data__row.highlighted td:first-child::before {
+  position: absolute;
+  content: "";
+  left: -4px;
+  top: 0;
+  height: 100%;
+  width: 4px;
+  background-color: #31708f;
+}
+
+@keyframes highlight-callout {
+  0% {
+    background-color: rgb(221.841875, 236.45, 243.638125);
+  }
+  5% {
+    background-color: rgb(221.841875, 236.45, 243.638125);
+  }
+  10% {
+    background-color: rgba(221.841875, 236.45, 243.638125, 0);
+  }
+  15% {
+    background-color: rgba(221.841875, 236.45, 243.638125, 0);
+  }
+  20% {
+    background-color: rgb(221.841875, 236.45, 243.638125);
+  }
+  25% {
+    background-color: rgb(221.841875, 236.45, 243.638125);
+  }
+  30% {
+    background-color: rgba(221.841875, 236.45, 243.638125, 0);
+  }
+  35% {
+    background-color: rgba(221.841875, 236.45, 243.638125, 0);
+  }
+  40% {
+    background-color: rgb(221.841875, 236.45, 243.638125);
+  }
+  45% {
+    background-color: rgb(221.841875, 236.45, 243.638125);
+  }
+  100% {
+    background-color: rgba(221.841875, 236.45, 243.638125, 0);
+  }
+}
+@keyframes highlight-settle {
+  0% {
+    transform: translateX(-10px);
+    animation-timing-function: ease-in-out;
+  }
+  45% {
+    transform: translateX(-15px);
+    animation-timing-function: ease-in;
+  }
+  55% {
+    transform: translateX(-15px);
+    animation-timing-function: ease-in;
+  }
+  100% {
+    transform: translateX(0);
+  }
+}
 @media screen and (min-width: 769px) {
   .c-table-ordering:not(.dragInProgress) .c-table-data__row:hover td.c-table-data__cell,
   .c-table-data .c-table-data__row:hover td.c-table-data__cell {
@@ -12134,7 +12205,7 @@ td.c-table-data__cell--number {
   resize: horizontal;
 }
 
-td.c-table-data__cell--highlighted {
+.c-table-data .c-table-data__row :not(.highlighted) td.c-table-data__cell--highlighted {
   background-color: #f9f9f9;
 }
 


### PR DESCRIPTION
This adds highlighting rows to the table.
There are two ways to highlight a row: directly, [on the row itself](https://github.com/ILIAS-eLearning/ILIAS/compare/trunk...nhaagen:11/UI/DataTable/HighlightRows?expand=1#diff-cdf8c6242a5254758584d31f8977a6e02abe764d01b10a619fa9a2925cb3b6d6R85-R86) or [via parameters ](https://github.com/ILIAS-eLearning/ILIAS/compare/trunk...nhaagen:11/UI/DataTable/HighlightRows?expand=1#diff-cdf8c6242a5254758584d31f8977a6e02abe764d01b10a619fa9a2925cb3b6d6R109-R114).

In order to use parameters, [the token has to be given to the table](https://github.com/ILIAS-eLearning/ILIAS/compare/trunk...nhaagen:11/UI/DataTable/HighlightRows?expand=1#diff-cdf8c6242a5254758584d31f8977a6e02abe764d01b10a619fa9a2925cb3b6d6R106); I already marked the method as deprecated, since I feel this is usually following an (prompt-) action and the token should be announced along with other things necessary for the action: 
please see https://github.com/ILIAS-eLearning/ILIAS/pull/10196; when adding an entry, the new lines should be highlighted afterwards, and [the method](https://github.com/ILIAS-eLearning/ILIAS/pull/10196/files#diff-0ed525cff8ee887ce8e9412ae0ca4888b33b0d824ea4fde6f037f7e18fbd47d2R71) would then read `public function withEntryCreation(Prompt $entry_creation, URLBuilderToken $highlight_token): self`

CSS is, as always, just a dummy and better left to @catenglaender. 
