### PR TITLE
T&A: Improve loading of test passes

### DIFF
--- a/Modules/Test/classes/class.ilTestPassesSelector.php
+++ b/Modules/Test/classes/class.ilTestPassesSelector.php
@@ -71,10 +71,7 @@ class ilTestPassesSelector
     private function loadPasses(): void
     {
         $query = '
-			SELECT DISTINCT tst_pass_result.* FROM tst_pass_result
-			LEFT JOIN tst_test_result
-			ON tst_pass_result.pass = tst_test_result.pass
-			AND tst_pass_result.active_fi = tst_test_result.active_fi
+			SELECT tst_pass_result.* FROM tst_pass_result
 			WHERE tst_pass_result.active_fi = %s
 			ORDER BY tst_pass_result.pass
 		';


### PR DESCRIPTION
Hi everyone,

In this PR, I'm proposing a change to the query for test passes in `ilTestPassesSelector`. These changes are related to reports of performance issues, particularly in connection with tests using randomized questions.

I removed the LEFT JOIN of the query. The rows from the right part of the JOIN part aren't needed anywhere in the query and aren't loaded at all due to the restrictions in the SELECT clause. Additionally, the DISTINCT can be removed at this point, since duplicate rows in the result can only occur because of the join in the first place.

We conducted several measurements in a test environment with large database tables. For a participant with five test passes and approximately 50 questions per pass, we measured an execution time of **3.4 seconds** for this query. After this change, the execution time comes to **0.0011 seconds**.

@thojou and I verified the change through mathematical substitution and through A/B testing, where both old and new queries were executed in a test environment and the results were compared.

As always, I look forward to your feedback and comments on this proposal.

Best Regards
@lukas-heinrich 