### PR TITLE
Registration: move double opt-in handling to dedicated services

### DIFF
--- a/components/ILIAS/Init/classes/class.ilStartUpGUI.php
+++ b/components/ILIAS/Init/classes/class.ilStartUpGUI.php
@@ -18,6 +18,10 @@
 
 declare(strict_types=1);
 
+use ILIAS\Registration\DualOptIn\Exception\DualOptInException;
+use ILIAS\Registration\DualOptIn\Repository\PendingRegistrationDatabaseRepository;
+use ILIAS\Registration\DualOptIn\Service\DualOptInServiceImpl;
+use ILIAS\Registration\DualOptIn\ValueObjects\PendingRegistrationHash;
 use Psr\Http\Message\ServerRequestInterface;
 use ILIAS\UICore\PageContentProvider;
 use ILIAS\Refinery\Factory as RefineryFactory;
@@ -27,7 +31,6 @@ use ILIAS\DataProtection\Consumer as DataProtection;
 use ILIAS\components\Authentication\Logout\ConfigurableLogoutTarget;
 use ILIAS\LegalDocuments\Conductor;
 use ILIAS\components\Authentication\Pages\AuthPageEditorContext;
-use ILIAS\User\Settings\NewAccountMail\Repository as NewAccountMailRepository;
 
 /**
  * @ilCtrl_Calls ilStartUpGUI: ilAccountRegistrationGUI, ilPasswordAssistanceGUI, ilLoginPageGUI, ilDashboardGUI
@@ -1507,15 +1510,30 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
     private function confirmRegistration(): void
     {
         $this->lng->loadLanguageModule('registration');
-
         ilUtil::setCookie('iltest', 'cookie', false);
-        $regitration_hash = trim(
-            $this->http->wrapper()->query()->retrieve(
-                'rh',
-                $this->refinery->byTrying([$this->refinery->kindlyTo()->string(), $this->refinery->always('')])
-            )
-        );
-        if ($regitration_hash === '') {
+
+        try {
+            $reg_hash = $this->refinery->to()
+                ->toNew(PendingRegistrationHash::class)
+                ->transform([$this->http->wrapper()->query()->retrieve('rh', $this->refinery->byTrying([
+                    $this->refinery->kindlyTo()->string(),
+                    $this->refinery->always(null)
+                ]))]);
+
+            $dual_opt_in_service = new DualOptInServiceImpl(
+                new PendingRegistrationDatabaseRepository($this->dic->database()),
+                $this->dic->database(),
+                $this->dic->logger()->user()
+            );
+            $user = $dual_opt_in_service->verifyHashAndActivateUser($reg_hash);
+        } catch (DualOptInException $exception) {
+            $this->mainTemplate->setOnScreenMessage(
+                ilGlobalTemplateInterface::MESSAGE_TYPE_FAILURE,
+                $this->lng->txt($exception->getMessage()),
+                true
+            );
+            $this->ctrl->redirectToURL(sprintf('./login.php?cmd=force_login&lang=%s', $this->lng->getLangKey()));
+        } catch (Exception $e) {
             $this->mainTemplate->setOnScreenMessage(
                 ilGlobalTemplateInterface::MESSAGE_TYPE_FAILURE,
                 $this->lng->txt('reg_confirmation_hash_not_passed'),
@@ -1524,71 +1542,12 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
             $this->ctrl->redirectToURL(sprintf('./login.php?cmd=force_login&lang=%s', $this->lng->getLangKey()));
         }
 
-        try {
-            $oRegSettings = new ilRegistrationSettings();
-
-            $usr_id = ilObjUser::_verifyRegistrationHash(trim($regitration_hash));
-            /** @var ilObjUser $user */
-            $user = ilObjectFactory::getInstanceByObjId($usr_id);
-            $user->setActive(true);
-            $password = '';
-            if ($oRegSettings->passwordGenerationEnabled()) {
-                $passwords = ilSecuritySettingsChecker::generatePasswords(1);
-                $password = $passwords[0];
-                $user->setPasswd($password, ilObjUser::PASSWD_PLAIN);
-                $user->setLastPasswordChangeTS(time());
-            }
-            $user->update();
-
-            $accountMail = (new ilAccountRegistrationMail(
-                $oRegSettings,
-                ilLoggerFactory::getLogger('user')
-            ))->withEmailConfirmationRegistrationMode();
-
-            if ($user->getPref('reg_target') ?? '') {
-                $accountMail = $accountMail->withPermanentLinkTarget($user->getPref('reg_target'));
-            }
-
-            $accountMail->send($user, $password);
-
-            $this->mainTemplate->setOnScreenMessage(
-                ilGlobalTemplateInterface::MESSAGE_TYPE_SUCCESS,
-                $this->lng->txt('reg_account_confirmation_successful'),
-                true
-            );
-            $this->ctrl->redirectToURL(sprintf('./login.php?cmd=force_login&lang=%s', $user->getLanguage()));
-        } catch (ilRegConfirmationLinkExpiredException $exception) {
-            $soap_client = new ilSoapClient();
-            $soap_client->setResponseTimeout(1);
-            $soap_client->enableWSDL(true);
-            $soap_client->init();
-
-            $this->logger->info(
-                'Triggered soap call (background process) for deletion of inactive user objects with expired confirmation hash values (dual opt in) ...'
-            );
-
-            $soap_client->call(
-                'deleteExpiredDualOptInUserObjects',
-                [
-                    $_COOKIE[session_name()] . '::' . CLIENT_ID,
-                    $exception->getCode() // user id
-                ]
-            );
-
-            $this->mainTemplate->setOnScreenMessage(
-                ilGlobalTemplateInterface::MESSAGE_TYPE_FAILURE,
-                $this->lng->txt($exception->getMessage()),
-                true
-            );
-            $this->ctrl->redirectToURL(sprintf('./login.php?cmd=force_login&lang=%s', $this->lng->getLangKey()));
-        } catch (ilRegistrationHashNotFoundException $exception) {
-            $this->mainTemplate->setOnScreenMessage(
-                ilGlobalTemplateInterface::MESSAGE_TYPE_FAILURE,
-                $this->lng->txt($exception->getMessage()),
-                true
-            );
-            $this->ctrl->redirectToURL(sprintf('./login.php?cmd=force_login&lang=%s', $this->lng->getLangKey()));
-        }
+        $this->mainTemplate->setOnScreenMessage(
+            ilGlobalTemplateInterface::MESSAGE_TYPE_SUCCESS,
+            $this->lng->txt('reg_account_confirmation_successful'),
+            true
+        );
+        $this->ctrl->redirectToURL(sprintf('./login.php?cmd=force_login&lang=%s', $user->getLanguage()));
     }
 
     /**

--- a/components/ILIAS/Registration/Registration.php
+++ b/components/ILIAS/Registration/Registration.php
@@ -20,6 +20,10 @@ declare(strict_types=1);
 
 namespace ILIAS;
 
+use ILIAS\Refinery\Factory;
+use ILIAS\Setup\Agent;
+use ilRegistrationAgent;
+
 class Registration implements Component\Component
 {
     public function init(
@@ -32,9 +36,9 @@ class Registration implements Component\Component
         array | \ArrayAccess &$pull,
         array | \ArrayAccess &$internal,
     ): void {
-        $contribute[\ILIAS\Setup\Agent::class] = static fn() =>
-            new \ilRegistrationAgent(
-                $pull[\ILIAS\Refinery\Factory::class]
+        $contribute[Agent::class] = static fn() =>
+            new ilRegistrationAgent(
+                $pull[Factory::class]
             );
 
         $contribute[Component\Resource\PublicAsset::class] = fn() =>

--- a/components/ILIAS/Registration/classes/Setup/class.ilRegistrationAgent.php
+++ b/components/ILIAS/Registration/classes/Setup/class.ilRegistrationAgent.php
@@ -16,18 +16,20 @@
  *
  *********************************************************************/
 
-use ILIAS\Setup;
+use ILIAS\Registration\DualOptIn\Setup\DualOptInDatabaseUpdateSteps;
+use ILIAS\Setup\Config;
+use ILIAS\Setup\ObjectiveCollection;
 use ILIAS\Setup\Objective;
-use ILIAS\Setup\Metrics;
 
-class ilRegistrationAgent extends Setup\Agent\NullAgent
+class ilRegistrationAgent extends ILIAS\Setup\Agent\NullAgent
 {
-    public function getUpdateObjective(?Setup\Config $config = null): Setup\Objective
+    public function getUpdateObjective(?Config $config = null): Objective
     {
-        return new Setup\ObjectiveCollection(
+        return new ObjectiveCollection(
             "Service/Registation Objectives",
             false,
-            new \ilRegistrationConfigUpdateObjective()
+            new \ilRegistrationConfigUpdateObjective(),
+            new ilDatabaseUpdateStepsExecutedObjective(new DualOptInDatabaseUpdateSteps()),
         );
     }
 }

--- a/components/ILIAS/Registration/classes/class.ilAccountRegistrationGUI.php
+++ b/components/ILIAS/Registration/classes/class.ilAccountRegistrationGUI.php
@@ -18,8 +18,10 @@
 
 declare(strict_types=1);
 
+use ILIAS\DI\Container;
+use ILIAS\Registration\DualOptIn\Repository\PendingRegistrationDatabaseRepository;
 use ILIAS\Language\UserSettings\Language as LanguageSetting;
-use ILIAS\User\Settings\NewAccountMail\Repository as NewAccountMailRepository;
+use ILIAS\Registration\DualOptIn\Service\DualOptInServiceImpl;
 use ILIAS\User\Settings\Settings as UserSettings;
 use ILIAS\User\Profile\Profile;
 use ILIAS\User\Profile\Fields\Standard\Alias;
@@ -41,6 +43,7 @@ class ilAccountRegistrationGUI
     protected UserSettings $user_settings;
 
     protected ?ilPropertyFormGUI $form = null;
+    protected Container $dic;
 
     protected ilGlobalTemplateInterface $tpl;
     protected ilCtrlInterface $ctrl;
@@ -62,6 +65,7 @@ class ilAccountRegistrationGUI
     {
         global $DIC;
 
+        $this->dic = $DIC;
         $this->tpl = $DIC->ui()->mainTemplate();
 
         $this->ctrl = $DIC->ctrl();
@@ -558,18 +562,14 @@ class ilAccountRegistrationGUI
         }
         // Send mail to new user
         // Registration with confirmation link ist enabled
-        if (!$this->code_was_used &&
-            $this->registration_settings->getRegistrationType() === ilRegistrationSettings::IL_REG_ACTIVATION) {
-            $mail = new ilRegistrationMimeMailNotification();
-            $mail->setType(ilRegistrationMimeMailNotification::TYPE_NOTIFICATION_ACTIVATION);
-            $mail->setRecipients([$this->userObj]);
-            $mail->setAdditionalInformation(
-                [
-                    'usr' => $this->userObj,
-                    'hash_lifetime' => $this->registration_settings->getRegistrationHashLifetime()
-                ]
+        $is_dual_opt_in_reg_mode = $this->registration_settings->getRegistrationType() === ilRegistrationSettings::IL_REG_ACTIVATION;
+        if (!$this->code_was_used && $is_dual_opt_in_reg_mode) {
+            $dual_opt_in_service = new DualOptInServiceImpl(
+                new PendingRegistrationDatabaseRepository($this->dic->database()),
+                $this->dic->database(),
+                $this->dic->logger()->user()
             );
-            $mail->send();
+            $dual_opt_in_service->distributeMailsOnRegistration($this->userObj, $this->registration_settings);
         } else {
             $accountMail = new ilAccountRegistrationMail(
                 $this->registration_settings,

--- a/components/ILIAS/Registration/classes/class.ilRegistrationAppEventListener.php
+++ b/components/ILIAS/Registration/classes/class.ilRegistrationAppEventListener.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\Registration\DualOptIn\Repository\PendingRegistrationDatabaseRepository;
+
+class ilRegistrationAppEventListener implements ilAppEventListener
+{
+    public static function handleEvent(string $a_component, string $a_event, array $a_parameter): void
+    {
+        if ($a_component === 'Services/User' && $a_event === 'deleteUser') {
+            global $DIC;
+
+            $pending_reg_repository = new PendingRegistrationDatabaseRepository($DIC->database());
+            $pending_reg_repository->deleteByUserId((int) $a_parameter['usr_id']);
+        }
+    }
+}

--- a/components/ILIAS/Registration/classes/class.ilRegistrationMimeMailNotification.php
+++ b/components/ILIAS/Registration/classes/class.ilRegistrationMimeMailNotification.php
@@ -18,53 +18,77 @@
 
 declare(strict_types=1);
 
+use ILIAS\Registration\DualOptIn\Entity\PendingRegistration;
+
 /**
  * Class for mime mail registration notifications
  * @author  Michael Jansen <mjansen@databay.de>
  */
 class ilRegistrationMimeMailNotification extends ilMimeMailNotification
 {
-    public const TYPE_NOTIFICATION_ACTIVATION = 32;
+    public const int TYPE_NOTIFICATION_ACTIVATION = 32;
+
+    private readonly ilObjUser $user;
+    private readonly PendingRegistration $pending_reg;
+    private readonly int $hash_lifetime_sec;
+
+
+    public function __construct(ilObjUser $user, PendingRegistration $pending_reg, int $hash_lifetime_sec)
+    {
+        parent::__construct();
+
+        $this->user = $user;
+        $this->pending_reg = $pending_reg;
+        $this->hash_lifetime_sec = $hash_lifetime_sec;
+    }
 
     public function send(): void
     {
-        if ($this->getType() === self::TYPE_NOTIFICATION_ACTIVATION) {
-            $additional_information = $this->getAdditionalInformation();
-            /**
-             * @var $user ilObjUser
-             */
-            $user = $additional_information['usr'];
-            $this->getLanguage()->loadLanguageModule("registration");
+        if ($this->getType() !== self::TYPE_NOTIFICATION_ACTIVATION) {
+            return;
+        }
 
-            foreach ($this->getRecipients() as $rcp) {
-                try {
-                    $this->handleCurrentRecipient($rcp);
-                } catch (ilMailException $e) {
-                    continue;
-                }
+        $this->getLanguage()->loadLanguageModule("registration");
 
-                $this->initMimeMail();
-                $this->setSubject($this->getLanguage()->txt('reg_mail_subject_confirmation'));
-                $this->setBody($this->getLanguage()->txt('reg_mail_body_salutation') . ' ' . $user->getFullname() . ',');
-                $this->appendBody("\n\n");
-                $this->appendBody($this->getLanguage()->txt('reg_mail_body_activation'));
-                $this->appendBody("\n");
-                $this->appendBody(ILIAS_HTTP_PATH . '/confirmReg.php?client_id=' . CLIENT_ID . '&rh=' . $user->generateRegistrationHash());
-                $this->appendBody("\n\n");
-                $this->appendBody(sprintf(
-                    $this->getLanguage()->txt('reg_mail_body_2_confirmation'),
-                    ilDatePresentation::secondsToString(
-                        $additional_information['hash_lifetime'],
-                        false,
-                        $this->getLanguage()
-                    )
-                ));
-                $this->appendBody("\n\n");
-                $this->appendBody($this->getLanguage()->txt('reg_mail_body_3_confirmation'));
-                $this->appendBody(ilMail::_getInstallationSignature());
-
-                $this->sendMimeMail($this->getCurrentRecipient());
+        foreach ($this->getRecipients() as $rcp) {
+            try {
+                $this->handleCurrentRecipient($rcp);
+            } catch (ilMailException $e) {
+                continue;
             }
+
+            $this->initMimeMail();
+            $this->setSubject($this->getLanguage()->txt('reg_mail_subject_confirmation'));
+            $this->setBody(
+                $this->getLanguage()->txt('reg_mail_body_salutation')
+                . ' '
+                . $this->user->getFullname()
+                . ','
+            );
+            $this->appendBody("\n\n");
+            $this->appendBody($this->getLanguage()->txt('reg_mail_body_activation'));
+            $this->appendBody("\n");
+            $this->appendBody(
+                ILIAS_HTTP_PATH
+                . '/confirmReg.php?client_id='
+                . CLIENT_ID
+                . '&rh='
+                . $this->pending_reg->getHashValue()
+            );
+            $this->appendBody("\n\n");
+            $this->appendBody(sprintf(
+                $this->getLanguage()->txt('reg_mail_body_2_confirmation'),
+                ilDatePresentation::secondsToString(
+                    $this->hash_lifetime_sec,
+                    false,
+                    $this->getLanguage()
+                )
+            ));
+            $this->appendBody("\n\n");
+            $this->appendBody($this->getLanguage()->txt('reg_mail_body_3_confirmation'));
+            $this->appendBody(ilMail::_getInstallationSignature());
+
+            $this->sendMimeMail($this->getCurrentRecipient());
         }
     }
 }

--- a/components/ILIAS/Registration/service.xml
+++ b/components/ILIAS/Registration/service.xml
@@ -1,0 +1,6 @@
+<?xml version = "1.0" encoding = "UTF-8"?>
+<service xmlns="http://www.w3.org" version="$Id$" id="registration">
+	<events>
+		<event type="listen" id="Services/User" />
+	</events>
+</service>

--- a/components/ILIAS/Registration/src/DualOptIn/Entity/PendingRegistration.php
+++ b/components/ILIAS/Registration/src/DualOptIn/Entity/PendingRegistration.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Registration\DualOptIn\Entity;
+
+use DateTimeImmutable;
+use ILIAS\Data\ObjectId;
+use ILIAS\Registration\DualOptIn\ValueObjects\PendingRegistrationHash;
+use ILIAS\Registration\DualOptIn\ValueObjects\PendingRegistrationId;
+
+final class PendingRegistration
+{
+    private PendingRegistrationId $id;
+    private ObjectId $usr_id;
+    private PendingRegistrationHash $hash;
+    private DateTimeImmutable $created_at;
+
+    public function __construct(
+        PendingRegistrationId $id,
+        ObjectId $usr_id,
+        PendingRegistrationHash $hash,
+        DateTimeImmutable $created_at,
+    ) {
+        $this->id = $id;
+        $this->usr_id = $usr_id;
+        $this->hash = $hash;
+        $this->created_at = $created_at;
+    }
+
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getUserId(): int
+    {
+        return $this->usr_id->toInt();
+    }
+
+    public function getHashValue(): string
+    {
+        return $this->hash->toString();
+    }
+
+    public function getCreateDate(): DateTimeImmutable
+    {
+        return $this->created_at;
+    }
+}

--- a/components/ILIAS/Registration/src/DualOptIn/Exception/DualOptInException.php
+++ b/components/ILIAS/Registration/src/DualOptIn/Exception/DualOptInException.php
@@ -18,11 +18,15 @@
 
 declare(strict_types=1);
 
+namespace ILIAS\Registration\DualOptIn\Exception;
+
+use ilException;
+
 /**
- * Class for user related exception handling in ILIAS.
+ * Class for registration related exception handling in ILIAS.
  * @author  Michael Jansen <mjansen@databay.de>
  * @version $Id$
  */
-class ilRegistrationHashNotFoundException extends ilRegistrationException
+class DualOptInException extends ilException
 {
 }

--- a/components/ILIAS/Registration/src/DualOptIn/Exception/PendingRegistrationExpiredException.php
+++ b/components/ILIAS/Registration/src/DualOptIn/Exception/PendingRegistrationExpiredException.php
@@ -18,10 +18,16 @@
 
 declare(strict_types=1);
 
+namespace ILIAS\Registration\DualOptIn\Exception;
+
 /**
  * Class for user related exception handling in ILIAS.
  * @author Michael Jansen <mjansen@databay.de>
  */
-class ilRegConfirmationLinkExpiredException extends ilRegistrationException
+class PendingRegistrationExpiredException extends DualOptInException
 {
+    public function __construct()
+    {
+        parent::__construct('reg_confirmation_hash_life_time_expired');
+    }
 }

--- a/components/ILIAS/Registration/src/DualOptIn/Exception/PendingRegistrationNotFoundException.php
+++ b/components/ILIAS/Registration/src/DualOptIn/Exception/PendingRegistrationNotFoundException.php
@@ -18,11 +18,17 @@
 
 declare(strict_types=1);
 
+namespace ILIAS\Registration\DualOptIn\Exception;
+
 /**
- * Class for registration related exception handling in ILIAS.
+ * Class for user related exception handling in ILIAS.
  * @author  Michael Jansen <mjansen@databay.de>
  * @version $Id$
  */
-class ilRegistrationException extends ilException
+class PendingRegistrationNotFoundException extends DualOptInException
 {
+    public function __construct()
+    {
+        parent::__construct('reg_confirmation_hash_not_found');
+    }
 }

--- a/components/ILIAS/Registration/src/DualOptIn/Repository/PendingRegistrationDatabaseRepository.php
+++ b/components/ILIAS/Registration/src/DualOptIn/Repository/PendingRegistrationDatabaseRepository.php
@@ -1,0 +1,150 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Registration\DualOptIn\Repository;
+
+use DateTimeImmutable;
+use ilDBConstants;
+use ilDBInterface;
+use ILIAS\Data\ObjectId;
+use ILIAS\Registration\DualOptIn\Entity\PendingRegistration;
+use ILIAS\Registration\DualOptIn\ValueObjects\PendingRegistrationHash;
+use ILIAS\Registration\DualOptIn\ValueObjects\PendingRegistrationId;
+
+readonly class PendingRegistrationDatabaseRepository implements PendingRegistrationRepository
+{
+    public function __construct(protected ilDBInterface $db)
+    {
+    }
+
+    public function findNewHash(): PendingRegistrationHash
+    {
+        do {
+            $unique_id = uniqid((string) mt_rand(), true);
+            $hash = substr(md5($unique_id), 0, 16);
+
+            $res = $this->db->queryf(
+                'SELECT COUNT(usr_id) cnt FROM reg_dual_opt_in WHERE reg_hash = %s',
+                [ilDBConstants::T_TEXT],
+                [$hash]
+            );
+            $row = $this->db->fetchObject($res);
+            if ($row->cnt > 0) {
+                continue;
+            }
+            break;
+        } while (true);
+
+        return new PendingRegistrationHash($hash);
+    }
+
+    public function store(PendingRegistration $reg): void
+    {
+        $this->db->manipulateF(
+            'REPLACE INTO reg_dual_opt_in (id, usr_id, reg_hash, creation_date) VALUES (%s, %s, %s, %s)',
+            [ilDBConstants::T_TEXT, ilDBConstants::T_INTEGER, ilDBConstants::T_TEXT, ilDBConstants::T_INTEGER],
+            [$reg->getId(), $reg->getUserId(), $reg->getHashValue(), $reg->getCreateDate()->getTimestamp()]
+        );
+    }
+
+    public function findByHashValue(string $hash_value): ?PendingRegistration
+    {
+        $res = $this->db->queryf(
+            'SELECT id, usr_id, reg_hash, creation_date FROM reg_dual_opt_in WHERE reg_hash = %s',
+            [ilDBConstants::T_TEXT],
+            [$hash_value]
+        );
+
+        $row = $this->db->fetchAssoc($res);
+        if (!$row) {
+            return null;
+        }
+
+        return $this->rebuildObjFromRow($row);
+    }
+
+    public function deleteById(string $id): void
+    {
+        $this->db->manipulateF(
+            'DELETE FROM reg_dual_opt_in WHERE id = %s',
+            [ilDBConstants::T_TEXT],
+            [$id]
+        );
+    }
+
+    public function deleteByUserId(int $usr_id): void
+    {
+        $this->db->manipulateF(
+            'DELETE FROM reg_dual_opt_in WHERE usr_id = %s',
+            [ilDBConstants::T_INTEGER],
+            [$usr_id]
+        );
+    }
+
+    /**
+     * @return list<PendingRegistration>
+     */
+    public function deleteExpired(int $cutoff_ts, ?int $prioritize_usr_id = null): array
+    {
+        $except_anon_and_sys = $this->db->in(
+            'h.usr_id',
+            [ANONYMOUS_USER_ID, SYSTEM_USER_ID],
+            true,
+            ilDBConstants::T_INTEGER
+        );
+
+        $query = '
+            SELECT h.*
+              FROM reg_dual_opt_in h
+              JOIN usr_data u ON u.usr_id = h.usr_id
+             WHERE u.active = 0
+               AND h.creation_date < %s
+               AND ' . $except_anon_and_sys . '
+             ORDER BY (CASE WHEN h.usr_id = %s THEN 0 ELSE 1 END), h.creation_date
+         ';
+
+        $res = $this->db->queryF(
+            $query,
+            [ilDBConstants::T_INTEGER, ilDBConstants::T_INTEGER],
+            [$cutoff_ts, $prioritize_usr_id ?? 0]
+        );
+
+        $expired_registrations = [];
+        while ($row = $this->db->fetchAssoc($res)) {
+            $this->deleteById($row['id']);
+            $expired_registrations[] = $this->rebuildObjFromRow($row);
+        }
+
+        return $expired_registrations;
+    }
+
+    /**
+     * @param array{id: string, usr_id: int, reg_hash: string, creation_date: int} $row
+     */
+    private function rebuildObjFromRow(array $row): PendingRegistration
+    {
+        $id = new PendingRegistrationId($row['id']);
+        $usr_id = new ObjectId($row['usr_id']);
+        $reg_hash = new PendingRegistrationHash($row['reg_hash']);
+        $created_at = new DateTimeImmutable('@' . $row['creation_date']);
+
+        return new PendingRegistration($id, $usr_id, $reg_hash, $created_at);
+    }
+}

--- a/components/ILIAS/Registration/src/DualOptIn/Repository/PendingRegistrationRepository.php
+++ b/components/ILIAS/Registration/src/DualOptIn/Repository/PendingRegistrationRepository.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Registration\DualOptIn\Repository;
+
+use ILIAS\Registration\DualOptIn\Entity\PendingRegistration;
+use ILIAS\Registration\DualOptIn\ValueObjects\PendingRegistrationHash;
+
+interface PendingRegistrationRepository
+{
+    public function findNewHash(): PendingRegistrationHash;
+
+    public function store(PendingRegistration $reg): void;
+
+    public function findByHashValue(string $hash_value): ?PendingRegistration;
+
+    public function deleteByUserId(int $usr_id): void;
+
+
+    /** @return list<PendingRegistration> */
+    public function deleteExpired(int $cutoff_ts, ?int $prioritize_usr_id = null): array;
+}

--- a/components/ILIAS/Registration/src/DualOptIn/Service/DualOptInService.php
+++ b/components/ILIAS/Registration/src/DualOptIn/Service/DualOptInService.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Registration\DualOptIn\Service;
+
+use ILIAS\Registration\DualOptIn\Exception\PendingRegistrationExpiredException;
+use ILIAS\Registration\DualOptIn\Exception\PendingRegistrationNotFoundException;
+use ILIAS\Registration\DualOptIn\ValueObjects\PendingRegistrationHash;
+use ilObjUser;
+use ilRegistrationSettings;
+
+interface DualOptInService
+{
+    /**
+     * @throws PendingRegistrationNotFoundException
+     * @throws PendingRegistrationExpiredException
+     */
+    public function verifyHashAndActivateUser(PendingRegistrationHash $hash): ilObjUser;
+
+    public function distributeMailsOnRegistration(ilObjUser $user, ilRegistrationSettings $settings): void;
+
+    public function deleteExpiredUserObjects(int $usr_id): void;
+}

--- a/components/ILIAS/Registration/src/DualOptIn/Service/DualOptInServiceImpl.php
+++ b/components/ILIAS/Registration/src/DualOptIn/Service/DualOptInServiceImpl.php
@@ -1,0 +1,219 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Registration\DualOptIn\Service;
+
+use DateInterval;
+use DateTimeInterface;
+use ilAccountRegistrationMail;
+use ilComponentLogger;
+use ilDBInterface;
+use ILIAS\Data\Clock\ClockFactoryImpl;
+use ILIAS\Data\ObjectId;
+use ILIAS\Registration\DualOptIn\Entity\PendingRegistration;
+use ILIAS\Registration\DualOptIn\ValueObjects\PendingRegistrationHash;
+use ILIAS\Registration\DualOptIn\ValueObjects\PendingRegistrationId;
+use ILIAS\Registration\DualOptIn\Exception\PendingRegistrationExpiredException;
+use ILIAS\Registration\DualOptIn\Exception\PendingRegistrationNotFoundException;
+use ILIAS\Registration\DualOptIn\Repository\PendingRegistrationRepository;
+use ILIAS\User\Settings\NewAccountMail\Repository as NewAccountMailRepository;
+use ilLoggerFactory;
+use ilObjectFactory;
+use ilObjUser;
+use ilRegistrationMimeMailNotification;
+use ilRegistrationSettings;
+use ilSecuritySettingsChecker;
+use ilSoapClient;
+
+class DualOptInServiceImpl implements DualOptInService
+{
+    public const string ID = "reg_hash_service";
+
+    public function __construct(
+        protected readonly PendingRegistrationRepository $pending_reg_repository,
+        protected readonly ilDBInterface $db,
+        protected readonly ilComponentLogger $logger,
+    ) {
+    }
+
+    /**
+     * @throws PendingRegistrationNotFoundException
+     * @throws PendingRegistrationExpiredException
+     */
+    public function verifyHashAndActivateUser(PendingRegistrationHash $hash): ilObjUser
+    {
+        $pending_reg = $this->verifyHash($hash);
+
+        /** @var ilObjUser $user */
+        $user = ilObjectFactory::getInstanceByObjId($pending_reg->getUserId());
+        $this->activateUser($user);
+
+        $this->pending_reg_repository->deleteById($pending_reg->getId());
+
+        return $user;
+    }
+
+    /**
+     * @throws PendingRegistrationNotFoundException
+     * @throws PendingRegistrationExpiredException
+     */
+    private function verifyHash(PendingRegistrationHash $hash): PendingRegistration
+    {
+        $pending_reg = $this->pending_reg_repository->findByHashValue($hash->toString());
+        if (!$pending_reg) {
+            throw new PendingRegistrationNotFoundException();
+        }
+
+        $lifetime = (new ilRegistrationSettings())->getRegistrationHashLifetime();
+        if ($lifetime > 0) {
+            $interval = new DateInterval("PT{$lifetime}S");
+            $cutoff = (new ClockFactoryImpl())->utc()->now()->sub($interval);
+            $created = $pending_reg->getCreateDate();
+
+            if ($created < $cutoff) {
+                $this->triggerExpiredUserCleanup($pending_reg->getUserId());
+                throw new PendingRegistrationExpiredException();
+            }
+        }
+
+        return $pending_reg;
+    }
+
+    public function distributeMailsOnRegistration(ilObjUser $user, ilRegistrationSettings $settings): void
+    {
+        $pending_reg = $this->createPendingRegistration($user->getId());
+
+        $mail = new ilRegistrationMimeMailNotification($user, $pending_reg, $settings->getRegistrationHashLifetime());
+        $mail->setType(ilRegistrationMimeMailNotification::TYPE_NOTIFICATION_ACTIVATION);
+        $mail->setRecipients([$user]);
+        $mail->send();
+    }
+
+    private function createPendingRegistration(int $usr_id): PendingRegistration
+    {
+        $uuid = PendingRegistrationId::create();
+        $user_id = new ObjectId($usr_id);
+        $hash = $this->pending_reg_repository->findNewHash();
+        $creation_date = (new ClockFactoryImpl())->utc()->now();
+
+        $pending_reg = new PendingRegistration($uuid, $user_id, $hash, $creation_date);
+        $this->pending_reg_repository->store($pending_reg);
+
+        return $pending_reg;
+    }
+
+    public function deleteExpiredUserObjects(int $usr_id): void
+    {
+        $this->logger->debug(
+            'Started deletion of inactive user objects with expired confirmation hash values (dual opt in) ...'
+        );
+        $lifetime = (new ilRegistrationSettings())->getRegistrationHashLifetime();
+
+        if ($lifetime <= 0) {
+            $this->logger->debug('Registration hash lifetime is <= 0, kipping deletion.');
+            return;
+        }
+
+        $interval = new DateInterval("PT{$lifetime}S");
+        $cutoff = (new ClockFactoryImpl())->utc()->now()->sub($interval);
+
+        $deleted_regs = $this->pending_reg_repository->deleteExpired($cutoff->getTimestamp(), $usr_id);
+
+        $this->logger->info(sprintf(
+            '%d inactive user objects eligible for deletion found and deleted (cutoff: %s, lifetime: %d s).',
+            count($deleted_regs),
+            $cutoff->format(DateTimeInterface::ATOM),
+            $lifetime
+        ));
+
+        $num_deleted_users = 0;
+        foreach ($deleted_regs as $deleted_reg) {
+            $user = ilObjectFactory::getInstanceByObjId($deleted_reg->getUserId(), false);
+            if (!($user instanceof ilObjUser)) {
+                continue;
+            }
+
+            $this->logger->info(sprintf(
+                'Deleting user (login: %s | id: %d) – expired dual opt-in (created: %s, cutoff: %s, lifetime: %d s)',
+                $user->getLogin(),
+                $user->getId(),
+                $deleted_reg->getCreateDate()->format(ilObjUser::DATABASE_DATE_FORMAT),
+                $cutoff->format(DateTimeInterface::ATOM),
+                $lifetime
+            ));
+
+            $user->delete();
+            ++$num_deleted_users;
+        }
+
+        $this->logger->info(sprintf(
+            '%d inactive user objects with expired confirmation hash values (dual opt-in) deleted.',
+            $num_deleted_users
+        ));
+    }
+
+    private function activateUser(ilObjUser $user): void
+    {
+        $user->setActive(true);
+
+        $settings = new ilRegistrationSettings();
+
+        $password = '';
+        if ($settings->passwordGenerationEnabled()) {
+            $password = ilSecuritySettingsChecker::generatePasswords(1)[0];
+            $user->setPasswd($password, ilObjUser::PASSWD_PLAIN);
+            $user->setLastPasswordChangeTS((new ClockFactoryImpl())->utc()->now()->getTimestamp());
+        }
+
+        $user->update();
+
+        $this->sendRegistrationMail($user, $settings, $password);
+    }
+
+    private function triggerExpiredUserCleanup(int $usr_id): void
+    {
+        $soap_client = new ilSoapClient();
+        $soap_client->setResponseTimeout(1);
+        $soap_client->enableWSDL(true);
+        $soap_client->init();
+
+        $this->logger->info(
+            'Triggered soap call (background process) for deletion of inactive user objects with expired confirmation hash values (dual opt in) ...'
+        );
+
+        $sid = session_id() . '::' . CLIENT_ID;
+        $soap_client->call('deleteExpiredDualOptInUserObjects', [$sid, $usr_id]);
+    }
+
+    private function sendRegistrationMail(ilObjUser $user, ilRegistrationSettings $settings, string $password): void
+    {
+        $account_mail = (new ilAccountRegistrationMail(
+            $settings,
+            ilLoggerFactory::getLogger('user'),
+            new NewAccountMailRepository($this->db)
+        ))->withEmailConfirmationRegistrationMode();
+
+        if ($user->getPref('reg_target') ?? '') {
+            $account_mail = $account_mail->withPermanentLinkTarget($user->getPref('reg_target'));
+        }
+
+        $account_mail->send($user, $password);
+    }
+}

--- a/components/ILIAS/Registration/src/DualOptIn/Setup/DualOptInDatabaseUpdateSteps.php
+++ b/components/ILIAS/Registration/src/DualOptIn/Setup/DualOptInDatabaseUpdateSteps.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Registration\DualOptIn\Setup;
+
+use ilDatabaseUpdateSteps;
+use ilDBConstants;
+use ilDBInterface;
+use ILIAS\Data\UUID\Factory as UUIDFactory;
+
+class DualOptInDatabaseUpdateSteps implements ilDatabaseUpdateSteps
+{
+    protected ilDBInterface $db;
+
+    public function prepare(ilDBInterface $db): void
+    {
+        $this->db = $db;
+    }
+
+    public function step_1(): void
+    {
+        if ($this->db->tableExists('reg_dual_opt_in')) {
+            return;
+        }
+
+        $fields = [
+            'id' => [
+                'type' => ilDBConstants::T_TEXT,
+                'length' => 36,
+                'fixed' => true,
+                'notnull' => true,
+            ],
+            'usr_id' => [
+                'type' => ilDBConstants::T_INTEGER,
+                'length' => 8,
+                'notnull' => true
+            ],
+            'reg_hash' => [
+                'type' => ilDBConstants::T_TEXT,
+                'length' => 16,
+                'fixed' => true,
+                'notnull' => true
+            ],
+            'creation_date' => [
+                'type' => ilDBConstants::T_INTEGER,
+                'length' => 8,
+                'notnull' => true
+            ]
+        ];
+
+        $this->db->createTable('reg_dual_opt_in', $fields);
+        $this->db->addPrimaryKey('reg_dual_opt_in', ['id']);
+    }
+
+    public function step_2(): void
+    {
+        if (
+            !$this->db->tableExists('usr_data') ||
+            !$this->db->tableColumnExists('usr_data', 'reg_hash')
+        ) {
+            return;
+        }
+
+        $res = $this->db->query(
+            "SELECT usr_id, reg_hash, create_date FROM usr_data WHERE reg_hash IS NOT NULL AND reg_hash <> ''"
+        );
+
+        while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
+            $this->db->manipulateF(
+                'INSERT INTO reg_dual_opt_in (id, usr_id, reg_hash, creation_date) VALUES (%s, %s, %s)',
+                [ilDBConstants::T_TEXT, ilDBConstants::T_INTEGER, ilDBConstants::T_TEXT, ilDBConstants::T_INTEGER],
+                [(new UUIDFactory())->uuid4(), $row->usr_id, $row->reg_hash, $row->create_date]
+            );
+        }
+    }
+
+    public function step_3(): void
+    {
+        if (
+            !$this->db->tableExists('usr_data') ||
+            !$this->db->tableColumnExists('usr_data', 'reg_hash')
+        ) {
+            return;
+        }
+
+        $this->db->dropTableColumn('usr_data', 'reg_hash');
+    }
+
+    public function step_4(): void
+    {
+        if (
+            $this->db->tableExists('reg_dual_opt_in') &&
+            !$this->db->indexExistsByFields('reg_dual_opt_in', ['reg_hash'])
+        ) {
+            $this->db->addIndex('reg_dual_opt_in', ['reg_hash'], 'i1');
+        }
+
+        if (
+            $this->db->tableExists('reg_dual_opt_in') &&
+            !$this->db->indexExistsByFields('reg_dual_opt_in', ['usr_id'])
+        ) {
+            $this->db->addIndex('reg_dual_opt_in', ['usr_id'], 'i2');
+        }
+    }
+}

--- a/components/ILIAS/Registration/src/DualOptIn/ValueObjects/PendingRegistrationHash.php
+++ b/components/ILIAS/Registration/src/DualOptIn/ValueObjects/PendingRegistrationHash.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Registration\DualOptIn\ValueObjects;
+
+final readonly class PendingRegistrationHash
+{
+    private string $value;
+
+    public function __construct(string $value)
+    {
+        $value = trim($value);
+
+        if ($value === '') {
+            throw new \InvalidArgumentException('Registration hash must not be empty.');
+        }
+
+        if (mb_strlen($value) < 16) {
+            throw new \InvalidArgumentException('Registration hash must be 16 characters.');
+        }
+
+        $this->value = $value;
+    }
+
+    public function equals(self $other): bool
+    {
+        return hash_equals($this->value, $other->value);
+    }
+
+    public function toString(): string
+    {
+        return $this->value;
+    }
+
+    public function __toString(): string
+    {
+        return $this->toString();
+    }
+}

--- a/components/ILIAS/Registration/src/DualOptIn/ValueObjects/PendingRegistrationId.php
+++ b/components/ILIAS/Registration/src/DualOptIn/ValueObjects/PendingRegistrationId.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Registration\DualOptIn\ValueObjects;
+
+use ILIAS\Data\UUID\Factory as UUIDFactory;
+
+final readonly class PendingRegistrationId
+{
+    private string $uuid;
+
+    public function __construct(string $uuid)
+    {
+        if (mb_strlen($uuid) !== 36) {
+            throw new \InvalidArgumentException('Registration uuid must be 32 characters (UUIDv4).');
+        }
+
+        $this->uuid = $uuid;
+    }
+
+    public static function create(): self
+    {
+        return new self((new UUIDFactory())->uuid4AsString());
+    }
+
+    public function toString(): string
+    {
+        return $this->uuid;
+    }
+
+    public function __toString(): string
+    {
+        return $this->toString();
+    }
+}

--- a/components/ILIAS/User/classes/class.ilObjUser.php
+++ b/components/ILIAS/User/classes/class.ilObjUser.php
@@ -1869,35 +1869,6 @@ class ilObjUser extends ilObject
         return true;
     }
 
-    public function generateRegistrationHash(): string
-    {
-        do {
-            $hashcode = substr(md5(uniqid(mt_rand(), true)), 0, 16);
-
-            $res = $this->db->queryf(
-                'SELECT COUNT(usr_id) cnt FROM usr_data WHERE reg_hash = %s',
-                [ilDBConstants::T_TEXT],
-                [$hashcode]
-            );
-            while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-                if ($row->cnt > 0) {
-                    continue 2;
-                }
-                break;
-            }
-
-            $this->db->manipulateF(
-                'UPDATE usr_data SET reg_hash = %s WHERE usr_id = %s',
-                [ilDBConstants::T_TEXT, ilDBConstants::T_INTEGER],
-                [$hashcode, $this->id]
-            );
-            break;
-        } while (true);
-
-        return $hashcode;
-    }
-
-
     private function buildTextFromArray(array $a_attr): string
     {
         if (count($a_attr) > 0) {
@@ -2249,53 +2220,6 @@ class ilObjUser extends ilObject
         );
 
         return $users;
-    }
-
-    public static function _verifyRegistrationHash(
-        string $a_hash
-    ): int {
-        global $DIC;
-        $db = $DIC['ilDB'];
-
-        $res = $db->queryf(
-            'SELECT usr_id, create_date FROM usr_data WHERE reg_hash = %s',
-            [ilDBConstants::T_TEXT],
-            [$a_hash]
-        );
-
-        $row = $db->fetchAssoc($res);
-        if (!$row) {
-            throw new ilRegistrationHashNotFoundException('reg_confirmation_hash_not_found');
-        }
-
-        $lifetime = (new ilRegistrationSettings())->getRegistrationHashLifetime();
-        if ($lifetime > 0) {
-            $cutoff = (new DataFactory())->clock()->utc()
-                ->now()->sub(
-                    new DateInterval("PT{$lifetime}S")
-                );
-
-            $created = DateTimeImmutable::createFromFormat(
-                self::DATABASE_DATE_FORMAT,
-                (string) $row['create_date'],
-                new DateTimeZone('UTC')
-            );
-
-            if ($created === false || $created < $cutoff) {
-                throw new ilRegConfirmationLinkExpiredException(
-                    'reg_confirmation_hash_life_time_expired',
-                    (int) $row['usr_id']
-                );
-            }
-        }
-
-        $db->manipulateF(
-            'UPDATE usr_data SET reg_hash = NULL WHERE usr_id = %s',
-            [ilDBConstants::T_INTEGER],
-            [(int) $row['usr_id']]
-        );
-
-        return (int) $row['usr_id'];
     }
 
     public static function getUserIdsByInactivityPeriod(

--- a/components/ILIAS/soap/classes/class.ilSoapUtils.php
+++ b/components/ILIAS/soap/classes/class.ilSoapUtils.php
@@ -18,6 +18,9 @@
 
 declare(strict_types=1);
 
+use ILIAS\Registration\DualOptIn\Repository\PendingRegistrationDatabaseRepository;
+use ILIAS\Registration\DualOptIn\Service\DualOptInServiceImpl;
+
 /**
  * Soap utitliy functions
  * @author Stefan Meyer <meyer@leifos.com>
@@ -457,80 +460,12 @@ class ilSoapUtils extends ilSoapAdministration
 
         global $DIC;
 
-        $db = $DIC->database();
-        $logger = $DIC->logger()->user();
-
-        $logger->debug(
-            'Started deletion of inactive user objects with expired confirmation hash values (dual opt in) ...'
+        $dual_opt_in_service = new DualOptInServiceImpl(
+            new PendingRegistrationDatabaseRepository($DIC->database()),
+            $DIC->database(),
+            $DIC->logger()->user(),
         );
-        $lifetime = (new ilRegistrationSettings())->getRegistrationHashLifetime();
-
-        if ($lifetime <= 0) {
-            $logger->debug('Registration hash lifetime is <= 0, kipping deletion.');
-            return true;
-        }
-
-        $utc_clock = (new \ILIAS\Data\Factory())->clock()->utc();
-        $now = $utc_clock->now();
-        $cutoff = $now->sub(new DateInterval('PT' . $lifetime . 'S'));
-        $formatted_cutoff = $cutoff->format(ilObjUser::DATABASE_DATE_FORMAT);
-
-        // Fetch only candidates that must be deleted, prioritize the triggering user
-        $query = '
-        SELECT usr_id, create_date
-          FROM usr_data
-         WHERE active = 0
-           AND reg_hash IS NOT NULL
-           AND reg_hash != \'\'
-           AND ' . $db->in('usr_id', [ANONYMOUS_USER_ID, SYSTEM_USER_ID], true, ilDBConstants::T_INTEGER) . '
-           AND create_date < %s
-         ORDER BY (CASE WHEN usr_id = %s THEN 0 ELSE 1 END), create_date';
-
-        $res = $db->queryF(
-            $query,
-            [ilDBConstants::T_TIMESTAMP, ilDBConstants::T_INTEGER],
-            [$formatted_cutoff, $usr_id]
-        );
-
-        $logger->info(sprintf(
-            '%d inactive user objects eligible for deletion found (cutoff: %s, lifetime: %d s).',
-            $db->numRows($res),
-            $cutoff->format(DateTimeInterface::ATOM),
-            $lifetime
-        ));
-
-        $num_deleted_users = 0;
-        while ($row = $db->fetchAssoc($res)) {
-            $uid = (int) $row['usr_id'];
-
-            $user = ilObjectFactory::getInstanceByObjId($uid, false);
-            if (!($user instanceof ilObjUser)) {
-                continue;
-            }
-
-            $created = DateTimeImmutable::createFromFormat(
-                ilObjUser::DATABASE_DATE_FORMAT,
-                (string) $row['create_date'],
-                new DateTimeZone('UTC')
-            );
-
-            $logger->info(sprintf(
-                'Deleting user (login: %s | id: %d) – expired dual opt-in (created: %s, cutoff: %s, lifetime: %d s)',
-                $user->getLogin(),
-                $uid,
-                $created ? $created->format(DateTimeInterface::ATOM) : '-',
-                $cutoff->format(DateTimeInterface::ATOM),
-                $lifetime
-            ));
-
-            $user->delete();
-            ++$num_deleted_users;
-        }
-
-        $logger->info(sprintf(
-            '%d inactive user objects with expired confirmation hash values (dual opt-in) deleted.',
-            $num_deleted_users
-        ));
+        $dual_opt_in_service->deleteExpiredUserObjects($usr_id);
 
         return true;
     }


### PR DESCRIPTION
This PR refactors the self-registration (double opt-in) process into a dedicated service and table. This should keep separation of concerns and ensuring better maintainability.

### Changes
- **Database**:
  - Add new database table `reg_dual_opt_in` with fields:
    - `id` (TEXT, PK, fixed length 36) [Uuidv4]
    - `usr_id` (INT)
    - `reg_hash` (TEXT, fixed length 16)
    - `creation_date` (INT)
  - Remove column `reg_hash` from table `usr_data` and migrate current hashes into the new table beforehand.
- `ilObjUser`:
  - Remove `generateRegistrationHash()` method and move logic into `DualOptInService`
  - Remove `_verifyRegistrationHash()` method and move logic into `DualOptInService`
- `ilAccountRegistrationGUI`:
  - Factor out **registration mail sending** logic into `DualOptInService`
- `ilStartUpGUI`: 
  - Factor out **verification** and **user activation** logic into `DualOptInService`
  - Optimize readability for Exception handling 
- `ilSoapUtils`: 
  - Factor out **handling for expired dual opt-in** logic into `DualOptInService` 
- Add event listener for `Services/User -> deleteUser` to remove corresponding records from `reg_dual_opt_in`.
- Create `RegistrationHash` entity and corresponding repository
- Create wrapper classes `PendingRegistrationHash` and `PendingRegistrationId`