### PR TITLE
[LTI] fix: Verification of LTI Result Service Calls

### DIFF
--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResultService.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResultService.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 use ceLTIc\LTI\OAuth\OAuthRequest;
 use ceLTIc\LTI\OAuth\OAuthServer;
 use ceLTIc\LTI\OAuth\OAuthSignatureMethod_HMAC_SHA1;
+use ceLTIc\LTI\OAuth\OAuthUtil;
 use ceLTIc\LTI\OAuthDataStore;
 
 /**
@@ -137,10 +138,12 @@ class ilLTIConsumerResultService
 
             // Verify the signature
             $this->readFields($this->result->obj_id);
-            $result = $this->checkSignature($this->fields['KEY'], $this->fields['SECRET']);
-            if ($result instanceof Exception) {
-                $logger->error('LTI Consumer Result Service: Incoming request');
-                $this->respondUnauthorized($result->getMessage());
+            try {
+                $this->checkSignature($this->fields['KEY'], $this->fields['SECRET']);
+            } catch (Exception $e) {
+                $logger->error('LTI Consumer Result Service: Incoming request failed: ' . $e->getMessage());
+                $logger->debug('Incoming request failed: ' . $e->getTraceAsString());
+                $this->respondUnauthorized();
                 return;
             }
 
@@ -385,15 +388,16 @@ class ilLTIConsumerResultService
     }
 
     /**
-     * Check the reqest signature
-     * @return bool    Exception or true
+     * Check the request signature
+     * @throws Exception in case of failure
      */
-    private function checkSignature(string $a_key, string $a_secret): bool
+    private function checkSignature(string $a_key, string $a_secret): void
     {
         $platform = new ilLTIPlatform();
 
         $platform->setKey($a_key);
         $platform->setSecret($a_secret);
+        $platform->setRecordId($this->result->obj_id);
 
         $store = new OAuthDataStore($platform);
 
@@ -401,14 +405,13 @@ class ilLTIConsumerResultService
         $method = new OAuthSignatureMethod_HMAC_SHA1();
         $server->add_signature_method($method);
 
-        $request = OAuthRequest::from_request();
-
-        try {
-            $server->verify_request($request);
-        } catch (Exception $e) {
-            return false;
+        $request_headers = OAuthUtil::get_headers();
+        if (isset($request_headers['Authorization']) && str_starts_with($request_headers['Authorization'], 'OAuth ')) {
+            $parameters = OAuthUtil::split_header($request_headers['Authorization']);
         }
-        return true;
+        $request = OAuthRequest::from_request(null, null, $parameters ?? []);
+
+        $server->verify_request($request);
     }
 
     protected function updateLP(): void


### PR DESCRIPTION
This patch fixes the incorrect handling of OAuth signature verification in the LTI 1.1 Result Service. Previously, failed signature checks were ignored, allowing unauthorized requests to update learning progress.

The fix reworks the `checkSignature()` method to properly throw exceptions when verification fails and adjusts `handleRequest()` to return an unauthorized response in such cases. It also:

Sets the record_id to the consumer object ID for proper nonce tracking.

Ensures the OAuth signature is built using only valid parameters, excluding the request body.

This resolves Mantis issue #45934.

Thanks to @fneumann for identifying and contributing the solution.
