### PR TITLE
10/legacy-UI/print-view closes modal 42797

### DIFF
--- a/components/ILIAS/Export/Print/templates/default/tpl.print_view_selection.html
+++ b/components/ILIAS/Export/Print/templates/default/tpl.print_view_selection.html
@@ -1,6 +1,6 @@
 <script>
     $("#il-exp-print-view-selection form").on("submit", function (event) {
-            $("#il-exp-print-view-selection form").closest(".modal").find("button.close").click();
+            $("#il-exp-print-view-selection form").closest(".c-modal").find("button").click();
             //event.preventDefault();
             {ON_SUBMIT_CODE}
         }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=42797

# Issue

Printing in Communication > Comments also prints the print modal. In 9, the modal closes before the browser print view opens.

<img width="2448" height="1856" alt="image" src="https://github.com/user-attachments/assets/cf4b74df-4088-48cc-bad6-40a2b4689567" />

# Changes

In 9, an inline JavaScript searches the nearest close button and clicks it. Since the modal has changed, the script no longer finds the button. By making the query less specific, the script once again finds the correct button.

<img width="1382" height="848" alt="image" src="https://github.com/user-attachments/assets/0d0f532b-dba4-47c2-a03e-c143a1f40819" />

# Outlook

As we could see here, querying a button like this can break easily. A modern implementation should work with signals sent to the parent modal.