### PR TITLE
[FIX] #45793 UI: `Field\Section` nesting level

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Section.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Section.php
@@ -19,8 +19,6 @@
 
 declare(strict_types=1);
 
-declare(strict_types=1);
-
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
 use ILIAS\Data\Factory as DataFactory;
@@ -43,13 +41,13 @@ class Section extends Group implements C\Input\Field\Section
         ?string $byline = null
     ) {
         parent::__construct($data_factory, $refinery, $lng, $inputs, $label, $byline);
-        $this->updateChildrenNestingLevels();
+        // only set/update nesting levels recursively once during construction.
+        $this->setSectionNestingLevelsRecursively($this->getInputs(), $this->getNestingLevel());
     }
 
     public function setNestingLevel(int $nesting_level): void
     {
         $this->nesting_level = $nesting_level;
-        $this->updateChildrenNestingLevels();
     }
 
     public function getNestingLevel(): int
@@ -57,18 +55,20 @@ class Section extends Group implements C\Input\Field\Section
         return $this->nesting_level;
     }
 
-    protected function setInputs(array $inputs): void
+    /**
+     * @param C\Input\Input[] $inputs
+     */
+    protected function setSectionNestingLevelsRecursively(array $inputs, int $current_nesting_level): void
     {
-        parent::setInputs($inputs);
-        $this->updateChildrenNestingLevels();
-    }
-
-    private function updateChildrenNestingLevels(): void
-    {
-        foreach ($this->getInputs() as $input) {
-            if ($input instanceof Section) {
-                $nesting_level = $this->getNestingLevel() + 1;
-                $input->setNestingLevel($nesting_level);
+        foreach ($inputs as $input) {
+            if ($input instanceof C\Input\Group && !($input instanceof self)) {
+                $this->setSectionNestingLevelsRecursively($input->getInputs(), $current_nesting_level);
+                continue;
+            }
+            if ($input instanceof self) {
+                $next_nesting_level = $current_nesting_level + 1;
+                $input->setNestingLevel($next_nesting_level);
+                $input->setSectionNestingLevelsRecursively($input->getInputs(), $next_nesting_level);
             }
         }
     }

--- a/components/ILIAS/UI/tests/Component/Input/Field/SectionInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/SectionInputTest.php
@@ -109,4 +109,27 @@ class SectionInputTest extends ILIAS_UI_TestBase
         $this->assertStringContainsString('<h3>Middle Section</h3>', $nested_sections_html);
         $this->assertStringContainsString('<h4>Inner Section</h4>', $nested_sections_html);
     }
+
+    public function testNestedSectionInsideGroupRendering(): void
+    {
+        $f = $this->getFieldFactory();
+        $inputs_level6 = [$f->text("input3", "input3 byline")];
+        $section_level6 = $f->section($inputs_level6, "Inner Section");
+
+        $group_level5 = $f->group([$section_level6]);
+
+        $inputs_level4 = [$f->text("input2", "input2 byline"), $group_level5];
+        $section_level4 = $f->section($inputs_level4, "Middle Section");
+
+        $group_level3 = $f->group([$section_level4]);
+
+        $inputs_level2 = [$f->text("input1", "input1 byline"), $group_level3];
+        $section_level2 = $f->section($inputs_level2, "Outermost Section");
+
+        $nested_sections_html = $this->render($section_level2);
+
+        $this->assertStringContainsString('<h2>Outermost Section</h2>', $nested_sections_html);
+        $this->assertStringContainsString('<h3>Middle Section</h3>', $nested_sections_html);
+        $this->assertStringContainsString('<h4>Inner Section</h4>', $nested_sections_html);
+    }
 }


### PR DESCRIPTION
Hi @kergomard,

Thx a lot for your proposal in #10107. While reviewing, I wondered if the initial implementation is actually correct. I had a hard time to understand whats happening due to the not-so-obvious recursion that is happening.

I tried to fix this by (re-)calculating all of the nesting-levels once during construction, instead of each time `setInputs()` is called - which is potentially several times for `Input\Group`s of any kind. The recursion is more obvious now and makes it possible to flatten nested `Input\Group`s which are not a `Field\Section` themselves more easily.

I checked-out your unit tests, so I added you as co-author here too. I leave your PR open until we have merged this, or decide against it.

Kind regards,
@thibsy 