### PR TITLE
Init/Error: Improve error handling in `error.php`

### DIFF
--- a/components/ILIAS/Init/resources/error.php
+++ b/components/ILIAS/Init/resources/error.php
@@ -18,31 +18,73 @@
 
 declare(strict_types=1);
 
+namespace ILIAS\Init;
+
 try {
     require_once '../vendor/composer/vendor/autoload.php';
-    ilInitialisation::initILIAS();
-    $DIC->globalScreen()->tool()->context()->claim()->external();
-    $local_tpl = new ilGlobalTemplate("tpl.main.html", true, true);
-    $local_tpl->addBlockFile("CONTENT", "content", "tpl.error.html");
-    $lng->loadLanguageModule("error");
-    // #13515 - link back to "system" [see ilWebAccessChecker::sendError()]
-    $nd = $tree->getNodeData(ROOT_FOLDER_ID);
-    $txt = $lng->txt('error_back_to_repository');
-    $local_tpl->SetCurrentBlock("ErrorLink");
-    $local_tpl->SetVariable("TXT_LINK", $txt);
-    $local_tpl->SetVariable("LINK", ilUtil::secureUrl(ILIAS_HTTP_PATH . '/ilias.php?baseClass=ilRepositoryGUI&amp;client_id=' . CLIENT_ID));
-    $local_tpl->ParseCurrentBlock();
+    \ilInitialisation::initILIAS();
 
-    ilSession::clear("referer");
-    ilSession::clear("message");
+    $DIC->globalScreen()->tool()->context()->claim()->external();
+
+    $lng->loadLanguageModule('error');
+    $txt = $lng->txt('error_back_to_repository');
+
+    $local_tpl = new \ilGlobalTemplate('tpl.error.html', true, true);
+    $local_tpl->setCurrentBlock('ErrorLink');
+    $local_tpl->setVariable('TXT_LINK', $txt);
+    $local_tpl->setVariable('LINK', \ilUtil::secureUrl(ILIAS_HTTP_PATH . '/ilias.php?baseClass=ilRepositoryGUI'));
+    $local_tpl->parseCurrentBlock();
+
+    \ilSession::clear('referer');
+    \ilSession::clear('message');
+
+    $DIC->http()->saveResponse(
+        $DIC->http()
+            ->response()
+            ->withStatus(500)
+            ->withHeader(\ILIAS\HTTP\Response\ResponseHeader::CONTENT_TYPE, 'text/html')
+    );
+
     $tpl->setContent($local_tpl->get());
     $tpl->printToStdout();
-} catch (Exception $e) {
-    if (defined('DEVMODE') && DEVMODE) {
+
+    $DIC->http()->close();
+} catch (\Throwable $e) {
+    if (\defined('DEVMODE') && DEVMODE) {
         throw $e;
     }
 
-    if (!($e instanceof \PDOException)) {
-        die($e->getMessage());
+    /*
+     * Since we are already in the `error.php` and an unexpected error occurred, we should not rely on the $DIC or any
+     * other components here and use "Vanilla PHP" instead to handle the error.
+     */
+    if (!headers_sent()) {
+        http_response_code(500);
+        header('Content-Type: text/plain; charset=UTF-8');
     }
+
+    $incident_id = session_id() . '_' . (new \Random\Randomizer())->getInt(1, 9999);
+    $timestamp = (new \DateTimeImmutable())->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d\TH:i:s\Z');
+
+    echo "Internal Server Error\n";
+    echo "Incident: $incident_id\n";
+    echo "Timestamp: $timestamp\n";
+    if ($e instanceof \PDOException) {
+        echo "Message: A database error occurred. Please contact the system administrator with the incident id.\n";
+    } else {
+        echo "Message: {$e->getMessage()}\n";
+    }
+
+    error_log(\sprintf(
+        "[%s] INCIDENT %s — Uncaught %s: %s in %s:%d\nStack trace:\n%s\n",
+        $timestamp,
+        $incident_id,
+        \get_class($e),
+        $e->getMessage(),
+        $e->getFile(),
+        $e->getLine(),
+        $e->getTraceAsString()
+    ));
+
+    exit(1);
 }


### PR DESCRIPTION
This commit improves the global error handling in `error.php`:

1. Remove building a global template from `tpl.main.html` since it only contains one  placeholder (see 2b8eafc630076a696caa5bd3df679c16cd4ea250) and provides no added value
2. Ensure a proper HTTP 500 status code is sent for normal error handling
3. Ensure a proper HTTP 500 status code is sent if an unexpected error occurs while rendering the error page
4. Log errors to `error_log` with minimal user-facing output, including an incident ID, timestamp, and message