### PR TITLE
Fix: Correct focus order in panel header for accessibility.

### DIFF
--- a/templates/default/070-components/UI-framework/Panel/_ui-component_panel.scss
+++ b/templates/default/070-components/UI-framework/Panel/_ui-component_panel.scss
@@ -53,12 +53,12 @@
 
 	.panel-viewcontrols {
 		@include break.on-screen-size(small) {
-			order: 3;
+			order: 2;
 			width: 100%;
 			justify-content: center;
 		}
 		@include break.on-screen-size(medium) {
-			order: 3;
+			order: 2;
 			width: 100%;
 			justify-content: center;
 		}
@@ -101,10 +101,10 @@
 		justify-content: flex-end;
 		margin-left: auto;
 		@include break.on-screen-size(small) {
-			order: 2;
+			order: 3;
 		}
 		@include break.on-screen-size(medium) {
-			order: 2;
+			order: 3;
 		}
 		@include break.on-screen-size(large) {
 			order: 3;


### PR DESCRIPTION
The standard panel component's header had a mismatch between the visual order of controls and the keyboard focus order on mobile/tablet views, violating WCAG 2.4.3 (Focus Order).

This was caused by CSS Flexbox `order` properties that visually re-arranged the actions and sortation controls on smaller screens without changing their underlying DOM order, creating a confusing and illogical navigation path for keyboard and screen reader users.

Changes:
- Modified `_ui-component_panel.scss` to align the flex `order` with the DOM order for `.panel-viewcontrols` and `.panel-controls` across all breakpoints.
- This ensures the tabbing sequence is consistent with the visual layout, providing a predictable user experience.
- The visual order on mobile now follows the DOM, presenting the sortation control before the actions dropdown.

Ticket [41479](https://mantis.ilias.de/view.php?id=41479)