### PR TITLE
[FIX] UI: reverse `Component\JavaScriptBindable` order.

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/JavaScriptBindable.php
+++ b/components/ILIAS/UI/src/Implementation/Component/JavaScriptBindable.php
@@ -54,7 +54,7 @@ trait JavaScriptBindable
         }
 
         $this->checkBinder($binder);
-        return $this->withOnLoadCode(fn ($id) => $current_binder($id) . "\n" . $binder($id));
+        return $this->withOnLoadCode(static fn($id) => $binder($id) . "\n" . $current_binder($id));
     }
 
     /**
@@ -66,12 +66,12 @@ trait JavaScriptBindable
     }
 
     /**
-     * @throw \InvalidArgumentException	if closure does not take one argument
+     * @throws \InvalidArgumentException if closure does not take one argument
      */
     private function checkBinder(Closure $binder): void
     {
         $refl = new ReflectionFunction($binder);
-        $args = array_map(fn ($arg) => $arg->name, $refl->getParameters());
+        $args = array_map(static fn($arg) => $arg->name, $refl->getParameters());
         if (array("id") !== $args) {
             throw new InvalidArgumentException('Expected closure "$binder" to have exactly one argument "$id".');
         }

--- a/components/ILIAS/UI/tests/Component/JavaScriptBindableTest.php
+++ b/components/ILIAS/UI/tests/Component/JavaScriptBindableTest.php
@@ -77,17 +77,22 @@ class JavaScriptBindableTest extends TestCase
 
     public function testWithAdditionalOnLoadCode(): void
     {
-        $m = $this->mock
-            ->withOnLoadCode(function ($id) {
-                return "Its me, $id!";
-            })
-            ->withAdditionalOnLoadCode(function ($id) {
-                return "And again, me: $id.";
-            });
+        $java_script_id = 'js-id-1';
+        $java_script_code_1 = 'first piece of JavaScript code with id: ';
+        $java_script_code_2 = 'second piece of JavaScript code with id: ';
 
-        $binder = $m->getOnLoadCode();
-        $this->assertInstanceOf(Closure::class, $binder);
-        $this->assertEquals("Its me, Mario!\nAnd again, me: Mario.", $binder("Mario"));
+        $java_script_bindable = $this
+            ->mock
+            ->withOnLoadCode(static fn($id) => $java_script_code_1 . $id)
+            ->withAdditionalOnLoadCode(static fn($id) => $java_script_code_2 . $id);
+
+        $java_script_binder = $java_script_bindable->getOnLoadCode();
+        $this->assertInstanceOf(Closure::class, $java_script_binder);
+        $this->assertEquals(
+            $java_script_code_2 . $java_script_id . "\n" .
+            $java_script_code_1 . $java_script_id,
+            $java_script_binder($java_script_id)
+        );
     }
 
     public function testWithAdditionalOnLoadCodeNoPrevious(): void


### PR DESCRIPTION
Hi @klees,

This has potential to cause some fallout, but IMO it's quite important. This

* Changes the JavaScript code order from first-to-last to last-to-first (reversed)
* and hereby ensures correct execution sequence

Currently, as a consumer of some `Component\JavaScriptBindable`, it is not possible to provide JavaScript (on-load) code that uses the facility offered by the component. Why is that? This is due to the fact that our Renderers will also register said facility using the same mechanism, so it will be appended. This leads to the initialisation-code being rendered last.

By reversing the order, consumers can now expect that a facility will be available and they can access it when providing their JavaScript code. This should probably be fixed with an improved mechanism altogether, but it will do for now.

Kind regards
@thibsy 