### PR TITLE
[FEATURE] ensure project `node` and `npm` versions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.3, 8.4]
-        nodejs: [ 23.x ]
+        nodejs: [ 22.x, 24.x ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,6 @@
+# enforces strict compatibility with the version of `node` and `npm`
+# as specified in the `package.json` file when running commands in
+# this project.
+# @see https://docs.npmjs.com/cli/v11/using-npm/config#engine-strict
+# @see https://docs.npmjs.com/cli/v11/configuring-npm/package-json#engines
+engine-strict=true

--- a/components/ILIAS/App/tests/RootFolderTest.php
+++ b/components/ILIAS/App/tests/RootFolderTest.php
@@ -25,6 +25,7 @@ use PHPUnit\Framework\TestCase;
 final class RootFolderTest extends TestCase
 {
     private const array ALLOWED_ROOT_FOLDER_FILES = [
+        '.npmrc',
         '.eslintrc.json',
         '.gitignore',
         '.htaccess',

--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -68,7 +68,7 @@ current configuration of the [ILIAS test server](https://test11.ilias.de), which
 | PHP          | 8.3, 8.4                                               | 8.4              |
 | Webserver    | nginx: 1.12.x – 1.18.x, Apache: ≥ 2.4.x                | Apache 2.4.52    |
 | JDK          | Open JDK Runtime 11, 17 or 21 LTS                      | OpenJDK 17       |
-| Node.js      | 22 (LTS), 23, 24 Recommended: 24                       | v24.10.0         |
+| Node.js      | 22 (LTS), 24 Recommended: 24                           | v24.10.0         |
 | Ghostscript  | 10.x                                                   | 9.55             |
 | Imagemagick  | 6.9.x                                                  | 6.9.11           |
 | Browser      | a contemporary browser supporting ES6, CSS3 and HTML 5 |                  |

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "directories": {
     "doc": "docs"
   },
+  "engines": {
+    "node": "^22.18 || ^24.0",
+    "npm": "^10.9.3 || ^11.3"
+  },
   "dependencies": {
     "@yaireo/tagify": "^4.32.1",
     "chart.js": "^4.4.7",


### PR DESCRIPTION
Hi all,

This is a follow-up on #10034 to add a project `.npmrc` config, so we can ensure we are all using similar-ish versions of `node` and `npm`. See:

* https://docs.npmjs.com/cli/v11/configuring-npm/package-json#engines
* https://docs.npmjs.com/cli/v11/using-npm/config#engine-strict

Merging this will set the min-requirement of `node` v24.0 and `npm` v11.6 – @mjansenDatabay I assign this to you, since you need to check the chat server. 

Kind regards
@thibsy 