### PR TITLE
setCmd Cleanup Part 2

### DIFF
--- a/components/ILIAS/ScormAicc/classes/class.ilObjSAHSLearningModuleGUI.php
+++ b/components/ILIAS/ScormAicc/classes/class.ilObjSAHSLearningModuleGUI.php
@@ -860,8 +860,6 @@ class ilObjSAHSLearningModuleGUI extends ilObjectGUI
     {
         $GLOBALS['DIC']->tabs()->setTabActive('export');
         $exp_gui = new ilExportGUI($this);
-        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
-        // $this->ctrl->setCmd("listExportFiles");
         $exp_gui->addFormat("xml");
         return $this->ctrl->forwardCommand($exp_gui);
     }

--- a/components/ILIAS/ScormAicc/classes/class.ilObjSAHSLearningModuleGUI.php
+++ b/components/ILIAS/ScormAicc/classes/class.ilObjSAHSLearningModuleGUI.php
@@ -860,6 +860,7 @@ class ilObjSAHSLearningModuleGUI extends ilObjectGUI
     {
         $GLOBALS['DIC']->tabs()->setTabActive('export');
         $exp_gui = new ilExportGUI($this);
+        // Here used to be $this->ctrl->setCmd("listExportFiles") in <10
         $exp_gui->addFormat("xml");
         return $this->ctrl->forwardCommand($exp_gui);
     }


### PR DESCRIPTION
Hello @Uwe-Kohnle 

We were asked to review "todo: removed deprecated ilCtrl methods" comments and this is the last one, however I'm not sure if we can just remove it or need to replace the usage of setCmd with something else. Scorm Exports/Imports in ILIAS 10 are a mess I have a feeling export() is not even called anymore, so it would probably make no difference. Could you please tell us what your opinion on this matter is.

@swischniak @qualitus-dahme FYI