### PR TITLE
T&A 45468: Prevents saving of invalid variable divider in formula question resulting in server crashing

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
@@ -606,18 +606,15 @@ class assFormulaQuestionGUI extends assQuestionGUI
                 }
 
                 $int_precision = $form->getItemByPostVar('intprecision_' . $variable->getVariable());
-                if (
-                    $int_precision instanceof ilFormPropertyGUI
-                    && !$variable->isIntPrecisionValid($int_precision->getValue(), $min_range_value, $max_range_value)
-                ) {
-                    $int_precision->setAlert($this->lng->txt('err_divider_too_big_specific'));
+                if (!$variable->isIntPrecisionValid($int_precision?->getValue(), $min_range_value, $max_range_value)) {
+                    $int_precision?->setAlert($this->lng->txt('err_divider_too_big_specific'));
                     $custom_errors = true;
                     continue;
                 }
 
                 $decimal_spots = $form->getItemByPostVar('precision_' . $variable->getVariable());
                 if ($decimal_spots instanceof ilFormPropertyGUI && $decimal_spots->getValue() === 0) {
-                    $int_precision->setAlert($this->lng->txt('err_division'));
+                    $int_precision?->setAlert($this->lng->txt('err_division'));
                     $custom_errors = true;
                 }
             }

--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
@@ -587,29 +587,36 @@ class assFormulaQuestionGUI extends assQuestionGUI
             $errors = !$form->checkInput();
 
             $custom_errors = false;
+            /** @var $variable assFormulaQuestionVariable */
             foreach ($variables as $variable) {
-                /**
-                 * @var $variable assFormulaQuestionVariable
-                 */
                 $min_range = $form->getItemByPostVar('range_min_' . $variable->getVariable());
                 $max_range = $form->getItemByPostVar('range_max_' . $variable->getVariable());
-                if ($min_range->getValue() > $max_range->getValue()) {
-                    $min_range->setAlert($this->lng->txt('err_range'));
-                    $max_range->setAlert($this->lng->txt('err_range'));
+                $min_range_value = $min_range?->getValue();
+                $max_range_value = $max_range?->getValue();
+
+                if ($min_range_value === null || $max_range_value === null) {
+                    $custom_errors = true;
+                    continue;
+                }
+
+                if ($min_range_value > $max_range_value) {
+                    $min_range?->setAlert($this->lng->txt('err_range'));
+                    $max_range?->setAlert($this->lng->txt('err_range'));
                     $custom_errors = true;
                 }
+
                 $int_precision = $form->getItemByPostVar('intprecision_' . $variable->getVariable());
-                if (!$variable->isIntPrecisionValid($int_precision->getValue(), $min_range->getValue(), $max_range->getValue())) {
+                if (
+                    $int_precision instanceof ilFormPropertyGUI
+                    && !$variable->isIntPrecisionValid($int_precision->getValue(), $min_range_value, $max_range_value)
+                ) {
                     $int_precision->setAlert($this->lng->txt('err_divider_too_big_specific'));
                     $custom_errors = true;
                     continue;
                 }
+
                 $decimal_spots = $form->getItemByPostVar('precision_' . $variable->getVariable());
-                if (
-                    $decimal_spots->getValue() === 0
-                    && $min_range->getValue() !== null
-                    && $max_range->getValue() !== null
-                ) {
+                if ($decimal_spots instanceof ilFormPropertyGUI && $decimal_spots->getValue() === 0) {
                     $int_precision->setAlert($this->lng->txt('err_division'));
                     $custom_errors = true;
                 }

--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
@@ -192,6 +192,9 @@ class assFormulaQuestionGUI extends assQuestionGUI
     public function editQuestion($checkonly = false, string $suggest_range_for_result = ''): bool
     {
         $save = $this->isSaveCommand();
+        if ($save) {
+            $this->writePostData(true);
+        }
 
         $this->getQuestionTemplate();
 
@@ -584,32 +587,31 @@ class assFormulaQuestionGUI extends assQuestionGUI
             $errors = !$form->checkInput();
 
             $custom_errors = false;
-            if (count($variables)) {
-                foreach ($variables as $variable) {
-                    /**
-                     * @var $variable assFormulaQuestionVariable
-                     */
-                    $min_range = $form->getItemByPostVar('range_min_' . $variable->getVariable());
-                    $max_range = $form->getItemByPostVar('range_max_' . $variable->getVariable());
-                    if ($min_range->getValue() > $max_range->getValue()) {
-                        $min_range->setAlert($this->lng->txt('err_range'));
-                        $max_range->setAlert($this->lng->txt('err_range'));
-                        $custom_errors = true;
-                    }
-                    $intPrecision = $form->getItemByPostVar('intprecision_' . $variable->getVariable());
-                    $decimal_spots = $form->getItemByPostVar('precision_' . $variable->getVariable());
-                    if ($decimal_spots->getValue() == 0
-                        && $min_range->getValue() !== null
-                        && $max_range->getValue() !== null
-                        && !$variable->isIntPrecisionValid(
-                            $intPrecision->getValue(),
-                            $min_range->getValue(),
-                            $max_range->getValue()
-                        )
-                    ) {
-                        $intPrecision->setAlert($this->lng->txt('err_division'));
-                        $custom_errors = true;
-                    }
+            foreach ($variables as $variable) {
+                /**
+                 * @var $variable assFormulaQuestionVariable
+                 */
+                $min_range = $form->getItemByPostVar('range_min_' . $variable->getVariable());
+                $max_range = $form->getItemByPostVar('range_max_' . $variable->getVariable());
+                if ($min_range->getValue() > $max_range->getValue()) {
+                    $min_range->setAlert($this->lng->txt('err_range'));
+                    $max_range->setAlert($this->lng->txt('err_range'));
+                    $custom_errors = true;
+                }
+                $int_precision = $form->getItemByPostVar('intprecision_' . $variable->getVariable());
+                if (!$variable->isIntPrecisionValid($int_precision->getValue(), $min_range->getValue(), $max_range->getValue())) {
+                    $int_precision->setAlert($this->lng->txt('err_divider_too_big_specific'));
+                    $custom_errors = true;
+                    continue;
+                }
+                $decimal_spots = $form->getItemByPostVar('precision_' . $variable->getVariable());
+                if (
+                    $decimal_spots->getValue() === 0
+                    && $min_range->getValue() !== null
+                    && $max_range->getValue() !== null
+                ) {
+                    $int_precision->setAlert($this->lng->txt('err_division'));
+                    $custom_errors = true;
                 }
             }
 

--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestionVariable.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestionVariable.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -41,49 +42,39 @@ class assFormulaQuestionVariable
         $this->setRangeMax($range_max_txt);
     }
 
-    public function getRandomValue()
+    public function getRandomValue(): float
     {
-        if ($this->getPrecision() === 0
-            && !$this->isIntPrecisionValid(
-                $this->getIntprecision(),
-                $this->getRangeMin(),
-                $this->getRangeMax()
-            )
+        if (
+            $this->getPrecision() === 0
+            && !$this->isIntPrecisionValid($this->getIntprecision(), $this->getRangeMin(), $this->getRangeMax())
         ) {
             global $DIC;
-            $lng = $DIC['lng'];
-            $DIC->ui()->mainTemplate()->setOnScreenMessage(
-                "failure",
-                $lng->txt('err_divider_too_big')
-            );
+            $DIC->ui()->mainTemplate()->setOnScreenMessage('failure', $DIC->language()->txt('err_divider_too_big'));
+            return 0.0;
         }
 
         $mul = ilMath::_pow(10, $this->getPrecision());
-        $r1 = round((float)ilMath::_mul($this->getRangeMin(), $mul));
+        $r1 = round((float) ilMath::_mul($this->getRangeMin(), $mul));
         $r2 = round((float) ilMath::_mul($this->getRangeMax(), $mul));
-        $calcval = $this->getRangeMin() - 1;
-        //test
+        $calc_val = $this->getRangeMin() - 1;
 
-        $roundedRangeMIN = round($this->getRangeMin(), $this->getPrecision());
-        $roundedRangeMAX = round($this->getRangeMax(), $this->getPrecision());
-        while ($calcval < $roundedRangeMIN || $calcval > $roundedRangeMAX) {
-            //		while($calcval < $this->getRangeMin() || $calcval > $this->getRangeMax())
-            $rnd = mt_rand((int) $r1, (int) $r2);
-            $calcval = ilMath::_div($rnd, $mul, $this->getPrecision());
-            if (($this->getPrecision() == 0) && ($this->getIntprecision() != 0)) {
-                if ($this->getIntprecision() > 0) {
-                    $modulo = $calcval % $this->getIntprecision();
-                    if ($modulo != 0) {
-                        if ($modulo < ilMath::_div($this->getIntprecision(), 2)) {
-                            $calcval = ilMath::_sub($calcval, $modulo, $this->getPrecision());
-                        } else {
-                            $calcval = ilMath::_add($calcval, ilMath::_sub($this->getIntprecision(), $modulo, $this->getPrecision()), $this->getPrecision());
-                        }
-                    }
+        $rounded_range_min = round($this->getRangeMin(), $this->getPrecision());
+        $rounded_range_max = round($this->getRangeMax(), $this->getPrecision());
+        while ($calc_val < $rounded_range_min || $calc_val > $rounded_range_max) {
+            $rnd = random_int((int) $r1, (int) $r2);
+            $calc_val = (float) ilMath::_div($rnd, $mul, $this->getPrecision());
+
+            if ($this->getPrecision() === 0 && $this->getIntprecision() > 0) {
+                $modulo = $calc_val % $this->getIntprecision();
+                if ($modulo !== 0) {
+                    $calc_val = $modulo < ilMath::_div($this->getIntprecision(), 2)
+                        ? (float) ilMath::_sub($calc_val, $modulo, $this->getPrecision())
+                        : (float) ilMath::_add($calc_val, ilMath::_sub($this->getIntprecision(), $modulo, $this->getPrecision()), $this->getPrecision());
                 }
             }
         }
-        return $calcval;
+
+        return (float) $calc_val;
     }
 
     public function setRandomValue(): void
@@ -91,18 +82,9 @@ class assFormulaQuestionVariable
         $this->setValue($this->getRandomValue());
     }
 
-    public function isIntPrecisionValid(?int $int_precision, float $min_range, float $max_range)
+    public function isIntPrecisionValid(?int $int_precision, float $min_range, float $max_range): bool
     {
-        if ($int_precision === null) {
-            return false;
-        }
-        $min_abs = abs($min_range);
-        $max_abs = abs($max_range);
-        $bigger_abs = $max_abs > $min_abs ? $max_abs : $min_abs;
-        if ($int_precision > $bigger_abs) {
-            return false;
-        }
-        return true;
+        return is_int($int_precision) && $int_precision <= max(abs($max_range), abs($min_range));
     }
 
     /************************************

--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestionVariable.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestionVariable.php
@@ -46,17 +46,21 @@ class assFormulaQuestionVariable
     {
         if (
             $this->getPrecision() === 0
-            && !$this->isIntPrecisionValid($this->getIntprecision(), $this->getRangeMin(), $this->getRangeMax())
+            && !$this->isIntPrecisionValid(
+                $this->getIntprecision(),
+                $this->getRangeMin(),
+                $this->getRangeMax()
+            )
         ) {
             global $DIC;
-            $DIC->ui()->mainTemplate()->setOnScreenMessage('failure', $DIC->language()->txt('err_divider_too_big'));
+            $DIC['tpl']->setOnScreenMessage('failure', $DIC['lng']->txt('err_divider_too_big'));
             return 0.0;
         }
 
         $mul = ilMath::_pow(10, $this->getPrecision());
         $r1 = round((float) ilMath::_mul($this->getRangeMin(), $mul));
         $r2 = round((float) ilMath::_mul($this->getRangeMax(), $mul));
-        $calc_val = $this->getRangeMin() - 1;
+        $calc_val = $this->getRangeMin() - 1.0;
 
         $rounded_range_min = round($this->getRangeMin(), $this->getPrecision());
         $rounded_range_max = round($this->getRangeMax(), $this->getPrecision());
@@ -74,7 +78,7 @@ class assFormulaQuestionVariable
             }
         }
 
-        return (float) $calc_val;
+        return $calc_val;
     }
 
     public function setRandomValue(): void
@@ -84,7 +88,8 @@ class assFormulaQuestionVariable
 
     public function isIntPrecisionValid(?int $int_precision, float $min_range, float $max_range): bool
     {
-        return is_int($int_precision) && $int_precision <= max(abs($max_range), abs($min_range));
+        $max = max(abs($max_range), abs($min_range));
+        return $int_precision !== null && $int_precision <= $max;
     }
 
     /************************************

--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestionVariable.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestionVariable.php
@@ -88,8 +88,7 @@ class assFormulaQuestionVariable
 
     public function isIntPrecisionValid(?int $int_precision, float $min_range, float $max_range): bool
     {
-        $max = max(abs($max_range), abs($min_range));
-        return $int_precision !== null && $int_precision <= $max;
+        return $int_precision !== null && $int_precision <= max(abs($max_range), abs($min_range));
     }
 
     /************************************

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -649,6 +649,7 @@ assessment#:#errFormulaQuestion#:#Eine Formelfrage enthält fehlerhafte Angaben
 assessment#:#errRecursionInResult#:#Die Formel enthält eine nicht auflösbare Rekursion.
 assessment#:#err_category_in_use#:#Die Kategorie kann nicht gelöscht werden. Eine oder mehrere Einheiten der Kategorie sind bereits in Benutzung.
 assessment#:#err_divider_too_big#:#Der Teiler einer der Variablen in dieser Frage ist zu gross.
+assessment#:#err_divider_too_big_specific#:#Der Teiler dieser Variable ist zu gross.
 assessment#:#err_division#:#Der von Ihnen gesetzte Wert macht es unmöglich einen gültigen Wert für die Variable zu generieren.
 assessment#:#err_duplicate_results#:#Sie haben eine Ergebnisvariable mehrfach verwendet. Das ist innerhalb des Aufgabentextes nicht erlaubt!
 assessment#:#err_no_formula#:#Bitte geben Sie eine Formel zur Berechnung des Ergebnisses an.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -649,6 +649,7 @@ assessment#:#errFormulaQuestion#:#A Formula Question contains incorrect informat
 assessment#:#errRecursionInResult#:#The formula contains an infinite recursion.
 assessment#:#err_category_in_use#:#At least one category cannot be deleted. One or more units of the category are already in use.
 assessment#:#err_divider_too_big#:#The divider of one of the variables in this question is too big.
+assessment#:#err_divider_too_big_specific#:#The divider of this variable is too big.
 assessment#:#err_division#:#The value you chose would make it impossible to generate a valid value for the variable.
 assessment#:#err_duplicate_results#:#You used a result variable more than once. This is not allowed in the question text.
 assessment#:#err_no_formula#:#You must enter a formula


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45468

Aims to fix prevention of saving of invalid variable divider in formula question resulting in server crashing.

Already reviewed by @thojou.