### PR TITLE
Notifications: make registration of service worker optional

### DIFF
--- a/components/ILIAS/JavaScript/resources/Basic.js
+++ b/components/ILIAS/JavaScript/resources/Basic.js
@@ -1019,4 +1019,6 @@ $(document).ready(() => {
   numericInputCheck();
 });
 
-navigator.serviceWorker.register('/service-worker.js');
+if (navigator.serviceWorker !== 'undefined') {
+  navigator.serviceWorker.register('/service-worker.js');
+}


### PR DESCRIPTION
In some cases (development environments or ancient/special servers), the serviceWorker is not available.
Since it is no requirement for ILIAS to run, it should be registered optional and only have an effect on its purposed functionality.