### PR TITLE
T&A 23367: Fixes Import of Specific Feedback in Matching Question when ILIAS Page Editor (IPE) is used

### DIFF
--- a/Modules/TestQuestionPool/classes/import/qti12/class.assMatchingQuestionImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assMatchingQuestionImport.php
@@ -180,6 +180,11 @@ class assMatchingQuestionImport extends assQuestionImport
             }
         }
 
+        // additional content editing mode information
+        $this->object->setAdditionalContentEditingMode(
+            $this->fetchAdditionalContentEditingModeInformation($item)
+        );
+
         $this->object->createNewQuestion();
         $this->addGeneralMetadata($item);
         $this->object->setTitle($item->getTitle());
@@ -237,10 +242,7 @@ class assMatchingQuestionImport extends assQuestionImport
             }
             $this->object->addMatchingPair(new assAnswerMatchingTerm('', '', (float) $term["ident"]), new assAnswerMatchingDefinition('', '', (int) $definition["answerorder"]), (float) $response['points']);
         }
-        // additional content editing mode information
-        $this->object->setAdditionalContentEditingMode(
-            $this->fetchAdditionalContentEditingModeInformation($item)
-        );
+
         $this->object->saveToDb();
         $this->importSuggestedSolutions($this->object->getId(), $item->suggested_solutions);
         foreach ($responses as $response) {


### PR DESCRIPTION
This PR attempts to solve https://mantis.ilias.de/view.php?id=23367.

Fixes content editing mode not being set when importing QPL, resulting in Page Editor Feedback not being shown.

Kind Regards,
@bidzanaaron 