### PR TITLE
OrgUnit: Remove info screen from root

### DIFF
--- a/components/ILIAS/OrgUnit/classes/class.ilObjOrgUnitGUI.php
+++ b/components/ILIAS/OrgUnit/classes/class.ilObjOrgUnitGUI.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 use ILIAS\OrgUnit\Provider\OrgUnitToolProvider;
 use ILIAS\ILIASObject\Properties\Translations\TranslationGUI;
+use ILIAS\UICore\GlobalTemplate;
 
 /**
  * Class ilObjOrgUnit GUI class
@@ -183,11 +184,9 @@ class ilObjOrgUnitGUI extends ilContainerGUI
                 break;
             case "ilinfoscreengui":
                 $this->tabs_gui->activateTab("info_short");
-                if (!$this->ilAccess->checkAccess(
-                    "read",
-                    "",
-                    $this->ref_id
-                ) and !$this->ilAccess->checkAccess("visible", "", $this->ref_id)) {
+                // info screen is only available to child org units with visible permission
+                if ($this->ref_id === ilObjOrgUnit::getRootOrgRefId()
+                    || !$this->ilAccess->checkAccess("visible", "", $this->ref_id)) {
                     $this->ilias->raiseError($this->lng->txt("msg_no_perm_read"), $this->ilias->error_obj->MESSAGE);
                 }
                 $info = new ilInfoScreenGUI($this);
@@ -388,9 +387,15 @@ class ilObjOrgUnitGUI extends ilContainerGUI
     public function view(): void
     {
         if (!$this->rbacsystem->checkAccess("read", $this->ref_id)) {
-            if ($this->rbacsystem->checkAccess("visible", $this->ref_id)) {
-                $this->tpl->setOnScreenMessage('failure', $this->lng->txt("msg_no_perm_read"));
-                $this->ctrl->redirectByClass('ilinfoscreengui', '');
+            // show failure message on info screen if info screen is available
+            if ($this->ref_id !== ilObjOrgUnit::getRootOrgRefId()
+                && $this->rbacsystem->checkAccess("visible", $this->ref_id)) {
+                $this->tpl->setOnScreenMessage(
+                    GlobalTemplate::MESSAGE_TYPE_FAILURE,
+                    $this->lng->txt("msg_no_perm_read"),
+                    true
+                );
+                $this->ctrl->redirectByClass([self::class, ilInfoScreenGUI::class], "showSummary");
             }
 
             $this->ilias->raiseError($this->lng->txt("msg_no_perm_read"), $this->ilias->error_obj->WARNING);
@@ -508,23 +513,25 @@ class ilObjOrgUnitGUI extends ilContainerGUI
 
     public function getTabs(): void
     {
-        $read_access_ref_id = $this->rbacsystem->checkAccess('visible', $this->object->getRefId())
-            && $this->rbacsystem->checkAccess('read', $this->object->getRefId());
-        if ($read_access_ref_id) {
+        if ($this->rbacsystem->checkAccess('read', $this->object->getRefId())) {
             $this->tabs_gui->addTab(
                 self::TAB_VIEW_CONTENT,
                 $this->lng->txt("content"),
                 $this->ctrl->getLinkTarget($this, "")
             );
-            $this->tabs_gui->addTab(
-                "info_short",
-                "Info",
-                $this->ctrl->getLinkTargetByClass([self::class, ilInfoScreenGUI::class], "showSummary")
-            );
         }
 
         // Tabs for OrgUnits exclusive root!
         if ($this->object->getRefId() != ilObjOrgUnit::getRootOrgRefId()) {
+
+            if ($this->rbacsystem->checkAccess('visible', $this->object->getRefId())) {
+                $this->tabs_gui->addTab(
+                    "info_short",
+                    "Info",
+                    $this->ctrl->getLinkTargetByClass([self::class, ilInfoScreenGUI::class], "showSummary")
+                );
+            }
+
             if (ilObjOrgUnitAccess::_checkAccessStaff($this->object->getRefId())) {
                 $this->tabs_gui->addTab(
                     self::TAB_STAFF,


### PR DESCRIPTION
This PR is in created the context of the feature request [Unbundling of Admin Permissions](https://docu.ilias.de/go/wiki/wpage_8648_1357).

The PR [Remove "visible" permission from administration nodes](https://github.com/ILIAS-eLearning/ILIAS/pull/10238) does not remove the "visible" permission from Org Units, because the single units share the same type with their admin node.  In ILIAS a "visible" permission is needed to list an item in the upper container and to show its info screen. This functionality should be kept for single Org Units.

The admin node of the Org Units, however, always needs a "read" permission to be listed in the admin menu and to be opened. As a consequence it's visible permission would only be needed for its info tab.

Except for Org Units and Emplyee Talk the admin nodes don't implement an info tab. The info tab for Org Units just shows its creation date and "root" as owner. Therefore this PR removes it from the admin node Of Org Units but keeps it for the Org Units within.
