### PR TITLE
Maps: Move administration from third party into own admin node

### DIFF
--- a/components/ILIAS/Administration/GlobalScreen/classes/AdministrationMainBarProvider.php
+++ b/components/ILIAS/Administration/GlobalScreen/classes/AdministrationMainBarProvider.php
@@ -226,7 +226,7 @@ class AdministrationMainBarProvider extends AbstractStaticMainMenuProvider
             "search_and_find" =>
                 array("seas", "mds", "taxs"),
             "extending_ilias" =>
-                array('ecss', "ltis", "wbdv", "cmis", "cmps", "extt"),
+                array('ecss', "ltis", "wbdv", "cmis", "cmps", "extt", 'maps'),
             "legal_regulations" =>
                 array("impr" ,"tos", "accs", 'dpro')
         );

--- a/components/ILIAS/Administration/classes/class.ilObjExternalToolsSettingsGUI.php
+++ b/components/ILIAS/Administration/classes/class.ilObjExternalToolsSettingsGUI.php
@@ -68,13 +68,9 @@ class ilObjExternalToolsSettingsGUI extends ilObjectGUI
 
         if ($rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
-                "settings",
-                $this->ctrl->getLinkTarget($this, "view"),
-                array("editMaps", "editMathJax", ""),
-                "",
-                ""
+                'wopi_settings',
+                $this->ctrl->getLinkTargetByClass(ilWOPIAdministrationGUI::class)
             );
-            $this->lng->loadLanguageModule('ecs');
         }
 
         if ($rbacsystem->checkAccess('edit_permission', $this->object->getRefId())) {
@@ -85,132 +81,6 @@ class ilObjExternalToolsSettingsGUI extends ilObjectGUI
                 'ilpermissiongui'
             );
         }
-    }
-
-
-    public function editMapsObject(): void
-    {
-        $tpl = $this->tpl;
-
-        $this->initSubTabs("editMaps");
-        $form = $this->getMapsForm();
-        $tpl->setContent($form->getHTML());
-    }
-
-    public function getMapsForm(): ilPropertyFormGUI
-    {
-        $ilAccess = $this->access;
-        $lng = $this->lng;
-        $ilCtrl = $this->ctrl;
-        $std_latitude = (float) ilMapUtil::getStdLatitude();
-        $std_longitude = (float) ilMapUtil::getStdLongitude();
-        $std_zoom = ilMapUtil::getStdZoom();
-        $type = ilMapUtil::getType();
-        $form = new ilPropertyFormGUI();
-        $form->setFormAction($ilCtrl->getFormAction($this));
-        $form->setTitle($lng->txt("maps_settings"));
-
-        // Enable Maps
-        $enable = new ilCheckboxInputGUI($lng->txt("maps_enable_maps"), "enable");
-        $enable->setChecked(ilMapUtil::isActivated());
-        $enable->setInfo($lng->txt("maps_enable_maps_info"));
-        $form->addItem($enable);
-
-        // Select type
-        $types = new ilSelectInputGUI($lng->txt("maps_map_type"), "type");
-        $types->setOptions(ilMapUtil::getAvailableMapTypes());
-        $types->setValue($type);
-        $form->addItem($types);
-
-        // map data server property
-        if ($type === "openlayers") {
-            $tile = new ilTextInputGUI($lng->txt("maps_tile_server"), "tile");
-            $tile->setValue(ilMapUtil::getStdTileServers());
-            $tile->setInfo(sprintf($lng->txt("maps_custom_tile_server_info"), ilMapUtil::DEFAULT_TILE));
-            $geolocation = new ilTextInputGUI($lng->txt("maps_geolocation_server"), "geolocation");
-            $geolocation->setValue(ilMapUtil::getStdGeolocationServer());
-            $geolocation->setInfo($lng->txt("maps_custom_geolocation_server_info"));
-
-            $form->addItem($tile);
-            $form->addItem($geolocation);
-        } else {
-            // api key for google
-            $key = new ilTextInputGUI("Google API Key", "api_key");
-            $key->setMaxLength(200);
-            $key->setValue(ilMapUtil::getApiKey());
-            $form->addItem($key);
-        }
-
-        // location property
-        $loc_prop = new ilLocationInputGUI(
-            $lng->txt("maps_std_location"),
-            "std_location"
-        );
-
-        $loc_prop->setLatitude($std_latitude);
-        $loc_prop->setLongitude($std_longitude);
-        $loc_prop->setZoom((int) $std_zoom);
-        $form->addItem($loc_prop);
-
-        if ($ilAccess->checkAccess("write", "", $this->object->getRefId())) {
-            $form->addCommandButton("saveMaps", $lng->txt("save"));
-            $form->addCommandButton("view", $lng->txt("cancel"));
-        }
-
-        return $form;
-    }
-
-    /**
-     * Save Maps Settings
-     */
-    public function saveMapsObject(): void
-    {
-        $ilCtrl = $this->ctrl;
-
-        $form = $this->getMapsForm();
-        if ($form->checkInput()) {
-            if ($form->getInput("type") === 'openlayers' && 'openlayers' === ilMapUtil::getType()) {
-                ilMapUtil::setStdTileServers($form->getInput("tile"));
-                ilMapUtil::setStdGeolocationServer(
-                    $form->getInput("geolocation")
-                );
-            } else {
-                ilMapUtil::setApiKey($form->getInput("api_key"));
-            }
-
-            ilMapUtil::setActivated($form->getInput("enable") === "1");
-            ilMapUtil::setType($form->getInput("type"));
-            $location = $form->getInput("std_location");
-            ilMapUtil::setStdLatitude((string) $location["latitude"]);
-            ilMapUtil::setStdLongitude((string) $location["longitude"]);
-            ilMapUtil::setStdZoom((string) $location["zoom"]);
-        }
-        $ilCtrl->redirect($this, "editMaps");
-    }
-
-    // init sub tabs
-    public function initSubTabs(string $a_cmd): void
-    {
-        $maps = $a_cmd === 'editMaps';
-        $mathjax = $a_cmd === 'editMathJax';
-        $wopi = $a_cmd === self::EDIT_WOPI;
-
-        $this->tabs_gui->addSubTabTarget(
-            "maps_extt_maps",
-            $this->ctrl->getLinkTarget($this, "editMaps"),
-            "",
-            "",
-            "",
-            $maps
-        );
-        $this->tabs_gui->addSubTabTarget(
-            "wopi_settings",
-            $this->ctrl->getLinkTargetByClass(ilWOPIAdministrationGUI::class),
-            "",
-            "",
-            "",
-            $wopi
-        );
     }
 
     public function executeCommand(): void
@@ -224,13 +94,7 @@ class ilObjExternalToolsSettingsGUI extends ilObjectGUI
         }
 
         switch ($next_class) {
-            case 'ilecssettingsgui':
-                $this->tabs_gui->setTabActive('ecs_server_settings');
-                $this->ctrl->forwardCommand(new ilECSSettingsGUI());
-                break;
-
             case strtolower(ilWOPIAdministrationGUI::class):
-                $this->initSubTabs(self::EDIT_WOPI);
                 $this->ctrl->forwardCommand(new ilWOPIAdministrationGUI());
                 break;
 
@@ -239,15 +103,8 @@ class ilObjExternalToolsSettingsGUI extends ilObjectGUI
                 $this->ctrl->forwardCommand($perm_gui);
                 $this->tabs_gui->setTabActive('perm_settings');
                 break;
-
             default:
-                $this->tabs_gui->setTabActive('settings');
-                if (!$cmd || $cmd === 'view') {
-                    $cmd = "editMaps";
-                }
-                $cmd .= "Object";
-                $this->$cmd();
-
+                $this->ctrl->redirectToURL($this->ctrl->getLinkTargetByClass(ilWOPIAdministrationGUI::class));
                 break;
         }
     }

--- a/components/ILIAS/Maps/Maps.php
+++ b/components/ILIAS/Maps/Maps.php
@@ -34,5 +34,9 @@ class Maps implements Component\Component
     ): void {
         $contribute[Component\Resource\PublicAsset::class] = fn() =>
             new Component\Resource\ComponentJS($this, "ServiceOpenLayers.js");
+        $contribute[\ILIAS\Setup\Agent::class] = fn() =>
+            new \ILIAS\Maps\Setup\Agent(
+                $pull[\ILIAS\Refinery\Factory::class]
+            );
     }
 }

--- a/components/ILIAS/Maps/classes/Setup/Agent.php
+++ b/components/ILIAS/Maps/classes/Setup/Agent.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Maps\Setup;
+
+use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Refinery\Transformation;
+use ILIAS\Setup\Objective;
+use ILIAS\Setup\Config;
+use ILIAS\Setup\Metrics\Storage;
+use ILIAS\Setup\Objective\NullObjective;
+use ILIAS\Setup\Agent as AgentInterface;
+use ilTreeAdminNodeAddedObjective;
+
+class Agent implements AgentInterface
+{
+    public function __construct(private readonly Refinery $refinery)
+    {
+    }
+
+    public function hasConfig(): bool
+    {
+        return false;
+    }
+
+    public function getArrayToConfigTransformation(): Transformation
+    {
+        return $this->refinery->identity();
+    }
+
+    public function getInstallObjective(?Config $config = null): Objective
+    {
+        return new NullObjective();
+    }
+
+    public function getUpdateObjective(?Config $config = null): Objective
+    {
+        return new ilTreeAdminNodeAddedObjective('maps', 'Maps');
+    }
+
+    public function getBuildObjective(): Objective
+    {
+        return new NullObjective();
+    }
+
+    public function getStatusObjective(Storage $storage): Objective
+    {
+        return new NullObjective();
+    }
+
+    public function getMigrations(): array
+    {
+        return [];
+    }
+
+    public function getNamedObjectives(?Config $config = null): array
+    {
+        return [];
+    }
+}

--- a/components/ILIAS/Maps/classes/class.ilObjMaps.php
+++ b/components/ILIAS/Maps/classes/class.ilObjMaps.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+final class ilObjMaps extends ilObject2
+{
+    protected function initType(): void
+    {
+        $this->type = 'maps';
+    }
+}

--- a/components/ILIAS/Maps/classes/class.ilObjMapsAccess.php
+++ b/components/ILIAS/Maps/classes/class.ilObjMapsAccess.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+final class ilObjMapsAccess extends ilObjectAccess
+{
+}

--- a/components/ILIAS/Maps/classes/class.ilObjMapsGUI.php
+++ b/components/ILIAS/Maps/classes/class.ilObjMapsGUI.php
@@ -1,0 +1,167 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+/**
+ * @ilCtrl_isCalledBy ilObjMapsGUI: ilAdministrationGUI
+ * @ilCtrl_Calls      ilObjMapsGUI: ilPermissionGUI
+ */
+class ilObjMapsGUI extends ilObjectGUI
+{
+    private readonly ilRbacSystem $rbacsystem;
+
+    public function __construct($data, int $id = 0, bool $call_by_reference = true, bool $prepare_output = true)
+    {
+        parent::__construct($data, $id, $call_by_reference, $prepare_output);
+        global $DIC;
+        $this->rbacsystem = $DIC->rbac()->system();
+    }
+
+    public function executeCommand(): void
+    {
+        if (!$this->rbacsystem->checkAccess('read', $this->object->getRefId())) {
+            $this->ilias->raiseError(
+                $this->lng->txt('permission_denied'),
+                $this->ilias->error_obj->MESSAGE
+            );
+        }
+
+        $this->lng->loadLanguageModule('maps');
+        $this->tpl->setTitle($this->lng->txt('obj_maps'));
+        $this->initTabs();
+        switch ($this->ctrl->getNextClass()) {
+            case strtolower(ilPermissionGUI::class):
+                $this->ctrl->forwardCommand(new ilPermissionGUI($this));
+                $this->tabs_gui->activateTab('permissions');
+                break;
+            default:
+                $cmd = $this->ctrl->getCmd('view');
+                if (in_array($cmd, ['view', 'save'], true)) {
+                    $this->tabs_gui->activateTab('view');
+                    $this->$cmd();
+                }
+                break;
+        }
+    }
+
+    public function view(): void
+    {
+        $this->tpl->setContent($this->buildForm()->getHTML());
+    }
+
+    private function initTabs(): void
+    {
+        $this->tabs_gui->addTab(
+            'view',
+            $this->lng->txt('view'),
+            $this->ctrl->getLinkTarget($this, 'view'),
+        );
+
+        $this->tabs_gui->addTab(
+            'permissions',
+            $this->lng->txt('perm_settings'),
+            $this->ctrl->getLinkTargetByClass([self::class, ilPermissionGUI::class], 'perm')
+        );
+    }
+
+    private function buildForm(): ilPropertyFormGUI
+    {
+        $lng = $this->lng;
+        $ilCtrl = $this->ctrl;
+        $std_latitude = (float) ilMapUtil::getStdLatitude();
+        $std_longitude = (float) ilMapUtil::getStdLongitude();
+        $std_zoom = ilMapUtil::getStdZoom();
+        $type = ilMapUtil::getType();
+        $form = new ilPropertyFormGUI();
+        $form->setFormAction($ilCtrl->getFormAction($this));
+        $form->setTitle($lng->txt('maps_settings'));
+
+        // Enable Maps
+        $enable = new ilCheckboxInputGUI($lng->txt('maps_enable_maps'), 'enable');
+        $enable->setChecked(ilMapUtil::isActivated());
+        $enable->setInfo($lng->txt('maps_enable_maps_info'));
+        $form->addItem($enable);
+
+        // Select type
+        $types = new ilSelectInputGUI($lng->txt('maps_map_type'), 'type');
+        $types->setOptions(ilMapUtil::getAvailableMapTypes());
+        $types->setValue($type);
+        $form->addItem($types);
+
+        // map data server property
+        if ($type === 'openlayers') {
+            $tile = new ilTextInputGUI($lng->txt('maps_tile_server'), 'tile');
+            $tile->setValue(ilMapUtil::getStdTileServers());
+            $tile->setInfo(sprintf($lng->txt('maps_custom_tile_server_info'), ilMapUtil::DEFAULT_TILE));
+            $geolocation = new ilTextInputGUI($lng->txt('maps_geolocation_server'), 'geolocation');
+            $geolocation->setValue(ilMapUtil::getStdGeolocationServer());
+            $geolocation->setInfo($lng->txt('maps_custom_geolocation_server_info'));
+
+            $form->addItem($tile);
+            $form->addItem($geolocation);
+        } else {
+            // api key for google
+            $key = new ilTextInputGUI('Google API Key', 'api_key');
+            $key->setMaxLength(200);
+            $key->setValue(ilMapUtil::getApiKey());
+            $form->addItem($key);
+        }
+
+        // location property
+        $loc_prop = new ilLocationInputGUI(
+            $lng->txt('maps_std_location'),
+            'std_location'
+        );
+
+        $loc_prop->setLatitude($std_latitude);
+        $loc_prop->setLongitude($std_longitude);
+        $loc_prop->setZoom((int) $std_zoom);
+        $form->addItem($loc_prop);
+
+        if ($this->access->checkAccess('write', '', $this->object->getRefId())) {
+            $form->addCommandButton('save', $lng->txt('save'));
+            $form->addCommandButton('view', $lng->txt('cancel'));
+        }
+
+        return $form;
+    }
+
+    private function save(): void
+    {
+        $form = $this->buildForm();
+        if ($form->checkInput()) {
+            if ($form->getInput('type') === 'openlayers' && 'openlayers' === ilMapUtil::getType()) {
+                ilMapUtil::setStdTileServers($form->getInput('tile'));
+                ilMapUtil::setStdGeolocationServer(
+                    $form->getInput('geolocation')
+                );
+            } else {
+                ilMapUtil::setApiKey($form->getInput('api_key'));
+            }
+
+            ilMapUtil::setActivated($form->getInput('enable') === '1');
+            ilMapUtil::setType($form->getInput('type'));
+            $location = $form->getInput('std_location');
+            ilMapUtil::setStdLatitude((string) $location['latitude']);
+            ilMapUtil::setStdLongitude((string) $location['longitude']);
+            ilMapUtil::setStdZoom((string) $location['zoom']);
+        }
+        $this->ctrl->redirect($this, 'view');
+    }
+}

--- a/components/ILIAS/Maps/service.xml
+++ b/components/ILIAS/Maps/service.xml
@@ -1,0 +1,11 @@
+<?xml version = "1.0" encoding = "UTF-8"?>
+<service xmlns="http://www.w3.org" version="$Id$" id="maps">
+  <baseclasses>
+  </baseclasses>
+  <objects>
+    <object id="maps" class_name="Maps" dir="classes" checkbox="0" inherit="0" translate="sys" rbac="1" system="1" administration="1">
+      <parent id="adm" max="1">adm</parent>
+    </object>
+  </objects>
+  <logging />
+</service>

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -4959,6 +4959,7 @@ common#:#obj_mail#:#Mail
 common#:#obj_mail_desc#:#Globale Mail-Einstellungen
 common#:#obj_mailr#:#Gelesene Mail
 common#:#obj_mailu#:#Ungelesene Mail
+common#:#obj_maps#:#Karten
 common#:#obj_mcst#:#Mediacast
 common#:#obj_mcst_duplicate#:#Mediacast kopieren
 common#:#obj_mcts#:#Mediacast
@@ -11682,7 +11683,6 @@ maps#:#maps_custom_geolocation_server_info#:#URL des Servers, über den die Geol
 maps#:#maps_custom_tile_server_info#:#URL des Servers für die Bereitstellung der Kacheln. Mehrere Einträge müssen mit Leerzeichen getrennt werden. Standardeingabe ist „%s“.
 maps#:#maps_enable_maps#:#Karten aktivieren
 maps#:#maps_enable_maps_info#:#Karten können systemweit in Profilen, Kursen und Gruppen angezeigt werden.
-maps#:#maps_extt_maps#:#Karten
 maps#:#maps_geolocation_server#:#Server für Reverse Geolocation
 maps#:#maps_google_maps#:#Google Maps
 maps#:#maps_https_for_reverse_lookup#:#Https für Reverse Lookup

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -4959,6 +4959,7 @@ common#:#obj_mail#:#Mail
 common#:#obj_mail_desc#:#Configure global mail settings here.
 common#:#obj_mailr#:#Read Mail
 common#:#obj_mailu#:#Unread Mail
+common#:#obj_maps#:#Maps
 common#:#obj_mcst#:#Mediacast
 common#:#obj_mcst_duplicate#:#Copy Mediacast
 common#:#obj_mcts#:#Mediacast
@@ -11685,7 +11686,6 @@ maps#:#maps_custom_geolocation_server_info#:#Server URL to provide geolocation-d
 maps#:#maps_custom_tile_server_info#:#Server URL to provide tile-data. Multiple inputs should be separated by spaces. Defaults is "%s".
 maps#:#maps_enable_maps#:#Enable Maps
 maps#:#maps_enable_maps_info#:#Activates Maps in user profiles, groups and courses.
-maps#:#maps_extt_maps#:#Maps
 maps#:#maps_geolocation_server#:#Server for Reverse Geolocation
 maps#:#maps_google_maps#:#Google Maps
 maps#:#maps_https_for_reverse_lookup#:#Https for Reverse Lookup


### PR DESCRIPTION
This PR is part of the following Feature Requests: https://docu.ilias.de/go/wiki/wpage_8602_1357 and https://docu.ilias.de/go/wiki/wpage_8648_1357
This PR moves the administration settings for the `Maps` component from the `Administration` to the `Maps` component itself.
Previously the settings where located at the admin node `Third Party Software`. This is moved to a new admin node `Maps`.
Additionally the `visible` access check is removed as it is stated in the FR.