### PR TITLE
Move WOPI administration to File Service

### DIFF
--- a/components/ILIAS/Administration/GlobalScreen/classes/AdministrationMainBarProvider.php
+++ b/components/ILIAS/Administration/GlobalScreen/classes/AdministrationMainBarProvider.php
@@ -226,7 +226,7 @@ class AdministrationMainBarProvider extends AbstractStaticMainMenuProvider
             "search_and_find" =>
                 array("seas", "mds", "taxs"),
             "extending_ilias" =>
-                array('ecss', "ltis", "wbdv", "cmis", "cmps", "extt", 'maps'),
+                array('ecss', "ltis", "wbdv", "cmis", "cmps", 'maps'),
             "legal_regulations" =>
                 array("impr" ,"tos", "accs", 'dpro')
         );

--- a/components/ILIAS/Administration/classes/class.ilObjExternalToolsSettingsGUI.php
+++ b/components/ILIAS/Administration/classes/class.ilObjExternalToolsSettingsGUI.php
@@ -26,7 +26,6 @@ declare(strict_types=1);
  */
 class ilObjExternalToolsSettingsGUI extends ilObjectGUI
 {
-    public const EDIT_WOPI = "editWopi";
     public ilRbacSystem $rbacsystem;
     public ilRbacReview $rbacreview;
 
@@ -52,7 +51,6 @@ class ilObjExternalToolsSettingsGUI extends ilObjectGUI
         $lng->loadLanguageModule("delic");
         $lng->loadLanguageModule("maps");
         $lng->loadLanguageModule("mathjax");
-        $lng->loadLanguageModule("wopi");
     }
 
     public function getAdminTabs(): void
@@ -65,13 +63,6 @@ class ilObjExternalToolsSettingsGUI extends ilObjectGUI
         $rbacsystem = $this->rbacsystem;
 
         $this->ctrl->setParameter($this, "ref_id", $this->object->getRefId());
-
-        if ($rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
-            $this->tabs_gui->addTarget(
-                'wopi_settings',
-                $this->ctrl->getLinkTargetByClass(ilWOPIAdministrationGUI::class)
-            );
-        }
 
         if ($rbacsystem->checkAccess('edit_permission', $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
@@ -94,9 +85,6 @@ class ilObjExternalToolsSettingsGUI extends ilObjectGUI
         }
 
         switch ($next_class) {
-            case strtolower(ilWOPIAdministrationGUI::class):
-                $this->ctrl->forwardCommand(new ilWOPIAdministrationGUI());
-                break;
 
             case 'ilpermissiongui':
                 $perm_gui = new ilPermissionGUI($this);
@@ -104,7 +92,7 @@ class ilObjExternalToolsSettingsGUI extends ilObjectGUI
                 $this->tabs_gui->setTabActive('perm_settings');
                 break;
             default:
-                $this->ctrl->redirectToURL($this->ctrl->getLinkTargetByClass(ilWOPIAdministrationGUI::class));
+                $this->ctrl->redirectToURL($this->ctrl->getLinkTargetByClass(ilPermissionGUI::class, 'perm'));
                 break;
         }
     }

--- a/components/ILIAS/FileServices/classes/class.ilObjFileServicesGUI.php
+++ b/components/ILIAS/FileServices/classes/class.ilObjFileServicesGUI.php
@@ -34,6 +34,7 @@ class ilObjFileServicesGUI extends ilObject2GUI
     protected const TAB_SETTINGS = 'settings';
     protected const TAB_OVERVIEW = 'resource_overview';
     protected const TAB_UPLOAD_LIMITS = 'upload_limits';
+    protected const TAB_WOPI = 'wopi_settings';
 
     protected ilTabsGUI $tabs;
     public ilLanguage $lng;
@@ -59,6 +60,7 @@ class ilObjFileServicesGUI extends ilObject2GUI
         $this->lng = $DIC->language();
         $this->lng->loadLanguageModule('adn');
         $this->lng->loadLanguageModule('irss');
+        $this->lng->loadLanguageModule('wopi');
         $this->ctrl = $DIC['ilCtrl'];
         $this->tpl = $DIC['tpl'];
         $this->tree = $DIC['tree'];
@@ -120,6 +122,11 @@ class ilObjFileServicesGUI extends ilObject2GUI
                 $limits_gui = new ilUploadLimitsOverviewGUI();
                 $this->ctrl->forwardCommand($limits_gui);
                 break;
+            case strtolower(ilWOPIAdministrationGUI::class):
+                $this->tabs_gui->activateTab(self::TAB_WOPI);
+                $wopi_gui = new ilWOPIAdministrationGUI();
+                $this->ctrl->forwardCommand($wopi_gui);
+                break;
             default:
                 if (!$cmd || $cmd === 'view') {
                     $cmd = self::CMD_EDIT_SETTINGS;
@@ -171,6 +178,19 @@ class ilObjFileServicesGUI extends ilObject2GUI
                 $this->ctrl->getLinkTargetByClass(ilUploadLimitsOverviewGUI::class),
             );
         }
+        // WOPI
+        if ($this->rbac_system->checkAccess(
+            "visible,read",
+            $this->object->getRefId()
+        )
+        ) {
+            $this->tabs_gui->addTab(
+                self::TAB_WOPI,
+                $this->lng->txt(self::TAB_WOPI),
+                $this->ctrl->getLinkTargetByClass(ilWOPIAdministrationGUI::class),
+            );
+        }
+
         // Permissions-tab
         if ($this->rbac_system->checkAccess(
             'edit_permission',

--- a/components/ILIAS/WOPI/classes/Administration/class.ilWOPIAdministrationGUI.php
+++ b/components/ILIAS/WOPI/classes/Administration/class.ilWOPIAdministrationGUI.php
@@ -34,7 +34,7 @@ use ILIAS\WOPI\Discovery\Action;
 /**
  * @author            Fabian Schmid <fabian@sr.solutions>
  *
- * @ilCtrl_isCalledBy ilWOPIAdministrationGUI: ilObjExternalToolsSettingsGUI
+ * @ilCtrl_isCalledBy ilWOPIAdministrationGUI: ilObjFileServicesGUI
  */
 class ilWOPIAdministrationGUI
 {
@@ -82,7 +82,7 @@ class ilWOPIAdministrationGUI
     {
         if (!$this->access->checkAccess("read", "", $this->ref_id)) {
             $this->maint_tpl->setOnScreenMessage('failure', $this->lng->txt("permission_denied"), true);
-            $this->ctrl->redirectByClass(ilObjExternalToolsSettingsGUI::class);
+            $this->ctrl->redirectByClass(ilObjFileServicesGUI::class);
         }
 
         $cmd = $this->ctrl->getCmd(self::CMD_DEFAULT);


### PR DESCRIPTION
This PR implements the feature request "Move WOPI administration to File Service":
https://docu.ilias.de/go/wiki/wpage_8760_1357

It just moves the former sub-tab "WOPI" from "Third Party Software" to a new tab "WOPI" of "File Services" in the Administration.