### PR TITLE
Add jstree as npm Dependency for ILIAS 11

### DIFF
--- a/components/ILIAS/UIComponent/UIComponent.php
+++ b/components/ILIAS/UIComponent/UIComponent.php
@@ -45,7 +45,7 @@ class UIComponent implements Component\Component
         $contribute[Component\Resource\PublicAsset::class] = fn() =>
             new Component\Resource\ComponentJS($this, "ilTextHighlighter.js");
 
-        /* $contribute[Component\Resource\PublicAsset::class] = static fn() => new class () implements Component\Resource\PublicAsset {
+        $contribute[Component\Resource\PublicAsset::class] = static fn() => new class () implements Component\Resource\PublicAsset {
             public function getSource(): string
             {
                 return "node_modules/jstree";
@@ -54,8 +54,7 @@ class UIComponent implements Component\Component
             {
                 return "node_modules/jstree";
             }
-        }; */
-
+        };
 
         /* This library was missing after discussing dependencies for ILIAS 10
         $contribute[Component\Resource\PublicAsset::class] = static fn() =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "chart.js": "^4.4.7",
         "dropzone": "^5.9.3",
         "jquery": "^3.7.1",
+        "jstree": "^3.3.17",
         "linkify-element": "^4.3.2",
         "linkifyjs": "^4.3.2",
         "mathjax": "^3.2.2",
@@ -3150,6 +3151,15 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
+    },
+    "node_modules/jstree": {
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/jstree/-/jstree-3.3.17.tgz",
+      "integrity": "sha512-V0Pl1B6BIaxHUQMiWkol37QlhlBKoZA9RUeUmm95+UnV2QeZsj2QP1sOQl/m2EIOyZXOOxOHvR0SYZLSDC7EFw==",
+      "license": "MIT",
+      "dependencies": {
+        "jquery": "^3.5.0"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "chart.js": "^4.4.7",
     "dropzone": "^5.9.3",
     "jquery": "^3.7.1",
+    "jstree": "^3.3.17",
     "linkify-element": "^4.3.2",
     "linkifyjs": "^4.3.2",
     "mathjax": "^3.2.2",
@@ -132,6 +133,13 @@
       "developer": null,
       "purpose": "We still use jQuery for many JS-related actions in ILIAS, unfortunately.",
       "last-update-for-ilias": "10.0"
+    },
+    "jstree": {
+      "introduction-date": null,
+      "approved-by": "Jour Fix",
+      "developer": "alex40724",
+      "purpose": "Legacy explorer tree representation",
+      "last-update-for-ilias": "11.0"
     },
     "sass": {
       "introduction-date": null,


### PR DESCRIPTION
Usage: Legacy explorer tree in UIComponent

Wrapped by: UIComponent

Reasoning: As discussed on the last legacy ui meeting, we still need this for the legacy explorer component, esp. the async mode being used by repository tree, org tree, and others

Maintenance: It gets at least a yearly release in the recent years. Code seems to be pretty stable.

NPM: https://www.npmjs.com/package/jstree