### PR TITLE
ECS: Implement Support for OpenID Connect

### DIFF
--- a/components/ILIAS/WebServices/ECS/classes/Auth/class.ilECSAuthFactory.php
+++ b/components/ILIAS/WebServices/ECS/classes/Auth/class.ilECSAuthFactory.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+class ilECSAuthFactory
+{
+    protected readonly ilLogger $logger;
+    protected readonly ilCtrlInterface $ctrl;
+    protected readonly ilLanguage $lng;
+
+    public function __construct()
+    {
+        global $DIC;
+
+        $this->logger = $DIC->logger()->wsrv();
+        $this->ctrl = $DIC->ctrl();
+        $this->lng = $DIC->language();
+    }
+
+    public function build(int $auth_type): ?ilECSAuthStrategy
+    {
+        return match ($auth_type) {
+            ilECSParticipantSetting::INCOMING_AUTH_TYPE_LOGIN_PAGE =>
+                new ilLoginPageAuthStrategy($this->ctrl, $this->logger, $this->lng),
+            ilECSParticipantSetting::INCOMING_AUTH_TYPE_SHIBBOLETH =>
+                new ilShibbolethAuthStrategy($this->ctrl, $this->logger),
+            ilECSParticipantSetting::INCOMING_AUTH_TYPE_OIDC =>
+                new ilOIDCAuthStrategy($this->ctrl, $this->logger),
+            default => null,
+        };
+    }
+
+    public function getAuthTypes(): array
+    {
+        return [
+            ilECSParticipantSetting::INCOMING_AUTH_TYPE_LOGIN_PAGE,
+            ilECSParticipantSetting::INCOMING_AUTH_TYPE_SHIBBOLETH,
+            ilECSParticipantSetting::INCOMING_AUTH_TYPE_OIDC,
+        ];
+    }
+
+    public function getAvailableStrategies(): array
+    {
+        $strategies = [];
+        foreach ($this->getAuthTypes() as $auth_type) {
+            $strategy = $this->build($auth_type);
+            if ($strategy->isActive()) {
+                $strategies[$auth_type] = $strategy;
+            }
+        }
+        return $strategies;
+    }
+}

--- a/components/ILIAS/WebServices/ECS/classes/Auth/class.ilECSAuthStrategy.php
+++ b/components/ILIAS/WebServices/ECS/classes/Auth/class.ilECSAuthStrategy.php
@@ -24,41 +24,4 @@ abstract class ilECSAuthStrategy
     abstract public function getName(): string;
 
     abstract public function handleLogin(string $redirection_target): void;
-
-
-    public static function build(int $auth_type): ?ilECSAuthStrategy
-    {
-        global $DIC;
-
-        return match ($auth_type) {
-            ilECSParticipantSetting::INCOMING_AUTH_TYPE_LOGIN_PAGE =>
-                new ilLoginPageAuthStrategy($DIC->ctrl(), $DIC->logger()->auth(), $DIC->language()),
-            ilECSParticipantSetting::INCOMING_AUTH_TYPE_SHIBBOLETH =>
-                new ilShibbolethAuthStrategy($DIC->ctrl(), $DIC->logger()->auth()),
-            ilECSParticipantSetting::INCOMING_AUTH_TYPE_OIDC =>
-                new ilOIDCAuthStrategy($DIC->ctrl(), $DIC->logger()->auth()),
-            default => null,
-        };
-    }
-
-    public static function getAuthTypes(): array
-    {
-        return [
-            ilECSParticipantSetting::INCOMING_AUTH_TYPE_LOGIN_PAGE,
-            ilECSParticipantSetting::INCOMING_AUTH_TYPE_SHIBBOLETH,
-            ilECSParticipantSetting::INCOMING_AUTH_TYPE_OIDC,
-        ];
-    }
-
-    public static function getAvailableStrategies(): array
-    {
-        $strategies = [];
-        foreach (self::getAuthTypes() as $auth_type) {
-            $strategy = self::build($auth_type);
-            if($strategy->isActive()) {
-                $strategies[$auth_type] = $strategy;
-            }
-        }
-        return $strategies;
-    }
 }

--- a/components/ILIAS/WebServices/ECS/classes/Auth/class.ilECSAuthStrategy.php
+++ b/components/ILIAS/WebServices/ECS/classes/Auth/class.ilECSAuthStrategy.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+abstract class ilECSAuthStrategy
+{
+    abstract public function isActive(): bool;
+
+    abstract public function getName(): string;
+
+    abstract public function handleLogin(string $redirection_target): void;
+
+
+    public static function build(int $auth_type): ?ilECSAuthStrategy
+    {
+        global $DIC;
+
+        return match ($auth_type) {
+            ilECSParticipantSetting::INCOMING_AUTH_TYPE_LOGIN_PAGE =>
+                new ilLoginPageAuthStrategy($DIC->ctrl(), $DIC->logger()->auth(), $DIC->language()),
+            ilECSParticipantSetting::INCOMING_AUTH_TYPE_SHIBBOLETH =>
+                new ilShibbolethAuthStrategy($DIC->ctrl(), $DIC->logger()->auth()),
+            ilECSParticipantSetting::INCOMING_AUTH_TYPE_OIDC =>
+                new ilOIDCAuthStrategy($DIC->ctrl(), $DIC->logger()->auth()),
+            default => null,
+        };
+    }
+
+    public static function getAuthTypes(): array
+    {
+        return [
+            ilECSParticipantSetting::INCOMING_AUTH_TYPE_LOGIN_PAGE,
+            ilECSParticipantSetting::INCOMING_AUTH_TYPE_SHIBBOLETH,
+            ilECSParticipantSetting::INCOMING_AUTH_TYPE_OIDC,
+        ];
+    }
+
+    public static function getAvailableStrategies(): array
+    {
+        $strategies = [];
+        foreach (self::getAuthTypes() as $auth_type) {
+            $strategy = self::build($auth_type);
+            if($strategy->isActive()) {
+                $strategies[$auth_type] = $strategy;
+            }
+        }
+        return $strategies;
+    }
+}

--- a/components/ILIAS/WebServices/ECS/classes/Auth/class.ilLoginPageAuthStrategy.php
+++ b/components/ILIAS/WebServices/ECS/classes/Auth/class.ilLoginPageAuthStrategy.php
@@ -38,7 +38,7 @@ class ilLoginPageAuthStrategy extends ilECSAuthStrategy
 
     public function handleLogin(string $redirection_target): void
     {
-        $this->logger->info('Redirect to oidc authentication');
+        $this->logger->info('Redirect to login authentication');
         ilSession::set('success', $this->lng->txt('ecs_login_success_ilias'));
         $this->ctrl->redirectToURL('login.php?target=' . $redirection_target);
     }

--- a/components/ILIAS/WebServices/ECS/classes/Auth/class.ilLoginPageAuthStrategy.php
+++ b/components/ILIAS/WebServices/ECS/classes/Auth/class.ilLoginPageAuthStrategy.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+class ilLoginPageAuthStrategy extends ilECSAuthStrategy
+{
+    public function __construct(
+        private ilCtrlInterface $ctrl,
+        private ilLogger $logger,
+        private ilLanguage $lng
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'ilias';
+    }
+
+    public function isActive(): bool
+    {
+        return true;
+    }
+
+    public function handleLogin(string $redirection_target): void
+    {
+        $this->logger->info('Redirect to oidc authentication');
+        ilSession::set('success', $this->lng->txt('ecs_login_success_ilias'));
+        $this->ctrl->redirectToURL('login.php?target=' . $redirection_target);
+    }
+}

--- a/components/ILIAS/WebServices/ECS/classes/Auth/class.ilOIDCAuthStrategy.php
+++ b/components/ILIAS/WebServices/ECS/classes/Auth/class.ilOIDCAuthStrategy.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+class ilOIDCAuthStrategy extends ilECSAuthStrategy
+{
+    public function __construct(
+        private readonly ilCtrlInterface $ctrl,
+        private readonly ilLogger $logger
+    ) {
+    }
+    public function isActive(): bool
+    {
+        return ilOpenIdConnectSettings::getInstance()->getActive();
+    }
+
+    public function getName(): string
+    {
+        return 'oidc';
+    }
+    public function handleLogin(string $redirection_target): void
+    {
+        $this->logger->info('Redirect to oidc authentication');
+        $this->ctrl->redirectToURL('openidconnect.php?target=' . $redirection_target);
+    }
+}

--- a/components/ILIAS/WebServices/ECS/classes/Auth/class.ilOIDCAuthStrategy.php
+++ b/components/ILIAS/WebServices/ECS/classes/Auth/class.ilOIDCAuthStrategy.php
@@ -24,6 +24,7 @@ class ilOIDCAuthStrategy extends ilECSAuthStrategy
         private readonly ilLogger $logger
     ) {
     }
+
     public function isActive(): bool
     {
         return ilOpenIdConnectSettings::getInstance()->getActive();
@@ -33,8 +34,16 @@ class ilOIDCAuthStrategy extends ilECSAuthStrategy
     {
         return 'oidc';
     }
+
     public function handleLogin(string $redirection_target): void
     {
+        // the target may be '/goto.php/crs/123' which is not supported by oidc (see `LegacyGotoHandler::handle`)
+        // instead it should be 'crs_123' and will be built to '/goto.php/?target=crs_123' in oidc login page
+        if (str_contains($redirection_target, 'goto.php/')) {
+            $redirection_target = ltrim(str_replace('goto.php', '', $redirection_target), '/');
+            $redirection_target = str_replace('/', '_', $redirection_target);
+        }
+
         $this->logger->info('Redirect to oidc authentication');
         $this->ctrl->redirectToURL('openidconnect.php?target=' . $redirection_target);
     }

--- a/components/ILIAS/WebServices/ECS/classes/Auth/class.ilShibbolethAuthStrategy.php
+++ b/components/ILIAS/WebServices/ECS/classes/Auth/class.ilShibbolethAuthStrategy.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+class ilShibbolethAuthStrategy extends ilECSAuthStrategy
+{
+    public function __construct(
+        private ilCtrlInterface $ctrl,
+        private ilLogger $logger
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'shib';
+    }
+
+    public function isActive(): bool
+    {
+        return (new ilShibbolethSettings())->isActive();
+    }
+
+    public function handleLogin(string $redirection_target): void
+    {
+        $this->logger->info('Redirect to shibboleth authentication');
+        $this->ctrl->redirectToURL('shib_login.php?target=' . $redirection_target);
+    }
+}

--- a/components/ILIAS/WebServices/ECS/classes/Course/class.ilECSCmsCourseMemberCommandQueueHandler.php
+++ b/components/ILIAS/WebServices/ECS/classes/Course/class.ilECSCmsCourseMemberCommandQueueHandler.php
@@ -435,13 +435,6 @@ class ilECSCmsCourseMemberCommandQueueHandler implements ilECSCommandQueueHandle
         }
         $auth_mode = $this->mapping->getAuthMode();
 
-        if (
-            $this->mapping->getAuthMode() ===
-            ilAuthUtils::_getAuthModeName(ilAuthUtils::AUTH_SHIBBOLETH)
-        ) {
-            $this->log->info('Not handling direct user creation for auth mode: ' . $auth_mode);
-            return;
-        }
         if (strpos($auth_mode, 'ldap') !== 0) {
             $this->log->info('Not handling direct user creation for auth mode: ' . $auth_mode);
             return;

--- a/components/ILIAS/WebServices/ECS/classes/class.ilAuthProviderECS.php
+++ b/components/ILIAS/WebServices/ECS/classes/class.ilAuthProviderECS.php
@@ -150,12 +150,13 @@ class ilAuthProviderECS extends ilAuthProvider
                 $this->refinery->kindlyTo()->bool()
             );
         }
-        $redirection_target = '';
         if ($this->http->wrapper()->query()->has('target')) {
             $redirection_target = $this->http->wrapper()->query()->retrieve(
                 'target',
                 $this->refinery->kindlyTo()->string()
             );
+        }else{
+            $redirection_target = $this->http->request()->getUri()->getPath();
         }
         $part_settings = new ilECSParticipantSetting(
             $this->getCurrentServer()->getServerId(),

--- a/components/ILIAS/WebServices/ECS/classes/class.ilAuthProviderECS.php
+++ b/components/ILIAS/WebServices/ECS/classes/class.ilAuthProviderECS.php
@@ -167,23 +167,10 @@ class ilAuthProviderECS extends ilAuthProvider
             $status->setAuthenticatedUserId($this->authSession->getUserId());
             return true;
         }
-        if (
-            $is_external_account &&
-            $part_settings->getIncomingAuthType() === ilECSParticipantSetting::INCOMING_AUTH_TYPE_LOGIN_PAGE
-        ) {
-            $this->getLogger()->info('ILIAS login page authentication required.');
-            ilSession::set('success', $this->lng->txt('ecs_login_success_ilias'));
+        if ($is_external_account) {
             $this->initRemoteUserWithRemoteId();
-            $this->ctrl->redirectToURL('login.php?target=' . $redirection_target);
+            ilECSAuthStrategy::build($part_settings->getIncomingAuthType())->handleLogin($redirection_target);
             return false;
-        }
-        if (
-            $is_external_account &&
-            $part_settings->getIncomingAuthType() === ilECSParticipantSetting::INCOMING_AUTH_TYPE_SHIBBOLETH
-        ) {
-            $this->getLogger()->info('Redirect to shibboleth authentication');
-            $this->initRemoteUserWithRemoteId();
-            $this->ctrl->redirectToURL('shib_login.php?target=' . $redirection_target);
         }
         if ($part_settings->areIncomingLocalAccountsSupported()) {
             // handle successful authentication

--- a/components/ILIAS/WebServices/ECS/classes/class.ilAuthProviderECS.php
+++ b/components/ILIAS/WebServices/ECS/classes/class.ilAuthProviderECS.php
@@ -42,6 +42,7 @@ class ilAuthProviderECS extends ilAuthProvider
 
     protected ilECSSetting $currentServer;
     protected ilECSServerSettings $servers;
+    protected ilECSAuthFactory $auth_factory;
 
 
     /**
@@ -63,6 +64,7 @@ class ilAuthProviderECS extends ilAuthProvider
         $this->refinery = $DIC->refinery();
         $this->authSession = $DIC['ilAuthSession'];
         $this->ctrl = $DIC->ctrl();
+        $this->auth_factory = new ilECSAuthFactory();
 
         $this->initECSServices();
     }
@@ -155,7 +157,7 @@ class ilAuthProviderECS extends ilAuthProvider
                 'target',
                 $this->refinery->kindlyTo()->string()
             );
-        }else{
+        } else {
             $redirection_target = $this->http->request()->getUri()->getPath();
         }
         $part_settings = new ilECSParticipantSetting(
@@ -170,7 +172,7 @@ class ilAuthProviderECS extends ilAuthProvider
         }
         if ($is_external_account) {
             $this->initRemoteUserWithRemoteId();
-            ilECSAuthStrategy::build($part_settings->getIncomingAuthType())->handleLogin($redirection_target);
+            $this->auth_factory->build($part_settings->getIncomingAuthType())->handleLogin($redirection_target);
             return false;
         }
         if ($part_settings->areIncomingLocalAccountsSupported()) {

--- a/components/ILIAS/WebServices/ECS/classes/class.ilECSAppEventListener.php
+++ b/components/ILIAS/WebServices/ECS/classes/class.ilECSAppEventListener.php
@@ -253,10 +253,7 @@ class ilECSAppEventListener implements ilAppEventListener
             $remote_user->getMid()
         );
         $server = ilECSSetting::getInstanceByServerId($remote_user->getServerId());
-        if (
-            $part->getIncomingAuthType() === ilECSParticipantSetting::INCOMING_AUTH_TYPE_LOGIN_PAGE ||
-            $part->getIncomingAuthType() === ilECSParticipantSetting::INCOMING_AUTH_TYPE_SHIBBOLETH
-        ) {
+        if (in_array($part->getIncomingAuthType(), ilECSAuthStrategy::getAuthTypes(), true)) {
             $this->logger->info('Assigning ' . $username . ' to global ecs role');
             $this->rbac_admin->assignUser($server->getGlobalRole(), $user_id);
         }

--- a/components/ILIAS/WebServices/ECS/classes/class.ilECSAppEventListener.php
+++ b/components/ILIAS/WebServices/ECS/classes/class.ilECSAppEventListener.php
@@ -27,6 +27,7 @@ class ilECSAppEventListener implements ilAppEventListener
     private ilLogger $logger;
     private ilSetting $settings;
     private ilRbacAdmin $rbac_admin;
+    private ilECSAuthFactory $auth_factory;
 
     public function __construct(
         \ilLogger $logger,
@@ -36,6 +37,7 @@ class ilECSAppEventListener implements ilAppEventListener
         $this->logger = $logger;
         $this->settings = $settings;
         $this->rbac_admin = $rbac_admin;
+        $this->auth_factory = new ilECSAuthFactory();
     }
 
     /**
@@ -52,6 +54,7 @@ class ilECSAppEventListener implements ilAppEventListener
             $DIC->logger()->wsrv(),
             $DIC->settings(),
             $DIC->rbac()->admin(),
+            new ilECSAuthFactory()
         );
         $eventHandler->handle($a_component, $a_event, $a_parameter);
     }
@@ -253,7 +256,7 @@ class ilECSAppEventListener implements ilAppEventListener
             $remote_user->getMid()
         );
         $server = ilECSSetting::getInstanceByServerId($remote_user->getServerId());
-        if (in_array($part->getIncomingAuthType(), ilECSAuthStrategy::getAuthTypes(), true)) {
+        if (in_array($part->getIncomingAuthType(), $this->auth_factory->getAuthTypes(), true)) {
             $this->logger->info('Assigning ' . $username . ' to global ecs role');
             $this->rbac_admin->assignUser($server->getGlobalRole(), $user_id);
         }

--- a/components/ILIAS/WebServices/ECS/classes/class.ilECSCommunityReader.php
+++ b/components/ILIAS/WebServices/ECS/classes/class.ilECSCommunityReader.php
@@ -19,8 +19,8 @@
 declare(strict_types=1);
 
 /**
-* @author Stefan Meyer <meyer@leifos.com>
-*/
+ * @author Stefan Meyer <meyer@leifos.com>
+ */
 class ilECSCommunityReader
 {
     private static ?array $instances = null;
@@ -30,6 +30,7 @@ class ilECSCommunityReader
     private ilLogger $logger;
     private ilECSSetting $settings;
     private ilECSConnector $connector;
+    private ilDBInterface $database;
 
     /**
      * @var ilECSCommunity[]
@@ -50,6 +51,7 @@ class ilECSCommunityReader
 
         $this->logger = $DIC->logger()->wsrv();
         $this->logger->debug(print_r($setting->getServerId(), true));
+        $this->database = $DIC->database();
         $this->settings = $setting;
 
         $this->connector = new ilECSConnector($this->settings);
@@ -209,9 +211,32 @@ class ilECSCommunityReader
                 }
                 $this->communities[] = $tmp_comm;
             }
+
+            $this->createNewParticipants();
         } catch (ilECSConnectorException $e) {
             $this->logger->error(__METHOD__ . ': Error connecting to ECS server. ' . $e->getMessage());
             throw $e;
+        }
+    }
+
+    private function createNewParticipants(): void
+    {
+        $query = $this->database->queryF(
+            "SELECT mid FROM ecs_part_settings WHERE sid = %s",
+            [ilDBConstants::T_INTEGER],
+            [$this->connector->getServer()->getServerId()]
+        );
+        $existing_ids = array_map(fn($row) => $row['mid'], $this->database->fetchAll($query));
+        $missing_ids = array_diff(array_keys($this->participants), $existing_ids);
+
+        foreach ($missing_ids as $mid) {
+            $participant = $this->getParticipantByMID($mid);
+            $community = $this->getCommunityByMID($mid);
+
+            $part_settings = ilECSParticipantSetting::getInstance($this->getServer()->getServerId(), $mid);
+            $part_settings->setTitle($participant->getParticipantName());
+            $part_settings->setCommunityName($community->getTitle());
+            $part_settings->update();
         }
     }
 }

--- a/components/ILIAS/WebServices/ECS/classes/class.ilECSCommunityReader.php
+++ b/components/ILIAS/WebServices/ECS/classes/class.ilECSCommunityReader.php
@@ -151,7 +151,7 @@ class ilECSCommunityReader
     public function getParticipantNameByMid($a_mid): string
     {
         return isset($this->participants[$a_mid]) ?
-            $this->participants[$a_mid]-> getParticipantName() :
+            $this->participants[$a_mid]->getParticipantName() :
             '';
     }
 

--- a/components/ILIAS/WebServices/ECS/classes/class.ilECSParticipantSetting.php
+++ b/components/ILIAS/WebServices/ECS/classes/class.ilECSParticipantSetting.php
@@ -37,6 +37,7 @@ class ilECSParticipantSetting
     public const INCOMING_AUTH_TYPE_INACTIVE = 0;
     public const INCOMING_AUTH_TYPE_LOGIN_PAGE = 1;
     public const INCOMING_AUTH_TYPE_SHIBBOLETH = 2;
+    public const INCOMING_AUTH_TYPE_OIDC = 3;
 
     public const OUTGOING_AUTH_MODE_DEFAULT = 'default';
 

--- a/components/ILIAS/WebServices/ECS/classes/class.ilECSParticipantSettingsGUI.php
+++ b/components/ILIAS/WebServices/ECS/classes/class.ilECSParticipantSettingsGUI.php
@@ -228,17 +228,11 @@ class ilECSParticipantSettingsGUI
         $external_auth_type->setValue(
             (string) $this->getParticipant()->getIncomingAuthType()
         );
-        $external_auth_type->addOption(
-            new ilRadioOption(
-                $this->lng->txt('ecs_export_auth_type_ilias'),
-                (string) ilECSParticipantSetting::INCOMING_AUTH_TYPE_LOGIN_PAGE
-            )
-        );
-        if ($this->isShibbolethActive()) {
+        foreach (ilECSAuthStrategy::getAvailableStrategies() as $auth_type => $auth_strategy) {
             $external_auth_type->addOption(
                 new ilRadioOption(
-                    $this->lng->txt('ecs_export_auth_type_shib'),
-                    (string) ilECSParticipantSetting::INCOMING_AUTH_TYPE_SHIBBOLETH
+                    $this->lng->txt("ecs_export_auth_type_{$auth_strategy->getName()}"),
+                    (string) $auth_type
                 )
             );
         }
@@ -315,22 +309,18 @@ class ilECSParticipantSettingsGUI
         return $form;
     }
 
-    protected function parseAvailableAuthModes($a_mode_incoming = true): array
+    protected function parseAvailableAuthModes(): array
     {
         $options = [];
-        if ($this->isShibbolethActive()) {
-            $options['shibboleth'] = $this->lng->txt('auth_shib');
+        foreach (ilECSAuthStrategy::getAvailableStrategies() as $auth_strategy) {
+            $options[$auth_strategy->getName()] = $this->lng->txt("auth{$auth_strategy->getName()}");
         }
+
         foreach (ilLDAPServer::getServerIds() as $server_id) {
             $server = ilLDAPServer::getInstanceByServerId($server_id);
             $options['ldap_' . $server->getServerId()] = $server->getName();
         }
         return $options;
-    }
-
-    protected function isShibbolethActive(): bool
-    {
-        return (bool) $this->settings->get('shib_active', '0');
     }
 
     /**

--- a/components/ILIAS/WebServices/ECS/classes/class.ilECSParticipantSettingsGUI.php
+++ b/components/ILIAS/WebServices/ECS/classes/class.ilECSParticipantSettingsGUI.php
@@ -37,6 +37,7 @@ class ilECSParticipantSettingsGUI
     protected UiFactory $ui_factory;
     protected ilToolbarGUI $toolbar;
     protected ilSetting $settings;
+    protected ilECSAuthFactory $auth_factory;
 
     public function __construct(int $a_server_id, int $a_mid)
     {
@@ -56,6 +57,7 @@ class ilECSParticipantSettingsGUI
         $this->lng->loadLanguageModule('ecs');
 
         $this->participant = new ilECSParticipantSetting($this->getServerId(), $this->getMid());
+        $this->auth_factory = new ilECSAuthFactory();
     }
 
     public function getServerId(): int
@@ -228,7 +230,7 @@ class ilECSParticipantSettingsGUI
         $external_auth_type->setValue(
             (string) $this->getParticipant()->getIncomingAuthType()
         );
-        foreach (ilECSAuthStrategy::getAvailableStrategies() as $auth_type => $auth_strategy) {
+        foreach ($this->auth_factory->getAvailableStrategies() as $auth_type => $auth_strategy) {
             $external_auth_type->addOption(
                 new ilRadioOption(
                     $this->lng->txt("ecs_export_auth_type_{$auth_strategy->getName()}"),
@@ -312,8 +314,8 @@ class ilECSParticipantSettingsGUI
     protected function parseAvailableAuthModes(): array
     {
         $options = [];
-        foreach (ilECSAuthStrategy::getAvailableStrategies() as $auth_strategy) {
-            $options[$auth_strategy->getName()] = $this->lng->txt("auth{$auth_strategy->getName()}");
+        foreach ($this->auth_factory->getAvailableStrategies() as $auth_strategy) {
+            $options[$auth_strategy->getName()] = $this->lng->txt("auth_{$auth_strategy->getName()}");
         }
 
         foreach (ilLDAPServer::getServerIds() as $server_id) {

--- a/components/ILIAS/WebServices/ECS/classes/class.ilECSSettingsGUI.php
+++ b/components/ILIAS/WebServices/ECS/classes/class.ilECSSettingsGUI.php
@@ -458,15 +458,15 @@ class ilECSSettingsGUI
         $this->initSettings((int) $_REQUEST['server_id']);
         $this->loadFromPost();
 
-        if (!$error = $this->settings->validate()) {
-            $this->settings->update();
-            $this->tpl->setOnScreenMessage('info', $this->lng->txt('settings_saved'), true);
-        } else {
-            $this->tpl->setOnScreenMessage('info', $this->lng->txt($error));
+        if ($error = $this->settings->validate()) {
+            $this->tpl->setOnScreenMessage('failure', $this->lng->txt($error));
             $this->edit();
-        }
+        } else {
+            $this->settings->update();
 
-        $this->overview();
+            $this->tpl->setOnScreenMessage('info', $this->lng->txt('settings_saved'));
+            $this->overview();
+        }
     }
 
     /**
@@ -561,7 +561,7 @@ class ilECSSettingsGUI
                 $this->tpl->setOnScreenMessage('failure', $server->getServer() . ': ' . $e->getMessage(), true);
             }
         }
-        $this->tpl->setOnScreenMessage('success', $this->lng->txt('settings_saved'), true);
+
         $this->ctrl->redirect($this, 'communities');
     }
 

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -9019,6 +9019,7 @@ ecs#:#ecs_export_auth_type#:#Authentifikations-Methode für Benutzer mit externe
 ecs#:#ecs_export_auth_type_ilias#:#Benutzerauthentifikation via LDAP
 ecs#:#ecs_export_auth_type_info#:#Bitte wählen Sie, mit welcher Authentifizierungsmethode sich Benutzer via ECS authentifizieren sollen, bei denen via ECS ein externes Benutzerattribut übertragen wurde.
 ecs#:#ecs_export_auth_type_none#:#Keine Benutzer mit externem Benutzerattribut zulassen
+ecs#:#ecs_export_auth_type_oidc#:#Benutzerauthentifikation via OpenID Connect
 ecs#:#ecs_export_auth_type_shib#:#Benutzerauthentifikation via Shibboleth
 ecs#:#ecs_export_created_body_a#:#Ein neuer Kurs wurde freigegeben:
 ecs#:#ecs_export_disabled#:#Nicht freigeben

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -9023,6 +9023,7 @@ ecs#:#ecs_export_auth_type#:#Authentication method for users with external user 
 ecs#:#ecs_export_auth_type_ilias#:#User authentication via LDAP
 ecs#:#ecs_export_auth_type_info#:#Please choose the authentication method for users to authenticate via ECS, for whom an external user attribute was transferred via ECS.
 ecs#:#ecs_export_auth_type_none#:#Do not allow users with external user attribute
+ecs#:#ecs_export_auth_type_oidc#:#User authentication via OpenID Connect
 ecs#:#ecs_export_auth_type_shib#:#User authentication via Shibboleth
 ecs#:#ecs_export_created_body_a#:#A new course has been released
 ecs#:#ecs_export_disabled#:#Do not release this Course


### PR DESCRIPTION
Hi everyone,

This PR proposes changes to the ECS component to integrate OIDC authentication. It implements the feature described in the wiki entry [ECS Support for OpenID Connect](https://docu.ilias.de/go/wiki/wpage_8365_1357) enabling authentication on external LMS platforms using OpenID Connect.

During development, we encountered several issues that limited ECS functionality and complicated implementation. Below are the problems we addressed in this PR, along with their fixes. For better traceability, each fix is in a separate commit.

| **Problem** | **Description** | **Report** | **Commit** |
| --- | --- | --- | --- |
| Missing dependency`jumbojett/openid-connect-php`in trunk | See #9560 |  | See #9560 |
| Exceptions during bootstrapping in`openidconnect.php` | Incomplete container initialization causes this error. The problem is resolved by using the`entry_point`method instead of`ilInitialisation::initILIAS()`, similar to`shib_login.php`. |  | ~`1abbeab1`~ |
| Incomplete data in`ecs_part_settings` | The`ecs_part_settings`table stores information about imported ECS participants. Entries are created only when settings are first saved, not during object import. This causes errors such as missing array keys and course labels. | [41215](https://mantis.ilias.de/view.php?id=41215)| `508a5a65` |
| Redirect to course fails | Clicking the remote link redirects participants to the dashboard instead of the course. This occurs because the link uses the format`goto.php/crs/123`, while`LegacyGotoHandler`expects`goto.php?target=crs_123`. |  | `75d16219` |
| Error message not displayed when saving invalid settings | Validation runs only when the ECS server is enabled. When errors occur, the participant overview appears instead of the form with the error message. | [43256](https://mantis.ilias.de/view.php?id=43256) | `253d0012` |

I look forward to comments and feedback on this PR. The changes were reviewed in an internal review process and approved by @thojou .

Best Regards
@lukas-heinrich 