### PR TITLE
Fix 43784: Add aria-live attribute to textarea remainder message

### DIFF
--- a/components/ILIAS/UI/src/templates/default/Input/tpl.textarea.html
+++ b/components/ILIAS/UI/src/templates/default/Input/tpl.textarea.html
@@ -7,7 +7,7 @@
     <!-- BEGIN with_max_limit -->maxlength="{MAX_LIMIT}"<!-- END with_max_limit -->
 ><!-- BEGIN value -->{VALUE}<!-- END value --></textarea>
 <!-- BEGIN remainder -->
-<div class="ui-input-textarea-remainder">
+<div class="ui-input-textarea-remainder" aria-live="polite">
     {REMAINDER_TEXT} <span data-action="remainder">{REMAINDER}</span>
 </div>
 <!-- END remainder -->

--- a/components/ILIAS/UI/tests/Component/Input/Field/TextareaTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/TextareaTest.php
@@ -178,7 +178,7 @@ class TextareaTest extends ILIAS_UI_TestBase
             $label,
             '
                 <textarea id="id_1" class="c-field-textarea" name="name_0" maxlength="20"></textarea>
-                <div class="ui-input-textarea-remainder"> ui_chars_remaining<span data-action="remainder">20</span></div>
+                <div class="ui-input-textarea-remainder" aria-live="polite"> ui_chars_remaining<span data-action="remainder">20</span></div>
             ',
             $byline,
             'id_1',
@@ -203,7 +203,7 @@ class TextareaTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML("
             <textarea id=\"$id\" class=\"c-field-textarea\" name=\"$name\" minlength=\"5\" maxlength=\"20\"></textarea>
-            <div class=\"ui-input-textarea-remainder\"> ui_chars_remaining <span data-action=\"remainder\">$max</span> </div>
+            <div class=\"ui-input-textarea-remainder\" aria-live=\"polite\"> ui_chars_remaining <span data-action=\"remainder\">$max</span> </div>
         ");
         $this->assertStringContainsString($expected, $this->render($textarea));
     }


### PR DESCRIPTION
This PR addresses the accessibility issue [43784](https://mantis.ilias.de/view.php?id=43784), where screen readers don't receive announcements of changes to the remaining character count for the test description field.

**Changes made:**

Added `aria-live="polite"` to the element displaying the remaining characters.


https://mantis.ilias.de/view.php?id=43784

**bugfix**, **kitchen sink**