### PR TITLE
Fix: Add dynamic aria-label to ViewControl Sortation button for accessibility.

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/ViewControl/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/ViewControl/Renderer.php
@@ -187,7 +187,13 @@ class Renderer extends AbstractComponentRenderer
         }
 
         $tpl->setVariable('LABEL', $label_prefix . ' ' . $options[$selected] . ' ');
-        $tpl->setVariable("ARIA_LABEL", $this->txt("sortation"));
+
+        $aria_label = $label_prefix;
+        if (isset($options[$selected])) {
+            $aria_label .= ' ' . $options[$selected];
+        }
+        $tpl->setVariable("ARIA_LABEL", $aria_label);
+
         return $tpl->get();
     }
 

--- a/components/ILIAS/UI/tests/Component/Panel/PanelSecondaryLegacyTest.php
+++ b/components/ILIAS/UI/tests/Component/Panel/PanelSecondaryLegacyTest.php
@@ -233,7 +233,7 @@ EOT;
         <div class="panel-title"><h2>Title</h2></div>
         <div class="panel-viewcontrols l-bar__space-keeper">
             <div class="dropdown il-viewcontrol il-viewcontrol-sortation l-bar__element" id="id_1">
-                <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="sortation" aria-haspopup="true" aria-expanded="false" aria-controls="id_1_ctrl">
+                <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="vc_sort B" aria-haspopup="true" aria-expanded="false" aria-controls="id_1_ctrl">
                     <span class="label">vc_sort B</span>
                     <span class="caret"></span>
                 </button>

--- a/components/ILIAS/UI/tests/Component/Panel/PanelSecondaryListingTest.php
+++ b/components/ILIAS/UI/tests/Component/Panel/PanelSecondaryListingTest.php
@@ -190,7 +190,7 @@ EOT;
         <div class="panel-title"><h2>Title</h2></div>
         <div class="panel-viewcontrols  l-bar__space-keeper">
             <div class="dropdown il-viewcontrol  il-viewcontrol-sortation l-bar__element" id="id_1">
-                <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="sortation" aria-haspopup="true" aria-expanded="false" aria-controls="id_1_ctrl">
+                <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="vc_sort A" aria-haspopup="true" aria-expanded="false" aria-controls="id_1_ctrl">
                     <span class="label">vc_sort A</span>
                     <span class="caret"></span>
                 </button>

--- a/components/ILIAS/UI/tests/Component/Panel/PanelTest.php
+++ b/components/ILIAS/UI/tests/Component/Panel/PanelTest.php
@@ -475,7 +475,7 @@ EOT;
         <div class="panel-title"><h2>Title</h2></div>
         <div class="panel-viewcontrols l-bar__space-keeper">
             <div class="dropdown il-viewcontrol il-viewcontrol-sortation l-bar__element" id="id_1">
-                <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="sortation" aria-haspopup="true" aria-expanded="false" aria-controls="id_1_ctrl">
+                <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="vc_sort B" aria-haspopup="true" aria-expanded="false" aria-controls="id_1_ctrl">
                     <span class="label">vc_sort B</span>
                     <span class="caret"></span>
                 </button>

--- a/components/ILIAS/UI/tests/Component/ViewControl/SortationTest.php
+++ b/components/ILIAS/UI/tests/Component/ViewControl/SortationTest.php
@@ -84,7 +84,7 @@ class SortationTest extends ILIAS_UI_TestBase
 
         $expected = <<<EOT
 <div class="dropdown il-viewcontrol il-viewcontrol-sortation l-bar__element" id="id_1">
-    <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="sortation" aria-haspopup="true" aria-expanded="false" aria-controls="id_1_ctrl">
+    <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="vc_sort Most Recent" aria-haspopup="true" aria-expanded="false" aria-controls="id_1_ctrl">
         <span class="label">vc_sort Most Recent</span>
         <span class="caret"></span>
     </button>
@@ -108,7 +108,7 @@ EOT;
 
         $expected = <<<EOT
 <div class="dropdown il-viewcontrol il-viewcontrol-sortation l-bar__element" id="id_1">
-    <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="sortation" aria-haspopup="true" aria-expanded="false" aria-controls="id_1_ctrl">
+    <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="vc_sort Most Recent" aria-haspopup="true" aria-expanded="false" aria-controls="id_1_ctrl">
         <span class="label">vc_sort Most Recent</span>
         <span class="caret"></span>
     </button>
@@ -144,7 +144,7 @@ EOT;
 
         $expected = <<<EOT
 <div class="dropdown il-viewcontrol il-viewcontrol-sortation l-bar__element"$id>
-    <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="sortation" aria-haspopup="true" aria-expanded="false" aria-controls="{$id_ctrl}">
+    <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="vc_sort Best" aria-haspopup="true" aria-expanded="false" aria-controls="{$id_ctrl}">
         <span class="label">vc_sort Best</span>
         <span class="caret"></span>
     </button>


### PR DESCRIPTION
The sortation control button in ViewControl\Sortation component had a static aria-label that did not indicate the currently selected sorting option.
This made it difficult for screen reader users to understand which sorting criterion was active. Ticket 43957

Changes:
- Modified `renderSortation()` method in ViewControl\Renderer.php to build a dynamic aria-label that includes the currently selected sorting option
- The aria-label now combines the label prefix (e.g., "Sort by:") with the selected option label (e.g., "highest possible score first")
- This ensures screen readers announce the complete sorting state to users

Example output:
- Before: `aria-label="Sortation"` (static, no context)
- After: `aria-label="Sort by: highest possible score first"` (dynamic, descriptive)

Ticket [43957](https://mantis.ilias.de/view.php?id=43957)