### PR TITLE
[DataCollection] Media error: Format(s) not supported or source(s) not found on uppercase file suffixes 

### DIFF
--- a/Modules/DataCollection/classes/Fields/Mob/class.ilDclMobRecordRepresentation.php
+++ b/Modules/DataCollection/classes/Fields/Mob/class.ilDclMobRecordRepresentation.php
@@ -70,7 +70,7 @@ class ilDclMobRecordRepresentation extends ilDclFileRecordRepresentation
 
         $components = [];
 
-        if (in_array($med->getSuffix(), ['jpg', 'jpeg', 'png', 'gif'])) {
+        if (in_array(strtolower($med->getSuffix()), ['jpg', 'jpeg', 'png', 'gif'])) {
             // Image
             $dir = ilObjMediaObject::_getDirectory($mob->getId());
 
@@ -87,7 +87,7 @@ class ilDclMobRecordRepresentation extends ilDclFileRecordRepresentation
             $components[] = $image;
         } else {
             $location = ilObjMediaObject::_getURL($mob->getId()) . "/" . $med->getLocation();
-            if ($med->getSuffix() == 'mp3') {
+            if (strtolower($med->getSuffix()) == 'mp3') {
                 $components[] = $this->factory->player()->audio($location);
             } else {
                 $components[] = $this->factory->player()->video($location);


### PR DESCRIPTION
Add strtolower for a case insensitive media file suffix recognition. Images or audios with MP3, JPEG, PNG are not recognised as such otherwise.