### PR TITLE
Multiple ViewControls on one page / Namesource

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Input/Container/Container.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Container/Container.php
@@ -47,7 +47,7 @@ abstract class Container implements C\Input\Container\Container
      */
     public function __construct(NameSource $name_source)
     {
-        $this->name_source = clone $name_source;
+        $this->name_source = $name_source->withReset();
     }
 
     /**

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Container/Filter/Filter.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Container/Filter/Filter.php
@@ -281,6 +281,17 @@ abstract class Filter implements C\Input\Container\Filter\Filter, CI\Input\NameS
     }
 
     /**
+     * Implementation of NameSource
+     */
+    public function withReset(): static
+    {
+        $clone = clone $this;
+        $clone->count = 0;
+        $clone->used_names = [];
+        return $clone;
+    }
+
+    /**
      * @inheritdoc
      */
     public function isActivated(): bool

--- a/components/ILIAS/UI/src/Implementation/Component/Input/FormInputNameSource.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/FormInputNameSource.php
@@ -51,4 +51,12 @@ class FormInputNameSource implements NameSource
             return $dedicated_name;
         }
     }
+
+    public function withReset(): static
+    {
+        $clone = clone $this;
+        $clone->count = 0;
+        $clone->used_names = [];
+        return $clone;
+    }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Input/NameSource.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/NameSource.php
@@ -29,4 +29,9 @@ interface NameSource
      * Generates a unique name on every call.
      */
     public function getNewName(): string;
+
+    /**
+     * Resets internal counters/used names and returns a copy
+     */
+    public function withReset(): static;
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Renderer.php
@@ -572,6 +572,10 @@ class Renderer extends AbstractComponentRenderer
             {
                 return $dedicated_name;
             }
+            public function withReset(): static
+            {
+                return $this;
+            }
         };
 
         $numeric_label = $this->txt("ui_table_order");

--- a/components/ILIAS/UI/tests/Component/Input/Container/Filter/FilterTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Filter/FilterTest.php
@@ -40,6 +40,10 @@ class FixedNameSourceFilter implements NameSource
     {
         return $this->name;
     }
+    public function withReset(): static
+    {
+        return $this;
+    }
 }
 
 class ConcreteFilter extends Filter

--- a/components/ILIAS/UI/tests/Component/Input/Container/Form/FormTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Form/FormTest.php
@@ -42,6 +42,11 @@ class FixedNameSource implements NameSource
     {
         return $this->name;
     }
+
+    public function withReset(): static
+    {
+        return $this;
+    }
 }
 
 class ConcreteForm extends Form

--- a/components/ILIAS/UI/tests/Component/Input/Container/Form/FormWithoutSubmitButtonsTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Form/FormWithoutSubmitButtonsTest.php
@@ -51,6 +51,13 @@ class InputNameSource implements NameSource
 
         return $name;
     }
+
+    public function withReset(): static
+    {
+        $clone = clone $this;
+        $clone->count = 0;
+        return $clone;
+    }
 }
 
 /**

--- a/components/ILIAS/UI/tests/Component/Input/Container/Form/StandardFormTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Form/StandardFormTest.php
@@ -65,6 +65,13 @@ class InputNameSource implements NameSource
 
         return $name;
     }
+
+    public function withReset(): static
+    {
+        $clone = clone $this;
+        $clone->count = 0;
+        return $clone;
+    }
 }
 
 /**

--- a/components/ILIAS/UI/tests/Component/Input/Field/HasDynamicInputsTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/HasDynamicInputsTest.php
@@ -157,6 +157,10 @@ class HasDynamicInputsTest extends TestCase
             {
                 return 'test_name';
             }
+            public function withReset(): static
+            {
+                return $this;
+            }
         };
     }
 

--- a/components/ILIAS/UI/tests/Component/Input/Field/InputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/InputTest.php
@@ -70,6 +70,13 @@ class DefNamesource implements NameSource
 
         return $name;
     }
+
+    public function withReset(): static
+    {
+        $clone = clone $this;
+        $clone->count = 0;
+        return $clone;
+    }
 }
 
 class DefInputData implements InputData

--- a/components/ILIAS/UI/tests/Component/Input/Field/LinkInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/LinkInputTest.php
@@ -110,6 +110,10 @@ class LinkInputTest extends ILIAS_UI_TestBase
                 {
                     return "dedicated_name";
                 }
+                public function withReset(): static
+                {
+                    return $this;
+                }
             });
         $input = $input->withInput(new class () implements InputData {
             public function getOr($_, $default): string

--- a/components/ILIAS/UI/tests/Component/Input/Field/MultiSelectInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/MultiSelectInputTest.php
@@ -78,6 +78,10 @@ class MultiSelectInputTest extends ILIAS_UI_TestBase
                 {
                     return "name";
                 }
+                public function withReset(): static
+                {
+                    return $this;
+                }
             });
         $ms = $ms->withInput(new class () implements InputData {
             /**

--- a/components/ILIAS/UI/tests/Component/Input/Field/OptionalGroupInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/OptionalGroupInputTest.php
@@ -89,6 +89,10 @@ class OptionalGroupInputTest extends ILIAS_UI_TestBase
             {
                 return "name0";
             }
+            public function withReset(): static
+            {
+                return $this;
+            }
         });
     }
 

--- a/components/ILIAS/UI/tests/Component/Input/Field/SwitchableGroupInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/SwitchableGroupInputTest.php
@@ -113,6 +113,10 @@ class SwitchableGroupInputTest extends ILIAS_UI_TestBase
             {
                 return "name0";
             }
+            public function withReset(): static
+            {
+                return $this;
+            }
         });
     }
 

--- a/components/ILIAS/UI/tests/Component/Input/FormInputNameSourceTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/FormInputNameSourceTest.php
@@ -57,4 +57,15 @@ class FormInputNameSourceTest extends TestCase
             $name_source->getNewDedicatedName('dedicated')
         );
     }
+
+    public function testNameSourceReset(): void
+    {
+        $name_source = new FormInputNameSource();
+        $name = $name_source->getNewName();
+        $name = $name_source->getNewName();
+        $this->assertEquals('input_1', $name);
+        $name = $name_source->withReset()->getNewName();
+        $this->assertEquals('input_0', $name);
+    }
+
 }

--- a/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlTestBase.php
+++ b/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlTestBase.php
@@ -40,6 +40,12 @@ abstract class ViewControlTestBase extends ILIAS_UI_TestBase
 
                 return $name;
             }
+            public function withReset(): static
+            {
+                $clone = clone $this;
+                $clone->count = 0;
+                return $clone;
+            }
         };
     }
 


### PR DESCRIPTION
With multiple Viewcontrols - rather multiple ViewControl Containers -  on a page, fields are not named uniquely.
