### PR TITLE
UI/Drilldown: Allow hiding filter

### DIFF
--- a/components/ILIAS/UI/src/Component/Menu/Drilldown.php
+++ b/components/ILIAS/UI/src/Component/Menu/Drilldown.php
@@ -27,4 +27,5 @@ use ILIAS\UI\Component\JavaScriptBindable;
  */
 interface Drilldown extends Menu, JavaScriptBindable
 {
+    public function withHiddenFilter(bool $filter_hidden): self;
 }

--- a/components/ILIAS/UI/src/Component/Menu/Drilldown.php
+++ b/components/ILIAS/UI/src/Component/Menu/Drilldown.php
@@ -27,5 +27,5 @@ use ILIAS\UI\Component\JavaScriptBindable;
  */
 interface Drilldown extends Menu, JavaScriptBindable
 {
-    public function withHiddenFilter(bool $filter_hidden): self;
+    public function withoutFilter(): self;
 }

--- a/components/ILIAS/UI/src/Component/Menu/Factory.php
+++ b/components/ILIAS/UI/src/Component/Menu/Factory.php
@@ -73,6 +73,8 @@ interface Factory
      *          A Drilldown Menu MUST contain further Submenus or Buttons.
      *      2: >
      *          Drilldown Menus MUST contain more than one entry (Submenu or Button).
+     *      3: >
+     *          Node filter should not be hidden using withoutFilter() purely by preference, there should be a valid reason to do so.
      *
      * ---
      * @param 	string $label

--- a/components/ILIAS/UI/src/Component/Menu/Factory.php
+++ b/components/ILIAS/UI/src/Component/Menu/Factory.php
@@ -49,6 +49,7 @@ interface Factory
      *     and a bulky button offers navigation to an upper level.
      *     The label of the Drilldown Menu will be shown as part of the label of
      *     the filter.
+     *     The filter can optionally be hidden/removed.
      *   effect: >
      *     The Drilldown Menu maybe presented in one or two columns depending on the available
      *     space.

--- a/components/ILIAS/UI/src/Implementation/Component/Menu/Drilldown.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Menu/Drilldown.php
@@ -35,6 +35,7 @@ class Drilldown extends Menu implements IMenu\Drilldown
 
     protected Signal $signal;
     protected ?string $persistence_id = null;
+    protected bool $filter_hidden = false;
 
     /**
      * @param array<Component\Menu\Sub, Component\Clickable, Component\Link\Link, Component\Divider\Horizontal, Component\Input\Field\Node\Node> $items
@@ -68,5 +69,18 @@ class Drilldown extends Menu implements IMenu\Drilldown
     public function getPersistenceId(): ?string
     {
         return $this->persistence_id;
+    }
+
+
+    public function withHiddenFilter(bool $filter_hidden): self
+    {
+        $clone = clone $this;
+        $clone->filter_hidden = $filter_hidden;
+        return $clone;
+    }
+
+    public function isFilterHidden(): bool
+    {
+        return $this->filter_hidden;
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Menu/Drilldown.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Menu/Drilldown.php
@@ -72,10 +72,10 @@ class Drilldown extends Menu implements IMenu\Drilldown
     }
 
 
-    public function withHiddenFilter(bool $filter_hidden): self
+    public function withoutFilter(): self
     {
         $clone = clone $this;
-        $clone->filter_hidden = $filter_hidden;
+        $clone->filter_hidden = true;
         return $clone;
     }
 

--- a/components/ILIAS/UI/src/Implementation/Component/Menu/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Menu/Renderer.php
@@ -100,7 +100,9 @@ class Renderer extends AbstractComponentRenderer
         $tpl->setVariable('BACKNAV', $back_button_html);
         $tpl->setVariable('DRILLDOWN', $items_html);
         $tpl->setVariable('NO_ITEMS_TEXT', $this->txt(self::NO_ITEMS_LABEL));
-        $this->addMenuFilter($component, $tpl, $default_renderer);
+        if (!$component->isFilterHidden()) {
+            $this->addMenuFilter($component, $tpl, $default_renderer);
+        }
 
         return $tpl->get();
     }

--- a/templates/default/070-components/UI-framework/Menu/_ui-component_drilldown.scss
+++ b/templates/default/070-components/UI-framework/Menu/_ui-component_drilldown.scss
@@ -49,12 +49,16 @@ $c-drilldown-menulevel-trigger-bg: transparent;
         // so backnav can be positioned on top
         display: flex;
         align-items: center;
+        box-shadow: none;
+        z-index: initial;
+
+        &.c-drilldown__header--showbacknav, &:has(.c-drilldown__filter){
         min-height: $c-drilldown-header-height;
         // content is centered by flex-box, not through padding
         margin-bottom: $c-drilldown-item-spacing;
         padding: l.$il-padding-xlarge-vertical l.$il-padding-xlarge-horizontal l.$il-padding-xlarge-vertical $c-drilldown-left-indent;
-        box-shadow: none;
-        z-index: initial;
+    }
+
         // so slate can cover up this specific header
         h2 {
             font-size: $il-font-size-xlarge;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -944,7 +944,7 @@ th {
   margin-top: var(--bs-gutter-y);
 }
 
-@media (min-width: 480px) {
+@media (min-width: 0px) {
   .col-xs {
     flex: 1 0 0%;
   }
@@ -2667,6 +2667,22 @@ ol.breadcrumb > li + li:before {
 .il-drilldown .menulevel, .navbar-form > a {
   display: inline-flex;
   vertical-align: middle;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  user-select: none;
+  touch-action: manipulation;
+  font-family: "Open Sans", Verdana, Arial, Helvetica, sans-serif;
+  text-align: center;
+  line-height: inherit;
+  font-size: inherit;
+  font-weight: 400;
+  text-decoration: none;
+  min-height: 28px;
+  min-width: 28px;
+  font-size: 0.75rem;
+  padding: 3px 6px;
+  gap: 6px;
 }
 .btn + .btn, .c-input-tree_select > input[type=button] + .btn, .c-drilldown .c-drilldown__menulevel--trigger + .btn, .c-input-tree_select > .btn + input[type=button], .c-input-tree_select > input[type=button] + input[type=button], .c-drilldown .c-input-tree_select > .c-drilldown__menulevel--trigger + input[type=button], .c-drilldown .btn + .c-drilldown__menulevel--trigger, .c-drilldown .c-input-tree_select > input[type=button] + .c-drilldown__menulevel--trigger, .c-drilldown .c-drilldown__menulevel--trigger + .c-drilldown__menulevel--trigger, .il-link.link-bulky + .btn, .c-input-tree_select > .il-link.link-bulky + input[type=button], .c-drilldown .il-link.link-bulky + .c-drilldown__menulevel--trigger,
 .il-drilldown .menulevel + .btn,
@@ -2684,32 +2700,10 @@ ol.breadcrumb > li + li:before {
 .il-drilldown .navbar-form > .menulevel + a, .navbar-form > a + a {
   margin-left: 3px;
 }
-.btn, .c-input-tree_select > input[type=button], .c-drilldown .c-drilldown__menulevel--trigger, .il-link.link-bulky,
-.il-drilldown .menulevel, .navbar-form > a {
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  user-select: none;
-  touch-action: manipulation;
-  font-family: "Open Sans", Verdana, Arial, Helvetica, sans-serif;
-  text-align: center;
-  line-height: inherit;
-  font-size: inherit;
-  font-weight: 400;
-  text-decoration: none;
-}
 .btn:focus-visible, .c-input-tree_select > input[type=button]:focus-visible, .c-drilldown .c-drilldown__menulevel--trigger:focus-visible, .il-link.link-bulky:focus-visible,
 .il-drilldown .menulevel:focus-visible, .navbar-form > a:focus-visible {
   outline: 3px solid #0078D7;
   box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 5px #FFFFFF;
-}
-.btn, .c-input-tree_select > input[type=button], .c-drilldown .c-drilldown__menulevel--trigger, .il-link.link-bulky,
-.il-drilldown .menulevel, .navbar-form > a {
-  min-height: 28px;
-  min-width: 28px;
-  font-size: 0.75rem;
-  padding: 3px 6px;
-  gap: 6px;
 }
 .btn .glyph, .c-input-tree_select > input[type=button] .glyph, .c-drilldown .c-drilldown__menulevel--trigger .glyph, .il-link.link-bulky .glyph,
 .il-drilldown .menulevel .glyph, .navbar-form > a .glyph,
@@ -2868,6 +2862,28 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
   display: inline-flex;
   vertical-align: middle;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  user-select: none;
+  touch-action: manipulation;
+  font-family: "Open Sans", Verdana, Arial, Helvetica, sans-serif;
+  text-align: center;
+  line-height: inherit;
+  font-size: inherit;
+  font-weight: 400;
+  text-decoration: none;
+  min-height: 2.2rem;
+  min-width: 2.2rem;
+  font-size: 0.75rem;
+  padding: 3px 6px;
+  gap: 6px;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
+  color: #4c6586;
+  border-width: 1px;
+  border-style: solid;
+  border-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
+  border-radius: 10px;
 }
 .btn-ctrl + .btn-ctrl, .il-viewcontrol-sortation > .btn-default + .btn-ctrl, .il-viewcontrol-sortation > .btn-link + .btn-ctrl,
 .il-viewcontrol-section > .btn-default + .btn-ctrl,
@@ -3726,41 +3742,6 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a + a {
   margin-left: 3px;
 }
-.btn-ctrl, .il-viewcontrol-sortation > .btn-default, .il-viewcontrol-sortation > .btn-link,
-.il-viewcontrol-section > .btn-default,
-.il-viewcontrol-section > .btn-link,
-.il-viewcontrol-section .btn-group > .btn-default,
-.il-viewcontrol-section .btn-group > .btn-link,
-.il-viewcontrol-pagination__sectioncontrol > .btn-default,
-.il-viewcontrol-pagination__sectioncontrol > .btn-link,
-.il-viewcontrol-pagination__num-of-items > .btn-default,
-.il-viewcontrol-pagination__num-of-items > .btn-link,
-.il-viewcontrol-pagination > .btn-default,
-.il-viewcontrol-pagination > .btn-link,
-.il-viewcontrol-pagination .dropdown > .btn-default,
-.il-viewcontrol-pagination .dropdown > .btn-link,
-.il-viewcontrol-pagination .last > .btn-default,
-.il-viewcontrol-pagination .last > .btn-link,
-.il-viewcontrol-mode > .btn-default,
-.il-viewcontrol-mode > .btn-link, .il-viewcontrol-sortation > .btn-default.btn,
-.il-viewcontrol-sortation .dropdown > .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn, .c-sequence__navigation--back > .btn-default, .c-sequence__navigation--back.navbar-form > a,
-.c-sequence__navigation--next > .btn-default,
-.c-sequence__navigation--next.navbar-form > a, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link, .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select > input[type=button],
-.ilTableNav > table > tbody > tr > td > .dropdown > .btn-default,
-.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  user-select: none;
-  touch-action: manipulation;
-  font-family: "Open Sans", Verdana, Arial, Helvetica, sans-serif;
-  text-align: center;
-  line-height: inherit;
-  font-size: inherit;
-  font-weight: 400;
-  text-decoration: none;
-}
 .btn-ctrl:focus-visible, .il-viewcontrol-sortation > .btn-default:focus-visible, .il-viewcontrol-sortation > .btn-link:focus-visible,
 .il-viewcontrol-section > .btn-default:focus-visible,
 .il-viewcontrol-section > .btn-link:focus-visible,
@@ -3786,41 +3767,6 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a:focus-visible {
   outline: 3px solid #0078D7;
   box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 5px #FFFFFF;
-}
-.btn-ctrl, .il-viewcontrol-sortation > .btn-default, .il-viewcontrol-sortation > .btn-link,
-.il-viewcontrol-section > .btn-default,
-.il-viewcontrol-section > .btn-link,
-.il-viewcontrol-section .btn-group > .btn-default,
-.il-viewcontrol-section .btn-group > .btn-link,
-.il-viewcontrol-pagination__sectioncontrol > .btn-default,
-.il-viewcontrol-pagination__sectioncontrol > .btn-link,
-.il-viewcontrol-pagination__num-of-items > .btn-default,
-.il-viewcontrol-pagination__num-of-items > .btn-link,
-.il-viewcontrol-pagination > .btn-default,
-.il-viewcontrol-pagination > .btn-link,
-.il-viewcontrol-pagination .dropdown > .btn-default,
-.il-viewcontrol-pagination .dropdown > .btn-link,
-.il-viewcontrol-pagination .last > .btn-default,
-.il-viewcontrol-pagination .last > .btn-link,
-.il-viewcontrol-mode > .btn-default,
-.il-viewcontrol-mode > .btn-link, .il-viewcontrol-sortation > .btn-default.btn,
-.il-viewcontrol-sortation .dropdown > .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn, .c-sequence__navigation--back > .btn-default, .c-sequence__navigation--back.navbar-form > a,
-.c-sequence__navigation--next > .btn-default,
-.c-sequence__navigation--next.navbar-form > a, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link, .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select > input[type=button],
-.ilTableNav > table > tbody > tr > td > .dropdown > .btn-default,
-.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
-  min-height: 2.2rem;
-  min-width: 2.2rem;
-  font-size: 0.75rem;
-  padding: 3px 6px;
-  gap: 6px;
-  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
-  color: #4c6586;
-  border-width: 1px;
-  border-style: solid;
-  border-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
-  border-radius: 10px;
 }
 .btn-ctrl:hover, .il-viewcontrol-sortation > .btn-default:hover, .il-viewcontrol-sortation > .btn-link:hover,
 .il-viewcontrol-section > .btn-default:hover,
@@ -4252,15 +4198,13 @@ button > .glyphicon {
   background-image: url("../images/media/loader.svg");
   background-color: #b0b0b0;
   border-color: #b0b0b0;
+  background-repeat: no-repeat;
+  background-position: right center;
+  padding-right: 18px;
 }
 .il-btn-with-loading-animation:hover {
   background-color: #b0b0b0;
   border-color: #b0b0b0;
-}
-.il-btn-with-loading-animation {
-  background-repeat: no-repeat;
-  background-position: right center;
-  padding-right: 18px;
 }
 
 .minimize, .close, .c-input-tree_select .c-input-tree_select__selection button[type=remove] {
@@ -4291,6 +4235,17 @@ button .minimize, button .close, button .c-input-tree_select .c-input-tree_selec
   white-space: nowrap;
   padding: 1px 3px;
   margin: 3px 6px 3px 0;
+  min-height: 28px;
+  min-width: 28px;
+  font-size: 0.75rem;
+  padding: 3px 6px;
+  gap: 6px;
+  background-color: #4c6586;
+  color: white;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #4c6586;
+  border-radius: 3px;
 }
 .btn-tag.btn-tag-inactive {
   cursor: default !important;
@@ -4319,19 +4274,6 @@ button .minimize, button .close, button .c-input-tree_select .c-input-tree_selec
   color: #161616;
   background-color: #75deea;
   border-color: rgb(132.9, 209.3615384615, 218.1);
-}
-.btn-tag {
-  min-height: 28px;
-  min-width: 28px;
-  font-size: 0.75rem;
-  padding: 3px 6px;
-  gap: 6px;
-  background-color: #4c6586;
-  color: white;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #4c6586;
-  border-radius: 3px;
 }
 .btn-tag:hover {
   text-decoration: none;
@@ -4456,6 +4398,7 @@ button .minimize, button .close, button .c-input-tree_select .c-input-tree_selec
   border: 1px solid #dddddd;
   border-radius: 0;
   box-shadow: none;
+  /* see bug #24947 */
 }
 .il-card .il-card-image-container {
   width: 100%;
@@ -4468,9 +4411,6 @@ button .minimize, button .close, button .c-input-tree_select .c-input-tree_selec
   width: 100%;
   max-height: 100%;
   margin: auto;
-}
-.il-card {
-  /* see bug #24947 */
 }
 .il-card a {
   overflow: hidden;
@@ -4915,6 +4855,9 @@ hr.il-divider-with-label {
 .c-entity.__actions .dropdown {
   height: max-content;
 }
+.c-entity.__secondary-identifier {
+  grid-area: second-id;
+}
 .c-entity.__secondary-identifier.--string, .c-entity.__secondary-identifier.--shy, .c-entity.__secondary-identifier.--shylink {
   width: 10rem;
 }
@@ -4923,9 +4866,6 @@ hr.il-divider-with-label {
 }
 .c-entity.__secondary-identifier.--image {
   width: 15rem;
-}
-.c-entity.__secondary-identifier {
-  grid-area: second-id;
 }
 .c-entity.__primary-identifier {
   grid-area: prim-id;
@@ -5135,6 +5075,8 @@ hr.il-divider-with-label {
   border-style: solid;
   border-color: rgb(84.5, 122.9090909091, 46.0909090909);
   border-radius: 10px;
+  min-width: 50%;
+  width: max-content;
 }
 .c-launcher .btn-bulky:hover {
   text-decoration: none;
@@ -5172,10 +5114,6 @@ hr.il-divider-with-label {
   border-style: solid;
   border-color: rgb(84.5, 122.9090909091, 46.0909090909);
   color: #000;
-}
-.c-launcher .btn-bulky {
-  min-width: 50%;
-  width: max-content;
 }
 .c-launcher .btn-bulky[disabled] {
   cursor: not-allowed;
@@ -5347,13 +5285,13 @@ main {
   display: block;
 }
 
-.il-layout-page-content:focus-visible {
-  outline: none;
-}
 .il-layout-page-content {
   display: flex;
   flex-flow: column;
   overflow: auto;
+}
+.il-layout-page-content:focus-visible {
+  outline: none;
 }
 .il-layout-page-content #mainspacekeeper {
   flex-grow: 1;
@@ -5673,15 +5611,15 @@ a[aria-disabled].il-link.link-bulky:hover {
 }
 
 /* common css for characteristic value listing */
-.il-listing-characteristic-value-row::after {
-  display: block;
-  clear: both;
-  content: "";
-}
 .il-listing-characteristic-value-row {
   /* i tried .ilClearFloat, did not work as expected */
   border-top: solid #dddddd 1px;
   padding: 12px 0;
+}
+.il-listing-characteristic-value-row::after {
+  display: block;
+  clear: both;
+  content: "";
 }
 
 .il-listing-characteristic-value-row:first-child {
@@ -5908,12 +5846,6 @@ a[aria-disabled].il-link.link-bulky:hover {
 .il-maincontrols-slate.il-maincontrols-slate-notification .il-maincontrols-slate-notification-title {
   padding: 12px;
 }
-.il-maincontrols-slate.il-maincontrols-slate-notification .il-maincontrols-slate-notification-title .btn-bulky .glyph :before {
-  content: " \e605";
-  font-family: "il-icons";
-  font-size: 1.0625rem;
-  margin-right: 10px;
-}
 .il-maincontrols-slate.il-maincontrols-slate-notification .il-maincontrols-slate-notification-title .btn-bulky {
   margin: -12px;
   border: none;
@@ -5922,6 +5854,12 @@ a[aria-disabled].il-link.link-bulky:hover {
   padding: 12px;
   background-color: transparent;
   width: 50%;
+}
+.il-maincontrols-slate.il-maincontrols-slate-notification .il-maincontrols-slate-notification-title .btn-bulky .glyph :before {
+  content: " \e605";
+  font-family: "il-icons";
+  font-size: 1.0625rem;
+  margin-right: 10px;
 }
 .il-maincontrols-slate #il-tag-slate-container .btn-bulky .glyph :before, .il-maincontrols-slate #ilHelpPanel .btn-bulky .glyph :before {
   content: " \e605";
@@ -6076,16 +6014,16 @@ a[aria-disabled].il-link.link-bulky:hover {
 .il-maincontrols-metabar .il-counter {
   font-size: 1.4375rem;
 }
-.il-maincontrols-metabar > li > .btn.btn-bulky:focus-visible, .il-maincontrols-metabar > li > a.il-link.link-bulky:focus-visible {
-  outline: none;
-  border: 3px solid #0078D7;
-  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 2px #FFFFFF;
-}
 .il-maincontrols-metabar > li > .btn.btn-bulky, .il-maincontrols-metabar > li > a.il-link.link-bulky {
   border: none;
   background-color: transparent;
   height: 60px;
   min-width: 60px;
+}
+.il-maincontrols-metabar > li > .btn.btn-bulky:focus-visible, .il-maincontrols-metabar > li > a.il-link.link-bulky:focus-visible {
+  outline: none;
+  border: 3px solid #0078D7;
+  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 2px #FFFFFF;
 }
 @media only screen and (max-width: 991px) {
   .il-maincontrols-metabar > li > .btn.btn-bulky, .il-maincontrols-metabar > li > a.il-link.link-bulky {
@@ -6138,15 +6076,13 @@ a[aria-disabled].il-link.link-bulky:hover {
   background-color: #fafafa;
   position: absolute;
   max-width: 500px;
-}
-.il-metabar-slates .il-maincontrols-slate {
-  min-width: 500px;
-}
-.il-metabar-slates {
   max-height: 90vh;
   overflow-y: auto;
   right: 0;
   top: 60px;
+}
+.il-metabar-slates .il-maincontrols-slate {
+  min-width: 500px;
 }
 .il-metabar-slates .bulky-label {
   margin-top: auto;
@@ -6258,6 +6194,20 @@ a[aria-disabled].il-link.link-bulky:hover {
 .il-mainbar-tools-button .il-link.link-bulky .bulky-label,
 .il-mainbar-tool-trigger-item .btn-bulky .bulky-label,
 .il-mainbar-tool-trigger-item .il-link.link-bulky .bulky-label {
+  /* edge, chrome, safari go here... */
+  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
+  word-break: break-word;
+  -ms-hyphens: auto;
+  -moz-hyphens: auto;
+  -webkit-hyphens: auto;
+  hyphens: auto;
+}
+.il-mainbar-triggers .btn-bulky .bulky-label,
+.il-mainbar-triggers .il-link.link-bulky .bulky-label,
+.il-mainbar-tools-button .btn-bulky .bulky-label,
+.il-mainbar-tools-button .il-link.link-bulky .bulky-label,
+.il-mainbar-tool-trigger-item .btn-bulky .bulky-label,
+.il-mainbar-tool-trigger-item .il-link.link-bulky .bulky-label {
   position: relative;
   max-height: 3em;
   overflow: hidden;
@@ -6277,14 +6227,6 @@ a[aria-disabled].il-link.link-bulky:hover {
   width: 30%;
   height: 1.5em;
   background: linear-gradient(to right, rgba(255, 255, 255, 0), rgb(255, 255, 255) 80%);
-}
-.il-mainbar-triggers .btn-bulky .bulky-label,
-.il-mainbar-triggers .il-link.link-bulky .bulky-label,
-.il-mainbar-tools-button .btn-bulky .bulky-label,
-.il-mainbar-tools-button .il-link.link-bulky .bulky-label,
-.il-mainbar-tool-trigger-item .btn-bulky .bulky-label,
-.il-mainbar-tool-trigger-item .il-link.link-bulky .bulky-label {
-  /* edge, chrome, safari go here... */
 }
 @supports (-webkit-line-clamp: 2) {
   .il-mainbar-triggers .btn-bulky .bulky-label,
@@ -6308,14 +6250,6 @@ a[aria-disabled].il-link.link-bulky:hover {
     display: none;
   }
 }
-.il-mainbar-triggers .btn-bulky .bulky-label,
-.il-mainbar-triggers .il-link.link-bulky .bulky-label,
-.il-mainbar-tools-button .btn-bulky .bulky-label,
-.il-mainbar-tools-button .il-link.link-bulky .bulky-label,
-.il-mainbar-tool-trigger-item .btn-bulky .bulky-label,
-.il-mainbar-tool-trigger-item .il-link.link-bulky .bulky-label {
-  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
-}
 @supports (-moz-line-clamp: 2) {
   .il-mainbar-triggers .btn-bulky .bulky-label,
   .il-mainbar-triggers .il-link.link-bulky .bulky-label,
@@ -6337,18 +6271,6 @@ a[aria-disabled].il-link.link-bulky:hover {
   .il-mainbar-tool-trigger-item .il-link.link-bulky .bulky-label:after {
     display: none;
   }
-}
-.il-mainbar-triggers .btn-bulky .bulky-label,
-.il-mainbar-triggers .il-link.link-bulky .bulky-label,
-.il-mainbar-tools-button .btn-bulky .bulky-label,
-.il-mainbar-tools-button .il-link.link-bulky .bulky-label,
-.il-mainbar-tool-trigger-item .btn-bulky .bulky-label,
-.il-mainbar-tool-trigger-item .il-link.link-bulky .bulky-label {
-  word-break: break-word;
-  -ms-hyphens: auto;
-  -moz-hyphens: auto;
-  -webkit-hyphens: auto;
-  hyphens: auto;
 }
 
 .il-mainbar-triggers .il-mainbar-entries {
@@ -6533,14 +6455,11 @@ a[aria-disabled].il-link.link-bulky:hover {
 .il-mainbar-tools-entries .btn-bulky.engaged, .il-mainbar-tools-entries .btn-bulky.engaged,
 .il-mainbar-tools-entries .il-link.link-bulky.engaged {
   background-color: white;
+  color: #2c2c2c;
 }
 .il-mainbar-tools-entries .btn-bulky.engaged:not(:focus-visible), .il-mainbar-tools-entries .btn-bulky.engaged:not(:focus-visible),
 .il-mainbar-tools-entries .il-link.link-bulky.engaged:not(:focus-visible) {
   border: 0;
-}
-.il-mainbar-tools-entries .btn-bulky.engaged, .il-mainbar-tools-entries .btn-bulky.engaged,
-.il-mainbar-tools-entries .il-link.link-bulky.engaged {
-  color: #2c2c2c;
 }
 .il-mainbar-tools-entries .btn-bulky.engaged .icon, .il-mainbar-tools-entries .btn-bulky.engaged .icon,
 .il-mainbar-tools-entries .il-link.link-bulky.engaged .icon {
@@ -6617,11 +6536,11 @@ a[aria-disabled].il-link.link-bulky:hover {
   position: relative;
 }
 
-.il-mainbar-slates > .il-maincontrols-slate.engaged > .il-maincontrols-slate-content > :first-child {
-  z-index: 1;
-}
 .il-mainbar-slates > .il-maincontrols-slate.engaged > .il-maincontrols-slate-content {
   height: 0px;
+}
+.il-mainbar-slates > .il-maincontrols-slate.engaged > .il-maincontrols-slate-content > :first-child {
+  z-index: 1;
 }
 .il-mainbar-slates > .il-maincontrols-slate.engaged > .il-maincontrols-slate-content .panel-secondary {
   margin-bottom: 0;
@@ -7049,6 +6968,11 @@ code {
   color: white;
 }
 .c-mode-info__label {
+  /* edge, chrome, safari go here... */
+  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
+  flex-grow: 1;
+}
+.c-mode-info__label {
   position: relative;
   max-height: 1.5em;
   overflow: hidden;
@@ -7064,9 +6988,6 @@ code {
   height: 1.5em;
   background: linear-gradient(to right, rgba(255, 255, 255, 0), rgb(255, 255, 255) 80%);
 }
-.c-mode-info__label {
-  /* edge, chrome, safari go here... */
-}
 @supports (-webkit-line-clamp: 2) {
   .c-mode-info__label {
     overflow: hidden;
@@ -7079,9 +7000,6 @@ code {
     display: none;
   }
 }
-.c-mode-info__label {
-  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
-}
 @supports (-moz-line-clamp: 2) {
   .c-mode-info__label {
     overflow: hidden;
@@ -7093,9 +7011,6 @@ code {
   .c-mode-info__label:after {
     display: none;
   }
-}
-.c-mode-info__label {
-  flex-grow: 1;
 }
 @media only screen and (max-width: 991px) {
   .c-mode-info__mobile-padding {
@@ -7125,6 +7040,16 @@ code {
 /** nagtive or positive contrast color for text and glyph **/
 /** contrast threshold for contrast color **/
 /** three color variants for neutral, important, breaking Head Infos **/
+.il-system-info {
+  line-height: 20px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+  height: 32px;
+  display: flex;
+  flex-wrap: nowrap;
+  flex-direction: row;
+  justify-content: flex-start;
+}
 .il-system-info.il-system-info-neutral {
   -webkit-box-shadow: inset 0px -10px 4px -10px rgba(0, 0, 0, 0.25);
   -moz-box-shadow: inset 0px -10px 4px -10px rgba(0, 0, 0, 0.25);
@@ -7175,16 +7100,6 @@ code {
 }
 .il-system-info.il-system-info-breaking a.glyph {
   color: white;
-}
-.il-system-info {
-  line-height: 20px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-  height: 32px;
-  display: flex;
-  flex-wrap: nowrap;
-  flex-direction: row;
-  justify-content: flex-start;
 }
 .il-system-info.full {
   height: auto;
@@ -7248,6 +7163,22 @@ code {
 .il-drilldown .menulevel, .navbar-form > a {
   display: inline-flex;
   vertical-align: middle;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  user-select: none;
+  touch-action: manipulation;
+  font-family: "Open Sans", Verdana, Arial, Helvetica, sans-serif;
+  text-align: center;
+  line-height: inherit;
+  font-size: inherit;
+  font-weight: 400;
+  text-decoration: none;
+  min-height: 28px;
+  min-width: 28px;
+  font-size: 0.75rem;
+  padding: 3px 6px;
+  gap: 6px;
 }
 
 .btn + .btn, .c-drilldown .c-drilldown__menulevel--trigger + .btn, .c-drilldown .btn + .c-drilldown__menulevel--trigger, .c-drilldown .c-drilldown__menulevel--trigger + .c-drilldown__menulevel--trigger, .il-link.link-bulky + .btn, .c-drilldown .il-link.link-bulky + .c-drilldown__menulevel--trigger,
@@ -7265,34 +7196,10 @@ code {
   margin-left: 3px;
 }
 
-.btn, .c-drilldown .c-drilldown__menulevel--trigger, .il-link.link-bulky,
-.il-drilldown .menulevel, .navbar-form > a {
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  user-select: none;
-  touch-action: manipulation;
-  font-family: "Open Sans", Verdana, Arial, Helvetica, sans-serif;
-  text-align: center;
-  line-height: inherit;
-  font-size: inherit;
-  font-weight: 400;
-  text-decoration: none;
-}
-
 .btn:focus-visible, .c-drilldown .c-drilldown__menulevel--trigger:focus-visible, .il-link.link-bulky:focus-visible,
 .il-drilldown .menulevel:focus-visible, .navbar-form > a:focus-visible {
   outline: 3px solid #0078D7;
   box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 5px #FFFFFF;
-}
-
-.btn, .c-drilldown .c-drilldown__menulevel--trigger, .il-link.link-bulky,
-.il-drilldown .menulevel, .navbar-form > a {
-  min-height: 28px;
-  min-width: 28px;
-  font-size: 0.75rem;
-  padding: 3px 6px;
-  gap: 6px;
 }
 
 .btn .glyph, .c-drilldown .c-drilldown__menulevel--trigger .glyph, .il-link.link-bulky .glyph,
@@ -7443,6 +7350,28 @@ input.btn, .c-drilldown input.c-drilldown__menulevel--trigger, input.il-link.lin
 .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
   display: inline-flex;
   vertical-align: middle;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  user-select: none;
+  touch-action: manipulation;
+  font-family: "Open Sans", Verdana, Arial, Helvetica, sans-serif;
+  text-align: center;
+  line-height: inherit;
+  font-size: inherit;
+  font-weight: 400;
+  text-decoration: none;
+  min-height: 2.2rem;
+  min-width: 2.2rem;
+  font-size: 0.75rem;
+  padding: 3px 6px;
+  gap: 6px;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
+  color: #4c6586;
+  border-width: 1px;
+  border-style: solid;
+  border-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
+  border-radius: 10px;
 }
 
 .btn-ctrl + .btn-ctrl, .c-sequence__navigation--back > .btn-default + .btn-ctrl, .c-sequence__navigation--back.navbar-form > a + .btn-ctrl,
@@ -7473,24 +7402,6 @@ input.btn, .c-drilldown input.c-drilldown__menulevel--trigger, input.il-link.lin
   margin-left: 3px;
 }
 
-.btn-ctrl, .c-sequence__navigation--back > .btn-default, .c-sequence__navigation--back.navbar-form > a,
-.c-sequence__navigation--next > .btn-default,
-.c-sequence__navigation--next.navbar-form > a, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link,
-.ilTableNav > table > tbody > tr > td > .dropdown > .btn-default,
-.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  user-select: none;
-  touch-action: manipulation;
-  font-family: "Open Sans", Verdana, Arial, Helvetica, sans-serif;
-  text-align: center;
-  line-height: inherit;
-  font-size: inherit;
-  font-weight: 400;
-  text-decoration: none;
-}
-
 .btn-ctrl:focus-visible, .c-sequence__navigation--back > .btn-default:focus-visible, .c-sequence__navigation--back.navbar-form > a:focus-visible,
 .c-sequence__navigation--next > .btn-default:focus-visible,
 .c-sequence__navigation--next.navbar-form > a:focus-visible, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link:focus-visible,
@@ -7498,24 +7409,6 @@ input.btn, .c-drilldown input.c-drilldown__menulevel--trigger, input.il-link.lin
 .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a:focus-visible {
   outline: 3px solid #0078D7;
   box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 5px #FFFFFF;
-}
-
-.btn-ctrl, .c-sequence__navigation--back > .btn-default, .c-sequence__navigation--back.navbar-form > a,
-.c-sequence__navigation--next > .btn-default,
-.c-sequence__navigation--next.navbar-form > a, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link,
-.ilTableNav > table > tbody > tr > td > .dropdown > .btn-default,
-.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
-  min-height: 2.2rem;
-  min-width: 2.2rem;
-  font-size: 0.75rem;
-  padding: 3px 6px;
-  gap: 6px;
-  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
-  color: #4c6586;
-  border-width: 1px;
-  border-style: solid;
-  border-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
-  border-radius: 10px;
 }
 
 .btn-ctrl:hover, .c-sequence__navigation--back > .btn-default:hover, .c-sequence__navigation--back.navbar-form > a:hover,
@@ -7788,17 +7681,14 @@ button > .glyphicon {
   background-image: url("../images/media/loader.svg");
   background-color: #b0b0b0;
   border-color: #b0b0b0;
+  background-repeat: no-repeat;
+  background-position: right center;
+  padding-right: 18px;
 }
 
 .il-btn-with-loading-animation:hover {
   background-color: #b0b0b0;
   border-color: #b0b0b0;
-}
-
-.il-btn-with-loading-animation {
-  background-repeat: no-repeat;
-  background-position: right center;
-  padding-right: 18px;
 }
 
 .minimize, .close {
@@ -7844,11 +7734,13 @@ button .minimize, button .close {
   position: relative;
   display: flex;
   align-items: center;
+  box-shadow: none;
+  z-index: initial;
+}
+.c-drilldown header.c-drilldown__header--showbacknav, .c-drilldown header:has(.c-drilldown__filter) {
   min-height: 80px;
   margin-bottom: 2px;
   padding: 9px 15px 9px 38px;
-  box-shadow: none;
-  z-index: initial;
 }
 .c-drilldown header h2 {
   font-size: 1.115rem;
@@ -8767,6 +8659,10 @@ ul.c-input--has-mustache-variables__definitions > li {
 .c-form .c-input[data-il-ui-component=switchable-group-field-input] > .c-input__field > .c-input {
   display: grid;
   grid-template-columns: 25% 75%;
+  grid-template-rows: repeat(3, max-content) 1fr;
+  transition-property: grid-template-rows;
+  transition-duration: 0.3s;
+  transition-timing-function: ease-in-out;
 }
 .c-form .c-input[data-il-ui-component=optional-group-field-input] > .c-input__field,
 .c-form .c-input[data-il-ui-component=switchable-group-field-input] > .c-input__field > .c-input > .c-input__field {
@@ -8777,15 +8673,12 @@ ul.c-input--has-mustache-variables__definitions > li {
 .c-form .c-input[data-il-ui-component=optional-group-field-input] > .c-input__field > .c-input,
 .c-form .c-input[data-il-ui-component=switchable-group-field-input] > .c-input__field > .c-input > .c-input__field > .c-input {
   margin: 0;
+  padding: 12px 15px;
+  background-color: #f9f9f9;
 }
 .c-form .c-input[data-il-ui-component=optional-group-field-input] > .c-input__field > .c-input:first-child,
 .c-form .c-input[data-il-ui-component=switchable-group-field-input] > .c-input__field > .c-input > .c-input__field > .c-input:first-child {
   margin-top: 6px;
-}
-.c-form .c-input[data-il-ui-component=optional-group-field-input] > .c-input__field > .c-input,
-.c-form .c-input[data-il-ui-component=switchable-group-field-input] > .c-input__field > .c-input > .c-input__field > .c-input {
-  padding: 12px 15px;
-  background-color: #f9f9f9;
 }
 .c-form .c-input[data-il-ui-component=optional-group-field-input] > .c-input__field > .c-input:hover, .c-form .c-input[data-il-ui-component=optional-group-field-input] > .c-input__field > .c-input:has(:focus-visible),
 .c-form .c-input[data-il-ui-component=switchable-group-field-input] > .c-input__field > .c-input > .c-input__field > .c-input:hover,
@@ -8807,13 +8700,6 @@ ul.c-input--has-mustache-variables__definitions > li {
 .c-form .c-input[data-il-ui-component=optional-group-field-input] > .c-input__error-msg,
 .c-form .c-input[data-il-ui-component=switchable-group-field-input] > .c-input__field > .c-input > .c-input__error-msg {
   grid-area: error;
-}
-.c-form .c-input[data-il-ui-component=optional-group-field-input],
-.c-form .c-input[data-il-ui-component=switchable-group-field-input] > .c-input__field > .c-input {
-  grid-template-rows: repeat(3, max-content) 1fr;
-  transition-property: grid-template-rows;
-  transition-duration: 0.3s;
-  transition-timing-function: ease-in-out;
 }
 .c-form .c-input[data-il-ui-component=optional-group-field-input] > .c-input__field,
 .c-form .c-input[data-il-ui-component=switchable-group-field-input] > .c-input__field > .c-input > .c-input__field {
@@ -8896,11 +8782,13 @@ ul.c-input--has-mustache-variables__definitions > li {
   position: relative;
   display: flex;
   align-items: center;
+  box-shadow: none;
+  z-index: initial;
+}
+.c-drilldown header.c-drilldown__header--showbacknav, .c-drilldown header:has(.c-drilldown__filter) {
   min-height: 80px;
   margin-bottom: 2px;
   padding: 9px 15px 9px 38px;
-  box-shadow: none;
-  z-index: initial;
 }
 .c-drilldown header h2 {
   font-size: 1.115rem;
@@ -9153,11 +9041,6 @@ ul.c-input--has-mustache-variables__definitions > li {
   width: calc(100% - 50.4px);
   float: left;
 }
-.c-input-tree_select .c-drilldown .c-input-node__select:focus-visible {
-  outline: none;
-  border: 3px solid #0078D7;
-  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 2px #FFFFFF;
-}
 .c-input-tree_select .c-drilldown .c-input-node__select {
   min-height: 50.4px;
   min-width: 50.4px;
@@ -9170,6 +9053,15 @@ ul.c-input--has-mustache-variables__definitions > li {
   border-style: solid;
   border-color: transparent;
   border-radius: 0px;
+  margin-bottom: 2px;
+  margin-left: 0;
+  display: none;
+  float: left;
+}
+.c-input-tree_select .c-drilldown .c-input-node__select:focus-visible {
+  outline: none;
+  border: 3px solid #0078D7;
+  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 2px #FFFFFF;
 }
 .c-input-tree_select .c-drilldown .c-input-node__select:hover {
   text-decoration: none;
@@ -9205,12 +9097,6 @@ ul.c-input--has-mustache-variables__definitions > li {
   border-style: solid;
   border-color: transparent;
   color: #000;
-}
-.c-input-tree_select .c-drilldown .c-input-node__select {
-  margin-bottom: 2px;
-  margin-left: 0;
-  display: none;
-  float: left;
 }
 .c-input-tree_select .c-drilldown .c-input-node__select:focus-visible {
   z-index: 100;
@@ -9352,12 +9238,10 @@ ul.c-input--has-mustache-variables__definitions > li {
 }
 .c-form .c-input__error-msg {
   margin-top: 3px;
+  margin-bottom: 0;
 }
 .c-form .c-input__error-msg:first-child {
   margin-top: 0;
-}
-.c-form .c-input__error-msg {
-  margin-bottom: 0;
 }
 .c-form .c-input[data-il-ui-component]:not([data-il-ui-component=section-field-input]):has(> .c-input__error-msg) {
   border-inline-start: 6px solid rgb(255, 214.54, 214.54);
@@ -12031,13 +11915,11 @@ div.alert ul {
   text-color: white;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
+  min-height: 20px;
+  font-size: 0.75rem;
 }
 .il-table-presentation-row .il-table-presentation-row-expanded .il-table-presentation-details .il-table-presentation-fields blockquote {
   border-color: #dddddd;
-}
-.il-table-presentation-row .il-table-presentation-row-expanded .il-table-presentation-details .il-table-presentation-fields {
-  min-height: 20px;
-  font-size: 0.75rem;
 }
 .il-table-presentation-row .il-table-presentation-row-expanded .il-table-presentation-details .il-table-presentation-fields .il-item-property-name {
   color: rgb(111.25, 111.25, 111.25);
@@ -14597,14 +14479,14 @@ ul.il-book-obj-selection li {
   width: 100%;
 }
 
-.chatroom-centered-checkboxes label {
-  margin: 0 5px 0 0;
-}
 .chatroom-centered-checkboxes {
   display: flex;
   align-items: center;
   justify-content: space-between;
   margin-bottom: 5px;
+}
+.chatroom-centered-checkboxes label {
+  margin: 0 5px 0 0;
 }
 
 @media only screen and (max-width: 991px) {
@@ -15560,12 +15442,10 @@ div#right_bottom_area iframe {
 }
 #il-mcst-img-gallery .modal-content {
   min-height: 100%;
+  background-color: black;
 }
 #il-mcst-img-gallery .modal-content img {
   margin: 30px auto 0 auto;
-}
-#il-mcst-img-gallery .modal-content {
-  background-color: black;
 }
 #il-mcst-img-gallery .modal-title {
   color: white;
@@ -15751,12 +15631,12 @@ div.ilPrtfToc {
   margin-top: 40px;
 }
 
+body.ilPrtfPdfBody {
+  margin: 0;
+}
 body.ilPrtfPdfBody > div.ilInvisibleBorder {
   padding: 0;
   padding-left: 40px;
-}
-body.ilPrtfPdfBody {
-  margin: 0;
 }
 
 body.ilPrtfPdfBody h1.ilc_PrintPageTitle {
@@ -17504,17 +17384,15 @@ table.calmini {
 table.calmini tr, table.calmini td, table.calmini th {
   border: none;
   padding: 5px 3px;
+  text-align: center;
+  vertical-align: middle;
+  color: #161616;
+  background-color: transparent;
 }
 @media only screen and (max-width: 991px) {
   table.calmini tr, table.calmini td, table.calmini th {
     padding: 5px 1px;
   }
-}
-table.calmini tr, table.calmini td, table.calmini th {
-  text-align: center;
-  vertical-align: middle;
-  color: #161616;
-  background-color: transparent;
 }
 table.calmini tr {
   background-color: white;
@@ -19272,6 +19150,16 @@ fieldset[disabled] .checkbox label {
 .form-horizontal {
   margin-bottom: 15px;
   background: white;
+  /*
+  // Reset spacing and right align labels, but scope to media queries so that
+  // labels on narrow viewports stack the same as a default form example.
+  @media (min-width: $screen-sm-min) {
+  	.control-label {
+  		text-align: right;
+  		margin-bottom: 0;
+  		padding-top: ($il-padding-base-vertical + 1); // Default padding plus a border
+  	}
+  } */
 }
 .form-horizontal .form-group {
   margin: 0px;
@@ -19324,18 +19212,6 @@ fieldset[disabled] .checkbox label {
 }
 .form-horizontal .control-label > .asterisk {
   padding-left: 3px;
-}
-.form-horizontal {
-  /*
-  // Reset spacing and right align labels, but scope to media queries so that
-  // labels on narrow viewports stack the same as a default form example.
-  @media (min-width: $screen-sm-min) {
-  	.control-label {
-  		text-align: right;
-  		margin-bottom: 0;
-  		padding-top: ($il-padding-base-vertical + 1); // Default padding plus a border
-  	}
-  } */
 }
 
 .ilFormHeader {
@@ -19611,17 +19487,17 @@ a#ilHelpClose {
   }
 }
 
-.ilStartupSection .control-label {
-  width: 33.33%;
-}
-.ilStartupSection .control-label + div {
-  width: 66.67%;
-}
 .ilStartupSection {
   padding-top: 20px;
   width: fit-content;
   margin-left: auto;
   margin-right: auto;
+}
+.ilStartupSection .control-label {
+  width: 33.33%;
+}
+.ilStartupSection .control-label + div {
+  width: 66.67%;
 }
 @media only screen and (max-width: 991px) {
   .ilStartupSection {
@@ -19653,6 +19529,8 @@ ul.ilStartupSectionLoginLinks li {
 div.ilStartupSection form.form-horizontal {
   border: 1px solid #dddddd;
   border-radius: 3px;
+  text-align: left;
+  width: 40em;
 }
 div.ilStartupSection form.form-horizontal .ilFormHeader {
   padding: 9px 15px;
@@ -19660,10 +19538,6 @@ div.ilStartupSection form.form-horizontal .ilFormHeader {
 }
 div.ilStartupSection form.form-horizontal .form-group {
   margin: 9px 0;
-}
-div.ilStartupSection form.form-horizontal {
-  text-align: left;
-  width: 40em;
 }
 @media only screen and (max-width: 991px) {
   div.ilStartupSection form.form-horizontal {
@@ -22438,6 +22312,10 @@ div.ilFrame {
 }
 
 .il-multi-line-cap-2 {
+  /* edge, chrome, safari go here... */
+  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
+}
+.il-multi-line-cap-2 {
   position: relative;
   max-height: 3em;
   overflow: hidden;
@@ -22453,9 +22331,6 @@ div.ilFrame {
   height: 1.5em;
   background: linear-gradient(to right, rgba(255, 255, 255, 0), rgb(255, 255, 255) 80%);
 }
-.il-multi-line-cap-2 {
-  /* edge, chrome, safari go here... */
-}
 @supports (-webkit-line-clamp: 2) {
   .il-multi-line-cap-2 {
     overflow: hidden;
@@ -22467,9 +22342,6 @@ div.ilFrame {
   .il-multi-line-cap-2:after {
     display: none;
   }
-}
-.il-multi-line-cap-2 {
-  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
 }
 @supports (-moz-line-clamp: 2) {
   .il-multi-line-cap-2 {
@@ -22484,6 +22356,10 @@ div.ilFrame {
   }
 }
 
+.il-multi-line-cap-3 {
+  /* edge, chrome, safari go here... */
+  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
+}
 .il-multi-line-cap-3 {
   position: relative;
   max-height: 4.5em;
@@ -22500,9 +22376,6 @@ div.ilFrame {
   height: 1.5em;
   background: linear-gradient(to right, rgba(255, 255, 255, 0), rgb(255, 255, 255) 80%);
 }
-.il-multi-line-cap-3 {
-  /* edge, chrome, safari go here... */
-}
 @supports (-webkit-line-clamp: 2) {
   .il-multi-line-cap-3 {
     overflow: hidden;
@@ -22514,9 +22387,6 @@ div.ilFrame {
   .il-multi-line-cap-3:after {
     display: none;
   }
-}
-.il-multi-line-cap-3 {
-  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
 }
 @supports (-moz-line-clamp: 2) {
   .il-multi-line-cap-3 {
@@ -22531,6 +22401,10 @@ div.ilFrame {
   }
 }
 
+.il-multi-line-cap-5 {
+  /* edge, chrome, safari go here... */
+  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
+}
 .il-multi-line-cap-5 {
   position: relative;
   max-height: 7.5em;
@@ -22547,9 +22421,6 @@ div.ilFrame {
   height: 1.5em;
   background: linear-gradient(to right, rgba(255, 255, 255, 0), rgb(255, 255, 255) 80%);
 }
-.il-multi-line-cap-5 {
-  /* edge, chrome, safari go here... */
-}
 @supports (-webkit-line-clamp: 2) {
   .il-multi-line-cap-5 {
     overflow: hidden;
@@ -22561,9 +22432,6 @@ div.ilFrame {
   .il-multi-line-cap-5:after {
     display: none;
   }
-}
-.il-multi-line-cap-5 {
-  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
 }
 @supports (-moz-line-clamp: 2) {
   .il-multi-line-cap-5 {
@@ -22578,6 +22446,10 @@ div.ilFrame {
   }
 }
 
+.il-multi-line-cap-10 {
+  /* edge, chrome, safari go here... */
+  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
+}
 .il-multi-line-cap-10 {
   position: relative;
   max-height: 15em;
@@ -22594,9 +22466,6 @@ div.ilFrame {
   height: 1.5em;
   background: linear-gradient(to right, rgba(255, 255, 255, 0), rgb(255, 255, 255) 80%);
 }
-.il-multi-line-cap-10 {
-  /* edge, chrome, safari go here... */
-}
 @supports (-webkit-line-clamp: 2) {
   .il-multi-line-cap-10 {
     overflow: hidden;
@@ -22608,9 +22477,6 @@ div.ilFrame {
   .il-multi-line-cap-10:after {
     display: none;
   }
-}
-.il-multi-line-cap-10 {
-  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
 }
 @supports (-moz-line-clamp: 2) {
   .il-multi-line-cap-10 {

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -8896,17 +8896,12 @@ ul.c-input--has-mustache-variables__definitions > li {
   position: relative;
   display: flex;
   align-items: center;
-  box-shadow: none;
-  z-index: initial;
-}
-
-.c-drilldown header.c-drilldown__header--showbacknav,
-.c-drilldown header:has(.c-drilldown__filter) {
   min-height: 80px;
   margin-bottom: 2px;
   padding: 9px 15px 9px 38px;
+  box-shadow: none;
+  z-index: initial;
 }
-
 .c-drilldown header h2 {
   font-size: 1.115rem;
   margin: 0;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -8896,12 +8896,17 @@ ul.c-input--has-mustache-variables__definitions > li {
   position: relative;
   display: flex;
   align-items: center;
-  min-height: 80px;
-  margin-bottom: 2px;
-  padding: 9px 15px 9px 38px;
   box-shadow: none;
   z-index: initial;
 }
+
+.c-drilldown header.c-drilldown__header--showbacknav,
+.c-drilldown header:has(.c-drilldown__filter) {
+  min-height: 80px;
+  margin-bottom: 2px;
+  padding: 9px 15px 9px 38px;
+}
+
 .c-drilldown header h2 {
   font-size: 1.115rem;
   margin: 0;


### PR DESCRIPTION
This PR makes it possible to hide the Node filter in the drilldown ui component.

## Before
<img width="335" height="576" alt="before" src="https://github.com/user-attachments/assets/cfc5a6b9-24ca-4db5-a3c3-887de9f340c8" />

## After
<img width="332" height="511" alt="after" src="https://github.com/user-attachments/assets/9680dc60-cb8e-47f1-9c65-4b7f98278d26" />

