### PR TITLE
Portfolio: Remove `back_url` usages

### DIFF
--- a/Modules/Course/classes/class.ilObjCourseGUI.php
+++ b/Modules/Course/classes/class.ilObjCourseGUI.php
@@ -1641,8 +1641,7 @@ class ilObjCourseGUI extends ilContainerGUI
             is_array($ids));
         if ($do_prtf) {
             $all_prtf = ilObjPortfolio::getAvailablePortfolioLinksForUserIds(
-                $ids,
-                $this->ctrl->getLinkTarget($this, "members")
+                $ids
             );
         }
 

--- a/Modules/Group/classes/class.ilObjGroupGUI.php
+++ b/Modules/Group/classes/class.ilObjGroupGUI.php
@@ -925,8 +925,7 @@ class ilObjGroupGUI extends ilContainerGUI
             is_array($ids));
         if ($do_prtf) {
             $all_prtf = ilObjPortfolio::getAvailablePortfolioLinksForUserIds(
-                $ids,
-                $this->ctrl->getLinkTarget($this, "members")
+                $ids
             );
         }
 

--- a/Modules/LearningSequence/classes/Members/class.ilLearningSequenceRoles.php
+++ b/Modules/LearningSequence/classes/Members/class.ilLearningSequenceRoles.php
@@ -220,8 +220,7 @@ class ilLearningSequenceRoles
 
         if ($portfolio_enabled) {
             $portfolios = ilObjPortfolio::getAvailablePortfolioLinksForUserIds(
-                $user_ids,
-                $this->ctrl->getLinkTargetByClass("ilLearningSequenceMembershipGUI", "members")
+                $user_ids
             );
         }
 

--- a/Modules/Portfolio/classes/class.StandardGUIRequest.php
+++ b/Modules/Portfolio/classes/class.StandardGUIRequest.php
@@ -95,11 +95,6 @@ class StandardGUIRequest
         return trim($this->str("file"));
     }
 
-    public function getBackUrl(): string
-    {
-        return trim($this->str("back_url"));
-    }
-
     public function getPortfolioPageId(): int
     {
         return $this->int("ppage");

--- a/Modules/Portfolio/classes/class.ilObjPortfolio.php
+++ b/Modules/Portfolio/classes/class.ilObjPortfolio.php
@@ -201,21 +201,15 @@ class ilObjPortfolio extends ilObjPortfolioBase implements ilAdvancedMetaDataSub
     }
 
     public static function getAvailablePortfolioLinksForUserIds(
-        array $a_owner_ids,
-        ?string $a_back_url = null
+        array $a_owner_ids
     ): array {
         $res = array();
 
         $access_handler = new ilPortfolioAccessHandler();
 
-        $params = null;
-        if ($a_back_url) {
-            $params = array("back_url" => rawurlencode($a_back_url));
-        }
-
         foreach ($access_handler->getShardObjectsDataForUserIds($a_owner_ids) as $owner_id => $items) {
             foreach ($items as $id => $title) {
-                $url = ilLink::_getLink($id, 'prtf', $params);
+                $url = ilLink::_getLink($id, 'prtf');
                 $res[$owner_id][$url] = $title;
             }
         }

--- a/Modules/Portfolio/classes/class.ilObjPortfolioBaseGUI.php
+++ b/Modules/Portfolio/classes/class.ilObjPortfolioBaseGUI.php
@@ -37,7 +37,6 @@ abstract class ilObjPortfolioBaseGUI extends ilObject2GUI
     protected string $page_mode; // preview|edit
     protected int $requested_ppage;
     protected int $requested_user_page;
-    protected string $requested_back_url = "";
     protected \ILIAS\DI\UIServices $ui;
     protected \ILIAS\HTTP\Services $http;
     protected \ILIAS\Style\Content\GUIService $content_style_gui;
@@ -78,16 +77,6 @@ abstract class ilObjPortfolioBaseGUI extends ilObject2GUI
         $this->requested_ppage = $this->port_request->getPortfolioPageId();
         $this->requested_user_page = $this->port_request->getUserPage();
 
-        // temp sanitization, should be done smarter in the future
-        $back = str_replace("&amp;", ":::", $this->port_request->getBackUrl());
-        $back = preg_replace(
-            "/[^a-zA-Z0-9_\.\?=:\s]/",
-            "",
-            $back
-        );
-        $this->requested_back_url = str_replace(":::", "&amp;", $back);
-
-        $this->ctrl->setParameterByClass("ilobjportfoliogui", "back_url", rawurlencode($this->requested_back_url));
         $cs = $DIC->contentStyle();
         $this->content_style_gui = $cs->gui();
         if ($this->object) {
@@ -644,41 +633,6 @@ abstract class ilObjPortfolioBaseGUI extends ilObject2GUI
         if ($this->user_id === ANONYMOUS_USER_ID &&
             $this->getType() === "prtf") {
             $this->tpl->setLoginTargetPar("prtf_" . $this->object->getId() . "_" . $current_page);
-        }
-
-        $back_caption = "";
-
-        // public profile
-        if ($this->requested_back_url != "") {
-            $back = $this->requested_back_url;
-        } elseif (strtolower($this->port_request->getBaseClass()) !== "ilpublicuserprofilegui" &&
-            $this->user_id && $this->user_id !== ANONYMOUS_USER_ID) {
-            if (!$this->checkPermissionBool("write")) {
-                // shared
-                if ($this->getType() === "prtf") {
-                    $this->ctrl->setParameterByClass("ilportfoliorepositorygui", "shr_id", $this->object->getOwner());
-                    $back = $this->ctrl->getLinkTargetByClass(array("ildashboardgui", "ilportfoliorepositorygui"), "showOther");
-                    $this->ctrl->setParameterByClass("ilportfoliorepositorygui", "shr_id", "");
-                }
-                // listgui / parent container
-                else {
-                    // #12819
-                    $tree = $this->tree;
-                    $parent_id = $tree->getParentId($this->node_id);
-                    $back = ilLink::_getStaticLink($parent_id);
-                }
-            }
-            // owner
-            else {
-                $back = $this->ctrl->getLinkTarget($this, "view");
-                if ($this->getType() === "prtf") {
-                    $back_caption = $this->lng->txt("prtf_back_to_portfolio_owner");
-                } else {
-                    // #19316
-                    $this->lng->loadLanguageModule("prtt");
-                    $back_caption = $this->lng->txt("prtt_edit");
-                }
-            }
         }
 
         // render tabs

--- a/Modules/Portfolio/classes/class.ilObjPortfolioGUI.php
+++ b/Modules/Portfolio/classes/class.ilObjPortfolioGUI.php
@@ -970,11 +970,11 @@ class ilObjPortfolioGUI extends ilObjPortfolioBaseGUI
 
         $id = explode("_", $a_target);
 
-        $ctrl->setParameterByClass("ilobjportfoliogui", "prt_id", $id[0]);
-        if (count($id) === 2) {
-            $ctrl->setParameterByClass("ilobjportfoliogui", "user_page", $id[1]);
+        $ctrl->setParameterByClass(self::class, 'prt_id', $id[0]);
+        if (count($id) === 2 && is_numeric($id[1])) {
+            $ctrl->setParameterByClass(self::class, 'user_page', $id[1]);
         }
-        $ctrl->redirectByClass(["ilsharedresourceGUI", "ilobjportfoliogui"], "preview");
+        $ctrl->redirectByClass([ilSharedResourceGUI::class, self::class], 'preview');
     }
 
     public function createPortfolioFromAssignment(): void

--- a/Services/User/classes/Profile/class.ilPublicUserProfileGUI.php
+++ b/Services/User/classes/Profile/class.ilPublicUserProfileGUI.php
@@ -482,12 +482,8 @@ class ilPublicUserProfileGUI implements ilCtrlBaseClassInterface
         }
 
         // portfolios
-        $back = ($this->getBackUrl() != '')
-            ? $this->getBackUrl()
-            : ilLink::_getStaticLink($this->getUserId(), 'usr', true);
         $port = ilObjPortfolio::getAvailablePortfolioLinksForUserIds(
-            [$this->getUserId()],
-            $back
+            [$this->getUserId()]
         );
         $cnt = 0;
         if (count($port) > 0) {


### PR DESCRIPTION
This commit suggests removing all `back_url` related code in the `Portfolio` component.
First of all: Building links with a named `back_url` HTTP query parameter in `\ilObjPortfolio::getAvailablePortfolioLinksForUserIds(...)` does not really work. The "URL Builder" does not support any kind of "named" query parameter in the generated URLs. A value in the `$a_params` array is just added as a path segment, e.g.: "go/.../[BACK_URL]".

Furthermore, the permanent link handling in `\ilObjPortfolioGUI::_goto(...)` expects `$id[1]` to be of type `int`. I came to this conclusion after checking the usages of `user_page`.
The current code results in the "Back URL" being passed to query parameter `user_page`, which then results in a `Refinery` error in the subsequent HTTP redirect:

`"The value "'[URL]'" can not be transformed into an integer"`

I then checked all usages of `back_url` in the `Portfolio` and identified, that there actually no real usage. All PHP variables built/assigned with values from
`ILIAS\Portfolio\StandardGUIRequest::getBackUrl(...)` are never used:
- The code in `ilObjPortfolioBaseGUI::__construct(...)` only appends the value to URLs built with `ilCtrlInterface` in the current request.
- The code in `ilObjPortfolioBaseGUI::preview(...)` does not use the build values `$back` and `$back_caption` at all.

Because of this, I also removed the `$a_back_url` from the callers of `\ilObjPortfolio::getAvailablePortfolioLinksForUserIds(...)`.