### PR TITLE
Fix: Add contextual label to MainBar close button.

### DIFF
--- a/components/ILIAS/UI/resources/js/MainControls/dist/mainbar.js
+++ b/components/ILIAS/UI/resources/js/MainControls/dist/mainbar.js
@@ -907,7 +907,7 @@ var persistence = function() {
 
             var triggerer = parts.triggerer.withHtmlId(dom_references[entry.id].triggerer),
                 slate = parts.slate.withHtmlId(dom_references[entry.id].slate);
-                
+
                 //a11y
                 triggerer.getElement().attr('aria-controls', slate.html_id);
                 triggerer.getElement().attr('aria-labelledby', triggerer.html_id);
@@ -926,6 +926,15 @@ var persistence = function() {
                     remover = parts.remover.withHtmlId(dom_references[entry.id].remover);
                     remover.mb_show(true);
                 }
+                
+                var slateName = triggerer.getElement().find('.bulky-label').text().trim();
+                if (slateName) {
+                    var closeButton = $('.il-mainbar-close-slates .btn-bulky');
+                    var closeLabel = il.Language.txt('close') + ' ' + slateName;
+                    closeButton.attr('aria-label', closeLabel);
+                    closeButton.find('.bulky-label').text(closeLabel);
+                }
+            
             } else {
                 triggerer.disengage();
                 slate.disengage();

--- a/components/ILIAS/UI/resources/js/MainControls/src/mainbar.renderer.js
+++ b/components/ILIAS/UI/resources/js/MainControls/src/mainbar.renderer.js
@@ -200,7 +200,7 @@
 
             var triggerer = parts.triggerer.withHtmlId(dom_references[entry.id].triggerer),
                 slate = parts.slate.withHtmlId(dom_references[entry.id].slate);
-                
+
                 //a11y
                 triggerer.getElement().attr('aria-controls', slate.html_id);
                 triggerer.getElement().attr('aria-labelledby', triggerer.html_id);
@@ -219,6 +219,15 @@
                     remover = parts.remover.withHtmlId(dom_references[entry.id].remover);
                     remover.mb_show(true);
                 }
+                
+                var slateName = triggerer.getElement().find('.bulky-label').text().trim();
+                if (slateName) {
+                    var closeButton = $('.il-mainbar-close-slates .btn-bulky');
+                    var closeLabel = il.Language.txt('close') + ' ' + slateName;
+                    closeButton.attr('aria-label', closeLabel);
+                    closeButton.find('.bulky-label').text(closeLabel);
+                }
+            
             } else {
                 triggerer.disengage();
                 slate.disengage();

--- a/components/ILIAS/UI/resources/js/MainControls/src/mainbar.renderer.js
+++ b/components/ILIAS/UI/resources/js/MainControls/src/mainbar.renderer.js
@@ -219,15 +219,6 @@
                     remover = parts.remover.withHtmlId(dom_references[entry.id].remover);
                     remover.mb_show(true);
                 }
-                
-                var slateName = triggerer.getElement().find('.bulky-label').text().trim();
-                if (slateName) {
-                    var closeButton = $('.il-mainbar-close-slates .btn-bulky');
-                    var closeLabel = il.Language.txt('close') + ' ' + slateName;
-                    closeButton.attr('aria-label', closeLabel);
-                    closeButton.find('.bulky-label').text(closeLabel);
-                }
-            
             } else {
                 triggerer.disengage();
                 slate.disengage();
@@ -307,6 +298,18 @@
             for(idx in model_state.tools) {
                 actions.renderEntry(model_state.tools[idx], true);
             }
+
+            if (model_state.last_active_top && dom_references[model_state.last_active_top]) {
+                var activeTriggerer = parts.triggerer.withHtmlId(dom_references[model_state.last_active_top].triggerer);
+                var slateName = activeTriggerer.getElement().find('.bulky-label').text().trim();
+                if (slateName) {
+                    var closeButton = $('.il-mainbar-close-slates .btn-bulky');
+                    var closeLabel = il.Language.txt('close') + ' ' + slateName;
+                    closeButton.attr('aria-label', closeLabel);
+                    closeButton.find('.bulky-label').text(closeLabel);
+                }
+            }
+
             //unfortunately, this does not work properly via a class
             $('.' + css.mainbar_entries).css('visibility', 'visible');
         },

--- a/components/ILIAS/UI/src/Implementation/Component/MainControls/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/MainControls/Renderer.php
@@ -391,6 +391,8 @@ class Renderer extends AbstractComponentRenderer
     {
         $trigger_signals = $this->trigger_signals;
 
+        $this->toJS('close');
+
         $inititally_active = $component->getActive();
 
         $component = $component->withOnLoadCode(


### PR DESCRIPTION
The close button in the MainBar subsections was only labeled as "Close" without indicating which specific subsection was being closed, causing accessibility issues for screen reader users.

Changes:
- Modified `mainbar.renderer.js` to dynamically update both aria-label and visible text of the close button when a slate is engaged
- Added `toJS('close')` in MainControls `Renderer.php` to expose the translation key to JavaScript
- Close button now displays contextual information (e.g., "Close Personal Workspace" instead of just "Close")

This fix improves WCAG 2.1 compliance by providing clear context about which UI element will be affected by the close action.

Ticket [43949](https://mantis.ilias.de/view.php?id=43949)