### PR TITLE
Cron: Move admin gui from Administration node to own node

### DIFF
--- a/components/ILIAS/Administration/GlobalScreen/classes/AdministrationMainBarProvider.php
+++ b/components/ILIAS/Administration/GlobalScreen/classes/AdministrationMainBarProvider.php
@@ -209,7 +209,7 @@ class AdministrationMainBarProvider extends AbstractStaticMainMenuProvider
         // admin menu layout
         $layout = array(
             "maintenance" =>
-                array("adm", "lngf", "hlps", "wfe", 'fils', 'logs', 'sysc', "recf", "root"),
+                array("adm", "cron", "lngf", "hlps", "wfe", 'fils', 'logs', 'sysc', "recf", "root"),
             "layout_and_navigation" =>
                 array("mme", "gsfo", "dshs", "stys", "adve"),
             "repository_and_objects" =>

--- a/components/ILIAS/Administration/classes/class.ilAdministrationSettingsFormHandler.php
+++ b/components/ILIAS/Administration/classes/class.ilAdministrationSettingsFormHandler.php
@@ -179,13 +179,10 @@ class ilAdministrationSettingsFormHandler
 
         // cron jobs - special handling
 
-        $parent_gui = new ilObjSystemFolderGUI(null, SYSTEM_FOLDER_ID, true);
-        $parent_gui->setCreationMode(true);
-
-        $gui = new ilCronManagerGUI();
+        $gui = ilObjCronGUI::create();
         $data = $gui->addToExternalSettingsForm($a_form_id);
-        if (is_array($data) && count($data)) {
-            self::parseFieldDefinition("cron", $a_form, $parent_gui, $data);
+        if ($data !== []) {
+            self::parseFieldDefinition("cron", $a_form, $gui, $data);
         }
     }
 
@@ -301,14 +298,14 @@ class ilAdministrationSettingsFormHandler
                     }
 
                     if ($has_write &&
-                        $rbacsystem->checkAccess("visible,read", $a_gui->getObject()->getRefId())) {
+                        $rbacsystem->checkAccess("read", $a_gui->getObject()->getRefId())) {
                         if (!$cmd) {
                             $cmd = "view";
                         }
                         $ilCtrl->setParameter($a_gui, "ref_id", $a_gui->getObject()->getRefId());
 
                         $ftpl->setCurrentBlock("edit_bl");
-                        $ftpl->setVariable("URL_EDIT", $ilCtrl->getLinkTargetByClass(array("ilAdministrationGUI", get_class($a_gui)), $cmd));
+                        $ftpl->setVariable("URL_EDIT", $ilCtrl->getLinkTargetByClass([ilAdministrationGUI::class, $a_gui::class], $cmd));
                         $ftpl->setVariable("TXT_EDIT", $lng->txt("adm_external_setting_edit"));
                         $ftpl->parseCurrentBlock();
                     }

--- a/components/ILIAS/Cron/Cron.php
+++ b/components/ILIAS/Cron/Cron.php
@@ -32,6 +32,9 @@ class Cron implements Component\Component
         array | \ArrayAccess &$pull,
         array | \ArrayAccess &$internal,
     ): void {
-        // ...
+        $contribute[\ILIAS\Setup\Agent::class] = fn() =>
+            new \ILIAS\Cron\Setup\Agent(
+                $pull[\ILIAS\Refinery\Factory::class]
+            );
     }
 }

--- a/components/ILIAS/Cron/service.xml
+++ b/components/ILIAS/Cron/service.xml
@@ -2,8 +2,13 @@
 <service xmlns="http://www.w3.org" version="$Id:$"
 	id="cron">
 	<baseclasses>
-		<baseclass name="ilCronManagerGUI" dir="classes" />
+		<baseclass name="ilObjCronGUI" dir="src" />
 	</baseclasses>
+        <objects>
+          <object id="cron" class_name="Cron" dir="src" checkbox="0" inherit="0" translate="sys" rbac="1" system="1" administration="1">
+            <parent id="adm" max="1">adm</parent>
+          </object>
+        </objects>
 	<pluginslots>
 		<pluginslot id="crnhk" name="CronHook" />
 	</pluginslots>

--- a/components/ILIAS/Cron/src/Job/Manager/UI/JobTable.php
+++ b/components/ILIAS/Cron/src/Job/Manager/UI/JobTable.php
@@ -24,6 +24,7 @@ use ILIAS\Cron\Job\Schedule\JobScheduleType;
 use ILIAS\Cron\Job\JobRepository;
 use ILIAS\Cron\Job\JobEntity;
 use ILIAS\Cron\Job\Collection\OrderedJobEntities;
+use ILIAS\Data\URI;
 
 class JobTable implements \ILIAS\UI\Component\Table\DataRetrieval
 {
@@ -35,24 +36,17 @@ class JobTable implements \ILIAS\UI\Component\Table\DataRetrieval
      * @param list<string> $table_action_namespace
      */
     public function __construct(
-        \ilCronManagerGUI $a_parent_obj,
-        string $a_parent_cmd,
+        URI $form_action,
         array $table_action_namespace,
         string $table_action_param_name,
         string $table_row_identifier_name,
         private readonly \ILIAS\UI\Factory $ui_factory,
         private readonly \Psr\Http\Message\ServerRequestInterface $request,
-        \ilCtrlInterface $ctrl,
         private readonly \ilLanguage $lng,
         private readonly \ILIAS\Cron\Job\JobCollection $job_collection,
         private readonly JobRepository $job_repository,
         private readonly bool $mayWrite = false
     ) {
-        $form_action = (new \ILIAS\Data\Factory())->uri(
-            \ilUtil::_getHttpPath() . '/' .
-            $ctrl->getLinkTarget($a_parent_obj, $a_parent_cmd)
-        );
-
         [
             $this->url_builder,
             $this->action_parameter_token,

--- a/components/ILIAS/Cron/src/Setup/Agent.php
+++ b/components/ILIAS/Cron/src/Setup/Agent.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Cron\Setup;
+
+use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Refinery\Transformation;
+use ILIAS\Setup\Objective;
+use ILIAS\Setup\Config;
+use ILIAS\Setup\Metrics\Storage;
+use ILIAS\Setup\Objective\NullObjective;
+use ILIAS\Setup\Agent as AgentInterface;
+use ilTreeAdminNodeAddedObjective;
+
+final class Agent implements AgentInterface
+{
+    public function __construct(private readonly Refinery $refinery)
+    {
+    }
+
+    public function hasConfig(): bool
+    {
+        return false;
+    }
+
+    public function getArrayToConfigTransformation(): Transformation
+    {
+        return $this->refinery->identity();
+    }
+
+    public function getInstallObjective(?Config $config = null): Objective
+    {
+        return new NullObjective();
+    }
+
+    public function getUpdateObjective(?Config $config = null): Objective
+    {
+        return new ilTreeAdminNodeAddedObjective('cron', 'Cron');
+    }
+
+    public function getBuildObjective(): Objective
+    {
+        return new NullObjective();
+    }
+
+    public function getStatusObjective(Storage $storage): Objective
+    {
+        return new NullObjective();
+    }
+
+    public function getMigrations(): array
+    {
+        return [];
+    }
+
+    public function getNamedObjectives(?Config $config = null): array
+    {
+        return [];
+    }
+}

--- a/components/ILIAS/Cron/src/class.ilObjCron.php
+++ b/components/ILIAS/Cron/src/class.ilObjCron.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+final class ilObjCron extends ilObject2
+{
+    protected function initType(): void
+    {
+        $this->type = 'cron';
+    }
+}

--- a/components/ILIAS/Cron/src/class.ilObjCronAccess.php
+++ b/components/ILIAS/Cron/src/class.ilObjCronAccess.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+final class ilObjCronAccess extends ilObjectAccess
+{
+}

--- a/components/ILIAS/Cron/src/class.ilObjCronGUI.php
+++ b/components/ILIAS/Cron/src/class.ilObjCronGUI.php
@@ -18,72 +18,62 @@
 
 declare(strict_types=1);
 
-use ILIAS\HTTP\Wrapper\WrapperFactory;
-use ILIAS\UI\Factory;
-use ILIAS\UI\Renderer;
-use ILIAS\Cron\Job\Schedule\JobScheduleType;
-use ILIAS\Cron\Job\Collection\OrderedJobEntities;
 use ILIAS\Cron\Job\JobRepository;
 use ILIAS\Cron\Job\JobManager;
-use ILIAS\Cron\Job\JobEntity;
+use ILIAS\HTTP\Wrapper\WrapperFactory;
 use ILIAS\Cron\Job\Manager\UI\JobTableFilterMediator;
 use ILIAS\Cron\Job\Manager\UI\JobTable;
 use ILIAS\Cron\Job\JobResult;
 use ILIAS\Cron\CronJob;
+use ILIAS\Cron\Job\JobEntity;
+use ILIAS\Cron\Job\Collection\OrderedJobEntities;
+use ILIAS\Cron\Job\Schedule\JobScheduleType;
+use ILIAS\Data\Factory as DataFactory;
 
 /**
- * @ilCtrl_Calls      ilCronManagerGUI: ilPropertyFormGUI
- * @ilCtrl_isCalledBy ilCronManagerGUI: ilAdministrationGUI
+ * @ilCtrl_isCalledBy ilObjCronGUI: ilAdministrationGUI
+ * @ilCtrl_Calls      ilObjCronGUI: ilPropertyFormGUI
+ * @ilCtrl_Calls      ilObjCronGUI: ilPermissionGUI
  */
-class ilCronManagerGUI
+final class ilObjCronGUI extends ilObjectGUI
 {
     private const array TABLE_ACTION_NAMESPACE = ['cron', 'jobs'];
     private const string TABLE_ACTION_PARAM_NAME = 'table_action';
     private const string TABLE_ACTION_IDENTIFIER_NAME = 'jid';
     private const string FORM_PARAM_SCHEDULE_PREFIX = 'schedule_';
+    public const string VIEW = 'view';
     public const FORM_PARAM_MAIN_SECTION = 'main';
     public const FORM_PARAM_JOB_INPUT = 'additional_job_input';
     public const FORM_PARAM_GROUP_SCHEDULE = 'schedule';
 
-    private readonly ilLanguage $lng;
-    private readonly ilCtrlInterface $ctrl;
-    private readonly ilSetting $settings;
-    private readonly ilGlobalTemplateInterface $tpl;
-    private readonly Factory $ui_factory;
-    private readonly Renderer $ui_renderer;
     private readonly ilUIService $ui_service;
     private readonly JobRepository $cron_repository;
     private readonly \ILIAS\DI\RBACServices $rbac;
-    private readonly ilErrorHandling $error;
     private readonly WrapperFactory $http_wrapper;
-    private readonly \ILIAS\HTTP\GlobalHttpState $http;
-    private readonly \ILIAS\Refinery\Factory $refinery;
     private readonly JobManager $cron_manager;
-    private readonly ilObjUser $actor;
+    private readonly DataFactory $data_factory;
 
     public function __construct()
     {
-        /** @var $DIC \ILIAS\DI\Container */
         global $DIC;
+        parent::__construct(...func_get_args());
 
-        $this->lng = $DIC->language();
-        $this->ctrl = $DIC->ctrl();
-        $this->settings = $DIC->settings();
-        $this->tpl = $DIC->ui()->mainTemplate();
-        $this->ui_factory = $DIC->ui()->factory();
-        $this->ui_renderer = $DIC->ui()->renderer();
         $this->ui_service = $DIC->uiService();
         $this->rbac = $DIC->rbac();
-        $this->error = $DIC['ilErr'];
         $this->http_wrapper = $DIC->http()->wrapper();
-        $this->http = $DIC->http();
-        $this->refinery = $DIC->refinery();
-        $this->actor = $DIC->user();
         $this->cron_repository = $DIC->cron()->repository();
         $this->cron_manager = $DIC->cron()->manager();
+        $this->data_factory = new DataFactory();
 
         $this->lng->loadLanguageModule('cron');
         $this->lng->loadLanguageModule('cmps');
+    }
+
+    public static function create(): self
+    {
+        return new self(null, current(ilObject::_getAllReferences(current(
+            ilObject::_getObjectsDataForType('cron')
+        )['id'])), true, false);
     }
 
     /**
@@ -116,7 +106,7 @@ class ilCronManagerGUI
             $filter = $tableFilterMediator->filter(
                 $this->ctrl->getFormAction(
                     $this,
-                    'render',
+                    self::VIEW,
                     '',
                     true
                 )
@@ -223,22 +213,30 @@ class ilCronManagerGUI
 
     public function executeCommand(): void
     {
-        if (!$this->rbac->system()->checkAccess('visible,read', SYSTEM_FOLDER_ID)) {
+        if (!$this->rbac->system()->checkAccess('read', SYSTEM_FOLDER_ID)) {
             $this->error->raiseError($this->lng->txt('no_permission'), $this->error->WARNING);
         }
+
+        $this->prepareOutput();
 
         $class = $this->ctrl->getNextClass($this) ?? '';
 
         switch (strtolower($class)) {
             case strtolower(ilPropertyFormGUI::class):
+                $this->tabs_gui->activateTab(self::VIEW);
                 $job_id = $this->getRequestValue($this->getJobIdParameterName(), $this->refinery->kindlyTo()->string());
                 $job = $this->cron_repository->getJobInstanceById(ilUtil::stripSlashes($job_id));
                 $form = $this->initLegacyEditForm($job);
                 $this->ctrl->forwardCommand($form);
-                break;
+                return;
+
+            case strtolower(ilPermissionGUI::class):
+                $this->ctrl->forwardCommand(new ilPermissionGUI($this));
+                return;
         }
 
-        $cmd = $this->ctrl->getCmd('render');
+        $this->tabs_gui->activateTab(self::VIEW);
+        $cmd = $this->ctrl->getCmd(self::VIEW);
         $this->$cmd();
     }
 
@@ -257,11 +255,11 @@ class ilCronManagerGUI
             'deactivate' => $this->deactivate(),
             'reset' => $this->reset(),
             'edit' => $this->edit(),
-            default => $this->render()
+            default => $this->view()
         };
     }
 
-    protected function render(): void
+    protected function view(): void
     {
         $tstamp = $this->lng->txt('cronjob_last_start_unknown');
         if ($this->settings->get('last_cronjob_start_ts')) {
@@ -286,7 +284,7 @@ class ilCronManagerGUI
         $filter = $tableFilterMediator->filter(
             $this->ctrl->getFormAction(
                 $this,
-                'render',
+                self::VIEW,
                 '',
                 true
             )
@@ -297,14 +295,12 @@ class ilCronManagerGUI
         );
 
         $tbl = new JobTable(
-            $this,
-            'handleTableActions',
+            $this->data_factory->uri(ilUtil::_getHttpPath() . '/' . $this->ctrl->getLinkTarget($this, 'handleTableActions')),
             self::TABLE_ACTION_NAMESPACE,
             self::TABLE_ACTION_PARAM_NAME,
             self::TABLE_ACTION_IDENTIFIER_NAME,
             $this->ui_factory,
             $this->http->request(),
-            $this->ctrl,
             $this->lng,
             $filtered_jobs,
             $this->cron_repository,
@@ -331,7 +327,7 @@ class ilCronManagerGUI
         if ($form === null) {
             $job_ids = $this->retrieveTableActionJobIds();
             if (count($job_ids) !== 1) {
-                $this->ctrl->redirect($this, 'render');
+                $this->ctrl->redirect($this, self::VIEW);
             }
 
             $job_id = current($job_ids);
@@ -341,7 +337,7 @@ class ilCronManagerGUI
                 $this->ctrl->redirect($this, 'editLegacy');
             }
 
-            $form = $this->initEditForm($job);
+            $form = $this->buildForm($job);
         }
 
         $this->tpl->setContent($this->ui_renderer->render($form));
@@ -356,7 +352,7 @@ class ilCronManagerGUI
         if ($a_form === null) {
             $job_ids = $this->retrieveTableActionJobIds();
             if (count($job_ids) !== 1) {
-                $this->ctrl->redirect($this, 'render');
+                $this->ctrl->redirect($this, self::VIEW);
             }
 
             $job_id = current($job_ids);
@@ -405,10 +401,10 @@ class ilCronManagerGUI
         ], true);
     }
 
-    protected function initEditForm(?CronJob $job): ILIAS\UI\Component\Input\Container\Form\Form
+    protected function buildForm(?CronJob $job): ILIAS\UI\Component\Input\Container\Form\Form
     {
         if (!($job instanceof CronJob)) {
-            $this->ctrl->redirect($this, 'render');
+            $this->ctrl->redirect($this, self::VIEW);
         }
 
         $this->ctrl->setParameter($this, $this->getJobIdParameterName(), $job->getId());
@@ -514,7 +510,7 @@ class ilCronManagerGUI
     protected function initLegacyEditForm(?CronJob $job): ilPropertyFormGUI
     {
         if (!($job instanceof CronJob)) {
-            $this->ctrl->redirect($this, 'render');
+            $this->ctrl->redirect($this, self::VIEW);
         }
 
         $this->ctrl->setParameter($this, $this->getJobIdParameterName(), $job->getId());
@@ -568,7 +564,7 @@ class ilCronManagerGUI
         }
 
         $form->addCommandButton('updateLegacy', $this->lng->txt('save'));
-        $form->addCommandButton('render', $this->lng->txt('cancel'));
+        $form->addCommandButton(self::VIEW, $this->lng->txt('cancel'));
 
         return $form;
     }
@@ -581,11 +577,11 @@ class ilCronManagerGUI
 
         $job_id = $this->getRequestValue($this->getJobIdParameterName(), $this->refinery->kindlyTo()->string());
         if (!$job_id) {
-            $this->ctrl->redirect($this, 'render');
+            $this->ctrl->redirect($this, self::VIEW);
         }
 
         $job = $this->cron_repository->getJobInstanceById($job_id);
-        $form = $this->initEditForm($job);
+        $form = $this->buildForm($job);
 
         $form_valid = false;
         $form_data = null;
@@ -623,7 +619,7 @@ class ilCronManagerGUI
             }
 
             $this->tpl->setOnScreenMessage('success', $this->lng->txt('cron_action_edit_success'), true);
-            $this->ctrl->redirect($this, 'render');
+            $this->ctrl->redirect($this, self::VIEW);
         }
 
         $this->edit($form);
@@ -641,7 +637,7 @@ class ilCronManagerGUI
 
         $job_id = $this->getRequestValue($this->getJobIdParameterName(), $this->refinery->kindlyTo()->string());
         if (!$job_id) {
-            $this->ctrl->redirect($this, 'render');
+            $this->ctrl->redirect($this, self::VIEW);
         }
 
         $job = $this->cron_repository->getJobInstanceById($job_id);
@@ -667,7 +663,7 @@ class ilCronManagerGUI
 
             if ($valid) {
                 $this->tpl->setOnScreenMessage('success', $this->lng->txt('cron_action_edit_success'), true);
-                $this->ctrl->redirect($this, 'render');
+                $this->ctrl->redirect($this, self::VIEW);
             }
         }
 
@@ -688,17 +684,17 @@ class ilCronManagerGUI
 
         $job_ids = $this->retrieveTableActionJobIds();
         if (count($job_ids) !== 1) {
-            $this->ctrl->redirect($this, 'render');
+            $this->ctrl->redirect($this, self::VIEW);
         }
 
         $job_id = current($job_ids);
-        if ($this->cron_manager->runJobManual($job_id, $this->actor)) {
+        if ($this->cron_manager->runJobManual($job_id, $this->user)) {
             $this->tpl->setOnScreenMessage('success', $this->lng->txt('cron_action_run_success'), true);
         } else {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt('cron_action_run_fail'), true);
         }
 
-        $this->ctrl->redirect($this, 'render');
+        $this->ctrl->redirect($this, self::VIEW);
     }
 
     public function activate(): void
@@ -716,7 +712,7 @@ class ilCronManagerGUI
         if ($jobs !== []) {
             foreach ($jobs as $job) {
                 if ($this->cron_manager->isJobInactive($job->getId())) {
-                    $this->cron_manager->resetJob($job, $this->actor);
+                    $this->cron_manager->resetJob($job, $this->user);
                 }
             }
 
@@ -725,7 +721,7 @@ class ilCronManagerGUI
             $this->tpl->setOnScreenMessage('info', $this->lng->txt('no_checkbox'), true);
         }
 
-        $this->ctrl->redirect($this, 'render');
+        $this->ctrl->redirect($this, self::VIEW);
     }
 
     public function deactivate(): void
@@ -743,7 +739,7 @@ class ilCronManagerGUI
         if ($jobs !== []) {
             foreach ($jobs as $job) {
                 if ($this->cron_manager->isJobActive($job->getId())) {
-                    $this->cron_manager->deactivateJob($job, $this->actor, true);
+                    $this->cron_manager->deactivateJob($job, $this->user, true);
                 }
             }
 
@@ -752,7 +748,7 @@ class ilCronManagerGUI
             $this->tpl->setOnScreenMessage('info', $this->lng->txt('no_checkbox'), true);
         }
 
-        $this->ctrl->redirect($this, 'render');
+        $this->ctrl->redirect($this, self::VIEW);
     }
 
     public function reset(): void
@@ -769,14 +765,14 @@ class ilCronManagerGUI
         $jobs = $this->getMultiActionData();
         if ($jobs !== []) {
             foreach ($jobs as $job) {
-                $this->cron_manager->resetJob($job, $this->actor);
+                $this->cron_manager->resetJob($job, $this->user);
             }
             $this->tpl->setOnScreenMessage('success', $this->lng->txt('cron_action_reset_success'), true);
         } else {
             $this->tpl->setOnScreenMessage('info', $this->lng->txt('no_checkbox'), true);
         }
 
-        $this->ctrl->redirect($this, 'render');
+        $this->ctrl->redirect($this, self::VIEW);
     }
 
     /**
@@ -811,7 +807,7 @@ class ilCronManagerGUI
         $jobs = $this->getMultiActionData();
         if ($jobs === []) {
             $this->tpl->setOnScreenMessage('info', $this->lng->txt('no_checkbox'), true);
-            $this->ctrl->redirect($this, 'render');
+            $this->ctrl->redirect($this, self::VIEW);
         }
 
         if ($a_action === 'run') {
@@ -821,7 +817,7 @@ class ilCronManagerGUI
 
             if ($jobs === []) {
                 $this->tpl->setOnScreenMessage('failure', $this->lng->txt('cron_no_executable_job_selected'), true);
-                $this->ctrl->redirect($this, 'render');
+                $this->ctrl->redirect($this, self::VIEW);
             }
         }
 
@@ -853,7 +849,7 @@ class ilCronManagerGUI
         }
 
         $cgui->setFormAction($this->ctrl->getFormAction($this, 'confirmed' . ucfirst($a_action)));
-        $cgui->setCancel($this->lng->txt('cancel'), 'render');
+        $cgui->setCancel($this->lng->txt('cancel'), self::VIEW);
         $cgui->setConfirm($this->lng->txt('cron_action_' . $a_action), 'confirmed' . ucfirst($a_action));
 
         $this->tpl->setContent($cgui->getHTML());
@@ -879,14 +875,14 @@ class ilCronManagerGUI
         }
 
         if ($fields !== []) {
-            $form_elements = [
+            return [
                 'cron_jobs' => [
-                    'jumpToCronJobs',
+                    self::VIEW,
                     $fields
                 ]
             ];
         }
 
-        return $form_elements;
+        return [];
     }
 }

--- a/components/ILIAS/Forum/classes/class.ilObjForumAdministrationGUI.php
+++ b/components/ILIAS/Forum/classes/class.ilObjForumAdministrationGUI.php
@@ -331,22 +331,29 @@ class ilObjForumAdministrationGUI extends ilObjectGUI
         return [];
     }
 
-    private function cronMessage(): Component
+    /**
+     * @return Component[]
+     */
+    private function cronMessage(): array
     {
-        $gui = new ilCronManagerGUI();
+        $gui = ilObjCronGUI::create();
         $data = $gui->addToExternalSettingsForm(ilAdministrationSettingsFormHandler::FORM_FORUM);
         $data = $data['cron_jobs'][1];
 
+        if (!$this->rbac_system->checkAccess('read', $gui->getRefId())) {
+            return [];
+        }
+
+        $this->ctrl->setParameterByClass(ilObjCronGUI::class, 'ref_id', $gui->getRefId());
         $url = $this->ctrl->getLinkTargetByClass(
-            [ilAdministrationGUI::class, ilObjSystemFolderGUI::class],
-            'jumpToCronJobs'
+            [ilAdministrationGUI::class, ilObjCronGUI::class],
         );
 
-        return $this->ui->factory()->messageBox()->info($this->lng->txt(key($data)) . ': ' . current($data))->withLinks(
-            [
+        return [
+            $this->ui->factory()->messageBox()->info($this->lng->txt(key($data)) . ': ' . current($data))->withLinks([
                 $this->ui->factory()->link()->standard($this->lng->txt('adm_external_setting_edit'), $url)
-            ]
-        );
+            ])
+        ];
     }
 
     private function forumJobActive(): bool

--- a/components/ILIAS/SystemFolder/classes/class.ilObjSystemFolderGUI.php
+++ b/components/ILIAS/SystemFolder/classes/class.ilObjSystemFolderGUI.php
@@ -28,7 +28,6 @@ use ILIAS\Setup\CLI\StatusCommand;
  * @author Stefan Meyer <meyer@leifos.com>
  *
  * @ilCtrl_Calls ilObjSystemFolderGUI: ilPermissionGUI
- * @ilCtrl_Calls ilObjSystemFolderGUI: ilObjectOwnershipManagementGUI, ilCronManagerGUI
  */
 class ilObjSystemFolderGUI extends ilObjectGUI
 {
@@ -103,12 +102,6 @@ class ilObjSystemFolderGUI extends ilObjectGUI
             case "ilobjectownershipmanagementgui":
                 $this->setSystemCheckSubTabs("no_owner");
                 $gui = $this->gui->ownership()->ownershipManagementGUI(0);
-                $this->ctrl->forwardCommand($gui);
-                break;
-
-            case "ilcronmanagergui":
-                $ilTabs->activateTab("cron_jobs");
-                $gui = new ilCronManagerGUI();
                 $this->ctrl->forwardCommand($gui);
                 break;
 
@@ -391,13 +384,6 @@ class ilObjSystemFolderGUI extends ilObjectGUI
         }
 
         if ($rbacsystem->checkAccess('visible,read', $this->object->getRefId())) {
-            $this->tabs_gui->addTarget(
-                'cron_jobs',
-                $this->ctrl->getLinkTargetByClass('ilCronManagerGUI', ''),
-                '',
-                get_class($this)
-            );
-
             $this->tabs_gui->addTarget(
                 'benchmarks',
                 $this->ctrl->getLinkTarget($this, 'benchmark'),
@@ -921,35 +907,6 @@ class ilObjSystemFolderGUI extends ilObjectGUI
         $lng = $this->lng;
         $this->saveHeaderTitlesObject(true);
     }
-
-
-    //
-    //
-    // Cron Jobs
-    //
-    //
-
-    /*
-     * OLD GLOBAL CRON JOB SWITCHES (ilSetting)
-     *
-     * cron_user_check => obsolete
-     * cron_inactive_user_delete => obsolete
-     * cron_inactivated_user_delete => obsolete
-     * cron_link_check => obsolete
-     * cron_web_resource_check => migrated
-     * cron_lucene_index => obsolete
-     * forum_notification => migrated
-     * mail_notification => migrated
-     * crsgrp_ntf => migrated
-     * cron_upd_adrbook => migrated
-     */
-
-    public function jumpToCronJobsObject(): void
-    {
-        // #13010 - this is used for external settings
-        $this->ctrl->redirectByClass("ilCronManagerGUI", "render");
-    }
-
 
     //
     //

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -275,6 +275,8 @@ administration#:#nothing_to_restore#:#Nichts wiederherzustellen...
 administration#:#obj_blga#:#Blog
 administration#:#obj_blga_desc#:#Globale Blogeinstellungen
 administration#:#obj_chta_desc#:#Administration des Chat-Objekts und des Chat-Servers
+administration#:#obj_cron#:#Cron Jobs
+administration#:#obj_cron_desc#:#Liste aller Cron Jobs
 administration#:#obj_excs#:#Übung
 administration#:#obj_excs_desc#:#Globale Übungseinstellungen
 administration#:#obj_gsfo#:#Fußzeile

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -275,6 +275,8 @@ administration#:#nothing_to_restore#:#Nothing to restore...
 administration#:#obj_blga#:#Blog
 administration#:#obj_blga_desc#:#Global Blog Settings
 administration#:#obj_chta_desc#:#Chat Administration
+administration#:#obj_cron#:#Cron Jobs
+administration#:#obj_cron_desc#:#List of all Cron Jobs
 administration#:#obj_excs#:#Exercise
 administration#:#obj_excs_desc#:#Global Exercise Settings
 administration#:#obj_gsfo#:#Footer


### PR DESCRIPTION
This PR is part of the following Feature Requests: https://docu.ilias.de/go/wiki/wpage_8602_1357 and https://docu.ilias.de/go/wiki/wpage_8648_1357
This PR moves the administration settings for the `Cron` component from the `Administration` to the `Cron` component itself.
Previously the settings where located at the admin node `System Settings and Maintenance`. This is moved to a new admin node `Cron`.
Additionally the following is changed:
- The visible access check is removed as it is stated in the FR.
- All references to the `ilCronManager` class are replaced with corresponding calls to `ilObjCronGUI` (linking to the cron tab).
- As the only class left in `classes` was `ilCronManager` the folder is deleted.
- As it was a double redirect the method `ilObjSystemFolderGUI::jumpToCronJobsObject` is removed and calls to it are replaced with direct links to the `ilObjCronGUI`.
