### PR TITLE
LegalDocuments: Add parent to footer links (ILIAS 10)

### DIFF
--- a/components/ILIAS/LegalDocuments/classes/GlobalScreen/FooterProvider.php
+++ b/components/ILIAS/LegalDocuments/classes/GlobalScreen/FooterProvider.php
@@ -68,8 +68,11 @@ class FooterProvider extends AbstractStaticFooterProvider
 
     private function item(string $id, string $title, object $obj): isItem
     {
-        return $obj instanceof Modal ?
-            $this->item_factory->modal($this->id_factory->identifier($id), $title, $obj)->withParent($this->parent_id) :
-            $this->item_factory->link($this->id_factory->identifier($id), $title)->withAction($obj);
+        $id = $this->id_factory->identifier($id);
+        $item = $obj instanceof Modal ?
+            $this->item_factory->modal($id, $title, $obj) :
+            $this->item_factory->link($id, $title)->withAction($obj);
+
+        return $item->withParent($this->parent_id);
     }
 }


### PR DESCRIPTION
This PR fixes Mantis Bug: https://mantis.ilias.de/view.php?id=45903
This PR adds the parent id to LegalDocument Footer Items of Type Link.