### PR TITLE
0044586: Replacing anchor tag with button element in the dashboard object tabs

### DIFF
--- a/components/ILIAS/JavaScript/resources/Basic.js
+++ b/components/ILIAS/JavaScript/resources/Basic.js
@@ -566,7 +566,7 @@ il.UICore = {
       let more_than_two_lines;
       more_than_two_lines = tabsHeight >= 50;
       if (more_than_two_lines) {
-        $('#ilLastTab a').removeClass('ilNoDisplay');
+        $('#ilLastTab .dropdown-toggle').removeClass('ilNoDisplay');
 
         // as long as we have two lines...
         while (more_than_two_lines) {
@@ -590,7 +590,7 @@ il.UICore = {
           tabsHeight = tabs.innerHeight();
         }
         if ($('#ilTabDropDown').children('li').length == 0) {
-          $('#ilLastTab a').addClass('ilNoDisplay');
+          $('#ilLastTab .dropdown-toggle').addClass('ilNoDisplay');
         }
         if (tabsHeight > 50 && !recheck) { // double chk height again
           il.UICore.collapseTabs(true);

--- a/components/ILIAS/UIComponent/Tabs/templates/default/tpl.tabs.html
+++ b/components/ILIAS/UIComponent/Tabs/templates/default/tpl.tabs.html
@@ -10,9 +10,9 @@
 	<li id="{ID}" class="{TAB_TYPE}">{LINK}<!-- BEGIN sel_text --> <span class="ilAccHidden">({TXT_SELECTED})</span><!-- END sel_text --></li>
 	<!-- END tab -->
 	<li id="ilLastTab">
-		<a class="btn dropdown-toggle ilNoDisplay" aria-label="{LAST_TAB_LABEL}" href="#">
+		<button class="btn dropdown-toggle ilNoDisplay" data-toggle="dropdown" aria-label="{LAST_TAB_LABEL}">
 			... <span class="caret"></span>
-		</a>
+		</button>
 		<ul class="dropdown-menu" id="ilTabDropDown">
 		</ul>
 	</li>

--- a/components/ILIAS/UIComponent/Tabs/templates/default/tpl.tabs.html
+++ b/components/ILIAS/UIComponent/Tabs/templates/default/tpl.tabs.html
@@ -10,7 +10,7 @@
 	<li id="{ID}" class="{TAB_TYPE}">{LINK}<!-- BEGIN sel_text --> <span class="ilAccHidden">({TXT_SELECTED})</span><!-- END sel_text --></li>
 	<!-- END tab -->
 	<li id="ilLastTab">
-		<button class="btn dropdown-toggle ilNoDisplay" data-toggle="dropdown" aria-label="{LAST_TAB_LABEL}">
+		<button class="btn btn-link dropdown-toggle ilNoDisplay" data-toggle="dropdown" aria-label="{LAST_TAB_LABEL}">
 			... <span class="caret"></span>
 		</button>
 		<ul class="dropdown-menu" id="ilTabDropDown">


### PR DESCRIPTION
This PR addresses accessibility issue 0044586: Link labeling instead of using button elements in the tab
https://mantis.ilias.de/view.php?id=44586

This PR is sister to https://github.com/ILIAS-eLearning/ILIAS/pull/10205 (This is for ilias 9+)