### PR TITLE
10/UI/tooltips on tabs, btn-bulky, link-bulky 42421

### DIFF
--- a/templates/default/070-components/UI-framework/MainControls/Slate/_ui-component_slate.scss
+++ b/templates/default/070-components/UI-framework/MainControls/Slate/_ui-component_slate.scss
@@ -31,6 +31,11 @@ $il-slate-tree-padding: $il-padding-small-vertical 0;
 			filter: invert(50%);
 		}
 	}
+	.c-tooltip__container:has(.btn-bulky),
+	.c-tooltip__container:has(.link-bulky) {
+		width: 100%;
+	}
+
 	.il-maincontrols-slate .btn-bulky {
 		background-color: $il-slate-bulky-level2-bg-color;
 	}

--- a/templates/default/070-components/UI-framework/_ui-component_tooltip.scss
+++ b/templates/default/070-components/UI-framework/_ui-component_tooltip.scss
@@ -25,6 +25,7 @@ $c-tooltip-z-index: 9999;
 	transform: translateX(-50%);
 	border: $c-tooltip-arrow-height solid transparent;
 	border-bottom-color: $c-tooltip-arrow-background-color;
+	z-index: $c-tooltip-z-index;
 }
 
 // Invisible bridge so users can move cursor from button to tooltip
@@ -35,6 +36,7 @@ $c-tooltip-z-index: 9999;
 	left: -20%;
 	display: block;
 	height: calc($c-tooltip-arrow-height * 2);
+	z-index: $c-tooltip-z-index;
 }
 
 // making bridge amd arrow visible
@@ -73,8 +75,8 @@ $c-tooltip-z-index: 9999;
 	max-width: $c-tooltip-max-width;
 	max-height: $c-tooltip-max-height;
 	overflow: auto;
-	z-index: $c-tooltip-z-index;
 	display: none;
+	z-index: $c-tooltip-z-index;
 	@include tool-typography.strip-paragraph-margin__first-and-last;
 }
 

--- a/templates/default/070-components/legacy/Services/UIComponent/_component_tabs.scss
+++ b/templates/default/070-components/legacy/Services/UIComponent/_component_tabs.scss
@@ -20,7 +20,8 @@ $nav-tabs-border: 2px solid $nav-tabs-active-link-hover-bg !default;
 		margin: 0 $il-padding-xs-horizontal 0 0;
 
 		// Actual tabs (as links)
-		> a {
+		> a,
+        > .c-tooltip__container > a {
 			margin: 0;
 			margin-right: 2px;
 			font-size: $il-font-size-base;
@@ -37,8 +38,8 @@ $nav-tabs-border: 2px solid $nav-tabs-active-link-hover-bg !default;
 		}
 
 		// Active state, and its :hover to override normal :hover
-		&.active>a {
-
+		&.active > a,
+        &.active > .c-tooltip__container > a {
 			&,
 			&:hover,
 			&:focus {
@@ -62,7 +63,8 @@ $nav-tabs-border: 2px solid $nav-tabs-active-link-hover-bg !default;
 	padding: $il-padding-large-vertical 0;
 	margin: 0;
 
-	> li:first-child > a {
+	> li:first-child > a,
+    > li:first-child > .c-tooltip__container > a {
 		padding-left: $il-padding-large-horizontal;
 	}
 
@@ -70,7 +72,8 @@ $nav-tabs-border: 2px solid $nav-tabs-active-link-hover-bg !default;
 	> li {
 		float: left;
 
-		> a {
+		> a,
+        > .c-tooltip__container > a {
 			border-radius: 0;
 			padding: $il-padding-base-vertical $il-padding-base;
 			font-size: ($il-font-size-small);
@@ -82,7 +85,8 @@ $nav-tabs-border: 2px solid $nav-tabs-active-link-hover-bg !default;
 			@include focus.clear-focus-for-override($clearAfter: true);
 			@include focus.il-focus();
 		}
-		&.active > a {
+		&.active > a,
+        &.active > .c-tooltip__container > a {
 			&,
 			&:hover,
 			&:focus {

--- a/templates/default/070-components/legacy/Services/UIComponent/_component_toolbar.scss
+++ b/templates/default/070-components/legacy/Services/UIComponent/_component_toolbar.scss
@@ -43,7 +43,7 @@ $il-toolbar-border: 1px solid $il-main-border-color !default;
 		position: relative;
 		display: block;
 
-		>a {
+		> a, > .c-tooltip__container > a {
 			position: relative;
 			display: block;
 			padding: $nav-link-padding;
@@ -56,7 +56,7 @@ $il-toolbar-border: 1px solid $il-main-border-color !default;
 		}
 
 		// Disabled state sets text to gray and nukes hover/tab effects
-		&.disabled>a {
+		&.disabled>a, &.disabled>.c-tooltip__container>a {
 			color: $nav-disabled-link-color;
 
 			&:hover,

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -2514,6 +2514,7 @@ code {
   transform: translateX(-50%);
   border: 0.5em solid transparent;
   border-bottom-color: #757575;
+  z-index: 9999;
 }
 
 .c-tooltip__container::after {
@@ -2523,6 +2524,7 @@ code {
   left: -20%;
   display: block;
   height: 1em;
+  z-index: 9999;
 }
 
 .c-tooltip__container.c-tooltip--visible::before,
@@ -2557,8 +2559,8 @@ code {
   max-width: 50vw;
   max-height: 40vh;
   overflow: auto;
-  z-index: 9999;
   display: none;
+  z-index: 9999;
 }
 .c-tooltip__container .c-tooltip p:first-child {
   margin-top: 0;
@@ -5876,6 +5878,10 @@ a[aria-disabled].il-link.link-bulky:hover {
 .il-maincontrols-slate .btn-bulky .icon,
 .il-maincontrols-slate .link-bulky .icon {
   filter: invert(50%);
+}
+.il-maincontrols-slate .c-tooltip__container:has(.btn-bulky),
+.il-maincontrols-slate .c-tooltip__container:has(.link-bulky) {
+  width: 100%;
 }
 .il-maincontrols-slate .il-maincontrols-slate .btn-bulky {
   background-color: #f9f9f9;
@@ -20146,7 +20152,8 @@ a.ilMediaLightboxClose:hover {
   float: left;
   margin: 0 3px 0 0;
 }
-#ilTab > li > a {
+#ilTab > li > a,
+#ilTab > li > .c-tooltip__container > a {
   margin: 0;
   margin-right: 2px;
   font-size: 0.875rem;
@@ -20155,37 +20162,45 @@ a.ilMediaLightboxClose:hover {
   border: 0 none;
   border-radius: 0px 0px 0 0;
 }
-#ilTab > li > a:hover {
+#ilTab > li > a:hover,
+#ilTab > li > .c-tooltip__container > a:hover {
   border-color: white white white;
 }
-#ilTab > li > a:focus {
+#ilTab > li > a:focus,
+#ilTab > li > .c-tooltip__container > a:focus {
   border: inherit;
   box-shadow: inherit;
   outline: none;
   outline-offset: 0px;
 }
-#ilTab > li > a:focus::after {
+#ilTab > li > a:focus::after,
+#ilTab > li > .c-tooltip__container > a:focus::after {
   content: none;
 }
-#ilTab > li > a:focus-visible {
+#ilTab > li > a:focus-visible,
+#ilTab > li > .c-tooltip__container > a:focus-visible {
   border: inherit;
   box-shadow: inherit;
   outline: none;
   outline-offset: 0px;
 }
-#ilTab > li > a:focus-visible::after {
+#ilTab > li > a:focus-visible::after,
+#ilTab > li > .c-tooltip__container > a:focus-visible::after {
   content: none;
 }
-#ilTab > li > a:focus {
+#ilTab > li > a:focus,
+#ilTab > li > .c-tooltip__container > a:focus {
   outline: none;
   outline-offset: 0px;
 }
-#ilTab > li > a:focus-visible {
+#ilTab > li > a:focus-visible,
+#ilTab > li > .c-tooltip__container > a:focus-visible {
   position: relative;
   outline: 2px solid #FFFFFF;
   outline-offset: 5px;
 }
-#ilTab > li > a:focus-visible::after {
+#ilTab > li > a:focus-visible::after,
+#ilTab > li > .c-tooltip__container > a:focus-visible::after {
   content: " ";
   position: absolute;
   top: -2px;
@@ -20195,7 +20210,7 @@ a.ilMediaLightboxClose:hover {
   border: 2px solid #FFFFFF;
   outline: 3px solid #0078D7;
 }
-#ilTab > li.active > a, #ilTab > li.active > a:hover, #ilTab > li.active > a:focus {
+#ilTab > li.active > a, #ilTab > li.active > a:hover, #ilTab > li.active > a:focus, #ilTab > li.active > .c-tooltip__container > a, #ilTab > li.active > .c-tooltip__container > a:hover, #ilTab > li.active > .c-tooltip__container > a:focus {
   color: white;
   cursor: default;
   background-color: #161616;
@@ -20212,49 +20227,59 @@ a.ilMediaLightboxClose:hover {
   padding: 6px 0;
   margin: 0;
 }
-#ilSubTab > li:first-child > a {
+#ilSubTab > li:first-child > a,
+#ilSubTab > li:first-child > .c-tooltip__container > a {
   padding-left: 12px;
 }
 #ilSubTab > li {
   float: left;
 }
-#ilSubTab > li > a {
+#ilSubTab > li > a,
+#ilSubTab > li > .c-tooltip__container > a {
   border-radius: 0;
   padding: 3px 9px;
   font-size: 0.75rem;
 }
-#ilSubTab > li > a:hover {
+#ilSubTab > li > a:hover,
+#ilSubTab > li > .c-tooltip__container > a:hover {
   text-decoration: underline;
   background-color: transparent;
 }
-#ilSubTab > li > a:focus {
+#ilSubTab > li > a:focus,
+#ilSubTab > li > .c-tooltip__container > a:focus {
   border: inherit;
   box-shadow: inherit;
   outline: none;
   outline-offset: 0px;
 }
-#ilSubTab > li > a:focus::after {
+#ilSubTab > li > a:focus::after,
+#ilSubTab > li > .c-tooltip__container > a:focus::after {
   content: none;
 }
-#ilSubTab > li > a:focus-visible {
+#ilSubTab > li > a:focus-visible,
+#ilSubTab > li > .c-tooltip__container > a:focus-visible {
   border: inherit;
   box-shadow: inherit;
   outline: none;
   outline-offset: 0px;
 }
-#ilSubTab > li > a:focus-visible::after {
+#ilSubTab > li > a:focus-visible::after,
+#ilSubTab > li > .c-tooltip__container > a:focus-visible::after {
   content: none;
 }
-#ilSubTab > li > a:focus {
+#ilSubTab > li > a:focus,
+#ilSubTab > li > .c-tooltip__container > a:focus {
   outline: none;
   outline-offset: 0px;
 }
-#ilSubTab > li > a:focus-visible {
+#ilSubTab > li > a:focus-visible,
+#ilSubTab > li > .c-tooltip__container > a:focus-visible {
   position: relative;
   outline: 2px solid #FFFFFF;
   outline-offset: 5px;
 }
-#ilSubTab > li > a:focus-visible::after {
+#ilSubTab > li > a:focus-visible::after,
+#ilSubTab > li > .c-tooltip__container > a:focus-visible::after {
   content: " ";
   position: absolute;
   top: -2px;
@@ -20264,7 +20289,7 @@ a.ilMediaLightboxClose:hover {
   border: 2px solid #FFFFFF;
   outline: 3px solid #0078D7;
 }
-#ilSubTab > li.active > a, #ilSubTab > li.active > a:hover, #ilSubTab > li.active > a:focus {
+#ilSubTab > li.active > a, #ilSubTab > li.active > a:hover, #ilSubTab > li.active > a:focus, #ilSubTab > li.active > .c-tooltip__container > a, #ilSubTab > li.active > .c-tooltip__container > a:hover, #ilSubTab > li.active > .c-tooltip__container > a:focus {
   color: #4c6586;
   background-color: transparent;
   text-decoration: underline;
@@ -20289,19 +20314,19 @@ a.ilMediaLightboxClose:hover {
   position: relative;
   display: block;
 }
-.nav > li > a {
+.nav > li > a, .nav > li > .c-tooltip__container > a {
   position: relative;
   display: block;
   padding: 6px 12px;
 }
-.nav > li > a:hover, .nav > li > a:focus {
+.nav > li > a:hover, .nav > li > a:focus, .nav > li > .c-tooltip__container > a:hover, .nav > li > .c-tooltip__container > a:focus {
   text-decoration: none;
   background-color: #f0f0f0;
 }
-.nav > li.disabled > a {
+.nav > li.disabled > a, .nav > li.disabled > .c-tooltip__container > a {
   color: #f9f9f9;
 }
-.nav > li.disabled > a:hover, .nav > li.disabled > a:focus {
+.nav > li.disabled > a:hover, .nav > li.disabled > a:focus, .nav > li.disabled > .c-tooltip__container > a:hover, .nav > li.disabled > .c-tooltip__container > a:focus {
   color: #f9f9f9;
   text-decoration: none;
   cursor: not-allowed;


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=42421

# Issue

Attaching KS UI Tooltips to legacy elements breaks the design

# Changes

<img width="800" height="850" alt="tooltips_bulky-btns_bulky-links_tabs" src="https://github.com/user-attachments/assets/93d28978-ac95-4d62-8f53-a42362da0f16" />


Following designs have been fixed to work with the additional container that the KS UI Tooltip requires:
* in slate
    * bulky-btn
    * bulky-link
* in mainbar
    * bulky-btn
    * bulky-link
* Tabs
* Sub-Tabs

# Outlook

* Tabs and Sub-Tabs need to become UI components. Support for tooltips could then be a fully thought through feature and not a band-aid.
* Bulky concept has to be refined and more examples have to be added to the Kitchen Sink so testing is easier and the limits and recommendations can be communicated more clearly.