### PR TITLE
Remove "visible" permission from administration nodes

### DIFF
--- a/components/ILIAS/AccessControl/classes/class.ilObjRoleFolderGUI.php
+++ b/components/ILIAS/AccessControl/classes/class.ilObjRoleFolderGUI.php
@@ -153,7 +153,7 @@ class ilObjRoleFolderGUI extends ilObjectGUI
     {
         $this->tabs_gui->activateTab('view');
 
-        if (!$this->rbac_system->checkAccess('visible,read', $this->object->getRefId())) {
+        if (!$this->rbac_system->checkAccess('read', $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('permission_denied'), $this->error->MESSAGE);
         }
 
@@ -207,7 +207,7 @@ class ilObjRoleFolderGUI extends ilObjectGUI
             $this->ctrl->getLinkTarget($this, 'view')
         );
 
-        if (!$this->rbac_system->checkAccess('visible,read', $this->object->getRefId())) {
+        if (!$this->rbac_system->checkAccess('read', $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('permission_denied'), $this->error->MESSAGE);
         }
 
@@ -714,7 +714,7 @@ class ilObjRoleFolderGUI extends ilObjectGUI
      */
     public function getAdminTabs(): void
     {
-        if ($this->checkPermissionBool("visible,read")) {
+        if ($this->checkPermissionBool("read")) {
             $this->tabs_gui->addTarget(
                 "view",
                 $this->ctrl->getLinkTarget($this, "view"),

--- a/components/ILIAS/Administration/GlobalScreen/classes/AdministrationMainBarProvider.php
+++ b/components/ILIAS/Administration/GlobalScreen/classes/AdministrationMainBarProvider.php
@@ -85,7 +85,7 @@ class AdministrationMainBarProvider extends AbstractStaticMainMenuProvider
                         ->withAction($action)
                         ->withSymbol($icon)
                         ->withVisibilityCallable(function () use ($ref_id) {
-                            return $this->dic->rbac()->system()->checkAccess('visible,read', (int) $ref_id);
+                            return $this->dic->rbac()->system()->checkAccess('read', (int) $ref_id);
                         });
                 }
 

--- a/components/ILIAS/Administration/classes/Setup/class.AdminNodesVisibilityRemovedObjective.php
+++ b/components/ILIAS/Administration/classes/Setup/class.AdminNodesVisibilityRemovedObjective.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Administration\Setup;
+
+use ILIAS\Setup\Environment;
+use ilIniFilesLoadedObjective;
+use ilDatabaseInitializedObjective;
+use ilIniFile;
+use ilDBInterface;
+use ilAccessRBACOperationDeletedObjective;
+use ILIAS\Setup\Objective;
+
+class AdminNodesVisibilityRemovedObjective implements Objective
+{
+    /** @var int @see \ilTreeAdminNodeAddedObjective::RBAC_OP_VISIBLE */
+    private const int RBAC_OP_VISIBLE = 2;
+
+    public function getHash(): string
+    {
+        return hash("sha256", self::class);
+    }
+
+    public function getLabel(): string
+    {
+        return "Remove visibility permissions from admin nodes";
+    }
+
+    public function isNotable(): bool
+    {
+        return true;
+    }
+
+    public function getPreconditions(Environment $environment): array
+    {
+        return [
+            new ilIniFilesLoadedObjective(),
+            new ilDatabaseInitializedObjective()
+        ];
+    }
+
+    public function achieve(Environment $environment): Environment
+    {
+        foreach ($this->getTypesToChange($environment) as $type) {
+            $objective = new ilAccessRBACOperationDeletedObjective($type, self::RBAC_OP_VISIBLE);
+            $objective->achieve($environment);
+        }
+        return $environment;
+    }
+
+    public function isApplicable(Environment $environment): bool
+    {
+        return !empty($this->getTypesToChange($environment));
+    }
+
+    /**
+     * Get the types of admin nodes where the visible permission needs to be removed
+     * @return string[]
+     */
+    private function getTypesToChange(Environment $environment): array
+    {
+        $client_ini = $environment->getResource(Environment::RESOURCE_CLIENT_INI);
+        $db = $environment->getResource(Environment::RESOURCE_DATABASE);
+
+        $folder_id = (int) $client_ini->readVariable('system', 'SYSTEM_FOLDER_ID');
+        if (!$folder_id) {
+            return [];
+        }
+
+        // get all types of admin nodes where the visible permission is still defined
+        // exclude the user folder which gets a special treatment in a separate objective
+        // exclude org units to keep the info screen of subunits visible without read access
+        $query = "
+            SELECT d1.`type`
+            FROM tree t
+            JOIN object_reference r ON r.ref_id = t.child
+            JOIN object_data d1 ON d1.obj_id = r.obj_id
+            JOIN object_data d2 ON d2.`type` = 'typ' AND d2.title = d1.`type`
+            JOIN rbac_ta a ON a.typ_id = d2.obj_id AND a.ops_id = %s
+            WHERE t.parent = %s
+            AND d1.`type` <> 'usrf'
+            AND d1.`type` <> 'orgu'
+            ORDER BY  d1.`type`
+        ";
+
+        $result = $db->queryF($query, ['integer', 'integer'], [self::RBAC_OP_VISIBLE, $folder_id]);
+
+        $types = [];
+        foreach ($db->fetchAll($result) as $row) {
+            $types[] = (string) $row['type'];
+        }
+        return $types;
+    }
+}

--- a/components/ILIAS/Administration/classes/Setup/class.ilAdministrationSetupAgent.php
+++ b/components/ILIAS/Administration/classes/Setup/class.ilAdministrationSetupAgent.php
@@ -44,7 +44,8 @@ class ilAdministrationSetupAgent extends NullAgent
             true,
             new ilDatabaseUpdateStepsExecutedObjective(new ilAdministrationDBUpdateSteps()),
             new ilTreeAdminNodeAddedObjective(ilObjGeneralSettings::TYPE, 'General Settings'),
-            new ilTreeAdminNodeAddedObjective(ilObjServerInfo::TYPE, 'Server Info')
+            new ilTreeAdminNodeAddedObjective(ilObjServerInfo::TYPE, 'Server Info'),
+            new AdminNodesVisibilityRemovedObjective()
         );
     }
 

--- a/components/ILIAS/Administration/classes/class.ilObjExternalToolsSettingsGUI.php
+++ b/components/ILIAS/Administration/classes/class.ilObjExternalToolsSettingsGUI.php
@@ -80,7 +80,7 @@ class ilObjExternalToolsSettingsGUI extends ilObjectGUI
         $cmd = $this->ctrl->getCmd();
         $this->prepareOutput();
 
-        if (!$this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess("read", $this->object->getRefId())) {
             $this->ilias->raiseError($this->lng->txt("permission_denied"), $this->ilias->error_obj->MESSAGE);
         }
 

--- a/components/ILIAS/AdministrativeNotification/classes/class.ilObjAdministrativeNotificationGUI.php
+++ b/components/ILIAS/AdministrativeNotification/classes/class.ilObjAdministrativeNotificationGUI.php
@@ -53,7 +53,7 @@ class ilObjAdministrativeNotificationGUI extends ilObject2GUI
     #[\Override]
     public function executeCommand(): void
     {
-        $this->admin_notification_access->checkAccessAndThrowException("visible,read");
+        $this->admin_notification_access->checkAccessAndThrowException("read");
 
         $next_class = $this->ctrl->getNextClass();
 

--- a/components/ILIAS/Authentication/classes/class.ilObjAuthSettingsGUI.php
+++ b/components/ILIAS/Authentication/classes/class.ilObjAuthSettingsGUI.php
@@ -64,7 +64,7 @@ class ilObjAuthSettingsGUI extends ilObjectGUI
         ?ILIAS\UI\Component\Input\Container\Form\Form $auth_mode_determination_form = null,
         ?ILIAS\UI\Component\Input\Container\Form\Form $registration_role_mapping_form = null
     ): void {
-        if (!$this->rbac_system->checkAccess('visible,read', $this->object->getRefId())) {
+        if (!$this->rbac_system->checkAccess('read', $this->object->getRefId())) {
             $this->ilias->raiseError($this->lng->txt('permission_denied'), $this->ilias->error_obj->MESSAGE);
         }
 
@@ -848,7 +848,7 @@ class ilObjAuthSettingsGUI extends ilObjectGUI
         $cmd = $this->ctrl->getCmd() ?? '';
         $this->prepareOutput();
 
-        if (!$this->rbac_system->checkAccess('visible,read', $this->object->getRefId())) {
+        if (!$this->rbac_system->checkAccess('read', $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('msg_no_perm_read'), $this->error->WARNING);
         }
 
@@ -948,7 +948,7 @@ class ilObjAuthSettingsGUI extends ilObjectGUI
     {
         $this->ctrl->setParameter($this, 'ref_id', $this->object->getRefId());
 
-        if ($this->rbac_system->checkAccess('visible,read', $this->object->getRefId())) {
+        if ($this->rbac_system->checkAccess('read', $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 'authentication_settings',
                 $this->ctrl->getLinkTarget($this, 'authSettings'),

--- a/components/ILIAS/Awareness/Administration/class.ilObjAwarenessAdministrationGUI.php
+++ b/components/ILIAS/Awareness/Administration/class.ilObjAwarenessAdministrationGUI.php
@@ -89,7 +89,7 @@ class ilObjAwarenessAdministrationGUI extends ilObjectGUI
     {
         $rbacsystem = $this->rbacsystem;
 
-        if ($rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($rbacsystem->checkAccess("read", $this->object->getRefId())) {
             $this->tabs_gui->addTab(
                 "settings",
                 $this->lng->txt("settings"),

--- a/components/ILIAS/Badge/classes/class.ilObjBadgeAdministrationGUI.php
+++ b/components/ILIAS/Badge/classes/class.ilObjBadgeAdministrationGUI.php
@@ -134,7 +134,7 @@ class ilObjBadgeAdministrationGUI extends ilObjectGUI implements ilCtrlSecurityI
     {
         $rbacsystem = $this->rbacsystem;
 
-        if ($rbacsystem->checkAccess('visible,read', $this->object->getRefId())) {
+        if ($rbacsystem->checkAccess('read', $this->object->getRefId())) {
             $this->tabs_gui->addTab(
                 'settings',
                 $this->lng->txt('settings'),

--- a/components/ILIAS/Bibliographic/classes/class.ilObjBibliographicAdminGUI.php
+++ b/components/ILIAS/Bibliographic/classes/class.ilObjBibliographicAdminGUI.php
@@ -114,7 +114,7 @@ class ilObjBibliographicAdminGUI extends ilObjectGUI
             ], ilBiblAdminRisFieldGUI::CMD_STANDARD));
         }
 
-        if ($rbacsystem->checkAccess('visible,read', $this->object->getRefId())) {
+        if ($rbacsystem->checkAccess('read', $this->object->getRefId())) {
             $this->tabs_gui->addTab(self::TAB_SETTINGS, $this->lng->txt('settings'), $this->ctrl->getLinkTargetByClass([
                 ilObjBibliographicAdminGUI::class,
                 ilBiblLibraryGUI::class,

--- a/components/ILIAS/Blog/Administration/class.ilObjBlogAdministrationGUI.php
+++ b/components/ILIAS/Blog/Administration/class.ilObjBlogAdministrationGUI.php
@@ -70,7 +70,7 @@ class ilObjBlogAdministrationGUI extends ilObjectGUI
 
     public function getAdminTabs(): void
     {
-        if ($this->checkPermissionBool("visible,read")) {
+        if ($this->checkPermissionBool("read")) {
             $this->tabs_gui->addTarget(
                 "settings",
                 $this->ctrl->getLinkTarget($this, "editSettings"),

--- a/components/ILIAS/COPage/Administration/class.ilObjAdvancedEditingGUI.php
+++ b/components/ILIAS/COPage/Administration/class.ilObjAdvancedEditingGUI.php
@@ -133,7 +133,7 @@ class ilObjAdvancedEditingGUI extends ilObjectGUI
 
     protected function getTabs(): void
     {
-        if ($this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($this->rbac_system->checkAccess("read", $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 "adve_page_editor_settings",
                 $this->ctrl->getLinkTarget($this, "showGeneralPageEditorSettings"),

--- a/components/ILIAS/Calendar/classes/class.ilObjCalendarSettingsGUI.php
+++ b/components/ILIAS/Calendar/classes/class.ilObjCalendarSettingsGUI.php
@@ -50,7 +50,7 @@ class ilObjCalendarSettingsGUI extends ilObjectGUI
 
         $this->prepareOutput();
 
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbac_system->checkAccess("read", $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('no_permission'), $this->error->WARNING);
         }
 
@@ -94,7 +94,7 @@ class ilObjCalendarSettingsGUI extends ilObjectGUI
 
     public function settings(?ilPropertyFormGUI $form = null): void
     {
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbac_system->checkAccess("read", $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('no_permission'), $this->error->WARNING);
         }
         $this->tabs_gui->setTabActive('settings');

--- a/components/ILIAS/Certificate/classes/class.ilObjCertificateSettingsGUI.php
+++ b/components/ILIAS/Certificate/classes/class.ilObjCertificateSettingsGUI.php
@@ -117,7 +117,7 @@ class ilObjCertificateSettingsGUI extends ilObjectGUI
             );
         }
 
-        if ($this->rbac_system->checkAccess('visible,read', $this->object->getRefId())) {
+        if ($this->rbac_system->checkAccess('read', $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 'settings',
                 $this->ctrl->getLinkTarget($this, 'settings'),

--- a/components/ILIAS/Component/classes/Settings/class.ilObjComponentSettingsGUI.php
+++ b/components/ILIAS/Component/classes/Settings/class.ilObjComponentSettingsGUI.php
@@ -315,7 +315,7 @@ class ilObjComponentSettingsGUI extends ilObjectGUI implements ilCtrlSecurityInt
 
     public function getAdminTabs(): void
     {
-        if ($this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($this->rbac_system->checkAccess("read", $this->object->getRefId())) {
             $this->tabs_gui->addTab(
                 self::TAB_PLUGINS,
                 $this->lng->txt("cmps_plugins"),

--- a/components/ILIAS/Contact/classes/class.ilObjContactAdministrationGUI.php
+++ b/components/ILIAS/Contact/classes/class.ilObjContactAdministrationGUI.php
@@ -135,7 +135,7 @@ class ilObjContactAdministrationGUI extends ilObject2GUI
 
     protected function showConfigurationForm(?StandardForm $form = null): void
     {
-        if (!$this->rbac_system->checkAccess('visible,read', $this->object->getRefId())) {
+        if (!$this->rbac_system->checkAccess('read', $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('no_permission'), $this->error->WARNING);
         }
 

--- a/components/ILIAS/ContentPage/classes/class.ilObjContentPageAdministrationGUI.php
+++ b/components/ILIAS/ContentPage/classes/class.ilObjContentPageAdministrationGUI.php
@@ -51,7 +51,7 @@ class ilObjContentPageAdministrationGUI extends ilObjectGUI
 
     public function getAdminTabs(): void
     {
-        if ($this->rbac_system->checkAccess('visible,read', $this->object->getRefId())) {
+        if ($this->rbac_system->checkAccess('read', $this->object->getRefId())) {
             $this->tabs_gui->addTarget('settings', $this->ctrl->getLinkTargetByClass(self::class, self::CMD_EDIT));
         }
 
@@ -67,7 +67,7 @@ class ilObjContentPageAdministrationGUI extends ilObjectGUI
 
     public function executeCommand(): void
     {
-        if (!$this->rbac_system->checkAccess('visible,read', $this->object->getRefId())) {
+        if (!$this->rbac_system->checkAccess('read', $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('no_permission'), $this->error->WARNING);
         }
 

--- a/components/ILIAS/Dashboard/Administration/classes/class.ilObjDashboardSettingsGUI.php
+++ b/components/ILIAS/Dashboard/Administration/classes/class.ilObjDashboardSettingsGUI.php
@@ -83,7 +83,7 @@ class ilObjDashboardSettingsGUI extends ilObjectGUI
 
         $this->prepareOutput();
 
-        if (!$this->rbac_system->checkAccess('visible,read', $this->object->getRefId())) {
+        if (!$this->rbac_system->checkAccess('read', $this->object->getRefId())) {
             throw new ilPermissionException($this->lng->txt('no_permission'));
         }
 
@@ -121,7 +121,7 @@ class ilObjDashboardSettingsGUI extends ilObjectGUI
 
     public function getAdminTabs(): void
     {
-        if ($this->rbac_system->checkAccess('visible,read', $this->object->getRefId())) {
+        if ($this->rbac_system->checkAccess('read', $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 'settings',
                 $this->ctrl->getLinkTarget($this, 'editSettings'),
@@ -265,7 +265,7 @@ class ilObjDashboardSettingsGUI extends ilObjectGUI
         $ctrl = $this->ctrl;
         $lng = $this->lng;
 
-        if ($this->rbac_system->checkAccess('visible,read', $this->object->getRefId())) {
+        if ($this->rbac_system->checkAccess('read', $this->object->getRefId())) {
             $tabs->addSubTab(
                 'general',
                 $lng->txt('general_settings'),

--- a/components/ILIAS/EmployeeTalk/classes/class.ilObjTalkTemplateAdministrationGUI.php
+++ b/components/ILIAS/EmployeeTalk/classes/class.ilObjTalkTemplateAdministrationGUI.php
@@ -155,11 +155,6 @@ final class ilObjTalkTemplateAdministrationGUI extends ilContainerGUI
         $this->tabs_gui->activateTab('view_content');
 
         if (!$this->rbacsystem->checkAccess("read", $this->getRefId())) {
-            if ($this->rbacsystem->checkAccess("visible", $this->getRefId())) {
-                $this->tpl->setOnScreenMessage('failure', $this->lng->txt("msg_no_perm_read"));
-                $this->ctrl->redirectByClass(strtolower(ilInfoScreenGUI::class), '');
-            }
-
             $this->ilias->raiseError($this->lng->txt("msg_no_perm_read"), $this->ilias->error_obj->WARNING);
         }
 
@@ -205,7 +200,7 @@ final class ilObjTalkTemplateAdministrationGUI extends ilContainerGUI
 
     protected function getTabs(): void
     {
-        $read_access_ref_id = $this->rbacsystem->checkAccess('visible,read', $this->object->getRefId());
+        $read_access_ref_id = $this->rbacsystem->checkAccess('read', $this->object->getRefId());
         if ($read_access_ref_id) {
             $this->tabs_gui->addTab('view_content', $this->lng->txt("content"), $this->ctrl->getLinkTarget($this, "view"));
             $this->tabs_gui->addTab(

--- a/components/ILIAS/Exercise/classes/class.ilObjExerciseAdministrationGUI.php
+++ b/components/ILIAS/Exercise/classes/class.ilObjExerciseAdministrationGUI.php
@@ -65,7 +65,7 @@ class ilObjExerciseAdministrationGUI extends ilObjectGUI
 
     public function getAdminTabs(): void
     {
-        if ($this->checkPermissionBool("visible,read")) {
+        if ($this->checkPermissionBool("read")) {
             $this->tabs_gui->addTarget(
                 "settings",
                 $this->ctrl->getLinkTarget($this, "editSettings"),

--- a/components/ILIAS/File/classes/class.ilObjFileAccessSettingsGUI.php
+++ b/components/ILIAS/File/classes/class.ilObjFileAccessSettingsGUI.php
@@ -133,7 +133,7 @@ class ilObjFileAccessSettingsGUI extends ilObjectGUI
     #[\Override]
     public function getAdminTabs(): void
     {
-        if ($this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($this->rbac_system->checkAccess("read", $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 'file_objects',
                 $this->ctrl->getLinkTarget($this, self::CMD_EDIT_SETTINGS),

--- a/components/ILIAS/FileServices/classes/class.ilObjFileServicesGUI.php
+++ b/components/ILIAS/FileServices/classes/class.ilObjFileServicesGUI.php
@@ -144,7 +144,7 @@ class ilObjFileServicesGUI extends ilObject2GUI
     {
         // General Settings for File-Services
         if ($this->rbac_system->checkAccess(
-            "visible,read",
+            "read",
             $this->object->getRefId()
         )
         ) {
@@ -156,7 +156,7 @@ class ilObjFileServicesGUI extends ilObject2GUI
         }
         // Resource-Overview
         if ($this->rbac_system->checkAccess(
-            "visible,read",
+            "read",
             $this->object->getRefId()
         )
         ) {
@@ -168,7 +168,7 @@ class ilObjFileServicesGUI extends ilObject2GUI
         }
         // Upload-Limit
         if ($this->rbac_system->checkAccess(
-            "visible,read",
+            "read",
             $this->object->getRefId()
         )
         ) {
@@ -180,7 +180,7 @@ class ilObjFileServicesGUI extends ilObject2GUI
         }
         // WOPI
         if ($this->rbac_system->checkAccess(
-            "visible,read",
+            "read",
             $this->object->getRefId()
         )
         ) {
@@ -279,7 +279,7 @@ class ilObjFileServicesGUI extends ilObject2GUI
     {
         $this->tabs_gui->setTabActive(self::TAB_SETTINGS);
 
-        $this->checkPermissionOrFail("visible,read");
+        $this->checkPermissionOrFail("read");
 
         // get form
         $form = $this->initSettingsForm();

--- a/components/ILIAS/Forum/classes/class.ilObjForumAdministrationGUI.php
+++ b/components/ILIAS/Forum/classes/class.ilObjForumAdministrationGUI.php
@@ -55,7 +55,7 @@ class ilObjForumAdministrationGUI extends ilObjectGUI
 
     public function executeCommand(): void
     {
-        if (!$this->rbac_system->checkAccess('visible,read', $this->object->getRefId())) {
+        if (!$this->rbac_system->checkAccess('read', $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('no_permission'), $this->error->WARNING);
         }
 
@@ -82,7 +82,7 @@ class ilObjForumAdministrationGUI extends ilObjectGUI
 
     public function getAdminTabs(): void
     {
-        if ($this->rbac_system->checkAccess('visible,read', $this->object->getRefId())) {
+        if ($this->rbac_system->checkAccess('read', $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 'settings',
                 $this->ctrl->getLinkTarget($this, 'editSettings'),

--- a/components/ILIAS/Help/Administration/class.ilObjHelpSettingsGUI.php
+++ b/components/ILIAS/Help/Administration/class.ilObjHelpSettingsGUI.php
@@ -69,7 +69,7 @@ class ilObjHelpSettingsGUI extends ilObject2GUI
 
         $this->prepareOutput();
 
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbac_system->checkAccess("read", $this->object->getRefId())) {
             throw new ilPermissionException($this->lng->txt('no_permission'));
         }
 
@@ -128,7 +128,7 @@ class ilObjHelpSettingsGUI extends ilObject2GUI
 
     public function getAdminTabs(): void
     {
-        if ($this->checkPermissionBool("visible,read")) {
+        if ($this->checkPermissionBool("read")) {
             $this->tabs_gui->addTab(
                 "settings",
                 $this->lng->txt("settings"),

--- a/components/ILIAS/ILIASObject/classes/class.ilObjObjectFolderGUI.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObjObjectFolderGUI.php
@@ -42,7 +42,7 @@ class ilObjObjectFolderGUI extends ilObjectGUI
     */
     public function viewObject(): void
     {
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbac_system->checkAccess("read", $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt("permission_denied"), $this->error->MESSAGE);
         }
 

--- a/components/ILIAS/LTIProvider/classes/class.ilObjLTIAdministrationGUI.php
+++ b/components/ILIAS/LTIProvider/classes/class.ilObjLTIAdministrationGUI.php
@@ -86,7 +86,7 @@ class ilObjLTIAdministrationGUI extends ilObjectGUI
 
     public function getAdminTabs(): void
     {
-        if ($this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($this->rbac_system->checkAccess("read", $this->object->getRefId())) {
             $this->tabs_gui->addTab(
                 'lti_providing',
                 $this->lng->txt("lti_providing_tab"),
@@ -115,7 +115,7 @@ class ilObjLTIAdministrationGUI extends ilObjectGUI
 
     protected function addProvidingSubtabs(): void
     {
-        if ($this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($this->rbac_system->checkAccess("read", $this->object->getRefId())) {
             // currently no general settings.
             //			$this->tabs_gui->addTab("settings",
             //				$this->lng->txt("settings"),
@@ -127,7 +127,7 @@ class ilObjLTIAdministrationGUI extends ilObjectGUI
                 $this->ctrl->getLinkTarget($this, "listConsumers")
             );
         }
-        if ($this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($this->rbac_system->checkAccess("read", $this->object->getRefId())) {
             $this->tabs_gui->addSubTab(
                 "releasedObjects",
                 $this->lng->txt("lti_released_objects"),

--- a/components/ILIAS/LearningHistory/Administration/classes/class.ilObjLearningHistorySettingsGUI.php
+++ b/components/ILIAS/LearningHistory/Administration/classes/class.ilObjLearningHistorySettingsGUI.php
@@ -63,7 +63,7 @@ class ilObjLearningHistorySettingsGUI extends ilObjectGUI
         $next_class = $ctrl->getNextClass($this);
         $cmd = $ctrl->getCmd("editSettings");
 
-        if (!$rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$rbacsystem->checkAccess("read", $this->object->getRefId())) {
             throw new ilPermissionException($this->lng->txt('no_permission'));
         }
 
@@ -94,7 +94,7 @@ class ilObjLearningHistorySettingsGUI extends ilObjectGUI
         $tabs = $this->tabs;
         $ctrl = $this->ctrl;
 
-        if ($rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($rbacsystem->checkAccess("read", $this->object->getRefId())) {
             $tabs->addTab(
                 "settings",
                 $lng->txt("settings"),

--- a/components/ILIAS/LearningModule/classes/class.ilObjLearningResourcesSettingsGUI.php
+++ b/components/ILIAS/LearningModule/classes/class.ilObjLearningResourcesSettingsGUI.php
@@ -56,7 +56,7 @@ class ilObjLearningResourcesSettingsGUI extends ilObjectGUI
 
         $this->prepareOutput();
 
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbac_system->checkAccess("read", $this->object->getRefId())) {
             throw new ilPermissionException($this->lng->txt('no_permission'));
         }
 
@@ -80,7 +80,7 @@ class ilObjLearningResourcesSettingsGUI extends ilObjectGUI
     {
         $rbac_system = $this->rbac_system;
 
-        if ($rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($rbac_system->checkAccess("read", $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 "cont_edit_lrs_settings",
                 $this->ctrl->getLinkTarget($this, "editSettings"),

--- a/components/ILIAS/Logging/classes/class.ilObjLoggingSettingsGUI.php
+++ b/components/ILIAS/Logging/classes/class.ilObjLoggingSettingsGUI.php
@@ -141,7 +141,7 @@ class ilObjLoggingSettingsGUI extends ilObjectGUI
 
     public function settings(?ilPropertyFormGUI $form = null)
     {
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbac_system->checkAccess("read", $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('permission_denied'), $this->error->MESSAGE);
         }
 

--- a/components/ILIAS/MediaCast/classes/class.ilObjMediaCastSettingsGUI.php
+++ b/components/ILIAS/MediaCast/classes/class.ilObjMediaCastSettingsGUI.php
@@ -60,7 +60,7 @@ class ilObjMediaCastSettingsGUI extends ilObjectGUI
 
         $this->prepareOutput();
 
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbac_system->checkAccess("read", $this->object->getRefId())) {
             throw new ilPermissionException($this->lng->txt('no_permission'));
         }
 
@@ -85,7 +85,7 @@ class ilObjMediaCastSettingsGUI extends ilObjectGUI
     {
         $rbac_system = $this->rbac_system;
 
-        if ($rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($rbac_system->checkAccess("read", $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 "mcst_edit_settings",
                 $this->ctrl->getLinkTarget($this, "editSettings"),

--- a/components/ILIAS/MediaObjects/classes/class.ilObjMediaObjectsSettingsGUI.php
+++ b/components/ILIAS/MediaObjects/classes/class.ilObjMediaObjectsSettingsGUI.php
@@ -58,7 +58,7 @@ class ilObjMediaObjectsSettingsGUI extends ilObjectGUI
 
         $this->prepareOutput();
 
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbac_system->checkAccess("read", $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('no_permission'), $this->error->WARNING);
         }
 

--- a/components/ILIAS/MetaData/classes/Settings/class.ilObjMDSettingsGUI.php
+++ b/components/ILIAS/MetaData/classes/Settings/class.ilObjMDSettingsGUI.php
@@ -53,7 +53,6 @@ class ilObjMDSettingsGUI extends ilObjectGUI
         $this->prepareOutput();
 
         if (
-            !$this->access_service->hasCurrentUserVisibleAccess() ||
             !$this->access_service->hasCurrentUserReadAccess()
         ) {
             throw new ilPermissionException($this->lng->txt('no_permission'));
@@ -104,7 +103,6 @@ class ilObjMDSettingsGUI extends ilObjectGUI
     public function getAdminTabs(): void
     {
         if (
-            $this->access_service->hasCurrentUserVisibleAccess() &&
             $this->access_service->hasCurrentUserReadAccess()
         ) {
             $this->tabs_gui->addTab(

--- a/components/ILIAS/News/classes/class.ilObjNewsSettingsGUI.php
+++ b/components/ILIAS/News/classes/class.ilObjNewsSettingsGUI.php
@@ -42,7 +42,7 @@ class ilObjNewsSettingsGUI extends ilObjectGUI
 
         $this->prepareOutput();
 
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbac_system->checkAccess("read", $this->object->getRefId())) {
             throw new ilPermissionException($this->lng->txt('no_permission'));
         }
 
@@ -67,7 +67,7 @@ class ilObjNewsSettingsGUI extends ilObjectGUI
     {
         $rbacsystem = $this->rbac_system;
 
-        if ($rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($rbacsystem->checkAccess("read", $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 "news_edit_news_settings",
                 $this->ctrl->getLinkTarget($this, "editSettings"),

--- a/components/ILIAS/Notes/Administration/classes/class.ilObjCommentsSettingsGUI.php
+++ b/components/ILIAS/Notes/Administration/classes/class.ilObjCommentsSettingsGUI.php
@@ -70,7 +70,7 @@ class ilObjCommentsSettingsGUI extends ilObjectGUI
         $next_class = $ctrl->getNextClass($this);
         $cmd = $ctrl->getCmd("editSettings");
 
-        if (!$rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$rbacsystem->checkAccess("read", $this->object->getRefId())) {
             throw new ilPermissionException($this->lng->txt('no_permission'));
         }
 
@@ -101,7 +101,7 @@ class ilObjCommentsSettingsGUI extends ilObjectGUI
         $tabs = $this->tabs;
         $ctrl = $this->ctrl;
 
-        if ($rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($rbacsystem->checkAccess("read", $this->object->getRefId())) {
             $tabs->addTab(
                 "settings",
                 $lng->txt("settings"),

--- a/components/ILIAS/Notes/Administration/classes/class.ilObjNotesSettingsGUI.php
+++ b/components/ILIAS/Notes/Administration/classes/class.ilObjNotesSettingsGUI.php
@@ -71,7 +71,7 @@ class ilObjNotesSettingsGUI extends ilObjectGUI
         $next_class = $ctrl->getNextClass($this);
         $cmd = $ctrl->getCmd("editSettings");
 
-        if (!$rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$rbacsystem->checkAccess("read", $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('no_permission'), $this->error->WARNING);
         }
 
@@ -102,7 +102,7 @@ class ilObjNotesSettingsGUI extends ilObjectGUI
         $tabs = $this->tabs;
         $ctrl = $this->ctrl;
 
-        if ($rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($rbacsystem->checkAccess("read", $this->object->getRefId())) {
             $tabs->addTab(
                 "settings",
                 $lng->txt("settings"),

--- a/components/ILIAS/Notifications/classes/class.ilObjNotificationAdminGUI.php
+++ b/components/ILIAS/Notifications/classes/class.ilObjNotificationAdminGUI.php
@@ -43,7 +43,7 @@ class ilObjNotificationAdminGUI extends ilObjectGUI
 
     public function executeCommand(): void
     {
-        if (!$this->rbac_system->checkAccess('visible,read', $this->object->getRefId())) {
+        if (!$this->rbac_system->checkAccess('read', $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('no_permission'), $this->error->WARNING);
         }
 
@@ -66,7 +66,7 @@ class ilObjNotificationAdminGUI extends ilObjectGUI
 
     public function getAdminTabs(): void
     {
-        if ($this->checkPermissionBool('visible,read')) {
+        if ($this->checkPermissionBool('read')) {
             $this->tabs_gui->addTab(
                 'settings',
                 $this->lng->txt('settings'),

--- a/components/ILIAS/PersonalWorkspace/Administration/classes/class.ilObjPersonalWorkspaceSettingsGUI.php
+++ b/components/ILIAS/PersonalWorkspace/Administration/classes/class.ilObjPersonalWorkspaceSettingsGUI.php
@@ -72,7 +72,7 @@ class ilObjPersonalWorkspaceSettingsGUI extends ilObjectGUI
         $next_class = $ctrl->getNextClass($this);
         $cmd = $ctrl->getCmd("editSettings");
 
-        if (!$rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$rbacsystem->checkAccess("read", $this->object->getRefId())) {
             throw new ilPermissionException($this->lng->txt('no_permission'));
         }
 
@@ -103,7 +103,7 @@ class ilObjPersonalWorkspaceSettingsGUI extends ilObjectGUI
         $tabs = $this->tabs;
         $ctrl = $this->ctrl;
 
-        if ($rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($rbacsystem->checkAccess("read", $this->object->getRefId())) {
             $tabs->addTab(
                 "settings",
                 $lng->txt("settings"),

--- a/components/ILIAS/PrivacySecurity/classes/class.ilObjPrivacySecurityGUI.php
+++ b/components/ILIAS/PrivacySecurity/classes/class.ilObjPrivacySecurityGUI.php
@@ -70,7 +70,7 @@ class ilObjPrivacySecurityGUI extends ilObjectGUI
 
         $this->prepareOutput();
 
-        if (!$this->rbac_system->checkAccess('visible,read', $this->object->getRefId())) {
+        if (!$this->rbac_system->checkAccess('read', $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('no_permission'), $this->error->WARNING);
         }
 
@@ -97,7 +97,7 @@ class ilObjPrivacySecurityGUI extends ilObjectGUI
      */
     public function getAdminTabs(): void
     {
-        if ($this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($this->rbac_system->checkAccess("read", $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 "show_privacy",
                 $this->ctrl->getLinkTarget($this, "showPrivacy"),

--- a/components/ILIAS/Search/classes/ObjGUI/class.ilObjSearchSettingsGUI.php
+++ b/components/ILIAS/Search/classes/ObjGUI/class.ilObjSearchSettingsGUI.php
@@ -132,7 +132,7 @@ class ilObjSearchSettingsGUI extends ilObjectGUI
 
     protected function redirectToSettings(): void
     {
-        if (!$this->rbac_system->checkAccess('visible,read', $this->object->getRefId())) {
+        if (!$this->rbac_system->checkAccess('read', $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('permission_denied'), $this->error->MESSAGE);
         }
 
@@ -153,7 +153,7 @@ class ilObjSearchSettingsGUI extends ilObjectGUI
 
     protected function redirectToLuceneSettings(): void
     {
-        if (!$this->rbac_system->checkAccess('visible,read', $this->object->getRefId())) {
+        if (!$this->rbac_system->checkAccess('read', $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('permission_denied'), $this->error->MESSAGE);
         }
 
@@ -179,7 +179,7 @@ class ilObjSearchSettingsGUI extends ilObjectGUI
 
     protected function getTabs(): void
     {
-        if ($this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($this->rbac_system->checkAccess("read", $this->object->getRefId())) {
             $this->tabs_gui->addTab(
                 'settings',
                 $this->lng->txt('settings'),

--- a/components/ILIAS/StudyProgramme/classes/class.ilObjStudyProgrammeAdminGUI.php
+++ b/components/ILIAS/StudyProgramme/classes/class.ilObjStudyProgrammeAdminGUI.php
@@ -89,7 +89,7 @@ class ilObjStudyProgrammeAdminGUI extends ilMembershipAdministrationGUI
     public function executeCommand(): void
     {
         //Check Permissions globally for all SubGUIs. We only check write permissions
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbac_system->checkAccess("read", $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt("no_permission"), $this->error->WARNING);
         }
         $next_class = $this->ctrl->getNextClass($this);
@@ -183,7 +183,7 @@ class ilObjStudyProgrammeAdminGUI extends ilMembershipAdministrationGUI
 
     public function getAdminTabs(): void
     {
-        if ($this->rbac_system->checkAccess('visible,read', $this->object->getRefId())) {
+        if ($this->rbac_system->checkAccess('read', $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 'settings',
                 $this->ctrl->getLinkTargetByClass('ilObjStudyProgrammeAdminGUI', 'view')

--- a/components/ILIAS/Style/classes/class.ilObjStyleSettingsGUI.php
+++ b/components/ILIAS/Style/classes/class.ilObjStyleSettingsGUI.php
@@ -120,7 +120,7 @@ class ilObjStyleSettingsGUI extends ilObjectGUI
     */
     public function getTabs(): void
     {
-        if ($this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($this->rbac_system->checkAccess("read", $this->object->getRefId())) {
             $this->tabs_gui->addTab(
                 "system_styles",
                 $this->lng->txt("system_styles"),

--- a/components/ILIAS/Survey/Administration/class.ilObjSurveyAdministrationGUI.php
+++ b/components/ILIAS/Survey/Administration/class.ilObjSurveyAdministrationGUI.php
@@ -190,7 +190,7 @@ class ilObjSurveyAdministrationGUI extends ilObjectGUI
     {
         $lng = $this->lng;
 
-        if ($this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($this->rbac_system->checkAccess("read", $this->object->getRefId())) {
             $this->tabs_gui->addTab(
                 "settings",
                 $lng->txt("settings"),

--- a/components/ILIAS/Tagging/classes/class.ilObjTaggingSettingsGUI.php
+++ b/components/ILIAS/Tagging/classes/class.ilObjTaggingSettingsGUI.php
@@ -67,7 +67,7 @@ class ilObjTaggingSettingsGUI extends ilObjectGUI
         $cmd = $this->ctrl->getCmd();
         $this->prepareOutput();
 
-        if (!$this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess("read", $this->object->getRefId())) {
             throw new ilObjectException($this->lng->txt("permission_denied"));
         }
 
@@ -91,7 +91,7 @@ class ilObjTaggingSettingsGUI extends ilObjectGUI
     {
         $rbacsystem = $this->rbacsystem;
 
-        if ($rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($rbacsystem->checkAccess("read", $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 "tagging_edit_settings",
                 $this->ctrl->getLinkTarget($this, "editSettings"),
@@ -121,7 +121,7 @@ class ilObjTaggingSettingsGUI extends ilObjectGUI
                 $this->ctrl->getLinkTarget($this, "editSettings")
             );
 
-            if ($this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
+            if ($this->rbacsystem->checkAccess("read", $this->object->getRefId())) {
                 $ilTabs->addSubTab(
                     "forbidden_tags",
                     $this->lng->txt("tagging_forbidden_tags"),

--- a/components/ILIAS/Taxonomy/classes/class.ilObjTaxonomyAdministrationGUI.php
+++ b/components/ILIAS/Taxonomy/classes/class.ilObjTaxonomyAdministrationGUI.php
@@ -68,7 +68,7 @@ class ilObjTaxonomyAdministrationGUI extends ilObjectGUI
     {
         $rbacsystem = $this->rbacsystem;
 
-        if ($rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($rbacsystem->checkAccess("read", $this->object->getRefId())) {
             $this->tabs_gui->addTab(
                 "settings",
                 $this->lng->txt("tax_admin_settings_repository"),

--- a/components/ILIAS/Test/classes/class.ilObjTestFolderGUI.php
+++ b/components/ILIAS/Test/classes/class.ilObjTestFolderGUI.php
@@ -83,7 +83,7 @@ class ilObjTestFolderGUI extends ilObjectGUI
                 $this->ctrl->forwardCommand($perm_gui);
                 break;
             case 'ilglobalunitconfigurationgui':
-                if (!$this->rbac_system->checkAccess('visible,read', $this->getTestFolder()->getRefId())) {
+                if (!$this->rbac_system->checkAccess('read', $this->getTestFolder()->getRefId())) {
                     $this->ilias->raiseError($this->lng->txt('permission_denied'), $this->ilias->error_obj->WARNING);
                 }
 
@@ -273,7 +273,7 @@ class ilObjTestFolderGUI extends ilObjectGUI
             $this->getLogdataSubtabs();
         }
 
-        if ($this->rbac_system->checkAccess('visible,read', $this->getTestFolder()->getRefId())) {
+        if ($this->rbac_system->checkAccess('read', $this->getTestFolder()->getRefId())) {
             $this->tabs_gui->addTarget(
                 'settings',
                 $this->ctrl->getLinkTarget($this, 'showGlobalSettings'),

--- a/components/ILIAS/Tracking/classes/class.ilObjUserTrackingGUI.php
+++ b/components/ILIAS/Tracking/classes/class.ilObjUserTrackingGUI.php
@@ -99,7 +99,7 @@ class ilObjUserTrackingGUI extends ilObjectGUI
             get_class($this)
         );
 
-        if ($this->rbac_system->checkAccess("visible,read", $this->ref_id)) {
+        if ($this->rbac_system->checkAccess("read", $this->ref_id)) {
             if (ilObjUserTracking::_enabledObjectStatistics()) {
                 $this->tabs_gui->addTarget(
                     "statistics",
@@ -142,7 +142,7 @@ class ilObjUserTrackingGUI extends ilObjectGUI
     public function settingsObject(?ilPropertyFormGUI $a_form = null): void
     {
         if (!$this->rbac_system->checkAccess(
-            "visible,read",
+            "read",
             $this->object->getRefId()
         )) {
             $this->error->raiseError(

--- a/components/ILIAS/Tree/classes/Setup/class.ilTreeAdminNodeAddedObjective.php
+++ b/components/ILIAS/Tree/classes/Setup/class.ilTreeAdminNodeAddedObjective.php
@@ -31,7 +31,6 @@ class ilTreeAdminNodeAddedObjective implements Setup\Objective
 
     protected array $rbac_ops = [
         self::RBAC_OP_EDIT_PERMISSIONS,
-        self::RBAC_OP_VISIBLE,
         self::RBAC_OP_READ,
         self::RBAC_OP_WRITE
     ];

--- a/components/ILIAS/WebDAV/classes/class.ilObjWebDAVGUI.php
+++ b/components/ILIAS/WebDAV/classes/class.ilObjWebDAVGUI.php
@@ -80,7 +80,7 @@ class ilObjWebDAVGUI extends ilObjectGUI
     #[\Override]
     public function getAdminTabs(): void
     {
-        if ($this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($this->rbac_system->checkAccess("read", $this->object->getRefId())) {
             $this->tabs_gui->addTab(
                 'webdav_general_settings',
                 $this->lng->txt("webdav_general_settings"),
@@ -127,7 +127,7 @@ class ilObjWebDAVGUI extends ilObjectGUI
     {
         $this->tabs_gui->activateTab('webdav_general_settings');
 
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbac_system->checkAccess("read", $this->object->getRefId())) {
             $this->error_handling->raiseError(
                 $this->lng->txt("no_permission"),
                 $this->error_handling->WARNING

--- a/components/ILIAS/WebResource/classes/class.ilObjWebResourceAdministrationGUI.php
+++ b/components/ILIAS/WebResource/classes/class.ilObjWebResourceAdministrationGUI.php
@@ -53,7 +53,7 @@ class ilObjWebResourceAdministrationGUI extends ilObjectGUI
         $this->prepareOutput();
 
         if (!$this->rbac_system->checkAccess(
-            "visible,read",
+            "read",
             $this->object->getRefId()
         )) {
             $this->error->raiseError(
@@ -81,7 +81,7 @@ class ilObjWebResourceAdministrationGUI extends ilObjectGUI
     public function getAdminTabs(): void
     {
         if ($this->rbac_system->checkAccess(
-            "visible,read",
+            "read",
             $this->object->getRefId()
         )) {
             $this->tabs_gui->addTarget(

--- a/components/ILIAS/WebServices/ECS/classes/class.ilObjECSSettingsGUI.php
+++ b/components/ILIAS/WebServices/ECS/classes/class.ilObjECSSettingsGUI.php
@@ -47,7 +47,7 @@ class ilObjECSSettingsGUI extends ilObjectGUI
 
         $this->prepareOutput();
 
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbac_system->checkAccess("read", $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('no_permission'), $this->error->WARNING);
         }
 

--- a/components/ILIAS/Wiki/classes/class.ilObjWikiSettingsGUI.php
+++ b/components/ILIAS/Wiki/classes/class.ilObjWikiSettingsGUI.php
@@ -64,7 +64,7 @@ class ilObjWikiSettingsGUI extends ilObject2GUI
 
         $this->prepareOutput();
 
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbac_system->checkAccess("read", $this->object->getRefId())) {
             $ilErr->raiseError($this->lng->txt('no_permission'), $ilErr->WARNING);
         }
 
@@ -91,7 +91,7 @@ class ilObjWikiSettingsGUI extends ilObject2GUI
 
         $ilTabs->activateTab("settings");
 
-        if ($this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($this->rbac_system->checkAccess("read", $this->object->getRefId())) {
             if (!$form) {
                 $form = $this->initForm();
                 $this->populateWithCurrentSettings($form);
@@ -146,7 +146,7 @@ class ilObjWikiSettingsGUI extends ilObject2GUI
 
     public function getAdminTabs(): void
     {
-        if ($this->checkPermissionBool("visible,read")) {
+        if ($this->checkPermissionBool("read")) {
             $this->tabs_gui->addTab(
                 "settings",
                 $this->lng->txt("settings"),


### PR DESCRIPTION
This PR is part of the feature request [Unbundling of Admin Permissions](https://docu.ilias.de/go/wiki/wpage_8648_1357)

It adds an `AdminNodesVisibilityRemovedObjective` that removes the "visible" permission from the types of the administration nodes (i.e. the direct children of the system folder). Additionally, it removes the checks for "visible" in the GUIs of these nodes and in `AdministrationMainBarProvider`. Access to admin nodes will only require their 'read' permission. 

As stated in the Jour Fix on October 13, 2025, the changes of the permission checks in components outside Administration are trivial and will be merged on behalf of the responsible authorities.

A special case is the node for **Organisation Units** because ist has the same type as the subunits created there. The PR keeps the "visible" permission for this type to support it for the subunits without "read" permission. A separate PR [OrgUnit: Remove info screen from root](https://github.com/ILIAS-eLearning/ILIAS/pull/10275) is created to handle this special case.

Another special case is the **User Folder** because another permission has to be introduced first. This will be treated in the separate PR [User: Add "Read All Accounts" permission to the User Folder](https://github.com/ILIAS-eLearning/ILIAS/pull/10242).

The checks for the "visible" permission of the **System Folder** will be removed in a separate PR that unbundles the functionalities of that folder.