### PR TITLE
T&A 45782: Fix participant table not displaying running attempt under best attempt scoring

### DIFF
--- a/components/ILIAS/Test/classes/Evaluation/class.ilTestEvaluationUserData.php
+++ b/components/ILIAS/Test/classes/Evaluation/class.ilTestEvaluationUserData.php
@@ -18,6 +18,7 @@
 
 declare(strict_types=1);
 
+use ILIAS\Test\Results\Data\StatusOfAttempt;
 use ILIAS\Test\Scoring\Marks\Mark;
 
 /**
@@ -208,7 +209,8 @@ class ilTestEvaluationUserData
 
     public function getScoredPass(): int
     {
-        if ($this->getPassScoring() === 1) {
+        $last_pass = $this->passes[$this->getLastPass()];
+        if ($this->getPassScoring() === ilObjTest::SCORE_BEST_PASS && $last_pass->getStatusOfAttempt() !== StatusOfAttempt::RUNNING) {
             return $this->getBestPass();
         }
 


### PR DESCRIPTION
This PR attempts to solve https://mantis.ilias.de/view.php?id=45782.

The participant table now displays the running attempt if there is one instead of always showing the best attempt.

Kind regards,
@bidzanaaron 