### PR TITLE
9/legacy-UI/ObjectListGUI/a11y mention page reload in label of expand/collapse

### DIFF
--- a/Modules/LTIConsumer/classes/class.ilObjLTIConsumerListGUI.php
+++ b/Modules/LTIConsumer/classes/class.ilObjLTIConsumerListGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Class ilObjLTIConsumer
@@ -76,14 +76,14 @@ class ilObjLTIConsumerListGUI extends ilObjectListGUI
                 $this->tpl->setVariable('EXP_HREF', $this->ctrl->getLinkTarget($this->container_obj, 'view', $this->getUniqueItemId(true)));
                 $this->ctrl->clearParameters($this->container_obj);
                 $this->tpl->setVariable('EXP_IMG', ilUtil::getImagePath('nav/tree_exp.svg'));
-                $this->tpl->setVariable('EXP_ALT', $this->lng->txt('collapse'));
+                $this->tpl->setVariable('EXP_ALT', $this->lng->txt('collapse_reload'));
             } else {
                 $this->ctrl->setParameter($this->container_obj, 'expand', $this->obj_id);
                 // "view" added, see #19922
                 $this->tpl->setVariable('EXP_HREF', $this->ctrl->getLinkTarget($this->container_obj, 'view', $this->getUniqueItemId(true)));
                 $this->ctrl->clearParameters($this->container_obj);
                 $this->tpl->setVariable('EXP_IMG', ilUtil::getImagePath('nav/tree_col.svg'));
-                $this->tpl->setVariable('EXP_ALT', $this->lng->txt('expand'));
+                $this->tpl->setVariable('EXP_ALT', $this->lng->txt('expand_reload'));
             }
 
             $this->tpl->parseCurrentBlock();

--- a/Services/Object/classes/class.ilObjectListGUI.php
+++ b/Services/Object/classes/class.ilObjectListGUI.php
@@ -2678,14 +2678,14 @@ class ilObjectListGUI
                 $this->tpl->setVariable('EXP_HREF', $this->ctrl->getLinkTarget($this->container_obj, 'view', $this->getUniqueItemId(true)));
                 $this->ctrl->clearParameters($this->container_obj);
                 $this->tpl->setVariable('EXP_IMG', ilUtil::getImagePath('nav/tree_exp.svg'));
-                $this->tpl->setVariable('EXP_ALT', $this->lng->txt('collapse'));
+                $this->tpl->setVariable('EXP_ALT', $this->lng->txt('collapse_reload'));
             } else {
                 $this->ctrl->setParameter($this->container_obj, 'expand', $this->obj_id);
                 // 'view' added, see #19922
                 $this->tpl->setVariable('EXP_HREF', $this->ctrl->getLinkTarget($this->container_obj, 'view', $this->getUniqueItemId(true)));
                 $this->ctrl->clearParameters($this->container_obj);
                 $this->tpl->setVariable('EXP_IMG', ilUtil::getImagePath('nav/tree_col.svg'));
-                $this->tpl->setVariable('EXP_ALT', $this->lng->txt('expand'));
+                $this->tpl->setVariable('EXP_ALT', $this->lng->txt('expand_reload'));
             }
 
             $this->tpl->parseCurrentBlock();

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -3725,6 +3725,7 @@ common#:#cnt_new#:#(%s Neu)
 common#:#collapse#:#Einklappen
 common#:#collapse_all#:#Alle zusammenklappen
 common#:#collapse_content#:#Inhalt einklappen
+common#:#collapse_reload#:#Hier klicken zum Verbergen der Details nach einem Neuladen der Seite.
 common#:#collapsed#:#Geschlossen
 common#:#columns#:#Spalten
 common#:#comma_separated#:#Kommagetrennt
@@ -4062,6 +4063,7 @@ common#:#exp_html#:#HTML exportieren
 common#:#expand#:#Ausklappen
 common#:#expand_all#:#Alle ausklappen
 common#:#expand_content#:#Inhalt ausklappen
+common#:#expand_reload#:#Hier klicken zum Ausklappen der Details nach einem Neuladen der Seite.
 common#:#expanded#:#Geöffnet
 common#:#export#:#Export
 common#:#export_format#:#Exportformat

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -3725,6 +3725,7 @@ common#:#cnt_new#:#(%s New)
 common#:#collapse#:#Collapse
 common#:#collapse_all#:#Collapse All
 common#:#collapse_content#:#Collapse Content
+common#:#collapse_reload#:#Click here to hide details after a page reload.
 common#:#collapsed#:#Collapsed
 common#:#columns#:#Columns
 common#:#comma_separated#:#Comma Separated
@@ -4062,6 +4063,7 @@ common#:#exp_html#:#Export HTML
 common#:#expand#:#Expand
 common#:#expand_all#:#Expand All
 common#:#expand_content#:#Expand Content
+common#:#expand_reload#:#Click here to see more details after a page reload.
 common#:#expanded#:#Expanded
 common#:#export#:#Export
 common#:#export_format#:#Export format


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=44398

# Issue

Some repository objects in lists can be expanded and collapsed. However, the previous labels were confusing to screen reader users because they do not mention that a full page reload will take place

<img width="1502" height="1320" alt="image" src="https://github.com/user-attachments/assets/02690cfc-4092-4006-82e1-68ec50868058" />

# Change

<img width="1454" height="319" alt="image" src="https://github.com/user-attachments/assets/c24b50ba-1b4f-4309-8844-ccd1a7f84fb6" />

New translation strings have been added for a label that now clarifies that expanding and collapsing will cause a full page reload.

# Outlook

In the long term, these sort of item accordions should not cause a page reload but expand and collapse in place.