### PR TITLE
RepositoryObject(Plugins): move Plugins to Components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,10 +21,6 @@
 *.swp
 *.swo
 
-# Core Components and Components From Other Vendors
-/components/*
-!/components/ILIAS
-
 # Generated Files
 /artifacts/*
 /ilias.ini.php

--- a/components/ILDemo/DemoRepoObject/DemoRepoObject.php
+++ b/components/ILDemo/DemoRepoObject/DemoRepoObject.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILDemo;
+
+use ILIAS\Component\Component;
+use ILIAS\Repository\RepositoryObject;
+
+class DemoRepoObject implements Component
+{
+    public function init(
+        array | \ArrayAccess &$define,
+        array | \ArrayAccess &$implement,
+        array | \ArrayAccess &$use,
+        array | \ArrayAccess &$contribute,
+        array | \ArrayAccess &$seek,
+        array | \ArrayAccess &$provide,
+        array | \ArrayAccess &$pull,
+        array | \ArrayAccess &$internal,
+    ): void {
+
+        $contribute[RepositoryObject::class] = fn() =>
+            new \ilDemoRepoObjPlugin(
+                'xdmo',
+                'DemoRepoObj',
+                ['cat', 'adm'], //parent types
+                true, //allow_copy
+                false, //use_orgu_permissions
+                false, //supports_lp
+                false, //supports_export
+            );
+
+        $contribute[RepositoryObject::class] = fn() =>
+            new RepositoryObject(
+                'other',
+                'some other RepoObj',
+            );
+
+        $contribute[\ILIAS\Component\Resource\PublicAsset::class] = static fn() =>
+            new class () implements \ILIAS\Component\Resource\PublicAsset {
+                public function getSource(): string
+                {
+                    $dir = __DIR__;
+                    $parts = explode(DIRECTORY_SEPARATOR, $dir);
+                    $parts = array_slice($parts, array_search('components', $parts));
+                    return implode(DIRECTORY_SEPARATOR, $parts) . '/templates/images';
+                }
+                public function getTarget(): string
+                {
+                    return "assets/xdmo/images";
+                }
+            };
+    }
+}

--- a/components/ILDemo/DemoRepoObject/classes/class.ilDemoRepoObjConfigGUI.php
+++ b/components/ILDemo/DemoRepoObject/classes/class.ilDemoRepoObjConfigGUI.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+/**
+ * @ilCtrl_isCalledBy ilDemoRepoObjConfigGUI: ilAdministrationGUI
+ */
+class ilDemoRepoObjConfigGUI extends ilPluginConfigGUI
+{
+    public function performCommand($cmd): void
+    {
+        global $DIC;
+        $tpl = $DIC['tpl'];
+        $tpl->setContent('config');
+        $tpl->printToStdout();
+    }
+}

--- a/components/ILDemo/DemoRepoObject/classes/class.ilDemoRepoObjPlugin.php
+++ b/components/ILDemo/DemoRepoObject/classes/class.ilDemoRepoObjPlugin.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+class ilDemoRepoObjPlugin extends ilRepositoryObjectPlugin
+{
+    public const COPY_OPERATION_ID = 58;
+
+    public function getPluginName(): string
+    {
+        return 'DemoRepoObj';
+    }
+
+    public function uninstallCustom(): void
+    {
+    }
+
+    /**
+     * @return bool
+     * @throws ilPluginException
+     */
+    protected function beforeActivation(): bool
+    {
+        parent::beforeActivation();
+        global $DIC;
+        $db = $DIC->database();
+
+        $type = $this->getId();
+
+        if (!$this->isRepositoryPlugin($type)) {
+            throw new ilPluginException("Object plugin type must start with an x. Current type is " . $type . ".");
+        }
+
+        $type_id = $this->getTypeId($type, $db);
+        if (!$type_id) {
+            $type_id = $this->createTypeId($type, $db);
+        }
+
+        $this->assignCopyPermissionToPlugin((int) $type_id, $db);
+
+        return true;
+    }
+
+    protected function isRepositoryPlugin(string $type): bool
+    {
+        return substr($type, 0, 1) == "x";
+    }
+
+    /**
+     * @param string $type
+     * @param $db
+     * @return int | null
+     */
+    protected function getTypeId(string $type, ilDBInterface $db)
+    {
+        $sql =
+             "SELECT obj_id FROM object_data" . PHP_EOL
+            . "WHERE type = " . $db->quote("typ", "text") . PHP_EOL
+            . "AND title = " . $db->quote($type, "text") . PHP_EOL
+        ;
+
+        $result = $db->query($sql);
+
+        if ($db->numRows($result) == 0) {
+            return null;
+        }
+
+        $rec = $db->fetchAssoc($result);
+        return $rec["obj_id"];
+    }
+
+    /**
+     * Create a new entry in object data
+     *
+     * @param string 	$type
+     * @param 			$db
+     *
+     * @return int
+     */
+    protected function createTypeId(string $type, ilDBInterface $db)
+    {
+        $type_id = $db->nextId("object_data");
+
+        $sql =
+             "INSERT INTO object_data" . PHP_EOL
+            . "(obj_id, type, title, description, owner, create_date, last_update)" . PHP_EOL
+            . "VALUES (" . PHP_EOL
+            . $db->quote($type_id, "integer") . "," . PHP_EOL
+            . $db->quote("typ", "text") . "," . PHP_EOL
+            . $db->quote($type, "text") . "," . PHP_EOL
+            . $db->quote("Plugin " . $this->getPluginName(), "text") . "," . PHP_EOL
+            . $db->quote(-1, "integer") . "," . PHP_EOL
+            . $db->quote(ilUtil::now(), "timestamp") . "," . PHP_EOL
+            . $db->quote(ilUtil::now(), "timestamp") . PHP_EOL
+            . ")" . PHP_EOL
+        ;
+
+        $db->manipulate($sql);
+
+        return $type_id;
+    }
+
+    protected function assignCopyPermissionToPlugin(int $type_id, ilDBInterface $db)
+    {
+        $ops = array(self::COPY_OPERATION_ID);
+
+        foreach ($ops as $op) {
+            if (!$this->permissionIsAssigned($type_id, $op, $db)) {
+                $sql =
+                     "INSERT INTO rbac_ta" . PHP_EOL
+                    . "(typ_id, ops_id)" . PHP_EOL
+                    . "VALUES (" . PHP_EOL
+                    . $db->quote($type_id, "integer") . "," . PHP_EOL
+                    . $db->quote($op, "integer") . PHP_EOL
+                    . ")" . PHP_EOL
+                ;
+
+                $db->manipulate($sql);
+            }
+        }
+    }
+
+    protected function permissionIsAssigned(int $type_id, int $op_id, ilDBInterface $db): bool
+    {
+        $sql =
+             "SELECT count(typ_id) as cnt" . PHP_EOL
+            . "FROM rbac_ta" . PHP_EOL
+            . "WHERE typ_id = " . $db->quote($type_id, "integer") . PHP_EOL
+            . "AND ops_id = " . $db->quote($op_id, "integer") . PHP_EOL
+        ;
+
+        $set = $db->query($sql);
+        $rec = $db->fetchAssoc($set);
+
+        return $rec["cnt"] > 0;
+    }
+
+}

--- a/components/ILDemo/DemoRepoObject/classes/class.ilObjDemoRepoObj.php
+++ b/components/ILDemo/DemoRepoObject/classes/class.ilObjDemoRepoObj.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+class ilObjDemoRepoObj extends ilObjectPlugin
+{
+    public const TYPE = 'xdmo';
+
+    public function __construct(int $a_ref_id = 0)
+    {
+        parent::__construct($a_ref_id);
+    }
+
+    public function initType(): void
+    {
+        $this->setType(self::TYPE);
+    }
+
+    public function doCreate(bool $clone_mode = false): void
+    {
+    }
+
+    public function doRead(): void
+    {
+    }
+
+    public function doUpdate(): void
+    {
+    }
+
+    public function doDelete(): void
+    {
+    }
+
+    public function doCloneObject($new_obj, $a_target_id, $a_copy_id = null): void
+    {
+    }
+
+    public function txtClosure(): Closure
+    {
+        return function (string $code) {
+            return $this->txt($code);
+        };
+    }
+
+    public function pluginTxt(string $code): string
+    {
+        return parent::txt($code);
+    }
+
+    public function getDirectory(): string
+    {
+        return $this->plugin->getDirectory();
+    }
+
+}

--- a/components/ILDemo/DemoRepoObject/classes/class.ilObjDemoRepoObjAccess.php
+++ b/components/ILDemo/DemoRepoObject/classes/class.ilObjDemoRepoObjAccess.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+class ilObjDemoRepoObjAccess extends ilObjectPluginAccess
+{
+    /**
+    * Checks wether a user may invoke a command or not
+    * (this method is called by ilAccessHandler::checkAccess)
+    *
+    * Please do not check any preconditions handled by
+    * ilConditionHandler here. Also don't do usual RBAC checks.
+    *
+    * @param string     $a_cmd          command (not permission!)
+    * @param string     $a_permission   permission
+    * @param int        $a_ref_id       reference id
+    * @param int        $a_obj_id       object id
+    * @param int        $a_user_id      user id (default is current user)
+    *
+    * @return boolean   true, if everything is ok
+    */
+    public function _checkAccess($a_cmd, $a_permission, $a_ref_id, $a_obj_id, $a_user_id = ""): bool
+    {
+        return true;
+    }
+}

--- a/components/ILDemo/DemoRepoObject/classes/class.ilObjDemoRepoObjGUI.php
+++ b/components/ILDemo/DemoRepoObject/classes/class.ilObjDemoRepoObjGUI.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+/**
+ * @ilCtrl_isCalledBy ilObjDemoRepoObjGUI: ilRepositoryGUI, ilAdministrationGUI, ilObjPluginDispatchGUI
+ * @ilCtrl_Calls ilObjDemoRepoObjGUI: ilPermissionGUI, ilInfoScreenGUI, ilObjectCopyGUI, ilCommonActionDispatcherGUI
+ */
+class ilObjDemoRepoObjGUI extends ilObjectPluginGUI
+{
+    public const CMD_SHOW_CONTENT = "showContent";
+    public const TAB_SHOW_CONTENT = "show_content";
+
+    protected function afterConstructor(): void
+    {
+    }
+
+    final public function getType(): string
+    {
+        return ilObjDemoRepoObj::TYPE;
+    }
+
+    protected function performNextClass(string $next_class): bool
+    {
+        switch ($next_class) {
+        }
+        return false;
+    }
+
+    public function getAfterCreationCmd(): string
+    {
+        return self::CMD_SHOW_CONTENT;
+    }
+
+    public function getStandardCmd(): string
+    {
+        return self::CMD_SHOW_CONTENT;
+    }
+
+    public function performCommand(string $cmd): void
+    {
+        switch ($cmd) {
+            case self::CMD_SHOW_CONTENT:
+                $this->tabs->activateTab(self::TAB_SHOW_CONTENT);
+                $content = $this->showContent();
+                $this->tpl->setContent($content);
+                break;
+            default:
+                throw new Exception("Unknown command: " . $cmd);
+        }
+    }
+
+    public function setTabs(): void
+    {
+        $this->addInfoTab();
+
+        $this->tabs->addTab(
+            self::TAB_SHOW_CONTENT,
+            $this->txt(self::TAB_SHOW_CONTENT),
+            $this->ctrl->getLinkTarget($this, self::CMD_SHOW_CONTENT)
+        );
+
+        $this->addPermissionTab();
+    }
+
+    protected function showContent()
+    {
+        $content = $this->txt('demo_view');
+        $template = $this->plugin->getTemplate("tpl.demo.html", true, true);
+        $template->setVariable('CONTENT', $content);
+        return $template->get();
+    }
+}

--- a/components/ILDemo/DemoRepoObject/classes/class.ilObjDemoRepoObjListGUI.php
+++ b/components/ILDemo/DemoRepoObject/classes/class.ilObjDemoRepoObjListGUI.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+class ilObjDemoRepoObjListGUI extends ilObjectPluginListGUI
+{
+    public function initCommands(): array
+    {
+        return [
+            [
+                "permission" => "read",
+                "cmd" => \ilObjDemoRepoObjGUI::CMD_SHOW_CONTENT,
+                "txt" => "show",
+                "default" => true
+            ],
+            [
+                "permission" => "write",
+                "cmd" => \ilObjDemoRepoObjGUI::CMD_SHOW_CONTENT,
+                "txt" => $this->lng->txt("edit"),
+                "default" => false
+            ],
+        ];
+    }
+
+    public function initType()
+    {
+        $this->setType(ilObjDemoRepoObj::TYPE);
+    }
+
+    /**
+    * Get name of gui class handling the commands
+    */
+    public function getGuiClass(): string
+    {
+        return "ilObjDemoRepoObjGUI";
+    }
+
+    public function getProperties(): array
+    {
+        return array();
+    }
+
+    protected function initListActions(): void
+    {
+        $this->delete_enabled = true;
+        $this->cut_enabled = true;
+        $this->subscribe_enabled = true;
+        $this->link_enabled = false;
+        $this->info_screen_enabled = true;
+        $this->copy_enabled = true;
+    }
+}

--- a/components/ILDemo/DemoRepoObject/lang/ilias_de.lang
+++ b/components/ILDemo/DemoRepoObject/lang/ilias_de.lang
@@ -1,0 +1,6 @@
+/**
+* This is a language file for tms plugins
+*/
+<!-- language file start -->
+demo_view#:#demo-view - Übersetzt.
+show_content#:#Ansicht

--- a/components/ILDemo/DemoRepoObject/lang/ilias_en.lang
+++ b/components/ILDemo/DemoRepoObject/lang/ilias_en.lang
@@ -1,0 +1,6 @@
+/**
+* This is a language file for tms plugins
+*/
+<!-- language file start -->
+demo_view#:#Translated.
+show_content#:#View

--- a/components/ILDemo/DemoRepoObject/templates/default/tpl.demo.html
+++ b/components/ILDemo/DemoRepoObject/templates/default/tpl.demo.html
@@ -1,0 +1,2 @@
+<h1>DEMO</h1>
+<p>{CONTENT}</p>

--- a/components/ILDemo/DemoRepoObject/templates/images/icon_xdmo.svg
+++ b/components/ILDemo/DemoRepoObject/templates/images/icon_xdmo.svg
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+        xmlns:dc="http://purl.org/dc/elements/1.1/"
+        xmlns:cc="http://creativecommons.org/ns#"
+        xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        xmlns:svg="http://www.w3.org/2000/svg"
+        xmlns="http://www.w3.org/2000/svg"
+        id="svg2"
+        xml:space="preserve"
+        style="enable-background:new 0 0 32 32;"
+        viewBox="0 0 32 32"
+        y="0px"
+        x="0px"
+        width="32px"
+        height="32px"
+        version="1.1"><metadata
+     id="metadata33"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+        rdf:resource="http://purl.org/dc/dcmitype/StillImage"/><dc:title></dc:title></cc:Work></rdf:RDF></metadata>
+    <defs
+            id="defs31"/>
+    <style
+            id="style4"
+            type="text/css">
+
+	.st4{display:none;fill:#F2F2F2;}
+	.st5{display:none;fill:none;stroke:#4C6486;stroke-width:3;stroke-miterlimit:10;}
+	.st6{display:none;}
+	.st7{display:inline;fill:#4C6486;}
+	.st8{display:none;fill:#4C6486;}
+	.st9{fill:#4C6486;}
+
+</style>
+    <g
+            id="default"><path
+       d="M26.5,26.7h-21c-0.6,0-1-0.4-1-1V7.3c0-0.6,0.4-1,1-1h21c0.6,0,1,0.4,1,1v18.3   C27.5,26.2,27.1,26.7,26.5,26.7z"
+       class="st4"
+       id="graue_Fläche" />
+        <path
+                id="path8"
+                d="M25.3,26.7H6.7c-0.6,0-1-0.4-1-1V7.1c0-0.6,0.4-1,1-1h18.6c0.6,0,1,0.4,1,1v18.6   C26.3,26.2,25.8,26.7,25.3,26.7z"
+                class="st5"/>
+        <g
+                class="st6"
+                id="abgerundet"><path
+         id="path11"
+         d="M11,24H7V7h4V4H6.7C5.3,4,4,4.8,4,6.1v18C4,25.5,5.3,27,6.7,27H11V24z"
+         class="st7" />
+            <path
+                    id="path13"
+                    d="M25.3,4H21v3h4v17h-4v3h4.3c1.4,0,2.7-1.5,2.7-2.8v-18C28,4.8,26.7,4,25.3,4z"
+                    class="st7"/></g>
+        <g
+                id="g15"
+                class="st6"><polygon
+         id="polygon17"
+         points="10,25 7,25 7,8 10,8 10,5 4,5 4,28 10,28   "
+         class="st7" />
+            <polygon
+                    id="polygon19"
+                    points="22,5 22,8 25,8 25,25 22,25 22,28 28,28 28,5   "
+                    class="st7"/></g>
+        <polygon
+                id="polygon21"
+                points="6,26 6,7 10,7 10,5 4,5 4,28 10,28 10,26  "
+                class="st8"/>
+        <g
+                id="g23"><polygon
+         id="polygon25"
+         points="10,25 6,25 6,7 10,7 10,5 4,5 4,27 10,27   "
+         class="st9" />
+            <polygon
+                    id="polygon27"
+                    points="22,5 22,7 26,7 26,25 22,25 22,27 28,27 28,5   "
+                    class="st9"/></g></g>
+    <g
+            id="layer1"><text
+       id="text3362"
+       y="20.768713"
+       x="6.9167366"
+       style="font-style:normal;font-weight:normal;font-size:15px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         style="font-size:12.5px"
+         y="20.768713"
+         x="6.9167366"
+         id="tspan3364">2do</tspan></text>
+</g></svg>

--- a/components/ILIAS/Administration/GlobalScreen/classes/AdministrationMainBarProvider.php
+++ b/components/ILIAS/Administration/GlobalScreen/classes/AdministrationMainBarProvider.php
@@ -75,7 +75,7 @@ class AdministrationMainBarProvider extends AbstractStaticMainMenuProvider
                         $action = "ilias.php?baseClass=ilAdministrationGUI&ref_id=" . $ref_id . "&admin_mode=repository";
                     } else {
                         $identification = $this->if->identifier("mm_adm_" . $titems[$group_item]["type"]);
-                        $action = "ilias.php?baseClass=ilAdministrationGUI&ref_id=" . $ref_id . "&cmd=jump";
+                        $action = $titems[$group_item]["href"] ?? "ilias.php?baseClass=ilAdministrationGUI&ref_id=" . $ref_id . "&cmd=jump";
                     }
 
                     $links[] = $this->globalScreen()
@@ -230,6 +230,46 @@ class AdministrationMainBarProvider extends AbstractStaticMainMenuProvider
             "legal_regulations" =>
                 array("impr" ,"tos", "accs", 'dpro')
         );
+
+        $additional_repo_objs = $this->dic['repository.objects']->getAll();
+        foreach ($additional_repo_objs as $aro) {
+            $config_gui_classname = $aro->getConfigGUIClassName();
+            if (class_exists($config_gui_classname)) {
+
+                $ctrl = $this->dic['ilCtrl'];
+                $gui = new $config_gui_classname();
+                $ctrl->setParameter($gui, \ilObjComponentSettingsGUI::P_PLUGIN_ID, $aro->getId());
+                $ctrl->setParameter($gui, \ilObjComponentSettingsGUI::P_CTYPE, $aro->getId());
+                $ctrl->setParameter($gui, \ilObjComponentSettingsGUI::P_CNAME, $aro->getName());
+                $ctrl->setParameter($gui, \ilObjComponentSettingsGUI::P_SLOT_ID, 'robj');
+                $ctrl->setParameter($gui, \ilObjComponentSettingsGUI::P_PLUGIN_NAME, $aro->getName());
+                $ctrl->setParameter(
+                    $gui,
+                    \ilObjComponentSettingsGUI::P_BACK,
+                    urlencode($this->dic->http()->request()->getUri()->__toString())
+                );
+                $href = $ctrl->getLinkTargetByClass(
+                    [\ilAdministrationGUI::class, $aro->getConfigGUIClassName()],
+                    \ilObjComponentSettingsGUI::CMD_CONFIGURE
+                );
+                $ctrl->setParameter($gui, \ilObjComponentSettingsGUI::P_PLUGIN_ID, null);
+                $ctrl->setParameter($gui, \ilObjComponentSettingsGUI::P_CTYPE, null);
+                $ctrl->setParameter($gui, \ilObjComponentSettingsGUI::P_CNAME, null);
+                $ctrl->setParameter($gui, \ilObjComponentSettingsGUI::P_SLOT_ID, null);
+                $ctrl->setParameter($gui, \ilObjComponentSettingsGUI::P_PLUGIN_NAME, null);
+                $ctrl->setParameter($gui, \ilObjComponentSettingsGUI::P_BACK, null);
+
+                $id = $aro->getId();
+                $titems[$id] = [
+                    'type' => $id,
+                    'title' => $aro->getName(),
+                    'ref_id' => -1,
+                    'href' => $href
+                ];
+                $layout['repository_and_objects'][] = $id;
+            }
+        }
+
         $groups = [];
         // now get all items and groups that are accessible
         foreach ($layout as $group => $entries) {

--- a/components/ILIAS/Administration/classes/class.ilAdministrationGUI.php
+++ b/components/ILIAS/Administration/classes/class.ilAdministrationGUI.php
@@ -19,6 +19,7 @@
 declare(strict_types=1);
 
 use ILIAS\Administration\AdminGUIRequest;
+use ILIAS\Repository\AdditionalRepositoryObjects;
 
 /**
 * Class ilAdministratioGUI
@@ -75,8 +76,9 @@ class ilAdministrationGUI implements ilCtrlBaseClassInterface
     protected bool $creation_mode = false;
     protected int $requested_obj_id = 0;
     protected AdminGUIRequest $request;
-    protected ilObjectGUI $gui_obj;
+    protected ilObjectGUI|ilPluginConfigGUI $gui_obj;
     private readonly ilLogger $logger;
+    protected readonly AdditionalRepositoryObjects $plugin_repository;
 
     public function __construct()
     {
@@ -100,6 +102,7 @@ class ilAdministrationGUI implements ilCtrlBaseClassInterface
         $this->rbacsystem = $rbacsystem;
         $this->objDefinition = $objDefinition;
         $this->ctrl = $ilCtrl;
+        $this->plugin_repository = $DIC['repository.objects'];
 
         $context = $DIC->globalScreen()->tool()->context();
         $context->claim()->administration();
@@ -109,24 +112,26 @@ class ilAdministrationGUI implements ilCtrlBaseClassInterface
             $DIC->refinery()
         );
 
-        $this->ctrl->saveParameter($this, array("ref_id", "admin_mode"));
+        if ($this->ctrl->getCmd() !== \ilObjComponentSettingsGUI::CMD_CONFIGURE) {
+            $this->ctrl->saveParameter($this, array("ref_id", "admin_mode"));
 
-        $this->admin_mode = $this->request->getAdminMode();
-        if ($this->admin_mode !== ilObjectGUI::ADMIN_MODE_REPOSITORY) {
-            $this->admin_mode = ilObjectGUI::ADMIN_MODE_SETTINGS;
+            $this->admin_mode = $this->request->getAdminMode();
+            if ($this->admin_mode !== ilObjectGUI::ADMIN_MODE_REPOSITORY) {
+                $this->admin_mode = ilObjectGUI::ADMIN_MODE_SETTINGS;
+            }
+
+            $this->ctrl->setReturn($this, "");
+
+            // determine current ref id and mode
+            $ref_id = $this->request->getRefId();
+            if ($tree->isInTree($ref_id)) {
+                $this->cur_ref_id = $ref_id;
+            } else {
+                throw new ilPermissionException("Invalid ref id.");
+            }
+
+            $this->requested_obj_id = $this->request->getObjId();
         }
-
-        $this->ctrl->setReturn($this, "");
-
-        // determine current ref id and mode
-        $ref_id = $this->request->getRefId();
-        if ($tree->isInTree($ref_id)) {
-            $this->cur_ref_id = $ref_id;
-        } else {
-            throw new ilPermissionException("Invalid ref id.");
-        }
-
-        $this->requested_obj_id = $this->request->getObjId();
     }
 
 
@@ -187,8 +192,13 @@ class ilAdministrationGUI implements ilCtrlBaseClassInterface
         switch ($next_class) {
             default:
 
+                if (preg_match("/configgui$/i", $next_class)) {
+                    $this->forwardConfigGUI($next_class);
+                }
+
                 // forward all other classes to gui commands
-                if ($next_class != "" && $next_class !== "iladministrationgui") {
+                elseif ($next_class != "" && $next_class !== "iladministrationgui") {
+
                     $class_path = $this->ctrl->lookupClassPath($next_class);
                     if (is_file($class_path)) {
                         require_once $class_path;   // note: org unit plugins still need the require
@@ -237,12 +247,25 @@ class ilAdministrationGUI implements ilCtrlBaseClassInterface
                         $this->tpl->setVariable("OBJECTS", $html);
                     }
                     $this->tpl->printToStdout();
-                } else {	//
+                } else {
                     $cmd = $this->ctrl->getCmd("forward");
                     $this->$cmd();
                 }
                 break;
         }
+    }
+
+    protected function forwardConfigGUI(string $name): void
+    {
+        $name = $this->ctrl->lookupOriginalClassName($name);
+        if (!class_exists($name)) {
+            throw new Exception("class $name not found!");
+        }
+        $gui = new $name();
+        $plugin_name = substr($name, 2, -9);
+        $plugin = $this->plugin_repository->getPluginByName($plugin_name);
+        $gui->setPluginObject($plugin);
+        $this->ctrl->forwardCommand($gui);
     }
 
     /**

--- a/components/ILIAS/Component/classes/Settings/class.ilObjComponentSettingsGUI.php
+++ b/components/ILIAS/Component/classes/Settings/class.ilObjComponentSettingsGUI.php
@@ -49,6 +49,7 @@ class ilObjComponentSettingsGUI extends ilObjectGUI implements ilCtrlSecurityInt
     public const P_PLUGIN_NAME = "pname";
     public const P_PLUGIN_ID = "plugin_id";
     public const P_ADMIN_MODE = 'admin_mode';
+    public const P_BACK = 'back';
 
     protected ilTabsGUI $tabs;
     protected ilRbacSystem $rbac_system;

--- a/components/ILIAS/Component/classes/class.ilPlugin.php
+++ b/components/ILIAS/Component/classes/class.ilPlugin.php
@@ -337,7 +337,12 @@ abstract class ilPlugin
 
     protected function buildLanguageHandler(): ilPluginLanguage
     {
-        return new ilPluginLanguage($this->getPluginInfo());
+        $plugin_info = $this->getPluginInfo();
+        $component = $plugin_info->getComponent();
+        $slot = $plugin_info->getPluginSlot();
+        $prefix = $component->getId() . "_" . $slot->getId() . "_" . $plugin_info->getId();
+        $path = $plugin_info->getPath() . "/lang";
+        return new ilPluginLanguage($prefix, $path);
     }
 
     /**

--- a/components/ILIAS/Component/classes/class.ilPluginConfigGUI.php
+++ b/components/ILIAS/Component/classes/class.ilPluginConfigGUI.php
@@ -60,7 +60,8 @@ abstract class ilPluginConfigGUI
         $lng = $DIC->language();
         $tpl = $DIC['tpl'];
         $request_wrapper = $DIC->http()->wrapper()->query();
-        $string_trafo = $DIC["refinery"]->kindlyTo()->string();
+        $refinery = $DIC["refinery"];
+        $string_trafo = $refinery->kindlyTo()->string();
 
         $ilCtrl->setParameterByClass("ilobjcomponentsettingsgui", "ctype", $request_wrapper->retrieve("ctype", $string_trafo));
         $ilCtrl->setParameterByClass("ilobjcomponentsettingsgui", "cname", $request_wrapper->retrieve("cname", $string_trafo));
@@ -82,6 +83,17 @@ abstract class ilPluginConfigGUI
             $ilTabs->setBackTarget(
                 $lng->txt("cmps_plugins"),
                 $ilCtrl->getLinkTargetByClass("ilobjcomponentsettingsgui", "listPlugins")
+            );
+        }
+
+        $back = $request_wrapper->retrieve(
+            \ilObjComponentSettingsGUI::P_BACK,
+            $refinery->byTrying([$string_trafo, $refinery->always(null)])
+        );
+        if ($back !== null) {
+            $ilTabs->setBackTarget(
+                $lng->txt("back"),
+                urldecode($back)
             );
         }
 

--- a/components/ILIAS/ILIASObject/classes/class.ilObject.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObject.php
@@ -1887,13 +1887,11 @@ class ilObject
             return ilUtil::getImagePath("standard/icon_{$type}.svg");
         }
 
-        if ($objDefinition->getClassName($type) !== '') {
-            $class_name = "il{$objDefinition->getClassName($type)}Plugin";
-            $location = $objDefinition->getLocation($type);
-            if (is_file($location . "/class.{$class_name}.php")) {
-                return call_user_func([$class_name, '_getIcon'], $type);
-            }
+        $plugin_repository = $DIC['repository.objects'];
+        if ($plugin_repository->has($type)) {
+            return ilUtil::getImagePath("../{$type}/images/icon_{$type}.svg");
         }
+
         return ilUtil::getImagePath('standard/icon_cmps.svg');
     }
 

--- a/components/ILIAS/ILIASObject/classes/class.ilObjectDefinition.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObjectDefinition.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Repository\AdditionalRepositoryObjects;
+
 /**
 * parses the objects.xml
 * it handles the xml-description of all ilias objects
@@ -33,6 +35,7 @@ class ilObjectDefinition
 
     protected ilSetting $settings;
     protected ilComponentRepository $component_repository;
+    protected readonly AdditionalRepositoryObjects $plugin_repository;
 
     protected array $obj_data = [];
     protected array $obj_group = [];
@@ -47,6 +50,7 @@ class ilObjectDefinition
         global $DIC;
 
         $this->component_repository = $DIC["component.repository"];
+        $this->plugin_repository = $DIC["repository.objects"];
         $this->settings = $DIC->settings();
         $this->readDefinitionData();
     }
@@ -110,9 +114,8 @@ class ilObjectDefinition
     protected static function getGroupedPluginObjectTypes(array $grouped_obj, string $slotId): array
     {
         global $DIC;
+        $plugins = $DIC['repository.objects']->getAll();
 
-        $component_repository = $DIC["component.repository"];
-        $plugins = $component_repository->getPluginSlotById($slotId)->getActivePlugins();
         foreach ($plugins as $plugin) {
             $pl_id = $plugin->getId();
             if (!isset($grouped_obj[$pl_id])) {
@@ -872,17 +875,14 @@ class ilObjectDefinition
      */
     protected function parsePluginData(string $slotId, bool $isInAdministration): void
     {
-        $plugins = $this->component_repository->getPluginSlotById($slotId)->getActivePlugins();
-        foreach ($plugins as $plugin) {
+        foreach ($this->plugin_repository->getAll() as $plugin) {
             $pl_id = $plugin->getId();
             if ($pl_id != "" && !isset($this->obj_data[$pl_id])) {
                 $loc = $plugin->getPath() . "/classes";
                 // The plugin_id is the same as the type_id in repository object plugins.
-                $pl = ilObjectPlugin::getPluginObjectByType($pl_id);
-
                 $this->obj_data[$pl_id] = [
                     "name" => $pl_id,
-                    "class_name" => $pl->getPluginName(),
+                    "class_name" => $plugin->getName(),
                     "plugin" => "1",
                     "location" => $loc,
                     "checkbox" => "1",
@@ -891,7 +891,8 @@ class ilObjectDefinition
                     "translate" => "0",
                     "devmode" => "0",
                     "allow_link" => "1",
-                    "allow_copy" => $pl->allowCopy() ? '1' : '0',
+                    "allow_copy" => $plugin->allowCopy() ? '1' : '0',
+                    "allow_copy" => '0',
                     "rbac" => "1",
                     "group" => null,
                     "system" => "0",
@@ -902,10 +903,10 @@ class ilObjectDefinition
                     "sideblock" => "0",
                     'export' => $plugin->supportsExport(),
                     'offline_handling' => '0',
-                    'orgunit_permissions' => $pl->useOrguPermissions() ? '1' : '0'
+                    'orgunit_permissions' => $plugin->useOrguPermissions() ? '1' : '0'
                 ];
 
-                $parent_types = $pl->getParentTypes();
+                $parent_types = $plugin->getParentTypes();
                 foreach ($parent_types as $parent_type) {
                     $this->obj_data[$parent_type]["subobjects"][$pl_id] = [
                         "name" => $pl_id,

--- a/components/ILIAS/ILIASObject/classes/class.ilObjectGUI.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObjectGUI.php
@@ -2200,14 +2200,15 @@ class ilObjectGUI implements ImplementsCreationCallback
         array $obj_types_in_group,
         array $subtypes
     ): array {
+
         $add_new_items_content_array = [];
-        foreach ($obj_types_in_group as $type) {
+        foreach (array_values($obj_types_in_group) as $idx => $type) {
             if (!array_key_exists($type, $subtypes)) {
                 continue;
             }
             $subitem = $subtypes[$type];
             $this->ctrl->setParameterByClass($create_target_class, 'new_type', $type);
-            $add_new_items_content_array[$subitem['pos']] = new AddNewItemElement(
+            $add_new_items_content_array[$subitem['pos'] . '_' . $idx] = new AddNewItemElement(
                 AddNewItemElementTypes::Object,
                 $this->getTranslatedObjectTypeNameFromItemArray($subitem),
                 empty($subitem['plugin'])

--- a/components/ILIAS/Init/Init.php
+++ b/components/ILIAS/Init/Init.php
@@ -126,6 +126,7 @@ class Init implements Component\Component
                 $pull[\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class],
                 $use[\ILIAS\Setup\AgentFinder::class],
                 $pull[\ILIAS\UI\Implementation\Component\Navigation\Factory::class],
+                $pull[\ILIAS\Repository\AdditionalRepositoryObjects::class],
             );
     }
 }

--- a/components/ILIAS/Init/src/AllModernComponents.php
+++ b/components/ILIAS/Init/src/AllModernComponents.php
@@ -95,6 +95,7 @@ class AllModernComponents implements \ILIAS\Component\EntryPoint
         protected \ILIAS\UI\Implementation\Component\Input\UploadLimitResolver $ui_upload_limit_resolver,
         protected \ILIAS\Setup\AgentFinder $setup_agent_finder,
         protected \ILIAS\UI\Implementation\Component\Navigation\Factory $ui_factory_navigation,
+        protected \ILIAS\Repository\AdditionalRepositoryObjects $repository_objects,
     ) {
     }
 
@@ -172,6 +173,7 @@ class AllModernComponents implements \ILIAS\Component\EntryPoint
         $DIC['ui.renderer'] = fn() => $this->ui_renderer;
         $DIC['setup.agentfinder'] = fn() => $this->setup_agent_finder;
         $DIC['ui.factory.navigation'] = fn() => $this->ui_factory_input_field;
+        $DIC['repository.objects'] = fn() => $this->repository_objects;
     }
 
     public function getName(): string

--- a/components/ILIAS/Language/classes/class.ilPluginLanguage.php
+++ b/components/ILIAS/Language/classes/class.ilPluginLanguage.php
@@ -23,16 +23,15 @@ declare(strict_types=1);
  */
 class ilPluginLanguage
 {
-    protected ilPluginInfo $plugin_info;
-
-    public function __construct(ilPluginInfo $plugin_info)
-    {
-        $this->plugin_info = $plugin_info;
+    public function __construct(
+        protected string $prefix,
+        protected string $path
+    ) {
     }
 
     protected function getLanguageDirectory(): string
     {
-        return $this->plugin_info->getPath() . "/lang";
+        return $this->path . "/lang";
     }
 
     /**
@@ -76,11 +75,7 @@ class ilPluginLanguage
 
     public function getPrefix(): string
     {
-        $plugin = $this->plugin_info;
-        $component = $plugin->getComponent();
-        $slot = $plugin->getPluginSlot();
-
-        return $component->getId() . "_" . $slot->getId() . "_" . $plugin->getId();
+        return $this->prefix;
     }
 
     /**

--- a/components/ILIAS/Repository/PluginSlot/class.ilObjectPlugin.php
+++ b/components/ILIAS/Repository/PluginSlot/class.ilObjectPlugin.php
@@ -24,28 +24,26 @@
 abstract class ilObjectPlugin extends ilObject2
 {
     protected ?ilPlugin $plugin = null;
-    protected ilComponentFactory $component_factory;
+    protected \ILIAS\Repository\AdditionalRepositoryObjects $plugin_repository;
 
     public function __construct(int $a_ref_id = 0)
     {
         global $DIC;
-        $this->component_factory = $DIC["component.factory"];
         $this->initType();
         parent::__construct($a_ref_id, true);
+        $this->plugin_repository = $DIC['repository.objects'];
         $this->plugin = $this->getPlugin();
     }
-
 
     /**
      * Return either a repoObject plugin or a orgunit extension plugin or null if the type is not a plugin.
      * @return null | ilRepositoryObjectPlugin | ilOrgUnitExtensionPlugin
      */
-    public static function getPluginObjectByType(string $type): ?ilPlugin
+    public static function getPluginObjectByType(string $type): ?ILIAS\Repository\RepositoryObject
     {
         global $DIC;
-        $component_factory = $DIC["component.factory"];
         try {
-            return $component_factory->getPlugin($type);
+            return $DIC['repository.objects']->get($type);
         } catch (InvalidArgumentException $e) {
             ilLoggerFactory::getLogger("obj")->log("There was an error while instantiating repo plugin obj of type: $type. Error: $e");
         }
@@ -60,14 +58,10 @@ abstract class ilObjectPlugin extends ilObject2
         return $pl->txt($lang_var);
     }
 
-    /**
-     * Get plugin object
-     * @throws ilPluginException
-     */
     protected function getPlugin(): ilPlugin
     {
         if (!$this->plugin) {
-            $this->plugin = $this->component_factory->getPlugin($this->getType());
+            $this->plugin = $this->plugin_repository->get($this->getType());
         }
         return $this->plugin;
     }

--- a/components/ILIAS/Repository/PluginSlot/class.ilObjectPluginGUI.php
+++ b/components/ILIAS/Repository/PluginSlot/class.ilObjectPluginGUI.php
@@ -24,12 +24,11 @@ use ILIAS\Repository\PluginSlot\PluginSlotGUIRequest;
  */
 abstract class ilObjectPluginGUI extends ilObject2GUI
 {
-    protected ilComponentRepository $component_repository;
     protected ilNavigationHistory $nav_history;
     protected ilTabsGUI $tabs;
     protected ?ilPlugin $plugin = null;
     protected PluginSlotGUIRequest $slot_request;
-    protected ilComponentFactory $component_factory;
+    protected \ILIAS\Repository\AdditionalRepositoryObjects $plugin_repository;
 
     public function __construct(
         int $a_ref_id = 0,
@@ -53,8 +52,8 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
         $this->tabs = $DIC->tabs();
         $this->locator = $DIC["ilLocator"];
         $this->user = $DIC->user();
-        $this->component_factory = $DIC["component.factory"];
-        $this->component_repository = $DIC["component.repository"];
+        $this->plugin_repository = $DIC['repository.objects'];
+
         parent::__construct($a_ref_id, $a_id_type, $a_parent_node_id);
         $this->plugin = $this->getPlugin();
     }
@@ -204,7 +203,7 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
     protected function getPlugin(): ilPlugin
     {
         if (!$this->plugin) {
-            $this->plugin = $this->component_factory->getPlugin($this->getType());
+            $this->plugin = $this->plugin_repository->get($this->getType());
         }
         return $this->plugin;
     }
@@ -412,9 +411,7 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 
     protected function supportsExport(): bool
     {
-        $component_repository = $this->component_repository;
-
-        return $component_repository->getPluginSlotById("robj")->getPluginByName($this->getPlugin()->getPluginName())->supportsExport();
+        return $this->plugin->supportsExport();
     }
 
     protected function lookupParentTitleInCreationMode(): string

--- a/components/ILIAS/Repository/PluginSlot/class.ilObjectPluginListGUI.php
+++ b/components/ILIAS/Repository/PluginSlot/class.ilObjectPluginListGUI.php
@@ -25,14 +25,13 @@
  */
 abstract class ilObjectPluginListGUI extends ilObjectListGUI
 {
-    protected ilComponentFactory $component_factory;
+    protected ILIAS\Repository\AdditionalRepositoryObjects $plugin_repository;
     protected ?ilRepositoryObjectPlugin $plugin = null;
 
     public function __construct(int $a_context = self::CONTEXT_REPOSITORY)
     {
         global $DIC;
-
-        $this->component_factory = $DIC["component.factory"];
+        $this->plugin_repository = $DIC['repository.objects'];
 
         parent::__construct($a_context);
 
@@ -63,7 +62,7 @@ abstract class ilObjectPluginListGUI extends ilObjectListGUI
     protected function getPlugin(): ?ilRepositoryObjectPlugin
     {
         if (!$this->plugin) {
-            $this->plugin = $this->component_factory->getPlugin($this->getType());
+            $this->plugin = $this->plugin_repository->get($this->getType());
         }
         return $this->plugin;
     }

--- a/components/ILIAS/Repository/PluginSlot/class.ilRepositoryObjectPlugin.php
+++ b/components/ILIAS/Repository/PluginSlot/class.ilRepositoryObjectPlugin.php
@@ -21,7 +21,7 @@
  *
  * @author Alexander Killing <killing@leifos.de>
  */
-abstract class ilRepositoryObjectPlugin extends ilPlugin
+abstract class ilRepositoryObjectPlugin extends \ILIAS\Repository\RepositoryObject
 {
     protected ilLanguage $lng;
 
@@ -48,8 +48,9 @@ abstract class ilRepositoryObjectPlugin extends ilPlugin
         }
 
         $component_repository = $DIC["component.repository"];
+        $plugin_repository = $DIC['repository.objects'];
 
-        $plugin = $component_repository->getPluginByName($a_pname);
+        $plugin = $plugin_repository->getPluginByName($a_pname);
         $component = $component_repository->getComponentByTypeAndName($a_ctype, $a_cname);
 
         $d2 = $component->getId() . "_" . $a_slot_id . "_" . $plugin->getId();
@@ -58,34 +59,22 @@ abstract class ilRepositoryObjectPlugin extends ilPlugin
         if (is_int(strpos($img, "Customizing"))) {
             return $img;
         }
-
+        //throw new \Exception('stop');
         $d = $plugin->getPath();
         return $d . "/templates/images/" . $a_img;
     }
 
-
-
     public static function _getIcon(string $a_type): string
     {
         global $DIC;
-        $component_repository = $DIC["component.repository"];
+        $plugin_repository = $DIC['repository.objects'];
         return self::_getImagePath(
             ilComponentInfo::TYPES[0],
             "Repository",
             "robj",
-            $component_repository->getPluginById($a_type)->getName(),
+            $plugin_repository->get($a_type)->getName(),
             "icon_" . $a_type . ".svg"
         );
-    }
-
-    public static function _getName(string $a_id): string
-    {
-        global $DIC;
-        $component_repository = $DIC["component.repository"];
-        if (!$component_repository->hasPluginId($a_id)) {
-            return "";
-        }
-        return $component_repository->getPluginById($a_id)->getName();
     }
 
     protected function beforeActivation(): bool
@@ -213,34 +202,4 @@ abstract class ilRepositoryObjectPlugin extends ilPlugin
         return false;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getParentTypes(): array
-    {
-        $par_types = ["root", "cat", "crs", "grp", "fold"];
-        return $par_types;
-    }
-
-    /**
-     * decides if this repository plugin can be copied
-     */
-    public function allowCopy(): bool
-    {
-        return false;
-    }
-
-    /**
-     * Decide if this repository plugin uses OrgUnit Permissions
-     */
-    public function useOrguPermissions(): bool
-    {
-        return false;
-    }
-
-    public function getPrefix(): string
-    {
-        $lh = $this->getLanguageHandler();
-        return $lh->getPrefix();
-    }
 }

--- a/components/ILIAS/Repository/PluginSlot/class.ilRepositoryObjectPluginSlot.php
+++ b/components/ILIAS/Repository/PluginSlot/class.ilRepositoryObjectPluginSlot.php
@@ -27,14 +27,12 @@ class ilRepositoryObjectPluginSlot
     public static function addCreatableSubObjects(array $a_obj_array): array
     {
         global $DIC;
+        $plugins = $DIC['repository.objects']->getAll();
 
-        $component_repository = $DIC["component.repository"];
-        $plugins = $component_repository->getPluginSlotById("robj")->getActivePlugins();
         foreach ($plugins as $plugin) {
             $pl_id = $plugin->getId();
             $a_obj_array[$pl_id] = ["name" => $pl_id, "lng" => $pl_id, "plugin" => true];
         }
-
         return $a_obj_array;
     }
 
@@ -44,19 +42,7 @@ class ilRepositoryObjectPluginSlot
         bool $a_active_status = true
     ): bool {
         global $DIC;
-
-        $component_repository = $DIC["component.repository"];
-
-        if (!$component_repository->hasPluginId($a_type)) {
-            return false;
-        }
-
-        if (!$a_active_status) {
-            return true;
-        }
-
-        $plugin = $component_repository->getPluginById($a_type);
-        return $plugin->isActive();
+        return $DIC['repository.objects']->has($a_type);
     }
 
     // Check whether a repository type is a plugin which has active learning progress
@@ -65,20 +51,8 @@ class ilRepositoryObjectPluginSlot
         bool $a_active_status = true
     ): bool {
         global $DIC;
-        $component_repository = $DIC["component.repository"];
-
-        if (!$component_repository->hasPluginId($a_type)) {
-            return false;
-        }
-        $slot = $component_repository->getPluginSlotById("robj");
-        if ($slot->hasPluginId($a_type)) {
-            $plugin = $slot->getPluginById($a_type);
-            if (!$a_active_status || $plugin->isActive()) {
-                if ($plugin->supportsLearningProgress()) {
-                    return true;
-                }
-            }
-        }
-        return false;
+        return $DIC['repository.objects']
+            ->get($a_type)
+            ->supportsLearningProgress();
     }
 }

--- a/components/ILIAS/Repository/Repository.php
+++ b/components/ILIAS/Repository/Repository.php
@@ -43,5 +43,11 @@ class Repository implements Component\Component
 
         $contribute[Component\Resource\PublicAsset::class] = fn() =>
             new Component\Resource\ComponentJS($this, "repository.js");
+
+        $provide[\ILIAS\Repository\AdditionalRepositoryObjects::class] = fn() =>
+            new \ILIAS\Repository\AdditionalRepositoryObjects(
+                $seek[\ILIAS\Repository\RepositoryObject::class]
+            );
+
     }
 }

--- a/components/ILIAS/Repository/classes/AdditionalRepositoryObjects.php
+++ b/components/ILIAS/Repository/classes/AdditionalRepositoryObjects.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Repository;
+
+class AdditionalRepositoryObjects
+{
+    private array $by_id = [];
+    private array $name_to_id = [];
+
+    public function __construct(
+        private array $repo_objects
+    ) {
+        $this->by_id = array_merge(
+            ...array_map(
+                fn($o) => [$o->getId() => $o],
+                $repo_objects
+            )
+        );
+        $this->name_to_id = array_merge(
+            ...array_map(
+                fn($o) => [$o->getName() => $o->getId()],
+                $repo_objects
+            )
+        );
+    }
+
+    public function getAll(): array
+    {
+        return $this->repo_objects;
+    }
+
+    public function get(string $id): RepositoryObject
+    {
+        return $this->by_id[$id];
+    }
+
+    public function has(string $id): bool
+    {
+        return array_key_exists($id, $this->by_id);
+    }
+
+    public function getPluginByName(string $name): \ilPlugin
+    {
+        return $this->get($this->name_to_id[$name]);
+    }
+
+}

--- a/components/ILIAS/Repository/classes/RepositoryObject.php
+++ b/components/ILIAS/Repository/classes/RepositoryObject.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Repository;
+
+class RepositoryObject extends \ilPlugin
+{
+    public function __construct(
+        protected string $id,
+        protected string $name,
+        protected $parent_types = ["root", "cat", "crs", "grp", "fold"],
+        protected bool $allow_copy = false,
+        protected bool $use_orgu_permissions = false,
+        protected bool $supports_lp = false,
+        protected bool $supports_export = false,
+    ) {
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getClassName(): string
+    {
+        return static::class;
+    }
+    public function getConfigGUIClassName(): string
+    {
+        return 'il' . $this->getName() . 'ConfigGUI';
+    }
+
+    public function getPath(): string
+    {
+        $loader = require dirname(__DIR__, 4) . '/vendor/composer/vendor/autoload.php';
+        $plugin_file = $loader->findFile($this->getClassname());
+        if (!$plugin_file) {
+            throw new \Exception('file not found in autoloader: ' . $this->getClassName());
+        }
+        return realpath(dirname($plugin_file) . '/..');
+    }
+
+    public function getPrefix(): string
+    {
+        return $this->id;
+    }
+
+    public function getTemplate(string $template, bool $par1 = true, bool $par2 = true): \ilTemplate
+    {
+        return new \ilTemplate(
+            $template,
+            $par1,
+            $par2,
+            $this->getPath()
+        );
+    }
+
+    protected function buildLanguageHandler(): \ilPluginLanguage
+    {
+        $lng = new \ilPluginLanguage(
+            $this->getId(),
+            $this->getPath()
+        );
+        //$lng->updateLanguages();
+        return $lng;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getParentTypes(): array
+    {
+        return $this->parent_types;
+    }
+    public function allowCopy(): bool
+    {
+        return $this->allow_copy;
+    }
+    public function useOrguPermissions(): bool
+    {
+        return $this->use_orgu_permissions;
+    }
+    public function supportsLearningProgress(): bool
+    {
+        return $this->supports_lp;
+    }
+    public function supportsExport(): bool
+    {
+        return $this->supports_export;
+    }
+
+}


### PR DESCRIPTION
This adds a collection of [additional Repository Objects](https://github.com/ILIAS-eLearning/ILIAS/pull/10223/files#diff-31314e944d2d5a6fd9a7ef39efdf71c43a5f2280a444b5b4d55bef5e695d0487) and [seeks](https://github.com/ILIAS-eLearning/ILIAS/pull/10223/files#diff-5e223574d83aafeecf911e81e68a5e98e9e1cf9ed9d451708e4645de8cedbb6eR49) for vendor-objects. The collection is available in allModernComponents and bypasses plugin- and component lookups.
Also, some basic props like allowCopy are set on initialisation and not defined via inheritance.

I included a second commit with a [DemoObject](https://github.com/ILIAS-eLearning/ILIAS/pull/10223/files#diff-d9f55347fa24f782bf3a74d276a0d1660478e2e93c576546bfd1944eaa4aab1b).
