### PR TITLE
User: Add "Read All Accounts" permission to the User Folder

### DIFF
--- a/components/ILIAS/User/classes/class.ilObjUserFolder.php
+++ b/components/ILIAS/User/classes/class.ilObjUserFolder.php
@@ -32,6 +32,9 @@ use ILIAS\User\Profile\Fields\Standard\Alias;
 
 class ilObjUserFolder extends ilObject
 {
+    public const string PERM_READ_ALL = 'read_all_accounts';
+    public const string PERM_READ_ALL_AND_WRITE = 'read_all_accounts,write';
+
     public const ORG_OP_EDIT_USER_ACCOUNTS = 'edit_user_accounts';
     public const FILE_TYPE_EXCEL = 'userfolder_export_excel_x86';
     public const FILE_TYPE_CSV = 'userfolder_export_csv';

--- a/components/ILIAS/User/classes/class.ilObjUserFolderGUI.php
+++ b/components/ILIAS/User/classes/class.ilObjUserFolderGUI.php
@@ -172,6 +172,8 @@ class ilObjUserFolderGUI extends ilObjectGUI
 
     public function executeCommand(): void
     {
+        $this->checkPermission('read');
+
         $next_class = $this->ctrl->getNextClass($this);
         $cmd = $this->ctrl->getCmd();
         $this->prepareOutput();
@@ -191,7 +193,7 @@ class ilObjUserFolderGUI extends ilObjectGUI
                 break;
             case strtolower(ilRepositorySearchGUI::class):
                 if (!$this->access->checkRbacOrPositionPermissionAccess(
-                    'read',
+                    \ilObjUserFolder::PERM_READ_ALL,
                     \ilObjUserFolder::ORG_OP_EDIT_USER_ACCOUNTS,
                     USER_FOLDER_ID
                 )) {
@@ -400,21 +402,6 @@ class ilObjUserFolderGUI extends ilObjectGUI
             );
         }
 
-        $list_of_users = null;
-        if (!$this->access->checkAccess('read', '', USER_FOLDER_ID)
-            && $this->access->checkRbacOrPositionPermissionAccess(
-                'read',
-                \ilObjUserFolder::ORG_OP_EDIT_USER_ACCOUNTS,
-                USER_FOLDER_ID
-            )) {
-            $list_of_users = $this->access->filterUserIdsByRbacOrPositionOfCurrentUser(
-                'read',
-                \ilObjUserFolder::ORG_OP_EDIT_USER_ACCOUNTS,
-                USER_FOLDER_ID,
-                \ilLocalUser::_getAllUserIds(\ilLocalUser::_getUserFolderId())
-            );
-        }
-
         $utab = new ilUserTableGUI(
             $this,
             'view',
@@ -423,7 +410,7 @@ class ilObjUserFolderGUI extends ilObjectGUI
         );
         $utab->addFilterItemValue(
             'user_ids',
-            $list_of_users
+            $this->retrieveUserList()
         );
         $utab->getItems();
 
@@ -452,7 +439,7 @@ class ilObjUserFolderGUI extends ilObjectGUI
     public function filterUserIdsByRbacOrPositionOfCurrentUser(array $user_ids): array
     {
         return $this->access->filterUserIdsByRbacOrPositionOfCurrentUser(
-            'read',
+            \ilObjUserFolder::PERM_READ_ALL,
             \ilObjUserFolder::ORG_OP_EDIT_USER_ACCOUNTS,
             USER_FOLDER_ID,
             $user_ids
@@ -848,18 +835,18 @@ class ilObjUserFolderGUI extends ilObjectGUI
             );
 
             if (!$this->access->checkAccess(
-                'read',
+                \ilObjUserFolder::PERM_READ_ALL,
                 '',
                 USER_FOLDER_ID
             ) &&
                 $this->access->checkRbacOrPositionPermissionAccess(
-                    'read',
+                    \ilObjUserFolder::PERM_READ_ALL,
                     \ilObjUserFolder::ORG_OP_EDIT_USER_ACCOUNTS,
                     USER_FOLDER_ID
                 )) {
                 $users = \ilLocalUser::_getAllUserIds(\ilLocalUser::_getUserFolderId());
                 $filtered_users = $this->access->filterUserIdsByRbacOrPositionOfCurrentUser(
-                    'read',
+                    \ilObjUserFolder::PERM_READ_ALL,
                     \ilObjUserFolder::ORG_OP_EDIT_USER_ACCOUNTS,
                     USER_FOLDER_ID,
                     $users
@@ -874,7 +861,7 @@ class ilObjUserFolderGUI extends ilObjectGUI
             return $utab->getUserIdsForFilter();
         } else {
             return $this->access->filterUserIdsByRbacOrPositionOfCurrentUser(
-                'read',
+                \ilObjUserFolder::PERM_READ_ALL,
                 ilObjUserFolder::ORG_OP_EDIT_USER_ACCOUNTS,
                 USER_FOLDER_ID,
                 $this->requested_ids
@@ -1907,7 +1894,7 @@ class ilObjUserFolderGUI extends ilObjectGUI
      */
     protected function performExportObject(): void
     {
-        $this->checkPermission('write,read');
+        $this->checkPermission(\ilObjUserFolder::PERM_READ_ALL_AND_WRITE);
 
         $this->object->buildExportFile($this->user_request->getExportType());
         $this->ctrl->redirect(
@@ -1918,7 +1905,7 @@ class ilObjUserFolderGUI extends ilObjectGUI
 
     public function exportObject(): void
     {
-        $this->checkPermission('write,read');
+        $this->checkPermission(\ilObjUserFolder::PERM_READ_ALL_AND_WRITE);
 
         $export_types = [
             'userfolder_export_excel_x86',
@@ -2021,8 +2008,8 @@ class ilObjUserFolderGUI extends ilObjectGUI
 
     public function searchUserAccessFilterCallable(array $a_user_ids): array // Missing array type.
     {
-        if ($this->checkPermissionBool('read', '', '', USER_FOLDER_ID)
-            || $this->checkPermissionBool('read_user')) {
+        if ($this->checkPermissionBool(\ilObjUserFolder::PERM_READ_ALL, '', '', USER_FOLDER_ID)
+            || $this->checkPermissionBool('read_users')) {
             return $a_user_ids;
         }
 
@@ -2132,7 +2119,7 @@ class ilObjUserFolderGUI extends ilObjectGUI
             );
         }
 
-        if ($this->checkPermissionBool('write,read')) {
+        if ($this->checkPermissionBool(\ilObjUserFolder::PERM_READ_ALL_AND_WRITE)) {
             $this->object->buildExportFile(
                 ilObjUserFolder::FILE_TYPE_EXCEL,
                 $user_ids
@@ -2168,7 +2155,7 @@ class ilObjUserFolderGUI extends ilObjectGUI
             );
         }
 
-        if ($this->checkPermissionBool('write,read')) {
+        if ($this->checkPermissionBool(\ilObjUserFolder::PERM_READ_ALL_AND_WRITE)) {
             $this->object->buildExportFile(
                 ilObjUserFolder::FILE_TYPE_CSV,
                 $user_ids
@@ -2203,7 +2190,7 @@ class ilObjUserFolderGUI extends ilObjectGUI
                 'view'
             );
         }
-        if ($this->checkPermissionBool('write,read')) {
+        if ($this->checkPermissionBool(\ilObjUserFolder::PERM_READ_ALL_AND_WRITE)) {
             $this->object->buildExportFile(
                 ilObjUserFolder::FILE_TYPE_XML,
                 $user_ids
@@ -2365,6 +2352,26 @@ class ilObjUserFolderGUI extends ilObjectGUI
             $this,
             'view'
         );
+    }
+
+    private function retrieveUserList(): ?array
+    {
+        if ($this->access->checkAccess(\ilObjUserFolder::PERM_READ_ALL, '', USER_FOLDER_ID)) {
+            return null;
+        }
+
+        if ($this->access->checkPositionAccess(
+            \ilObjUserFolder::ORG_OP_EDIT_USER_ACCOUNTS,
+            USER_FOLDER_ID
+        )) {
+            return $this->access->filterUserIdsByPositionOfCurrentUser(
+                \ilObjUserFolder::ORG_OP_EDIT_USER_ACCOUNTS,
+                USER_FOLDER_ID,
+                \ilLocalUser::_getAllUserIds(\ilLocalUser::_getUserFolderId())
+            );
+        }
+
+        return [];
     }
 
     private function checkbox(string $name): ilCheckboxInputGUI

--- a/components/ILIAS/User/classes/class.ilObjUserGUI.php
+++ b/components/ILIAS/User/classes/class.ilObjUserGUI.php
@@ -220,10 +220,13 @@ class ilObjUserGUI extends ilObjectGUI
             );
         }
 
-        // learning progress
-        if ($this->rbac_system->checkAccess('read', $this->ref_id) and
-            ilObjUserTracking::_enabledLearningProgress() and
-            ilObjUserTracking::_enabledUserRelatedData()) {
+        if ((
+            $this->context === Context::LocalUserAdministration
+                && $this->rbac_system->checkAccess('read', $this->ref_id)
+            || $this->context === Context::UserAdministration
+                && $this->rbac_system->checkAccess(\ilObjUserFolder::PERM_READ_ALL, $this->ref_id)
+        ) && ilObjUserTracking::_enabledLearningProgress()
+            && ilObjUserTracking::_enabledUserRelatedData()) {
             $this->tabs_gui->addTarget(
                 'learning_progress',
                 $this->ctrl->getLinkTargetByClass('illearningprogressgui', ''),
@@ -1322,29 +1325,25 @@ class ilObjUserGUI extends ilObjectGUI
 
     private function checkUserWritePermission(): void
     {
-        if ($this->usrf_ref_id === USER_FOLDER_ID
-            && (
-                !$this->rbac_system->checkAccess('visible,read', $this->usrf_ref_id)
-                || !$this->rbac_system->checkAccess('write', $this->usrf_ref_id)
-                    && (
-                        !$this->access->checkPositionAccess(\ilObjUserFolder::ORG_OP_EDIT_USER_ACCOUNTS, $this->usrf_ref_id)
-                        || $this->access->checkPositionAccess(\ilObjUserFolder::ORG_OP_EDIT_USER_ACCOUNTS, $this->usrf_ref_id)
-                            && !in_array(
-                                $this->object->getId(),
-                                $this->access->filterUserIdsByPositionOfCurrentUser(
-                                    \ilObjUserFolder::ORG_OP_EDIT_USER_ACCOUNTS,
-                                    USER_FOLDER_ID,
-                                    [$this->object->getId()]
-                                )
-                            )
+        if ($this->context === Context::UserAdministration
+            && !(
+                $this->rbac_system->checkAccess(\ilObjUserFolder::PERM_READ_ALL_AND_WRITE, $this->usrf_ref_id)
+                || $this->access->checkPositionAccess(\ilObjUserFolder::ORG_OP_EDIT_USER_ACCOUNTS, $this->usrf_ref_id)
+                    && in_array(
+                        $this->object->getId(),
+                        $this->access->filterUserIdsByPositionOfCurrentUser(
+                            \ilObjUserFolder::ORG_OP_EDIT_USER_ACCOUNTS,
+                            USER_FOLDER_ID,
+                            [$this->object->getId()]
+                        )
                     )
-            )
-        ) {
+            )) {
             $this->tpl->setOnScreenMessage(
                 'failure',
-                $this->lng->txt('msg_no_perm_modify_user')
+                $this->lng->txt('msg_no_perm_modify_user'),
+                true
             );
-            $this->ctrl->redirectByClass(ilObjUserFolderAccess::class);
+            $this->ctrl->redirectByClass(ilObjUserFolderGUI::class);
         }
 
         // if called from local administration $this->usrf_ref_id is category id

--- a/components/ILIAS/User/src/Presentation/AdminTabs.php
+++ b/components/ILIAS/User/src/Presentation/AdminTabs.php
@@ -300,7 +300,7 @@ class AdminTabs
     private function readAccessToAccountsGranted(): bool
     {
         return $this->access->checkRbacOrPositionPermissionAccess(
-            'read',
+            \ilObjUserFolder::PERM_READ_ALL,
             \ilObjUserFolder::ORG_OP_EDIT_USER_ACCOUNTS,
             $this->ref_id
         );
@@ -308,9 +308,9 @@ class AdminTabs
 
     private function editSettingsAccessGranted(): bool
     {
-        return $this->access->checkRbacOrPositionPermissionAccess(
+        return $this->access->checkAccess(
             'write',
-            \ilObjUserFolder::ORG_OP_EDIT_USER_ACCOUNTS,
+            '',
             $this->ref_id
         );
     }

--- a/components/ILIAS/User/src/Setup/AddReadAllAccountsPermissionObjective.php
+++ b/components/ILIAS/User/src/Setup/AddReadAllAccountsPermissionObjective.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\User\Setup;
+
+use ILIAS\Setup\Objective;
+use ILIAS\Setup\Environment;
+use ilAccessCustomRBACOperationAddedObjective;
+use ilAccessRBACOperationClonedObjective;
+use ilDatabaseInitializedObjective;
+
+class AddReadAllAccountsPermissionObjective implements Objective
+{
+    private const string TYPE = 'usrf';
+    private const int VISIBLE = 2;
+    private const int READ = 3;
+
+    public function getHash(): string
+    {
+        return hash('sha256', self::class);
+    }
+
+    public function getLabel(): string
+    {
+        return ('Add the "Read All Accounts" permission to the user folder');
+    }
+
+    public function isNotable(): bool
+    {
+        return true;
+    }
+
+    public function getPreconditions(Environment $environment): array
+    {
+        return [
+            new ilDatabaseInitializedObjective()
+        ];
+    }
+
+    public function achieve(Environment $environment): Environment
+    {
+        (new ilAccessCustomRBACOperationAddedObjective(
+            'read_all_accounts',
+            'read all accounts',
+            'object',
+            2100,
+            [self::TYPE]
+        ))->achieve($environment);
+
+        $new_id = $this->getAddedOperationId($environment);
+        if ($new_id !== null) {
+
+            (new ilAccessRBACOperationClonedObjective(
+                self::TYPE,
+                self::READ,
+                $new_id
+            ))->achieve($environment);
+
+            (new ilAccessRBACOperationClonedObjective(
+                self::TYPE,
+                self::VISIBLE,
+                self::READ
+            ))->achieve($environment);
+
+            (new \ilAccessRBACOperationDeletedObjective(
+                self::TYPE,
+                self::VISIBLE
+            ))->achieve($environment);
+        }
+
+        return $environment;
+    }
+
+    public function isApplicable(Environment $environment): bool
+    {
+        return $this->getAddedOperationId($environment) === null;
+    }
+
+    private function getAddedOperationId(Environment $environment): ?int
+    {
+        /** @var \ilDBInterface $db */
+        $db = $environment->getResource(Environment::RESOURCE_DATABASE);
+
+        $query = 'SELECT ops_id FROM rbac_operations WHERE operation ="read_all_accounts"';
+        $result = $db->query($query);
+        while ($row = $db->fetchAssoc($result)) {
+            return (int) $row['ops_id'];
+        }
+        return null;
+    }
+}

--- a/components/ILIAS/User/src/Setup/Agent.php
+++ b/components/ILIAS/User/src/Setup/Agent.php
@@ -81,6 +81,7 @@ class Agent implements SetupAgent
             new \ilDatabaseUpdateStepsExecutedObjective(
                 new DBUpdateSteps11()
             ),
+            new AddReadAllAccountsPermissionObjective(),
             new CollectSettingsObjective($this->user_settings_contributions),
             new CollectTypesObjective($this->user_custom_profile_fields),
             new CollectListenersObjective($this->user_field_attributes_change_listeners)

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -14606,6 +14606,7 @@ rbac#:#rcrs_edit_permission#:#Rechteeinstellungen ändern
 rbac#:#rcrs_read#:#Lesezugriff auf ECS-Kurs
 rbac#:#rcrs_visible#:#ECS-Kurs ist sichtbar
 rbac#:#rcrs_write#:#ECS-Kurs bearbeiten
+rbac#:#read_all_accounts#:#Alle Anmeldekonten einsehen
 rbac#:#read_comp#:#Lesezugriff Kompetenzen
 rbac#:#read_learning_progress#:#Lernfortschritt anderer Benutzer einsehen
 rbac#:#read_outcomes#:#Lernerfahrungen anderer Benutzer anzeigen
@@ -14778,6 +14779,7 @@ rbac#:#usrf_edit_permission#:#Rechteeinstellungen für die Anmeldekontenverwaltu
 rbac#:#usrf_edit_roleassignment#:#Rollenzuweisung von Anmeldekonten ändern
 rbac#:#usrf_push_desktop_items#:#Erlaube ILIAS-Objekte anderen Benutzern als empfohlene Inhalte vorzulegen.
 rbac#:#usrf_read#:#Lesezugriff auf Anmeldekontenverwaltung
+rbac#:#usrf_read_all_accounts#:#Lesezugriff auf alle Anmeldekonten
 rbac#:#usrf_read_users#:#Lesezugriff auf Anmeldekonten für lokale Administration
 rbac#:#usrf_visible#:#Anmeldekontenverwaltung ist sichtbar
 rbac#:#usrf_write#:#Einstellungen in Anmeldekontenverwaltung bearbeiten

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -14609,6 +14609,7 @@ rbac#:#rcrs_edit_permission#:#User can change permission settings
 rbac#:#rcrs_read#:#User can use ECS Course
 rbac#:#rcrs_visible#:#ECS Course is visible
 rbac#:#rcrs_write#:#User can edit settings of ECS Course
+rbac#:#read_all_accounts#:#Read All Accounts
 rbac#:#read_comp#:#Read Competences
 rbac#:#read_learning_progress#:#View learning progress of other users
 rbac#:#read_outcomes#:#View learning experiences of other users
@@ -14781,6 +14782,7 @@ rbac#:#usrf_edit_permission#:#User can change permission settings in User admini
 rbac#:#usrf_edit_roleassignment#:#User can change role assignment of user account
 rbac#:#usrf_push_desktop_items#:#User is allowed to add recommended content for role members.
 rbac#:#usrf_read#:#User has read access to User administration
+rbac#:#usrf_read_all_accounts#:#User can list all accounts in User administration
 rbac#:#usrf_read_users#:#User has read access to local user accounts (local administrators)
 rbac#:#usrf_visible#:#User administration is visible
 rbac#:#usrf_write#:#Edit settings in User administration


### PR DESCRIPTION
This PR is part of the feature request [Unbundling of Admin Permissions](https://docu.ilias.de/go/wiki/wpage_8648_1357).

It introduces a new permission "Read All Accounts" to the User Administration. A user now needs this permission instead of "Read" to view all accounts. Users not having this permission may still see accounts for their organisational units position. 

An account can be edited if both permissions "Read All Accounts" and "Edit Settings" are given, or if the organisational position allows to edit the account.

The "Read" permission is now a requirement for the whole user administration. The "Visible" permission is removed. Former values are changed accordingly:

- Read => Read All Accounts
- Visible => Read