### PR TITLE
Fix: Ensure focus visibility for “Show more” button in responsive view

### DIFF
--- a/templates/default/070-components/UI-framework/MainControls/_ui-component_metabar.scss
+++ b/templates/default/070-components/UI-framework/MainControls/_ui-component_metabar.scss
@@ -82,7 +82,6 @@ $il-metabar-small-glyph-size: 1.25rem;
 		&.engaged {
 			box-shadow: $il-mainbar-shadow-right;
 			background-color: $il-metabar-slates-bg-color;
-			border: $il-metabar-entry-border;
 			color: initial;
 			outline-color: transparent;
 		}

--- a/templates/default/070-components/UI-framework/MainControls/_ui-component_metabar.scss
+++ b/templates/default/070-components/UI-framework/MainControls/_ui-component_metabar.scss
@@ -83,7 +83,8 @@ $il-metabar-small-glyph-size: 1.25rem;
 			box-shadow: $il-mainbar-shadow-right;
 			background-color: $il-metabar-slates-bg-color;
 			color: initial;
-			outline-color: transparent;
+			border: $il-metabar-entry-border;
+			@include f.il-focus-border-only();
 		}
 		.glyphicon {
 			color: $il-metabar-glyph-color;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -6074,7 +6074,12 @@ a[aria-disabled].il-link.link-bulky:hover {
   box-shadow: 1px 3px 4px rgba(0, 0, 0, 0.1);
   background-color: #fafafa;
   color: initial;
-  outline-color: transparent;
+  border: none;
+}
+.il-maincontrols-metabar > li > .btn.btn-bulky.engaged:focus-visible, .il-maincontrols-metabar > li > a.il-link.link-bulky.engaged:focus-visible {
+  outline: none;
+  border: 3px solid #0078D7;
+  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 2px #FFFFFF;
 }
 .il-maincontrols-metabar > li > .btn.btn-bulky .glyphicon, .il-maincontrols-metabar > li > a.il-link.link-bulky .glyphicon {
   color: #737373;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -6073,7 +6073,6 @@ a[aria-disabled].il-link.link-bulky:hover {
 .il-maincontrols-metabar > li > .btn.btn-bulky.engaged, .il-maincontrols-metabar > li > a.il-link.link-bulky.engaged {
   box-shadow: 1px 3px 4px rgba(0, 0, 0, 0.1);
   background-color: #fafafa;
-  border: none;
   color: initial;
   outline-color: transparent;
 }


### PR DESCRIPTION
Adjusted the focus styling of the “Show more” button in the responsive and zoomed views to ensure that the element remains visibly highlighted when focused. This improves keyboard navigation and compliance with accessibility guidelines (BITV 9.2.4.7).
- Removed border assignment in the engaget state of the button in `_ui-component_metabar.scss`

Ticket [43958](https://mantis.ilias.de/view.php?id=43958)