### PR TITLE
ks: section dropdown

### DIFF
--- a/components/ILIAS/UI/src/Component/ViewControl/Factory.php
+++ b/components/ILIAS/UI/src/Component/ViewControl/Factory.php
@@ -23,6 +23,7 @@ namespace ILIAS\UI\Component\ViewControl;
 use ILIAS\UI\Component\Button\Button;
 use ILIAS\UI\Component\Component;
 use ILIAS\UI\Component\Button\Month;
+use ILIAS\UI\Component\Dropdown\Standard as StandardDropdown;
 
 /**
  * This is how the factory for UI elements looks.
@@ -62,18 +63,24 @@ interface Factory
      *      days/weeks/months in a calendar or entries in a blog.
      *   composition: >
      *      Section View Controls are composed of three Buttons. The Button on the left caries a Back Glyph, the Button
-     *      in the middle is either a Default- or Split Button labeling the data displayed below and the Button on the right carries
+     *      in the middle is either a Default-, Month Button or a Dropdown labeling the data displayed below and the Button on the right carries
      *      a next Glyph.
      *   effect: >
      *      Clicking on the Buttons left or right changes the selection of the displayed data by a fixed interval. Clicking
      *      the Button in the middle opens the sections hinted by the label of the button (e.g. "Today").
+     *
+     * rules:
+     *   usage:
+     *     1: >
+     *       Dropdowns MUST NOT be used for any other purpose than skipping a section of the navigation
+     *       (e.g. jumping from Chapter 1 to Chapter 5).
      * ---
-     * @param   \ILIAS\UI\Component\Button\Button $previous_action Button to be placed in the left.
-     * @param   \ILIAS\UI\Component\Button\Button|\ILIAS\UI\Component\Button\Month $button Button to be placed in the middle (Month Button or Default Button).
-     * @param   \ILIAS\UI\Component\Button\Button $next_action Button to be placed in the right.
+     * @param Button                $previous_action Button to be placed in the left.
+     * @param Button|Month|StandardDropdown $button          Button to be placed in the middle (Month Button or Default Button).
+     * @param Button                $next_action     Button to be placed in the right.
      * @return \ILIAS\UI\Component\ViewControl\Section
      */
-    public function section(Button $previous_action, Component $button, Button $next_action): Section;
+    public function section(Button $previous_action, Button|Month|StandardDropdown $button, Button $next_action): Section;
 
     /**
      * ---

--- a/components/ILIAS/UI/src/Component/ViewControl/Factory.php
+++ b/components/ILIAS/UI/src/Component/ViewControl/Factory.php
@@ -21,7 +21,6 @@ declare(strict_types=1);
 namespace ILIAS\UI\Component\ViewControl;
 
 use ILIAS\UI\Component\Button\Button;
-use ILIAS\UI\Component\Component;
 use ILIAS\UI\Component\Button\Month;
 use ILIAS\UI\Component\Dropdown\Standard as StandardDropdown;
 

--- a/components/ILIAS/UI/src/Component/ViewControl/Section.php
+++ b/components/ILIAS/UI/src/Component/ViewControl/Section.php
@@ -22,6 +22,8 @@ namespace ILIAS\UI\Component\ViewControl;
 
 use ILIAS\UI\Component\Component;
 use ILIAS\UI\Component\Button\Button;
+use ILIAS\UI\Component\Button\Month;
+use ILIAS\UI\Component\Dropdown\Standard as StandardDropdown;
 
 /**
  * This describes a Section Control
@@ -39,9 +41,7 @@ interface Section extends Component
     public function getNextActions(): Button;
 
     /**
-     * Returns the Default- or Month Button placed in the middle of the control
-     *
-     * @return Component the Default- or Month Button placed in the middle of the control
+     * Returns the Default-, Month Button or Dropdown placed in the middle of the control.
      */
-    public function getSelectorButton(): Component;
+    public function getSelectorButton(): Button|Month|StandardDropdown;
 }

--- a/components/ILIAS/UI/src/Implementation/Component/ViewControl/Factory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/ViewControl/Factory.php
@@ -24,6 +24,8 @@ use ILIAS\UI\Component\ViewControl as VC;
 use ILIAS\UI\Component\Button\Button;
 use ILIAS\UI\Implementation\Component\SignalGeneratorInterface;
 use ILIAS\UI\Component\Component;
+use ILIAS\UI\Component\Button\Month;
+use ILIAS\UI\Component\Dropdown\Standard as StandardDropdown;
 
 class Factory implements VC\Factory
 {
@@ -39,7 +41,7 @@ class Factory implements VC\Factory
         return new Mode($labelled_actions, $aria_label);
     }
 
-    public function section(Button $previous_action, Component $button, Button $next_action): Section
+    public function section(Button $previous_action, Button|Month|StandardDropdown $button, Button $next_action): Section
     {
         return new Section($previous_action, $button, $next_action);
     }

--- a/components/ILIAS/UI/src/Implementation/Component/ViewControl/Factory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/ViewControl/Factory.php
@@ -23,7 +23,6 @@ namespace ILIAS\UI\Implementation\Component\ViewControl;
 use ILIAS\UI\Component\ViewControl as VC;
 use ILIAS\UI\Component\Button\Button;
 use ILIAS\UI\Implementation\Component\SignalGeneratorInterface;
-use ILIAS\UI\Component\Component;
 use ILIAS\UI\Component\Button\Month;
 use ILIAS\UI\Component\Dropdown\Standard as StandardDropdown;
 

--- a/components/ILIAS/UI/src/Implementation/Component/ViewControl/Section.php
+++ b/components/ILIAS/UI/src/Implementation/Component/ViewControl/Section.php
@@ -25,6 +25,7 @@ use ILIAS\UI\Implementation\Component\ComponentHelper;
 use ILIAS\UI\Component\Component;
 use ILIAS\UI\Component\Button\Month;
 use ILIAS\UI\Component\Button\Button;
+use ILIAS\UI\Component\Dropdown;
 
 class Section implements C\ViewControl\Section
 {
@@ -36,7 +37,7 @@ class Section implements C\ViewControl\Section
 
     public function __construct(Button $previous_action, Component $button, Button $next_action)
     {
-        if (!$button instanceof Month) {
+        if (!($button instanceof Month) && !($button instanceof Dropdown\Standard)) {
             $this->checkArgInstanceOf("button", $button, Button::class);
         }
         $this->previous_action = $previous_action;

--- a/components/ILIAS/UI/src/Implementation/Component/ViewControl/Section.php
+++ b/components/ILIAS/UI/src/Implementation/Component/ViewControl/Section.php
@@ -22,24 +22,24 @@ namespace ILIAS\UI\Implementation\Component\ViewControl;
 
 use ILIAS\UI\Component as C;
 use ILIAS\UI\Implementation\Component\ComponentHelper;
-use ILIAS\UI\Component\Component;
 use ILIAS\UI\Component\Button\Month;
 use ILIAS\UI\Component\Button\Button;
-use ILIAS\UI\Component\Dropdown;
+use ILIAS\UI\Component\Dropdown\Standard as StandardDropdown;
 
 class Section implements C\ViewControl\Section
 {
     use ComponentHelper;
 
     protected Button $previous_action;
-    protected Component $button;
+    protected Button|Month|StandardDropdown $button;
     protected Button $next_action;
 
-    public function __construct(Button $previous_action, Component $button, Button $next_action)
+    public function __construct(
+        Button $previous_action,
+        Button|Month|StandardDropdown $button,
+        Button $next_action
+    )
     {
-        if (!($button instanceof Month) && !($button instanceof Dropdown\Standard)) {
-            $this->checkArgInstanceOf("button", $button, Button::class);
-        }
         $this->previous_action = $previous_action;
         $this->button = $button;
         $this->next_action = $next_action;
@@ -62,11 +62,9 @@ class Section implements C\ViewControl\Section
     }
 
     /**
-     * Returns the Default- or Split-Button placed in the middle of the control
-     *
-     * @return Component the Default- or Split-Button placed in the middle of the control
+     * Returns the Default-, Month Button or Dropdown placed in the middle of the control.
      */
-    public function getSelectorButton(): Component
+    public function getSelectorButton(): Button|Month|StandardDropdown
     {
         return $this->button;
     }

--- a/components/ILIAS/UI/src/examples/ViewControl/Section/dropdown.php
+++ b/components/ILIAS/UI/src/examples/ViewControl/Section/dropdown.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 declare(strict_types=1);
 
 namespace ILIAS\UI\examples\ViewControl\Section;

--- a/components/ILIAS/UI/src/examples/ViewControl/Section/dropdown.php
+++ b/components/ILIAS/UI/src/examples/ViewControl/Section/dropdown.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\ViewControl\Section;
+
+/**
+ * ---
+ * expected output: >
+ *   ILIAS shows three controls next to each other: A "Back" glyph, a dropdown "Second Section" and a "Next" glyph.
+ *   When clicking on "Second Section" a dropdown with three entries "First Section", "Second Section" and "Third Section"
+ *   is displayed.
+ * ---
+ */
+function dropdown(): string
+{
+    //Loading factories
+    global $DIC;
+    $f = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+
+    //Here the real magic to draw the controls
+    $back = $f->button()->standard("Back", "#");
+    $next = $f->button()->standard("Next", "#");
+    $middle = $f->dropdown()->standard(
+        [
+            $f->link()->standard("First Section", "#"),
+            $f->link()->standard("Second Section", "#"),
+            $f->link()->standard("Third Section", "#")
+        ]
+    )->withLabel("Second Section");
+    $view_control_section = $f->viewControl()->section($back, $middle, $next);
+    $html = $renderer->render($view_control_section);
+    return $html;
+}

--- a/components/ILIAS/UI/src/examples/ViewControl/Section/dropdown.php
+++ b/components/ILIAS/UI/src/examples/ViewControl/Section/dropdown.php
@@ -22,6 +22,9 @@ namespace ILIAS\UI\examples\ViewControl\Section;
 
 /**
  * ---
+ * description: >
+ *   Example of a Section View Control using a Dropdown to navigate between non-adjacent sections.
+ *
  * expected output: >
  *   ILIAS shows three controls next to each other: A "Back" glyph, a dropdown "Second Section" and a "Next" glyph.
  *   When clicking on "Second Section" a dropdown with three entries "First Section", "Second Section" and "Third Section"

--- a/components/ILIAS/UI/src/examples/ViewControl/Section/dropdown_with_long_title.php
+++ b/components/ILIAS/UI/src/examples/ViewControl/Section/dropdown_with_long_title.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 declare(strict_types=1);
 
 namespace ILIAS\UI\examples\ViewControl\Section;

--- a/components/ILIAS/UI/src/examples/ViewControl/Section/dropdown_with_long_title.php
+++ b/components/ILIAS/UI/src/examples/ViewControl/Section/dropdown_with_long_title.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\ViewControl\Section;
+
+/**
+ * ---
+ * expected output: >
+ *   ILIAS shows three controls next to each other: A "Back" glyph, a dropdown
+ *   "Second section with a very long title to check the responsive behaviour" and a "Next" glyph.
+ *   When clicking on "Second Section..." a dropdown with three entries "First Section", "Second Section..."
+ *   and "Third Section" is displayed. The dropdown button will have a maximum size of
+ *   around 50% of the view width on smaller screens and around 400px on larger screens.
+ * ---
+ */
+function dropdown_with_long_title(): string
+{
+    //Loading factories
+    global $DIC;
+    $f = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+
+    //Here the real magic to draw the controls
+    $back = $f->button()->standard("Back", "#");
+    $next = $f->button()->standard("Next", "#");
+    $middle = $f->dropdown()->standard(
+        [
+            $f->link()->standard("First Section", "#"),
+            $f->link()->standard("Second section with a very long title to check the responsive behaviour", "#"),
+            $f->link()->standard("Third Section", "#")
+        ]
+    )->withLabel("Second section with a very long title to check the responsive behaviour");
+    $view_control_section = $f->viewControl()->section($back, $middle, $next);
+    $html = $renderer->render($view_control_section);
+    return $html;
+}

--- a/components/ILIAS/UI/src/examples/ViewControl/Section/dropdown_with_long_title.php
+++ b/components/ILIAS/UI/src/examples/ViewControl/Section/dropdown_with_long_title.php
@@ -22,6 +22,9 @@ namespace ILIAS\UI\examples\ViewControl\Section;
 
 /**
  * ---
+ * description: >
+ *   Example of a Section View Control using a Dropdown with a long label to demonstrate responsive behavior.
+ *
  * expected output: >
  *   ILIAS shows three controls next to each other: A "Back" glyph, a dropdown
  *   "Second section with a very long title to check the responsive behaviour" and a "Next" glyph.

--- a/components/ILIAS/UI/tests/Component/ViewControl/ViewControlTest.php
+++ b/components/ILIAS/UI/tests/Component/ViewControl/ViewControlTest.php
@@ -179,4 +179,25 @@ class ViewControlTest extends ILIAS_UI_TestBase
 </div>
 EOT;
     }
+
+    /**
+     * Test if dropdown is accepted as second parameter and rendered as part
+     * of the overall html
+     */
+    public function testViewControlSectionDropdownRender(): void
+    {
+        $f = $this->getViewControlFactory();
+        $r = $this->getDefaultRenderer();
+
+        $back = new I\Component\Button\Standard("", "http://www.ilias.de");
+        $next = new I\Component\Button\Standard("", "http://www.github.com");
+        $dropdown = new I\Component\Dropdown\Standard([
+            new I\Component\Button\Shy("", "http://www.github.com"),
+            new I\Component\Button\Shy("", "http://www.ilias.com"),
+        ]);
+        $section = $this->getViewControlFactory()->section($back, $dropdown, $next);
+        $html = $this->normalizeHTML($r->render($section));
+        $this->assertTrue(str_contains($html, "dropdown-menu"));
+    }
+
 }

--- a/components/ILIAS/UI/tests/Component/ViewControl/ViewControlTest.php
+++ b/components/ILIAS/UI/tests/Component/ViewControl/ViewControlTest.php
@@ -187,7 +187,6 @@ EOT;
     public function testViewControlSectionDropdownRender(): void
     {
         $f = $this->getViewControlFactory();
-        $r = $this->getDefaultRenderer();
 
         $back = new I\Component\Button\Standard("", "http://www.ilias.de");
         $next = new I\Component\Button\Standard("", "http://www.github.com");
@@ -195,9 +194,10 @@ EOT;
             new I\Component\Button\Shy("", "http://www.github.com"),
             new I\Component\Button\Shy("", "http://www.ilias.com"),
         ]);
-        $section = $this->getViewControlFactory()->section($back, $dropdown, $next);
+        $r = $this->getDefaultRenderer(null, [$dropdown]);
+        $section = $f->section($back, $dropdown, $next);
         $html = $this->normalizeHTML($r->render($section));
-        $this->assertTrue(str_contains($html, "dropdown-menu"));
+        $this->assertStringContainsString($dropdown->getCanonicalName(), $html);
     }
 
 }

--- a/templates/default/070-components/UI-framework/ViewControl/_ui-component_viewcontrol.scss
+++ b/templates/default/070-components/UI-framework/ViewControl/_ui-component_viewcontrol.scss
@@ -1,5 +1,6 @@
 @use "../../../010-settings/" as *;
 @use "../../../050-layout/basics" as *;
+@use "../../../050-layout/layout_breakpoints" as *;
 @use "../../../070-components/UI-framework/Button/ui-component_button" as *;
 @use "../../../050-layout/layout_container-query" as container-query;
 
@@ -41,6 +42,7 @@ $il-vc-pagination-btn-active-bg: $il-main-bg;
 .il-viewcontrol-sortation,
 .il-viewcontrol-section,
 .il-viewcontrol-section .btn-group,
+.il-viewcontrol-section .dropdown,
 .il-viewcontrol-pagination__sectioncontrol,
 .il-viewcontrol-pagination__num-of-items,
 .il-viewcontrol-pagination,
@@ -62,6 +64,23 @@ $il-vc-pagination-btn-active-bg: $il-main-bg;
 		cursor: default;
 		pointer-events: none;
 		background-color: $il-btn-ctrl-bg;
+	}
+}
+
+.il-viewcontrol-section .dropdown > .btn-default {
+	border: 1px solid $il-btn-ctrl-engaged-border;
+	background-color: $il-main-bg;
+	display: inline-block;
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	min-width: 100px;
+	max-width: 400px;
+	@media screen and (max-width: $screen-md-max) {
+		max-width: 50vw;
+	}
+	@media screen and (max-width: $screen-sm-max) {
+		max-width: 50vw;
 	}
 }
 

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -2695,6 +2695,22 @@ ol.breadcrumb > li + li:before {
 .il-drilldown .menulevel, .navbar-form > a {
   display: inline-flex;
   vertical-align: middle;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  user-select: none;
+  touch-action: manipulation;
+  font-family: "Open Sans", Verdana, Arial, Helvetica, sans-serif;
+  text-align: center;
+  line-height: inherit;
+  font-size: inherit;
+  font-weight: 400;
+  text-decoration: none;
+  min-height: 28px;
+  min-width: 28px;
+  font-size: 0.75rem;
+  padding: 3px 6px;
+  gap: 6px;
 }
 .btn + .btn, .c-input-tree_select > input[type=button] + .btn, .c-drilldown .c-drilldown__menulevel--trigger + .btn, .c-input-tree_select > .btn + input[type=button], .c-input-tree_select > input[type=button] + input[type=button], .c-drilldown .c-input-tree_select > .c-drilldown__menulevel--trigger + input[type=button], .c-drilldown .btn + .c-drilldown__menulevel--trigger, .c-drilldown .c-input-tree_select > input[type=button] + .c-drilldown__menulevel--trigger, .c-drilldown .c-drilldown__menulevel--trigger + .c-drilldown__menulevel--trigger, .il-link.link-bulky + .btn, .c-input-tree_select > .il-link.link-bulky + input[type=button], .c-drilldown .il-link.link-bulky + .c-drilldown__menulevel--trigger,
 .il-drilldown .menulevel + .btn,
@@ -2712,32 +2728,10 @@ ol.breadcrumb > li + li:before {
 .il-drilldown .navbar-form > .menulevel + a, .navbar-form > a + a {
   margin-left: 3px;
 }
-.btn, .c-input-tree_select > input[type=button], .c-drilldown .c-drilldown__menulevel--trigger, .il-link.link-bulky,
-.il-drilldown .menulevel, .navbar-form > a {
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  user-select: none;
-  touch-action: manipulation;
-  font-family: "Open Sans", Verdana, Arial, Helvetica, sans-serif;
-  text-align: center;
-  line-height: inherit;
-  font-size: inherit;
-  font-weight: 400;
-  text-decoration: none;
-}
 .btn:focus-visible, .c-input-tree_select > input[type=button]:focus-visible, .c-drilldown .c-drilldown__menulevel--trigger:focus-visible, .il-link.link-bulky:focus-visible,
 .il-drilldown .menulevel:focus-visible, .navbar-form > a:focus-visible {
   outline: 3px solid #0078D7;
   box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 5px #FFFFFF;
-}
-.btn, .c-input-tree_select > input[type=button], .c-drilldown .c-drilldown__menulevel--trigger, .il-link.link-bulky,
-.il-drilldown .menulevel, .navbar-form > a {
-  min-height: 28px;
-  min-width: 28px;
-  font-size: 0.75rem;
-  padding: 3px 6px;
-  gap: 6px;
 }
 .btn .glyph, .c-input-tree_select > input[type=button] .glyph, .c-drilldown .c-drilldown__menulevel--trigger .glyph, .il-link.link-bulky .glyph,
 .il-drilldown .menulevel .glyph, .navbar-form > a .glyph,
@@ -2876,6 +2870,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-section > .btn-link,
 .il-viewcontrol-section .btn-group > .btn-default,
 .il-viewcontrol-section .btn-group > .btn-link,
+.il-viewcontrol-section .dropdown > .btn-default,
+.il-viewcontrol-section .dropdown > .btn-link,
 .il-viewcontrol-pagination__sectioncontrol > .btn-default,
 .il-viewcontrol-pagination__sectioncontrol > .btn-link,
 .il-viewcontrol-pagination__num-of-items > .btn-default,
@@ -2896,12 +2892,36 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
   display: inline-flex;
   vertical-align: middle;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  user-select: none;
+  touch-action: manipulation;
+  font-family: "Open Sans", Verdana, Arial, Helvetica, sans-serif;
+  text-align: center;
+  line-height: inherit;
+  font-size: inherit;
+  font-weight: 400;
+  text-decoration: none;
+  min-height: 2.2rem;
+  min-width: 2.2rem;
+  font-size: 0.75rem;
+  padding: 3px 6px;
+  gap: 6px;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
+  color: #4c6586;
+  border-width: 1px;
+  border-style: solid;
+  border-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
+  border-radius: 10px;
 }
 .btn-ctrl + .btn-ctrl, .il-viewcontrol-sortation > .btn-default + .btn-ctrl, .il-viewcontrol-sortation > .btn-link + .btn-ctrl,
 .il-viewcontrol-section > .btn-default + .btn-ctrl,
 .il-viewcontrol-section > .btn-link + .btn-ctrl,
 .il-viewcontrol-section .btn-group > .btn-default + .btn-ctrl,
 .il-viewcontrol-section .btn-group > .btn-link + .btn-ctrl,
+.il-viewcontrol-section .dropdown > .btn-default + .btn-ctrl,
+.il-viewcontrol-section .dropdown > .btn-link + .btn-ctrl,
 .il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-ctrl,
 .il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-ctrl,
 .il-viewcontrol-pagination__num-of-items > .btn-default + .btn-ctrl,
@@ -2920,6 +2940,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-section.il-viewcontrol-sortation > .btn-link + .btn-default,
 .il-viewcontrol-section .btn-group.il-viewcontrol-sortation > .btn-default + .btn-default,
 .il-viewcontrol-section .btn-group.il-viewcontrol-sortation > .btn-link + .btn-default,
+.il-viewcontrol-section .dropdown.il-viewcontrol-sortation > .btn-default + .btn-default,
+.il-viewcontrol-section .dropdown.il-viewcontrol-sortation > .btn-link + .btn-default,
 .il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-sortation > .btn-default + .btn-default,
 .il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-sortation > .btn-link + .btn-default,
 .il-viewcontrol-pagination__num-of-items.il-viewcontrol-sortation > .btn-default + .btn-default,
@@ -2938,6 +2960,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-section.il-viewcontrol-sortation > .btn-link + .btn-link,
 .il-viewcontrol-section .btn-group.il-viewcontrol-sortation > .btn-default + .btn-link,
 .il-viewcontrol-section .btn-group.il-viewcontrol-sortation > .btn-link + .btn-link,
+.il-viewcontrol-section .dropdown.il-viewcontrol-sortation > .btn-default + .btn-link,
+.il-viewcontrol-section .dropdown.il-viewcontrol-sortation > .btn-link + .btn-link,
 .il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-sortation > .btn-default + .btn-link,
 .il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-sortation > .btn-link + .btn-link,
 .il-viewcontrol-pagination__num-of-items.il-viewcontrol-sortation > .btn-default + .btn-link,
@@ -2959,6 +2983,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-section > .btn-link + .btn-default,
 .il-viewcontrol-section .btn-group.il-viewcontrol-section > .btn-default + .btn-default,
 .il-viewcontrol-section .btn-group.il-viewcontrol-section > .btn-link + .btn-default,
+.il-viewcontrol-section .dropdown.il-viewcontrol-section > .btn-default + .btn-default,
+.il-viewcontrol-section .dropdown.il-viewcontrol-section > .btn-link + .btn-default,
 .il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-section > .btn-default + .btn-default,
 .il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-section > .btn-link + .btn-default,
 .il-viewcontrol-pagination__num-of-items.il-viewcontrol-section > .btn-default + .btn-default,
@@ -2981,6 +3007,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-section > .btn-link + .btn-link,
 .il-viewcontrol-section .btn-group.il-viewcontrol-section > .btn-default + .btn-link,
 .il-viewcontrol-section .btn-group.il-viewcontrol-section > .btn-link + .btn-link,
+.il-viewcontrol-section .dropdown.il-viewcontrol-section > .btn-default + .btn-link,
+.il-viewcontrol-section .dropdown.il-viewcontrol-section > .btn-link + .btn-link,
 .il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-section > .btn-default + .btn-link,
 .il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-section > .btn-link + .btn-link,
 .il-viewcontrol-pagination__num-of-items.il-viewcontrol-section > .btn-default + .btn-link,
@@ -3003,6 +3031,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-section .il-viewcontrol-section.btn-group > .btn-link + .btn-default,
 .il-viewcontrol-section .btn-group > .btn-default + .btn-default,
 .il-viewcontrol-section .btn-group > .btn-link + .btn-default,
+.il-viewcontrol-section .dropdown.btn-group > .btn-default + .btn-default,
+.il-viewcontrol-section .dropdown.btn-group > .btn-link + .btn-default,
 .il-viewcontrol-section .il-viewcontrol-pagination__sectioncontrol.btn-group > .btn-default + .btn-default,
 .il-viewcontrol-section .il-viewcontrol-pagination__sectioncontrol.btn-group > .btn-link + .btn-default,
 .il-viewcontrol-section .il-viewcontrol-pagination__num-of-items.btn-group > .btn-default + .btn-default,
@@ -3031,6 +3061,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-section .il-viewcontrol-section.btn-group > .btn-link + .btn-link,
 .il-viewcontrol-section .btn-group > .btn-default + .btn-link,
 .il-viewcontrol-section .btn-group > .btn-link + .btn-link,
+.il-viewcontrol-section .dropdown.btn-group > .btn-default + .btn-link,
+.il-viewcontrol-section .dropdown.btn-group > .btn-link + .btn-link,
 .il-viewcontrol-section .il-viewcontrol-pagination__sectioncontrol.btn-group > .btn-default + .btn-link,
 .il-viewcontrol-section .il-viewcontrol-pagination__sectioncontrol.btn-group > .btn-link + .btn-link,
 .il-viewcontrol-section .il-viewcontrol-pagination__num-of-items.btn-group > .btn-default + .btn-link,
@@ -3052,6 +3084,66 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-section .il-viewcontrol-sortation .dropdown.btn-group > .btn-default.btn + .btn-link,
 .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .l-bar__element.btn-group > .btn-default.btn + .btn-link,
 .il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.btn-group > .btn-default.btn + .btn-link,
+.il-viewcontrol-section .dropdown > .btn-ctrl + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-sortation.dropdown > .btn-default + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-sortation.dropdown > .btn-link + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-section.dropdown > .btn-default + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-section.dropdown > .btn-link + .btn-default,
+.il-viewcontrol-section .btn-group.dropdown > .btn-default + .btn-default,
+.il-viewcontrol-section .btn-group.dropdown > .btn-link + .btn-default,
+.il-viewcontrol-section .dropdown > .btn-default + .btn-default,
+.il-viewcontrol-section .dropdown > .btn-link + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-default + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-link + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination__num-of-items.dropdown > .btn-default + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination__num-of-items.dropdown > .btn-link + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination.dropdown > .btn-default + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination.dropdown > .btn-link + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown > .btn-default + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown > .btn-default + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown > .btn-link + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown > .btn-link + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-section .last.dropdown > .btn-default + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination .last.dropdown > .btn-default + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-section .last.dropdown > .btn-link + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination .last.dropdown > .btn-link + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-mode.dropdown > .btn-default + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-mode.dropdown > .btn-link + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-sortation.dropdown > .btn-default.btn + .btn-default,
+.il-viewcontrol-sortation .il-viewcontrol-section .dropdown > .btn-default.btn + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-sortation .dropdown > .btn-default.btn + .btn-default,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .l-bar__element.dropdown > .btn-default.btn + .btn-default,
+.il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.dropdown > .btn-default.btn + .btn-default,
+.il-viewcontrol-section .dropdown > .btn-ctrl + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-sortation.dropdown > .btn-default + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-sortation.dropdown > .btn-link + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-section.dropdown > .btn-default + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-section.dropdown > .btn-link + .btn-link,
+.il-viewcontrol-section .btn-group.dropdown > .btn-default + .btn-link,
+.il-viewcontrol-section .btn-group.dropdown > .btn-link + .btn-link,
+.il-viewcontrol-section .dropdown > .btn-default + .btn-link,
+.il-viewcontrol-section .dropdown > .btn-link + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-default + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-link + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination__num-of-items.dropdown > .btn-default + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination__num-of-items.dropdown > .btn-link + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination.dropdown > .btn-default + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination.dropdown > .btn-link + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown > .btn-default + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown > .btn-default + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown > .btn-link + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown > .btn-link + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-section .last.dropdown > .btn-default + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination .last.dropdown > .btn-default + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-section .last.dropdown > .btn-link + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination .last.dropdown > .btn-link + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-mode.dropdown > .btn-default + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-mode.dropdown > .btn-link + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-sortation.dropdown > .btn-default.btn + .btn-link,
+.il-viewcontrol-sortation .il-viewcontrol-section .dropdown > .btn-default.btn + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-sortation .dropdown > .btn-default.btn + .btn-link,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .l-bar__element.dropdown > .btn-default.btn + .btn-link,
+.il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.dropdown > .btn-default.btn + .btn-link,
 .il-viewcontrol-pagination__sectioncontrol > .btn-ctrl + .btn-default,
 .il-viewcontrol-sortation.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-default,
 .il-viewcontrol-sortation.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-default,
@@ -3059,6 +3151,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-section.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-default,
 .il-viewcontrol-section .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-default,
 .il-viewcontrol-section .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-default,
+.il-viewcontrol-section .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-default,
+.il-viewcontrol-section .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-default,
 .il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-default,
 .il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-default,
 .il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-default,
@@ -3081,6 +3175,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-section.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-link,
 .il-viewcontrol-section .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-link,
 .il-viewcontrol-section .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-link,
+.il-viewcontrol-section .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-link,
+.il-viewcontrol-section .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-link,
 .il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-link,
 .il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-link,
 .il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-link,
@@ -3103,6 +3199,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-section.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-default,
 .il-viewcontrol-section .btn-group.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-default,
 .il-viewcontrol-section .btn-group.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-default,
+.il-viewcontrol-section .dropdown.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-default,
+.il-viewcontrol-section .dropdown.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-default,
 .il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-default,
 .il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-default,
 .il-viewcontrol-pagination__num-of-items > .btn-default + .btn-default,
@@ -3125,6 +3223,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-section.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-link,
 .il-viewcontrol-section .btn-group.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-link,
 .il-viewcontrol-section .btn-group.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-link,
+.il-viewcontrol-section .dropdown.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-link,
+.il-viewcontrol-section .dropdown.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-link,
 .il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-link,
 .il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-link,
 .il-viewcontrol-pagination__num-of-items > .btn-default + .btn-link,
@@ -3147,6 +3247,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-section.il-viewcontrol-pagination > .btn-link + .btn-default,
 .il-viewcontrol-section .btn-group.il-viewcontrol-pagination > .btn-default + .btn-default,
 .il-viewcontrol-section .btn-group.il-viewcontrol-pagination > .btn-link + .btn-default,
+.il-viewcontrol-section .dropdown.il-viewcontrol-pagination > .btn-default + .btn-default,
+.il-viewcontrol-section .dropdown.il-viewcontrol-pagination > .btn-link + .btn-default,
 .il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination > .btn-default + .btn-default,
 .il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination > .btn-link + .btn-default,
 .il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination > .btn-default + .btn-default,
@@ -3169,6 +3271,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-section.il-viewcontrol-pagination > .btn-link + .btn-link,
 .il-viewcontrol-section .btn-group.il-viewcontrol-pagination > .btn-default + .btn-link,
 .il-viewcontrol-section .btn-group.il-viewcontrol-pagination > .btn-link + .btn-link,
+.il-viewcontrol-section .dropdown.il-viewcontrol-pagination > .btn-default + .btn-link,
+.il-viewcontrol-section .dropdown.il-viewcontrol-pagination > .btn-link + .btn-link,
 .il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination > .btn-default + .btn-link,
 .il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination > .btn-link + .btn-link,
 .il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination > .btn-default + .btn-link,
@@ -3193,6 +3297,10 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-pagination .il-viewcontrol-section .btn-group.dropdown > .btn-default + .btn-default,
 .il-viewcontrol-section .il-viewcontrol-pagination .btn-group.dropdown > .btn-link + .btn-default,
 .il-viewcontrol-pagination .il-viewcontrol-section .btn-group.dropdown > .btn-link + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown > .btn-default + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown > .btn-default + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown > .btn-link + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown > .btn-link + .btn-default,
 .il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-default + .btn-default,
 .il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-link + .btn-default,
 .il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.dropdown > .btn-default + .btn-default,
@@ -3219,6 +3327,10 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-pagination .il-viewcontrol-section .btn-group.dropdown > .btn-default + .btn-link,
 .il-viewcontrol-section .il-viewcontrol-pagination .btn-group.dropdown > .btn-link + .btn-link,
 .il-viewcontrol-pagination .il-viewcontrol-section .btn-group.dropdown > .btn-link + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown > .btn-default + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown > .btn-default + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown > .btn-link + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown > .btn-link + .btn-link,
 .il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-default + .btn-link,
 .il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-link + .btn-link,
 .il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.dropdown > .btn-default + .btn-link,
@@ -3245,6 +3357,10 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-pagination .il-viewcontrol-section .btn-group.last > .btn-default + .btn-default,
 .il-viewcontrol-section .il-viewcontrol-pagination .btn-group.last > .btn-link + .btn-default,
 .il-viewcontrol-pagination .il-viewcontrol-section .btn-group.last > .btn-link + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown.last > .btn-default + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown.last > .btn-default + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown.last > .btn-link + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown.last > .btn-link + .btn-default,
 .il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.last > .btn-default + .btn-default,
 .il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.last > .btn-link + .btn-default,
 .il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.last > .btn-default + .btn-default,
@@ -3271,6 +3387,10 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-pagination .il-viewcontrol-section .btn-group.last > .btn-default + .btn-link,
 .il-viewcontrol-section .il-viewcontrol-pagination .btn-group.last > .btn-link + .btn-link,
 .il-viewcontrol-pagination .il-viewcontrol-section .btn-group.last > .btn-link + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown.last > .btn-default + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown.last > .btn-default + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown.last > .btn-link + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown.last > .btn-link + .btn-link,
 .il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.last > .btn-default + .btn-link,
 .il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.last > .btn-link + .btn-link,
 .il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.last > .btn-default + .btn-link,
@@ -3295,6 +3415,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-section.il-viewcontrol-mode > .btn-link + .btn-default,
 .il-viewcontrol-section .btn-group.il-viewcontrol-mode > .btn-default + .btn-default,
 .il-viewcontrol-section .btn-group.il-viewcontrol-mode > .btn-link + .btn-default,
+.il-viewcontrol-section .dropdown.il-viewcontrol-mode > .btn-default + .btn-default,
+.il-viewcontrol-section .dropdown.il-viewcontrol-mode > .btn-link + .btn-default,
 .il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-mode > .btn-default + .btn-default,
 .il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-mode > .btn-link + .btn-default,
 .il-viewcontrol-pagination__num-of-items.il-viewcontrol-mode > .btn-default + .btn-default,
@@ -3317,6 +3439,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-section.il-viewcontrol-mode > .btn-link + .btn-link,
 .il-viewcontrol-section .btn-group.il-viewcontrol-mode > .btn-default + .btn-link,
 .il-viewcontrol-section .btn-group.il-viewcontrol-mode > .btn-link + .btn-link,
+.il-viewcontrol-section .dropdown.il-viewcontrol-mode > .btn-default + .btn-link,
+.il-viewcontrol-section .dropdown.il-viewcontrol-mode > .btn-link + .btn-link,
 .il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-mode > .btn-default + .btn-link,
 .il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-mode > .btn-link + .btn-link,
 .il-viewcontrol-pagination__num-of-items.il-viewcontrol-mode > .btn-default + .btn-link,
@@ -3336,6 +3460,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-section.il-viewcontrol-sortation > .btn-link + .btn-default.btn,
 .il-viewcontrol-section .btn-group.il-viewcontrol-sortation > .btn-default + .btn-default.btn,
 .il-viewcontrol-section .btn-group.il-viewcontrol-sortation > .btn-link + .btn-default.btn,
+.il-viewcontrol-section .dropdown.il-viewcontrol-sortation > .btn-default + .btn-default.btn,
+.il-viewcontrol-section .dropdown.il-viewcontrol-sortation > .btn-link + .btn-default.btn,
 .il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-sortation > .btn-default + .btn-default.btn,
 .il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-sortation > .btn-link + .btn-default.btn,
 .il-viewcontrol-pagination__num-of-items.il-viewcontrol-sortation > .btn-default + .btn-default.btn,
@@ -3359,6 +3485,10 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-sortation .il-viewcontrol-section .btn-group.dropdown > .btn-default + .btn-default.btn,
 .il-viewcontrol-section .il-viewcontrol-sortation .btn-group.dropdown > .btn-link + .btn-default.btn,
 .il-viewcontrol-sortation .il-viewcontrol-section .btn-group.dropdown > .btn-link + .btn-default.btn,
+.il-viewcontrol-section .il-viewcontrol-sortation .dropdown > .btn-default + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-section .dropdown > .btn-default + .btn-default.btn,
+.il-viewcontrol-section .il-viewcontrol-sortation .dropdown > .btn-link + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-section .dropdown > .btn-link + .btn-default.btn,
 .il-viewcontrol-sortation .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-default + .btn-default.btn,
 .il-viewcontrol-sortation .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-link + .btn-default.btn,
 .il-viewcontrol-sortation .il-viewcontrol-pagination__num-of-items.dropdown > .btn-default + .btn-default.btn,
@@ -3388,6 +3518,10 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .btn-group.l-bar__element > .btn-default + .btn-default.btn,
 .il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .btn-group.l-bar__element > .btn-link + .btn-default.btn,
 .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .btn-group.l-bar__element > .btn-link + .btn-default.btn,
+.il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .dropdown.l-bar__element > .btn-default + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .dropdown.l-bar__element > .btn-default + .btn-default.btn,
+.il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .dropdown.l-bar__element > .btn-link + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .dropdown.l-bar__element > .btn-link + .btn-default.btn,
 .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination__sectioncontrol.l-bar__element > .btn-default + .btn-default.btn,
 .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination__sectioncontrol.l-bar__element > .btn-link + .btn-default.btn,
 .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination__num-of-items.l-bar__element > .btn-default + .btn-default.btn,
@@ -3412,6 +3546,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .c-sequence__navigation--back.il-viewcontrol-section > .btn-default + .btn-link,
 .il-viewcontrol-section .c-sequence__navigation--back.btn-group > .btn-default + .btn-default,
 .il-viewcontrol-section .c-sequence__navigation--back.btn-group > .btn-default + .btn-link,
+.il-viewcontrol-section .c-sequence__navigation--back.dropdown > .btn-default + .btn-default,
+.il-viewcontrol-section .c-sequence__navigation--back.dropdown > .btn-default + .btn-link,
 .c-sequence__navigation--back.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-default,
 .c-sequence__navigation--back.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-link,
 .c-sequence__navigation--back.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-default,
@@ -3430,6 +3566,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .c-sequence__navigation--back.navbar-form.il-viewcontrol-section > a + .btn-link,
 .il-viewcontrol-section .c-sequence__navigation--back.navbar-form.btn-group > a + .btn-default,
 .il-viewcontrol-section .c-sequence__navigation--back.navbar-form.btn-group > a + .btn-link,
+.il-viewcontrol-section .c-sequence__navigation--back.navbar-form.dropdown > a + .btn-default,
+.il-viewcontrol-section .c-sequence__navigation--back.navbar-form.dropdown > a + .btn-link,
 .c-sequence__navigation--back.navbar-form.il-viewcontrol-pagination__sectioncontrol > a + .btn-default,
 .c-sequence__navigation--back.navbar-form.il-viewcontrol-pagination__sectioncontrol > a + .btn-link,
 .c-sequence__navigation--back.navbar-form.il-viewcontrol-pagination__num-of-items > a + .btn-default,
@@ -3451,6 +3589,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .c-sequence__navigation--next.il-viewcontrol-section > .btn-default + .btn-link,
 .il-viewcontrol-section .c-sequence__navigation--next.btn-group > .btn-default + .btn-default,
 .il-viewcontrol-section .c-sequence__navigation--next.btn-group > .btn-default + .btn-link,
+.il-viewcontrol-section .c-sequence__navigation--next.dropdown > .btn-default + .btn-default,
+.il-viewcontrol-section .c-sequence__navigation--next.dropdown > .btn-default + .btn-link,
 .c-sequence__navigation--next.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-default,
 .c-sequence__navigation--next.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-link,
 .c-sequence__navigation--next.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-default,
@@ -3473,6 +3613,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .c-sequence__navigation--next.navbar-form.il-viewcontrol-section > a + .btn-link,
 .il-viewcontrol-section .c-sequence__navigation--next.navbar-form.btn-group > a + .btn-default,
 .il-viewcontrol-section .c-sequence__navigation--next.navbar-form.btn-group > a + .btn-link,
+.il-viewcontrol-section .c-sequence__navigation--next.navbar-form.dropdown > a + .btn-default,
+.il-viewcontrol-section .c-sequence__navigation--next.navbar-form.dropdown > a + .btn-link,
 .c-sequence__navigation--next.navbar-form.il-viewcontrol-pagination__sectioncontrol > a + .btn-default,
 .c-sequence__navigation--next.navbar-form.il-viewcontrol-pagination__sectioncontrol > a + .btn-link,
 .c-sequence__navigation--next.navbar-form.il-viewcontrol-pagination__num-of-items > a + .btn-default,
@@ -3492,6 +3634,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .c-sequence__navigation--back.il-viewcontrol-section > .btn-link + .btn-default,
 .il-viewcontrol-section .c-sequence__navigation--back.btn-group > .btn-default + .btn-default,
 .il-viewcontrol-section .c-sequence__navigation--back.btn-group > .btn-link + .btn-default,
+.il-viewcontrol-section .c-sequence__navigation--back.dropdown > .btn-default + .btn-default,
+.il-viewcontrol-section .c-sequence__navigation--back.dropdown > .btn-link + .btn-default,
 .c-sequence__navigation--back.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-default,
 .c-sequence__navigation--back.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-default,
 .c-sequence__navigation--back.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-default,
@@ -3510,6 +3654,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .c-sequence__navigation--back.navbar-form.il-viewcontrol-section > .btn-link + a,
 .il-viewcontrol-section .c-sequence__navigation--back.navbar-form.btn-group > .btn-default + a,
 .il-viewcontrol-section .c-sequence__navigation--back.navbar-form.btn-group > .btn-link + a,
+.il-viewcontrol-section .c-sequence__navigation--back.navbar-form.dropdown > .btn-default + a,
+.il-viewcontrol-section .c-sequence__navigation--back.navbar-form.dropdown > .btn-link + a,
 .c-sequence__navigation--back.navbar-form.il-viewcontrol-pagination__sectioncontrol > .btn-default + a,
 .c-sequence__navigation--back.navbar-form.il-viewcontrol-pagination__sectioncontrol > .btn-link + a,
 .c-sequence__navigation--back.navbar-form.il-viewcontrol-pagination__num-of-items > .btn-default + a,
@@ -3531,6 +3677,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .c-sequence__navigation--next.il-viewcontrol-section > .btn-link + .btn-default,
 .il-viewcontrol-section .c-sequence__navigation--next.btn-group > .btn-default + .btn-default,
 .il-viewcontrol-section .c-sequence__navigation--next.btn-group > .btn-link + .btn-default,
+.il-viewcontrol-section .c-sequence__navigation--next.dropdown > .btn-default + .btn-default,
+.il-viewcontrol-section .c-sequence__navigation--next.dropdown > .btn-link + .btn-default,
 .c-sequence__navigation--next.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-default,
 .c-sequence__navigation--next.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-default,
 .c-sequence__navigation--next.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-default,
@@ -3555,6 +3703,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .c-sequence__navigation--next.navbar-form.il-viewcontrol-section > .btn-link + a,
 .il-viewcontrol-section .c-sequence__navigation--next.navbar-form.btn-group > .btn-default + a,
 .il-viewcontrol-section .c-sequence__navigation--next.navbar-form.btn-group > .btn-link + a,
+.il-viewcontrol-section .c-sequence__navigation--next.navbar-form.dropdown > .btn-default + a,
+.il-viewcontrol-section .c-sequence__navigation--next.navbar-form.dropdown > .btn-link + a,
 .c-sequence__navigation--next.navbar-form.il-viewcontrol-pagination__sectioncontrol > .btn-default + a,
 .c-sequence__navigation--next.navbar-form.il-viewcontrol-pagination__sectioncontrol > .btn-link + a,
 .c-sequence__navigation--next.navbar-form.il-viewcontrol-pagination__num-of-items > .btn-default + a,
@@ -3580,6 +3730,10 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select > input[type=button] + .btn-default,
 .il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link + .btn-link,
 .il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select > input[type=button] + .btn-link,
+.il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .btn-group.dropdown > .btn-link + .btn-default,
+.il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select.dropdown > input[type=button] + .btn-default,
+.il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .btn-group.dropdown > .btn-link + .btn-link,
+.il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select.dropdown > input[type=button] + .btn-link,
 .ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-default,
 .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select.il-viewcontrol-pagination__sectioncontrol > input[type=button] + .btn-default,
 .ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-link,
@@ -3619,6 +3773,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-section > .btn-default + .btn-link,
 .il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .dropdown.btn-group > .btn-default + .btn-default,
 .il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .dropdown.btn-group > .btn-default + .btn-link,
+.il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default + .btn-default,
+.il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default + .btn-link,
 .ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-default,
 .ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-link,
 .ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-default,
@@ -3641,6 +3797,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-section > a + .btn-link,
 .il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.btn-group > a + .btn-default,
 .il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.btn-group > a + .btn-link,
+.il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a + .btn-default,
+.il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a + .btn-link,
 .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-pagination__sectioncontrol > a + .btn-default,
 .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-pagination__sectioncontrol > a + .btn-link,
 .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-pagination__num-of-items > a + .btn-default,
@@ -3660,6 +3818,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-section > .btn-link + .btn-link,
 .il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .btn-group > .btn-default + .btn-link,
 .il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link + .btn-link,
+.il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .btn-group.dropdown > .btn-default + .btn-link,
+.il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .btn-group.dropdown > .btn-link + .btn-link,
 .ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-link,
 .ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-link,
 .ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-link,
@@ -3678,6 +3838,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-section.c-input-tree_select > .btn-link + input[type=button],
 .il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select > .btn-default + input[type=button],
 .il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select > .btn-link + input[type=button],
+.il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .btn-group.dropdown.c-input-tree_select > .btn-default + input[type=button],
+.il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .btn-group.dropdown.c-input-tree_select > .btn-link + input[type=button],
 .ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-pagination__sectioncontrol.c-input-tree_select > .btn-default + input[type=button],
 .ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-pagination__sectioncontrol.c-input-tree_select > .btn-link + input[type=button],
 .ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-pagination__num-of-items.c-input-tree_select > .btn-default + input[type=button],
@@ -3707,6 +3869,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-section > .btn-link + .btn-default,
 .il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .dropdown.btn-group > .btn-default + .btn-default,
 .il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .dropdown.btn-group > .btn-link + .btn-default,
+.il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default + .btn-default,
+.il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .dropdown > .btn-link + .btn-default,
 .ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-default,
 .ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-default,
 .ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-default,
@@ -3733,6 +3897,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-section > .btn-link + a,
 .il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.btn-group > .btn-default + a,
 .il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.btn-group > .btn-link + a,
+.il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > .btn-default + a,
+.il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > .btn-link + a,
 .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-pagination__sectioncontrol > .btn-default + a,
 .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-pagination__sectioncontrol > .btn-link + a,
 .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-pagination__num-of-items > .btn-default + a,
@@ -3754,46 +3920,13 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a + a {
   margin-left: 3px;
 }
-.btn-ctrl, .il-viewcontrol-sortation > .btn-default, .il-viewcontrol-sortation > .btn-link,
-.il-viewcontrol-section > .btn-default,
-.il-viewcontrol-section > .btn-link,
-.il-viewcontrol-section .btn-group > .btn-default,
-.il-viewcontrol-section .btn-group > .btn-link,
-.il-viewcontrol-pagination__sectioncontrol > .btn-default,
-.il-viewcontrol-pagination__sectioncontrol > .btn-link,
-.il-viewcontrol-pagination__num-of-items > .btn-default,
-.il-viewcontrol-pagination__num-of-items > .btn-link,
-.il-viewcontrol-pagination > .btn-default,
-.il-viewcontrol-pagination > .btn-link,
-.il-viewcontrol-pagination .dropdown > .btn-default,
-.il-viewcontrol-pagination .dropdown > .btn-link,
-.il-viewcontrol-pagination .last > .btn-default,
-.il-viewcontrol-pagination .last > .btn-link,
-.il-viewcontrol-mode > .btn-default,
-.il-viewcontrol-mode > .btn-link, .il-viewcontrol-sortation > .btn-default.btn,
-.il-viewcontrol-sortation .dropdown > .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn, .c-sequence__navigation--back > .btn-default, .c-sequence__navigation--back.navbar-form > a,
-.c-sequence__navigation--next > .btn-default,
-.c-sequence__navigation--next.navbar-form > a, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link, .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select > input[type=button],
-.ilTableNav > table > tbody > tr > td > .dropdown > .btn-default,
-.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  user-select: none;
-  touch-action: manipulation;
-  font-family: "Open Sans", Verdana, Arial, Helvetica, sans-serif;
-  text-align: center;
-  line-height: inherit;
-  font-size: inherit;
-  font-weight: 400;
-  text-decoration: none;
-}
 .btn-ctrl:focus-visible, .il-viewcontrol-sortation > .btn-default:focus-visible, .il-viewcontrol-sortation > .btn-link:focus-visible,
 .il-viewcontrol-section > .btn-default:focus-visible,
 .il-viewcontrol-section > .btn-link:focus-visible,
 .il-viewcontrol-section .btn-group > .btn-default:focus-visible,
 .il-viewcontrol-section .btn-group > .btn-link:focus-visible,
+.il-viewcontrol-section .dropdown > .btn-default:focus-visible,
+.il-viewcontrol-section .dropdown > .btn-link:focus-visible,
 .il-viewcontrol-pagination__sectioncontrol > .btn-default:focus-visible,
 .il-viewcontrol-pagination__sectioncontrol > .btn-link:focus-visible,
 .il-viewcontrol-pagination__num-of-items > .btn-default:focus-visible,
@@ -3815,46 +3948,13 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
   outline: 3px solid #0078D7;
   box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 5px #FFFFFF;
 }
-.btn-ctrl, .il-viewcontrol-sortation > .btn-default, .il-viewcontrol-sortation > .btn-link,
-.il-viewcontrol-section > .btn-default,
-.il-viewcontrol-section > .btn-link,
-.il-viewcontrol-section .btn-group > .btn-default,
-.il-viewcontrol-section .btn-group > .btn-link,
-.il-viewcontrol-pagination__sectioncontrol > .btn-default,
-.il-viewcontrol-pagination__sectioncontrol > .btn-link,
-.il-viewcontrol-pagination__num-of-items > .btn-default,
-.il-viewcontrol-pagination__num-of-items > .btn-link,
-.il-viewcontrol-pagination > .btn-default,
-.il-viewcontrol-pagination > .btn-link,
-.il-viewcontrol-pagination .dropdown > .btn-default,
-.il-viewcontrol-pagination .dropdown > .btn-link,
-.il-viewcontrol-pagination .last > .btn-default,
-.il-viewcontrol-pagination .last > .btn-link,
-.il-viewcontrol-mode > .btn-default,
-.il-viewcontrol-mode > .btn-link, .il-viewcontrol-sortation > .btn-default.btn,
-.il-viewcontrol-sortation .dropdown > .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn, .c-sequence__navigation--back > .btn-default, .c-sequence__navigation--back.navbar-form > a,
-.c-sequence__navigation--next > .btn-default,
-.c-sequence__navigation--next.navbar-form > a, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link, .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select > input[type=button],
-.ilTableNav > table > tbody > tr > td > .dropdown > .btn-default,
-.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
-  min-height: 2.2rem;
-  min-width: 2.2rem;
-  font-size: 0.75rem;
-  padding: 3px 6px;
-  gap: 6px;
-  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
-  color: #4c6586;
-  border-width: 1px;
-  border-style: solid;
-  border-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
-  border-radius: 10px;
-}
 .btn-ctrl:hover, .il-viewcontrol-sortation > .btn-default:hover, .il-viewcontrol-sortation > .btn-link:hover,
 .il-viewcontrol-section > .btn-default:hover,
 .il-viewcontrol-section > .btn-link:hover,
 .il-viewcontrol-section .btn-group > .btn-default:hover,
 .il-viewcontrol-section .btn-group > .btn-link:hover,
+.il-viewcontrol-section .dropdown > .btn-default:hover,
+.il-viewcontrol-section .dropdown > .btn-link:hover,
 .il-viewcontrol-pagination__sectioncontrol > .btn-default:hover,
 .il-viewcontrol-pagination__sectioncontrol > .btn-link:hover,
 .il-viewcontrol-pagination__num-of-items > .btn-default:hover,
@@ -3885,6 +3985,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-section > .btn-link:active,
 .il-viewcontrol-section .btn-group > .btn-default:active,
 .il-viewcontrol-section .btn-group > .btn-link:active,
+.il-viewcontrol-section .dropdown > .btn-default:active,
+.il-viewcontrol-section .dropdown > .btn-link:active,
 .il-viewcontrol-pagination__sectioncontrol > .btn-default:active,
 .il-viewcontrol-pagination__sectioncontrol > .btn-link:active,
 .il-viewcontrol-pagination__num-of-items > .btn-default:active,
@@ -3915,6 +4017,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-section > .btn-link:focus,
 .il-viewcontrol-section .btn-group > .btn-default:focus,
 .il-viewcontrol-section .btn-group > .btn-link:focus,
+.il-viewcontrol-section .dropdown > .btn-default:focus,
+.il-viewcontrol-section .dropdown > .btn-link:focus,
 .il-viewcontrol-pagination__sectioncontrol > .btn-default:focus,
 .il-viewcontrol-pagination__sectioncontrol > .btn-link:focus,
 .il-viewcontrol-pagination__num-of-items > .btn-default:focus,
@@ -3941,6 +4045,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-section > [disabled].btn-link,
 .il-viewcontrol-section .btn-group > [disabled].btn-default,
 .il-viewcontrol-section .btn-group > [disabled].btn-link,
+.il-viewcontrol-section .dropdown > [disabled].btn-default,
+.il-viewcontrol-section .dropdown > [disabled].btn-link,
 .il-viewcontrol-pagination__sectioncontrol > [disabled].btn-default,
 .il-viewcontrol-pagination__sectioncontrol > [disabled].btn-link,
 .il-viewcontrol-pagination__num-of-items > [disabled].btn-default,
@@ -3966,6 +4072,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-section > .btn-link fieldset[disabled],
 .il-viewcontrol-section .btn-group > .btn-default fieldset[disabled],
 .il-viewcontrol-section .btn-group > .btn-link fieldset[disabled],
+.il-viewcontrol-section .dropdown > .btn-default fieldset[disabled],
+.il-viewcontrol-section .dropdown > .btn-link fieldset[disabled],
 .il-viewcontrol-pagination__sectioncontrol > .btn-default fieldset[disabled],
 .il-viewcontrol-pagination__sectioncontrol > .btn-link fieldset[disabled],
 .il-viewcontrol-pagination__num-of-items > .btn-default fieldset[disabled],
@@ -4001,6 +4109,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-section > .engaged.btn-link,
 .il-viewcontrol-section .btn-group > .engaged.btn-default,
 .il-viewcontrol-section .btn-group > .engaged.btn-link,
+.il-viewcontrol-section .dropdown > .engaged.btn-default,
+.il-viewcontrol-section .dropdown > .engaged.btn-link,
 .il-viewcontrol-pagination__sectioncontrol > .engaged.btn-default,
 .il-viewcontrol-pagination__sectioncontrol > .engaged.btn-link,
 .il-viewcontrol-pagination__num-of-items > .engaged.btn-default,
@@ -4030,6 +4140,8 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-section > .engaged.btn-link,
 .il-viewcontrol-section .btn-group > .engaged.btn-default,
 .il-viewcontrol-section .btn-group > .engaged.btn-link,
+.il-viewcontrol-section .dropdown > .engaged.btn-default,
+.il-viewcontrol-section .dropdown > .engaged.btn-link,
 .il-viewcontrol-pagination__sectioncontrol > .engaged.btn-default,
 .il-viewcontrol-pagination__sectioncontrol > .engaged.btn-link,
 .il-viewcontrol-pagination__num-of-items > .engaged.btn-default,
@@ -4054,6 +4166,10 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-section .open .btn-group > .btn-default,
 .open .il-viewcontrol-section .btn-group > .btn-link,
 .il-viewcontrol-section .open .btn-group > .btn-link,
+.open .il-viewcontrol-section .dropdown > .btn-default,
+.il-viewcontrol-section .open .dropdown > .btn-default,
+.open .il-viewcontrol-section .dropdown > .btn-link,
+.il-viewcontrol-section .open .dropdown > .btn-link,
 .open .il-viewcontrol-pagination__sectioncontrol > .btn-default,
 .open .il-viewcontrol-pagination__sectioncontrol > .btn-link,
 .open .il-viewcontrol-pagination__num-of-items > .btn-default,
@@ -4088,6 +4204,10 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-section .open .btn-group > .btn-default,
 .open .il-viewcontrol-section .btn-group > .btn-link,
 .il-viewcontrol-section .open .btn-group > .btn-link,
+.open .il-viewcontrol-section .dropdown > .btn-default,
+.il-viewcontrol-section .open .dropdown > .btn-default,
+.open .il-viewcontrol-section .dropdown > .btn-link,
+.il-viewcontrol-section .open .dropdown > .btn-link,
 .open .il-viewcontrol-pagination__sectioncontrol > .btn-default,
 .open .il-viewcontrol-pagination__sectioncontrol > .btn-link,
 .open .il-viewcontrol-pagination__num-of-items > .btn-default,
@@ -4280,15 +4400,13 @@ button > .glyphicon {
   background-image: url("../images/media/loader.svg");
   background-color: #b0b0b0;
   border-color: #b0b0b0;
+  background-repeat: no-repeat;
+  background-position: right center;
+  padding-right: 18px;
 }
 .il-btn-with-loading-animation:hover {
   background-color: #b0b0b0;
   border-color: #b0b0b0;
-}
-.il-btn-with-loading-animation {
-  background-repeat: no-repeat;
-  background-position: right center;
-  padding-right: 18px;
 }
 
 .minimize, .close, .c-input-tree_select .c-input-tree_select__selection button[type=remove] {
@@ -4319,6 +4437,17 @@ button .minimize, button .close, button .c-input-tree_select .c-input-tree_selec
   white-space: nowrap;
   padding: 1px 3px;
   margin: 3px 6px 3px 0;
+  min-height: 28px;
+  min-width: 28px;
+  font-size: 0.75rem;
+  padding: 3px 6px;
+  gap: 6px;
+  background-color: #4c6586;
+  color: white;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #4c6586;
+  border-radius: 3px;
 }
 .btn-tag.btn-tag-inactive {
   cursor: default !important;
@@ -4347,19 +4476,6 @@ button .minimize, button .close, button .c-input-tree_select .c-input-tree_selec
   color: #161616;
   background-color: #75deea;
   border-color: rgb(132.9, 209.3615384615, 218.1);
-}
-.btn-tag {
-  min-height: 28px;
-  min-width: 28px;
-  font-size: 0.75rem;
-  padding: 3px 6px;
-  gap: 6px;
-  background-color: #4c6586;
-  color: white;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #4c6586;
-  border-radius: 3px;
 }
 .btn-tag:hover {
   text-decoration: none;
@@ -4484,6 +4600,7 @@ button .minimize, button .close, button .c-input-tree_select .c-input-tree_selec
   border: 1px solid #dddddd;
   border-radius: 0;
   box-shadow: none;
+  /* see bug #24947 */
 }
 .il-card .il-card-image-container {
   width: 100%;
@@ -4496,9 +4613,6 @@ button .minimize, button .close, button .c-input-tree_select .c-input-tree_selec
   width: 100%;
   max-height: 100%;
   margin: auto;
-}
-.il-card {
-  /* see bug #24947 */
 }
 .il-card a {
   overflow: hidden;
@@ -4943,6 +5057,9 @@ hr.il-divider-with-label {
 .c-entity.__actions .dropdown {
   height: max-content;
 }
+.c-entity.__secondary-identifier {
+  grid-area: second-id;
+}
 .c-entity.__secondary-identifier.--string, .c-entity.__secondary-identifier.--shy, .c-entity.__secondary-identifier.--shylink {
   width: 10rem;
 }
@@ -4951,9 +5068,6 @@ hr.il-divider-with-label {
 }
 .c-entity.__secondary-identifier.--image {
   width: 15rem;
-}
-.c-entity.__secondary-identifier {
-  grid-area: second-id;
 }
 .c-entity.__primary-identifier {
   grid-area: prim-id;
@@ -5193,6 +5307,8 @@ hr.il-divider-with-label {
   border-style: solid;
   border-color: rgb(84.5, 122.9090909091, 46.0909090909);
   border-radius: 10px;
+  min-width: 50%;
+  width: max-content;
 }
 .c-launcher .btn-bulky:hover {
   text-decoration: none;
@@ -5230,10 +5346,6 @@ hr.il-divider-with-label {
   border-style: solid;
   border-color: rgb(84.5, 122.9090909091, 46.0909090909);
   color: #000;
-}
-.c-launcher .btn-bulky {
-  min-width: 50%;
-  width: max-content;
 }
 .c-launcher .btn-bulky[disabled] {
   cursor: not-allowed;
@@ -5405,13 +5517,13 @@ main {
   display: block;
 }
 
-.il-layout-page-content:focus-visible {
-  outline: none;
-}
 .il-layout-page-content {
   display: flex;
   flex-flow: column;
   overflow: auto;
+}
+.il-layout-page-content:focus-visible {
+  outline: none;
 }
 .il-layout-page-content #mainspacekeeper {
   flex-grow: 1;
@@ -5731,15 +5843,15 @@ a[aria-disabled].il-link.link-bulky:hover {
 }
 
 /* common css for characteristic value listing */
-.il-listing-characteristic-value-row::after {
-  display: block;
-  clear: both;
-  content: "";
-}
 .il-listing-characteristic-value-row {
   /* i tried .ilClearFloat, did not work as expected */
   border-top: solid #dddddd 1px;
   padding: 12px 0;
+}
+.il-listing-characteristic-value-row::after {
+  display: block;
+  clear: both;
+  content: "";
 }
 
 .il-listing-characteristic-value-row:first-child {
@@ -5962,12 +6074,6 @@ a[aria-disabled].il-link.link-bulky:hover {
 .il-maincontrols-slate.il-maincontrols-slate-notification .il-maincontrols-slate-notification-title {
   padding: 12px;
 }
-.il-maincontrols-slate.il-maincontrols-slate-notification .il-maincontrols-slate-notification-title .btn-bulky .glyph :before {
-  content: " \e605";
-  font-family: "il-icons";
-  font-size: 1.0625rem;
-  margin-right: 10px;
-}
 .il-maincontrols-slate.il-maincontrols-slate-notification .il-maincontrols-slate-notification-title .btn-bulky {
   margin: -12px;
   border: none;
@@ -5976,6 +6082,12 @@ a[aria-disabled].il-link.link-bulky:hover {
   padding: 12px;
   background-color: transparent;
   width: 50%;
+}
+.il-maincontrols-slate.il-maincontrols-slate-notification .il-maincontrols-slate-notification-title .btn-bulky .glyph :before {
+  content: " \e605";
+  font-family: "il-icons";
+  font-size: 1.0625rem;
+  margin-right: 10px;
 }
 .il-maincontrols-slate #il-tag-slate-container .btn-bulky .glyph :before, .il-maincontrols-slate #ilHelpPanel .btn-bulky .glyph :before {
   content: " \e605";
@@ -6130,16 +6242,16 @@ a[aria-disabled].il-link.link-bulky:hover {
 .il-maincontrols-metabar .il-counter {
   font-size: 1.4375rem;
 }
-.il-maincontrols-metabar > li > .btn.btn-bulky:focus-visible, .il-maincontrols-metabar > li > a.il-link.link-bulky:focus-visible {
-  outline: none;
-  border: 3px solid #0078D7;
-  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 2px #FFFFFF;
-}
 .il-maincontrols-metabar > li > .btn.btn-bulky, .il-maincontrols-metabar > li > a.il-link.link-bulky {
   border: none;
   background-color: transparent;
   height: 60px;
   min-width: 60px;
+}
+.il-maincontrols-metabar > li > .btn.btn-bulky:focus-visible, .il-maincontrols-metabar > li > a.il-link.link-bulky:focus-visible {
+  outline: none;
+  border: 3px solid #0078D7;
+  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 2px #FFFFFF;
 }
 @media only screen and (max-width: 991px) {
   .il-maincontrols-metabar > li > .btn.btn-bulky, .il-maincontrols-metabar > li > a.il-link.link-bulky {
@@ -6188,15 +6300,13 @@ a[aria-disabled].il-link.link-bulky:hover {
   background-color: #fafafa;
   position: absolute;
   max-width: 500px;
-}
-.il-metabar-slates .il-maincontrols-slate {
-  min-width: 500px;
-}
-.il-metabar-slates {
   max-height: 90vh;
   overflow-y: auto;
   right: 0;
   top: 60px;
+}
+.il-metabar-slates .il-maincontrols-slate {
+  min-width: 500px;
 }
 .il-metabar-slates .bulky-label {
   margin-top: auto;
@@ -6308,6 +6418,20 @@ a[aria-disabled].il-link.link-bulky:hover {
 .il-mainbar-tools-button .il-link.link-bulky .bulky-label,
 .il-mainbar-tool-trigger-item .btn-bulky .bulky-label,
 .il-mainbar-tool-trigger-item .il-link.link-bulky .bulky-label {
+  /* edge, chrome, safari go here... */
+  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
+  word-break: break-word;
+  -ms-hyphens: auto;
+  -moz-hyphens: auto;
+  -webkit-hyphens: auto;
+  hyphens: auto;
+}
+.il-mainbar-triggers .btn-bulky .bulky-label,
+.il-mainbar-triggers .il-link.link-bulky .bulky-label,
+.il-mainbar-tools-button .btn-bulky .bulky-label,
+.il-mainbar-tools-button .il-link.link-bulky .bulky-label,
+.il-mainbar-tool-trigger-item .btn-bulky .bulky-label,
+.il-mainbar-tool-trigger-item .il-link.link-bulky .bulky-label {
   position: relative;
   max-height: 3em;
   overflow: hidden;
@@ -6327,14 +6451,6 @@ a[aria-disabled].il-link.link-bulky:hover {
   width: 30%;
   height: 1.5em;
   background: linear-gradient(to right, rgba(255, 255, 255, 0), rgb(255, 255, 255) 80%);
-}
-.il-mainbar-triggers .btn-bulky .bulky-label,
-.il-mainbar-triggers .il-link.link-bulky .bulky-label,
-.il-mainbar-tools-button .btn-bulky .bulky-label,
-.il-mainbar-tools-button .il-link.link-bulky .bulky-label,
-.il-mainbar-tool-trigger-item .btn-bulky .bulky-label,
-.il-mainbar-tool-trigger-item .il-link.link-bulky .bulky-label {
-  /* edge, chrome, safari go here... */
 }
 @supports (-webkit-line-clamp: 2) {
   .il-mainbar-triggers .btn-bulky .bulky-label,
@@ -6358,14 +6474,6 @@ a[aria-disabled].il-link.link-bulky:hover {
     display: none;
   }
 }
-.il-mainbar-triggers .btn-bulky .bulky-label,
-.il-mainbar-triggers .il-link.link-bulky .bulky-label,
-.il-mainbar-tools-button .btn-bulky .bulky-label,
-.il-mainbar-tools-button .il-link.link-bulky .bulky-label,
-.il-mainbar-tool-trigger-item .btn-bulky .bulky-label,
-.il-mainbar-tool-trigger-item .il-link.link-bulky .bulky-label {
-  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
-}
 @supports (-moz-line-clamp: 2) {
   .il-mainbar-triggers .btn-bulky .bulky-label,
   .il-mainbar-triggers .il-link.link-bulky .bulky-label,
@@ -6387,18 +6495,6 @@ a[aria-disabled].il-link.link-bulky:hover {
   .il-mainbar-tool-trigger-item .il-link.link-bulky .bulky-label:after {
     display: none;
   }
-}
-.il-mainbar-triggers .btn-bulky .bulky-label,
-.il-mainbar-triggers .il-link.link-bulky .bulky-label,
-.il-mainbar-tools-button .btn-bulky .bulky-label,
-.il-mainbar-tools-button .il-link.link-bulky .bulky-label,
-.il-mainbar-tool-trigger-item .btn-bulky .bulky-label,
-.il-mainbar-tool-trigger-item .il-link.link-bulky .bulky-label {
-  word-break: break-word;
-  -ms-hyphens: auto;
-  -moz-hyphens: auto;
-  -webkit-hyphens: auto;
-  hyphens: auto;
 }
 
 .il-mainbar-triggers .il-mainbar-entries {
@@ -6583,14 +6679,11 @@ a[aria-disabled].il-link.link-bulky:hover {
 .il-mainbar-tools-entries .btn-bulky.engaged, .il-mainbar-tools-entries .btn-bulky.engaged,
 .il-mainbar-tools-entries .il-link.link-bulky.engaged {
   background-color: white;
+  color: #2c2c2c;
 }
 .il-mainbar-tools-entries .btn-bulky.engaged:not(:focus-visible), .il-mainbar-tools-entries .btn-bulky.engaged:not(:focus-visible),
 .il-mainbar-tools-entries .il-link.link-bulky.engaged:not(:focus-visible) {
   border: 0;
-}
-.il-mainbar-tools-entries .btn-bulky.engaged, .il-mainbar-tools-entries .btn-bulky.engaged,
-.il-mainbar-tools-entries .il-link.link-bulky.engaged {
-  color: #2c2c2c;
 }
 .il-mainbar-tools-entries .btn-bulky.engaged .icon, .il-mainbar-tools-entries .btn-bulky.engaged .icon,
 .il-mainbar-tools-entries .il-link.link-bulky.engaged .icon {
@@ -6667,11 +6760,11 @@ a[aria-disabled].il-link.link-bulky:hover {
   position: relative;
 }
 
-.il-mainbar-slates > .il-maincontrols-slate.engaged > .il-maincontrols-slate-content > :first-child {
-  z-index: 1;
-}
 .il-mainbar-slates > .il-maincontrols-slate.engaged > .il-maincontrols-slate-content {
   height: 0px;
+}
+.il-mainbar-slates > .il-maincontrols-slate.engaged > .il-maincontrols-slate-content > :first-child {
+  z-index: 1;
 }
 .il-mainbar-slates > .il-maincontrols-slate.engaged > .il-maincontrols-slate-content .panel-secondary {
   margin-bottom: 0;
@@ -7099,6 +7192,11 @@ code {
   color: white;
 }
 .c-mode-info__label {
+  /* edge, chrome, safari go here... */
+  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
+  flex-grow: 1;
+}
+.c-mode-info__label {
   position: relative;
   max-height: 1.5em;
   overflow: hidden;
@@ -7114,9 +7212,6 @@ code {
   height: 1.5em;
   background: linear-gradient(to right, rgba(255, 255, 255, 0), rgb(255, 255, 255) 80%);
 }
-.c-mode-info__label {
-  /* edge, chrome, safari go here... */
-}
 @supports (-webkit-line-clamp: 2) {
   .c-mode-info__label {
     overflow: hidden;
@@ -7129,9 +7224,6 @@ code {
     display: none;
   }
 }
-.c-mode-info__label {
-  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
-}
 @supports (-moz-line-clamp: 2) {
   .c-mode-info__label {
     overflow: hidden;
@@ -7143,9 +7235,6 @@ code {
   .c-mode-info__label:after {
     display: none;
   }
-}
-.c-mode-info__label {
-  flex-grow: 1;
 }
 @media only screen and (max-width: 991px) {
   .c-mode-info__mobile-padding {
@@ -7175,6 +7264,16 @@ code {
 /** nagtive or positive contrast color for text and glyph **/
 /** contrast threshold for contrast color **/
 /** three color variants for neutral, important, breaking Head Infos **/
+.il-system-info {
+  line-height: 20px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+  height: 32px;
+  display: flex;
+  flex-wrap: nowrap;
+  flex-direction: row;
+  justify-content: flex-start;
+}
 .il-system-info.il-system-info-neutral {
   -webkit-box-shadow: inset 0px -10px 4px -10px rgba(0, 0, 0, 0.25);
   -moz-box-shadow: inset 0px -10px 4px -10px rgba(0, 0, 0, 0.25);
@@ -7225,16 +7324,6 @@ code {
 }
 .il-system-info.il-system-info-breaking a.glyph {
   color: white;
-}
-.il-system-info {
-  line-height: 20px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-  height: 32px;
-  display: flex;
-  flex-wrap: nowrap;
-  flex-direction: row;
-  justify-content: flex-start;
 }
 .il-system-info.full {
   height: auto;
@@ -7298,6 +7387,22 @@ code {
 .il-drilldown .menulevel, .navbar-form > a {
   display: inline-flex;
   vertical-align: middle;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  user-select: none;
+  touch-action: manipulation;
+  font-family: "Open Sans", Verdana, Arial, Helvetica, sans-serif;
+  text-align: center;
+  line-height: inherit;
+  font-size: inherit;
+  font-weight: 400;
+  text-decoration: none;
+  min-height: 28px;
+  min-width: 28px;
+  font-size: 0.75rem;
+  padding: 3px 6px;
+  gap: 6px;
 }
 
 .btn + .btn, .c-drilldown .c-drilldown__menulevel--trigger + .btn, .c-drilldown .btn + .c-drilldown__menulevel--trigger, .c-drilldown .c-drilldown__menulevel--trigger + .c-drilldown__menulevel--trigger, .il-link.link-bulky + .btn, .c-drilldown .il-link.link-bulky + .c-drilldown__menulevel--trigger,
@@ -7315,34 +7420,10 @@ code {
   margin-left: 3px;
 }
 
-.btn, .c-drilldown .c-drilldown__menulevel--trigger, .il-link.link-bulky,
-.il-drilldown .menulevel, .navbar-form > a {
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  user-select: none;
-  touch-action: manipulation;
-  font-family: "Open Sans", Verdana, Arial, Helvetica, sans-serif;
-  text-align: center;
-  line-height: inherit;
-  font-size: inherit;
-  font-weight: 400;
-  text-decoration: none;
-}
-
 .btn:focus-visible, .c-drilldown .c-drilldown__menulevel--trigger:focus-visible, .il-link.link-bulky:focus-visible,
 .il-drilldown .menulevel:focus-visible, .navbar-form > a:focus-visible {
   outline: 3px solid #0078D7;
   box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 5px #FFFFFF;
-}
-
-.btn, .c-drilldown .c-drilldown__menulevel--trigger, .il-link.link-bulky,
-.il-drilldown .menulevel, .navbar-form > a {
-  min-height: 28px;
-  min-width: 28px;
-  font-size: 0.75rem;
-  padding: 3px 6px;
-  gap: 6px;
 }
 
 .btn .glyph, .c-drilldown .c-drilldown__menulevel--trigger .glyph, .il-link.link-bulky .glyph,
@@ -7493,6 +7574,28 @@ input.btn, .c-drilldown input.c-drilldown__menulevel--trigger, input.il-link.lin
 .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
   display: inline-flex;
   vertical-align: middle;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  user-select: none;
+  touch-action: manipulation;
+  font-family: "Open Sans", Verdana, Arial, Helvetica, sans-serif;
+  text-align: center;
+  line-height: inherit;
+  font-size: inherit;
+  font-weight: 400;
+  text-decoration: none;
+  min-height: 2.2rem;
+  min-width: 2.2rem;
+  font-size: 0.75rem;
+  padding: 3px 6px;
+  gap: 6px;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
+  color: #4c6586;
+  border-width: 1px;
+  border-style: solid;
+  border-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
+  border-radius: 10px;
 }
 
 .btn-ctrl + .btn-ctrl, .c-sequence__navigation--back > .btn-default + .btn-ctrl, .c-sequence__navigation--back.navbar-form > a + .btn-ctrl,
@@ -7523,24 +7626,6 @@ input.btn, .c-drilldown input.c-drilldown__menulevel--trigger, input.il-link.lin
   margin-left: 3px;
 }
 
-.btn-ctrl, .c-sequence__navigation--back > .btn-default, .c-sequence__navigation--back.navbar-form > a,
-.c-sequence__navigation--next > .btn-default,
-.c-sequence__navigation--next.navbar-form > a, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link,
-.ilTableNav > table > tbody > tr > td > .dropdown > .btn-default,
-.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  user-select: none;
-  touch-action: manipulation;
-  font-family: "Open Sans", Verdana, Arial, Helvetica, sans-serif;
-  text-align: center;
-  line-height: inherit;
-  font-size: inherit;
-  font-weight: 400;
-  text-decoration: none;
-}
-
 .btn-ctrl:focus-visible, .c-sequence__navigation--back > .btn-default:focus-visible, .c-sequence__navigation--back.navbar-form > a:focus-visible,
 .c-sequence__navigation--next > .btn-default:focus-visible,
 .c-sequence__navigation--next.navbar-form > a:focus-visible, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link:focus-visible,
@@ -7548,24 +7633,6 @@ input.btn, .c-drilldown input.c-drilldown__menulevel--trigger, input.il-link.lin
 .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a:focus-visible {
   outline: 3px solid #0078D7;
   box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 5px #FFFFFF;
-}
-
-.btn-ctrl, .c-sequence__navigation--back > .btn-default, .c-sequence__navigation--back.navbar-form > a,
-.c-sequence__navigation--next > .btn-default,
-.c-sequence__navigation--next.navbar-form > a, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link,
-.ilTableNav > table > tbody > tr > td > .dropdown > .btn-default,
-.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
-  min-height: 2.2rem;
-  min-width: 2.2rem;
-  font-size: 0.75rem;
-  padding: 3px 6px;
-  gap: 6px;
-  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
-  color: #4c6586;
-  border-width: 1px;
-  border-style: solid;
-  border-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
-  border-radius: 10px;
 }
 
 .btn-ctrl:hover, .c-sequence__navigation--back > .btn-default:hover, .c-sequence__navigation--back.navbar-form > a:hover,
@@ -7838,17 +7905,14 @@ button > .glyphicon {
   background-image: url("../images/media/loader.svg");
   background-color: #b0b0b0;
   border-color: #b0b0b0;
+  background-repeat: no-repeat;
+  background-position: right center;
+  padding-right: 18px;
 }
 
 .il-btn-with-loading-animation:hover {
   background-color: #b0b0b0;
   border-color: #b0b0b0;
-}
-
-.il-btn-with-loading-animation {
-  background-repeat: no-repeat;
-  background-position: right center;
-  padding-right: 18px;
 }
 
 .minimize, .close {
@@ -8810,6 +8874,10 @@ button .minimize, button .close {
 .c-form .c-input[data-il-ui-component=switchable-group-field-input] > .c-input__field > .c-input {
   display: grid;
   grid-template-columns: 25% 75%;
+  grid-template-rows: repeat(3, max-content) 1fr;
+  transition-property: grid-template-rows;
+  transition-duration: 0.3s;
+  transition-timing-function: ease-in-out;
 }
 .c-form .c-input[data-il-ui-component=optional-group-field-input] > .c-input__field,
 .c-form .c-input[data-il-ui-component=switchable-group-field-input] > .c-input__field > .c-input > .c-input__field {
@@ -8820,15 +8888,12 @@ button .minimize, button .close {
 .c-form .c-input[data-il-ui-component=optional-group-field-input] > .c-input__field > .c-input,
 .c-form .c-input[data-il-ui-component=switchable-group-field-input] > .c-input__field > .c-input > .c-input__field > .c-input {
   margin: 0;
+  padding: 12px 15px;
+  background-color: #f9f9f9;
 }
 .c-form .c-input[data-il-ui-component=optional-group-field-input] > .c-input__field > .c-input:first-child,
 .c-form .c-input[data-il-ui-component=switchable-group-field-input] > .c-input__field > .c-input > .c-input__field > .c-input:first-child {
   margin-top: 6px;
-}
-.c-form .c-input[data-il-ui-component=optional-group-field-input] > .c-input__field > .c-input,
-.c-form .c-input[data-il-ui-component=switchable-group-field-input] > .c-input__field > .c-input > .c-input__field > .c-input {
-  padding: 12px 15px;
-  background-color: #f9f9f9;
 }
 .c-form .c-input[data-il-ui-component=optional-group-field-input] > .c-input__field > .c-input:hover, .c-form .c-input[data-il-ui-component=optional-group-field-input] > .c-input__field > .c-input:has(:focus-visible),
 .c-form .c-input[data-il-ui-component=switchable-group-field-input] > .c-input__field > .c-input > .c-input__field > .c-input:hover,
@@ -8850,13 +8915,6 @@ button .minimize, button .close {
 .c-form .c-input[data-il-ui-component=optional-group-field-input] > .c-input__error-msg,
 .c-form .c-input[data-il-ui-component=switchable-group-field-input] > .c-input__field > .c-input > .c-input__error-msg {
   grid-area: error;
-}
-.c-form .c-input[data-il-ui-component=optional-group-field-input],
-.c-form .c-input[data-il-ui-component=switchable-group-field-input] > .c-input__field > .c-input {
-  grid-template-rows: repeat(3, max-content) 1fr;
-  transition-property: grid-template-rows;
-  transition-duration: 0.3s;
-  transition-timing-function: ease-in-out;
 }
 .c-form .c-input[data-il-ui-component=optional-group-field-input] > .c-input__field,
 .c-form .c-input[data-il-ui-component=switchable-group-field-input] > .c-input__field > .c-input > .c-input__field {
@@ -9196,11 +9254,6 @@ button .minimize, button .close {
   width: calc(100% - 50.4px);
   float: left;
 }
-.c-input-tree_select .c-drilldown .c-input-node__select:focus-visible {
-  outline: none;
-  border: 3px solid #0078D7;
-  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 2px #FFFFFF;
-}
 .c-input-tree_select .c-drilldown .c-input-node__select {
   min-height: 50.4px;
   min-width: 50.4px;
@@ -9213,6 +9266,15 @@ button .minimize, button .close {
   border-style: solid;
   border-color: transparent;
   border-radius: 0px;
+  margin-bottom: 2px;
+  margin-left: 0;
+  display: none;
+  float: left;
+}
+.c-input-tree_select .c-drilldown .c-input-node__select:focus-visible {
+  outline: none;
+  border: 3px solid #0078D7;
+  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 2px #FFFFFF;
 }
 .c-input-tree_select .c-drilldown .c-input-node__select:hover {
   text-decoration: none;
@@ -9248,12 +9310,6 @@ button .minimize, button .close {
   border-style: solid;
   border-color: transparent;
   color: #000;
-}
-.c-input-tree_select .c-drilldown .c-input-node__select {
-  margin-bottom: 2px;
-  margin-left: 0;
-  display: none;
-  float: left;
 }
 .c-input-tree_select .c-drilldown .c-input-node__select:focus-visible {
   z-index: 100;
@@ -9392,12 +9448,10 @@ button .minimize, button .close {
 }
 .c-form .c-input__error-msg {
   margin-top: 3px;
+  margin-bottom: 0;
 }
 .c-form .c-input__error-msg:first-child {
   margin-top: 0;
-}
-.c-form .c-input__error-msg {
-  margin-bottom: 0;
 }
 .c-form .c-input[data-il-ui-component]:not([data-il-ui-component=section-field-input]):has(> .c-input__error-msg) {
   border-inline-start: 6px solid rgb(255, 214.54, 214.54);
@@ -12057,13 +12111,11 @@ div.alert ul {
   text-color: white;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
+  min-height: 20px;
+  font-size: 0.75rem;
 }
 .il-table-presentation-row .il-table-presentation-row-expanded .il-table-presentation-details .il-table-presentation-fields blockquote {
   border-color: #dddddd;
-}
-.il-table-presentation-row .il-table-presentation-row-expanded .il-table-presentation-details .il-table-presentation-fields {
-  min-height: 20px;
-  font-size: 0.75rem;
 }
 .il-table-presentation-row .il-table-presentation-row-expanded .il-table-presentation-details .il-table-presentation-fields .il-item-property-name {
   color: rgb(111.25, 111.25, 111.25);
@@ -12515,6 +12567,8 @@ tr.c-table-data__row.c-table-data__row--drag-settle {
 .il-viewcontrol-sortation.il-viewcontrol-section > .btn-link,
 .il-viewcontrol-section .il-viewcontrol-sortation.btn-group > .btn-default,
 .il-viewcontrol-section .il-viewcontrol-sortation.btn-group > .btn-link,
+.il-viewcontrol-section .il-viewcontrol-sortation.dropdown > .btn-default,
+.il-viewcontrol-section .il-viewcontrol-sortation.dropdown > .btn-link,
 .il-viewcontrol-sortation.il-viewcontrol-pagination__sectioncontrol > .btn-default,
 .il-viewcontrol-sortation.il-viewcontrol-pagination__sectioncontrol > .btn-link,
 .il-viewcontrol-sortation.il-viewcontrol-pagination__num-of-items > .btn-default,
@@ -12539,6 +12593,8 @@ tr.c-table-data__row.c-table-data__row--drag-settle {
 .il-viewcontrol-section > .btn-link,
 .il-viewcontrol-section .il-viewcontrol-section.btn-group > .btn-default,
 .il-viewcontrol-section .il-viewcontrol-section.btn-group > .btn-link,
+.il-viewcontrol-section .il-viewcontrol-section.dropdown > .btn-default,
+.il-viewcontrol-section .il-viewcontrol-section.dropdown > .btn-link,
 .il-viewcontrol-section.il-viewcontrol-pagination__sectioncontrol > .btn-default,
 .il-viewcontrol-section.il-viewcontrol-pagination__sectioncontrol > .btn-link,
 .il-viewcontrol-section.il-viewcontrol-pagination__num-of-items > .btn-default,
@@ -12565,6 +12621,8 @@ tr.c-table-data__row.c-table-data__row--drag-settle {
 .il-viewcontrol-section .btn-group.il-viewcontrol-section > .btn-link,
 .il-viewcontrol-section .btn-group > .btn-default,
 .il-viewcontrol-section .btn-group > .btn-link,
+.il-viewcontrol-section .btn-group.dropdown > .btn-default,
+.il-viewcontrol-section .btn-group.dropdown > .btn-link,
 .il-viewcontrol-section .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-default,
 .il-viewcontrol-section .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-link,
 .il-viewcontrol-section .btn-group.il-viewcontrol-pagination__num-of-items > .btn-default,
@@ -12581,6 +12639,38 @@ tr.c-table-data__row.c-table-data__row--drag-settle {
 .il-viewcontrol-pagination .il-viewcontrol-section .btn-group.last > .btn-link,
 .il-viewcontrol-section .btn-group.il-viewcontrol-mode > .btn-default,
 .il-viewcontrol-section .btn-group.il-viewcontrol-mode > .btn-link,
+.il-viewcontrol-section .dropdown > .btn-default,
+.il-viewcontrol-section .dropdown > .btn-link,
+.il-viewcontrol-section .dropdown > .btn-ctrl,
+.il-viewcontrol-section .dropdown.il-viewcontrol-sortation > .btn-default.btn,
+.il-viewcontrol-section .il-viewcontrol-sortation .dropdown > .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-section .dropdown > .btn-default.btn,
+.il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .dropdown.l-bar__element > .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .dropdown.l-bar__element > .btn-default.btn,
+.il-viewcontrol-section .dropdown.il-viewcontrol-sortation > .btn-default,
+.il-viewcontrol-section .dropdown.il-viewcontrol-sortation > .btn-link,
+.il-viewcontrol-section .dropdown.il-viewcontrol-section > .btn-default,
+.il-viewcontrol-section .dropdown.il-viewcontrol-section > .btn-link,
+.il-viewcontrol-section .dropdown.btn-group > .btn-default,
+.il-viewcontrol-section .dropdown.btn-group > .btn-link,
+.il-viewcontrol-section .dropdown > .btn-default,
+.il-viewcontrol-section .dropdown > .btn-link,
+.il-viewcontrol-section .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-default,
+.il-viewcontrol-section .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-link,
+.il-viewcontrol-section .dropdown.il-viewcontrol-pagination__num-of-items > .btn-default,
+.il-viewcontrol-section .dropdown.il-viewcontrol-pagination__num-of-items > .btn-link,
+.il-viewcontrol-section .dropdown.il-viewcontrol-pagination > .btn-default,
+.il-viewcontrol-section .dropdown.il-viewcontrol-pagination > .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown > .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown > .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown > .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown > .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown.last > .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown.last > .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown.last > .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown.last > .btn-link,
+.il-viewcontrol-section .dropdown.il-viewcontrol-mode > .btn-default,
+.il-viewcontrol-section .dropdown.il-viewcontrol-mode > .btn-link,
 .il-viewcontrol-pagination__sectioncontrol > .btn-default,
 .il-viewcontrol-pagination__sectioncontrol > .btn-link,
 .il-viewcontrol-pagination__sectioncontrol > .btn-ctrl,
@@ -12593,6 +12683,8 @@ tr.c-table-data__row.c-table-data__row--drag-settle {
 .il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-section > .btn-link,
 .il-viewcontrol-section .il-viewcontrol-pagination__sectioncontrol.btn-group > .btn-default,
 .il-viewcontrol-section .il-viewcontrol-pagination__sectioncontrol.btn-group > .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-link,
 .il-viewcontrol-pagination__sectioncontrol > .btn-default,
 .il-viewcontrol-pagination__sectioncontrol > .btn-link,
 .il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination__num-of-items > .btn-default,
@@ -12617,6 +12709,8 @@ tr.c-table-data__row.c-table-data__row--drag-settle {
 .il-viewcontrol-pagination__num-of-items.il-viewcontrol-section > .btn-link,
 .il-viewcontrol-section .il-viewcontrol-pagination__num-of-items.btn-group > .btn-default,
 .il-viewcontrol-section .il-viewcontrol-pagination__num-of-items.btn-group > .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination__num-of-items.dropdown > .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination__num-of-items.dropdown > .btn-link,
 .il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination__sectioncontrol > .btn-default,
 .il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination__sectioncontrol > .btn-link,
 .il-viewcontrol-pagination__num-of-items > .btn-default,
@@ -12641,6 +12735,8 @@ tr.c-table-data__row.c-table-data__row--drag-settle {
 .il-viewcontrol-pagination.il-viewcontrol-section > .btn-link,
 .il-viewcontrol-section .il-viewcontrol-pagination.btn-group > .btn-default,
 .il-viewcontrol-section .il-viewcontrol-pagination.btn-group > .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination.dropdown > .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination.dropdown > .btn-link,
 .il-viewcontrol-pagination.il-viewcontrol-pagination__sectioncontrol > .btn-default,
 .il-viewcontrol-pagination.il-viewcontrol-pagination__sectioncontrol > .btn-link,
 .il-viewcontrol-pagination.il-viewcontrol-pagination__num-of-items > .btn-default,
@@ -12669,6 +12765,10 @@ tr.c-table-data__row.c-table-data__row--drag-settle {
 .il-viewcontrol-section .il-viewcontrol-pagination .dropdown.btn-group > .btn-default,
 .il-viewcontrol-pagination .il-viewcontrol-section .dropdown.btn-group > .btn-link,
 .il-viewcontrol-section .il-viewcontrol-pagination .dropdown.btn-group > .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown > .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown > .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown > .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown > .btn-link,
 .il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-default,
 .il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-link,
 .il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__num-of-items > .btn-default,
@@ -12697,6 +12797,10 @@ tr.c-table-data__row.c-table-data__row--drag-settle {
 .il-viewcontrol-section .il-viewcontrol-pagination .last.btn-group > .btn-default,
 .il-viewcontrol-pagination .il-viewcontrol-section .last.btn-group > .btn-link,
 .il-viewcontrol-section .il-viewcontrol-pagination .last.btn-group > .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-section .last.dropdown > .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination .last.dropdown > .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-section .last.dropdown > .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination .last.dropdown > .btn-link,
 .il-viewcontrol-pagination .last.il-viewcontrol-pagination__sectioncontrol > .btn-default,
 .il-viewcontrol-pagination .last.il-viewcontrol-pagination__sectioncontrol > .btn-link,
 .il-viewcontrol-pagination .last.il-viewcontrol-pagination__num-of-items > .btn-default,
@@ -12721,6 +12825,8 @@ tr.c-table-data__row.c-table-data__row--drag-settle {
 .il-viewcontrol-mode.il-viewcontrol-section > .btn-link,
 .il-viewcontrol-section .il-viewcontrol-mode.btn-group > .btn-default,
 .il-viewcontrol-section .il-viewcontrol-mode.btn-group > .btn-link,
+.il-viewcontrol-section .il-viewcontrol-mode.dropdown > .btn-default,
+.il-viewcontrol-section .il-viewcontrol-mode.dropdown > .btn-link,
 .il-viewcontrol-mode.il-viewcontrol-pagination__sectioncontrol > .btn-default,
 .il-viewcontrol-mode.il-viewcontrol-pagination__sectioncontrol > .btn-link,
 .il-viewcontrol-mode.il-viewcontrol-pagination__num-of-items > .btn-default,
@@ -12744,6 +12850,8 @@ tr.c-table-data__row.c-table-data__row--drag-settle {
 .il-viewcontrol-sortation.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-section .il-viewcontrol-sortation.btn-group > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-section .il-viewcontrol-sortation.btn-group > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-sortation.dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-sortation.dropdown > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-sortation.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-sortation.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-sortation.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
@@ -12766,6 +12874,8 @@ tr.c-table-data__row.c-table-data__row--drag-settle {
 .il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-section .il-viewcontrol-section.btn-group > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-section .il-viewcontrol-section.btn-group > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-section.dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-section.dropdown > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-section.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-section.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-section.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
@@ -12790,6 +12900,8 @@ tr.c-table-data__row.c-table-data__row--drag-settle {
 .il-viewcontrol-section .btn-group.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-section .btn-group > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-section .btn-group > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .btn-group.dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .btn-group.dropdown > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-section .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-section .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-section .btn-group.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
@@ -12806,6 +12918,36 @@ tr.c-table-data__row.c-table-data__row--drag-settle {
 .il-viewcontrol-pagination .il-viewcontrol-section .btn-group.last > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-section .btn-group.il-viewcontrol-mode > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-section .btn-group.il-viewcontrol-mode > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .dropdown > .btn-ctrl:has(> .glyph.disabled),
+.il-viewcontrol-section .dropdown.il-viewcontrol-sortation > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-sortation .dropdown > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-sortation .il-viewcontrol-section .dropdown > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .dropdown.l-bar__element > .btn-default.btn:has(> .glyph.disabled),
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .dropdown.l-bar__element > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-section .dropdown.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .dropdown.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .dropdown.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .dropdown.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .dropdown.btn-group > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .dropdown.btn-group > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .dropdown > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .dropdown.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .dropdown.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .dropdown.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .dropdown.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown.last > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown.last > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown.last > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown.last > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .dropdown.il-viewcontrol-mode > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .dropdown.il-viewcontrol-mode > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-pagination__sectioncontrol > .btn-ctrl:has(> .glyph.disabled),
 .il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-sortation > .btn-default.btn:has(> .glyph.disabled),
 .il-viewcontrol-sortation .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-default.btn:has(> .glyph.disabled),
@@ -12816,6 +12958,8 @@ tr.c-table-data__row.c-table-data__row--drag-settle {
 .il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-section .il-viewcontrol-pagination__sectioncontrol.btn-group > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-section .il-viewcontrol-pagination__sectioncontrol.btn-group > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
@@ -12838,6 +12982,8 @@ tr.c-table-data__row.c-table-data__row--drag-settle {
 .il-viewcontrol-pagination__num-of-items.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-section .il-viewcontrol-pagination__num-of-items.btn-group > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-section .il-viewcontrol-pagination__num-of-items.btn-group > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination__num-of-items.dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination__num-of-items.dropdown > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
@@ -12860,6 +13006,8 @@ tr.c-table-data__row.c-table-data__row--drag-settle {
 .il-viewcontrol-pagination.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-section .il-viewcontrol-pagination.btn-group > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-section .il-viewcontrol-pagination.btn-group > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination.dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination.dropdown > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-pagination.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-pagination.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-pagination.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
@@ -12886,6 +13034,10 @@ tr.c-table-data__row.c-table-data__row--drag-settle {
 .il-viewcontrol-section .il-viewcontrol-pagination .dropdown.btn-group > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-pagination .il-viewcontrol-section .dropdown.btn-group > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-section .il-viewcontrol-pagination .dropdown.btn-group > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
@@ -12912,6 +13064,10 @@ tr.c-table-data__row.c-table-data__row--drag-settle {
 .il-viewcontrol-section .il-viewcontrol-pagination .last.btn-group > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-pagination .il-viewcontrol-section .last.btn-group > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-section .il-viewcontrol-pagination .last.btn-group > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section .last.dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination .last.dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section .last.dropdown > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination .last.dropdown > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-pagination .last.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-pagination .last.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-pagination .last.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
@@ -12934,6 +13090,8 @@ tr.c-table-data__row.c-table-data__row--drag-settle {
 .il-viewcontrol-mode.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-section .il-viewcontrol-mode.btn-group > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-section .il-viewcontrol-mode.btn-group > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-mode.dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-mode.dropdown > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-mode.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-mode.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-mode.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
@@ -12950,6 +13108,27 @@ tr.c-table-data__row.c-table-data__row--drag-settle {
   cursor: default;
   pointer-events: none;
   background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
+}
+
+.il-viewcontrol-section .dropdown > .btn-default {
+  border: 1px solid #4c6586;
+  background-color: white;
+  display: inline-block;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  min-width: 100px;
+  max-width: 400px;
+}
+@media screen and (max-width: 1199px) {
+  .il-viewcontrol-section .dropdown > .btn-default {
+    max-width: 50vw;
+  }
+}
+@media screen and (max-width: 991px) {
+  .il-viewcontrol-section .dropdown > .btn-default {
+    max-width: 50vw;
+  }
 }
 
 .il-viewcontrol-sortation > .btn-default.btn,
@@ -14623,14 +14802,14 @@ ul.il-book-obj-selection li {
   width: 100%;
 }
 
-.chatroom-centered-checkboxes label {
-  margin: 0 5px 0 0;
-}
 .chatroom-centered-checkboxes {
   display: flex;
   align-items: center;
   justify-content: space-between;
   margin-bottom: 5px;
+}
+.chatroom-centered-checkboxes label {
+  margin: 0 5px 0 0;
 }
 
 @media only screen and (max-width: 991px) {
@@ -15586,12 +15765,10 @@ div#right_bottom_area iframe {
 }
 #il-mcst-img-gallery .modal-content {
   min-height: 100%;
+  background-color: black;
 }
 #il-mcst-img-gallery .modal-content img {
   margin: 30px auto 0 auto;
-}
-#il-mcst-img-gallery .modal-content {
-  background-color: black;
 }
 #il-mcst-img-gallery .modal-title {
   color: white;
@@ -15777,12 +15954,12 @@ div.ilPrtfToc {
   margin-top: 40px;
 }
 
+body.ilPrtfPdfBody {
+  margin: 0;
+}
 body.ilPrtfPdfBody > div.ilInvisibleBorder {
   padding: 0;
   padding-left: 40px;
-}
-body.ilPrtfPdfBody {
-  margin: 0;
 }
 
 body.ilPrtfPdfBody h1.ilc_PrintPageTitle {
@@ -17531,17 +17708,15 @@ table.calmini {
 table.calmini tr, table.calmini td, table.calmini th {
   border: none;
   padding: 5px 3px;
+  text-align: center;
+  vertical-align: middle;
+  color: #161616;
+  background-color: transparent;
 }
 @media only screen and (max-width: 991px) {
   table.calmini tr, table.calmini td, table.calmini th {
     padding: 5px 1px;
   }
-}
-table.calmini tr, table.calmini td, table.calmini th {
-  text-align: center;
-  vertical-align: middle;
-  color: #161616;
-  background-color: transparent;
 }
 table.calmini tr {
   background-color: white;
@@ -19308,6 +19483,16 @@ fieldset[disabled] .checkbox label {
 .form-horizontal {
   margin-bottom: 15px;
   background: white;
+  /*
+  // Reset spacing and right align labels, but scope to media queries so that
+  // labels on narrow viewports stack the same as a default form example.
+  @media (min-width: $screen-sm-min) {
+  	.control-label {
+  		text-align: right;
+  		margin-bottom: 0;
+  		padding-top: ($il-padding-base-vertical + 1); // Default padding plus a border
+  	}
+  } */
 }
 .form-horizontal .form-group {
   margin: 0px;
@@ -19357,18 +19542,6 @@ fieldset[disabled] .checkbox label {
 }
 .form-horizontal .control-label.col-sm-3.il_textarea {
   width: 100%;
-}
-.form-horizontal {
-  /*
-  // Reset spacing and right align labels, but scope to media queries so that
-  // labels on narrow viewports stack the same as a default form example.
-  @media (min-width: $screen-sm-min) {
-  	.control-label {
-  		text-align: right;
-  		margin-bottom: 0;
-  		padding-top: ($il-padding-base-vertical + 1); // Default padding plus a border
-  	}
-  } */
 }
 
 .ilFormHeader {
@@ -19648,17 +19821,17 @@ a#ilHelpClose {
   }
 }
 
-.ilStartupSection .control-label {
-  width: 33.33%;
-}
-.ilStartupSection .control-label + div {
-  width: 66.67%;
-}
 .ilStartupSection {
   padding-top: 20px;
   width: fit-content;
   margin-left: auto;
   margin-right: auto;
+}
+.ilStartupSection .control-label {
+  width: 33.33%;
+}
+.ilStartupSection .control-label + div {
+  width: 66.67%;
 }
 @media only screen and (max-width: 991px) {
   .ilStartupSection {
@@ -19683,6 +19856,8 @@ ul.ilStartupSectionRegistrationLinks li {
 div.ilStartupSection form.form-horizontal {
   border: 1px solid #dddddd;
   border-radius: 3px;
+  text-align: left;
+  width: 40em;
 }
 div.ilStartupSection form.form-horizontal .ilFormHeader {
   padding: 9px 15px;
@@ -19690,10 +19865,6 @@ div.ilStartupSection form.form-horizontal .ilFormHeader {
 }
 div.ilStartupSection form.form-horizontal .form-group {
   margin: 9px 0;
-}
-div.ilStartupSection form.form-horizontal {
-  text-align: left;
-  width: 40em;
 }
 @media only screen and (max-width: 991px) {
   div.ilStartupSection form.form-horizontal {
@@ -22612,6 +22783,10 @@ div.ilFrame {
 }
 
 .il-multi-line-cap-2 {
+  /* edge, chrome, safari go here... */
+  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
+}
+.il-multi-line-cap-2 {
   position: relative;
   max-height: 3em;
   overflow: hidden;
@@ -22627,9 +22802,6 @@ div.ilFrame {
   height: 1.5em;
   background: linear-gradient(to right, rgba(255, 255, 255, 0), rgb(255, 255, 255) 80%);
 }
-.il-multi-line-cap-2 {
-  /* edge, chrome, safari go here... */
-}
 @supports (-webkit-line-clamp: 2) {
   .il-multi-line-cap-2 {
     overflow: hidden;
@@ -22641,9 +22813,6 @@ div.ilFrame {
   .il-multi-line-cap-2:after {
     display: none;
   }
-}
-.il-multi-line-cap-2 {
-  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
 }
 @supports (-moz-line-clamp: 2) {
   .il-multi-line-cap-2 {
@@ -22658,6 +22827,10 @@ div.ilFrame {
   }
 }
 
+.il-multi-line-cap-3 {
+  /* edge, chrome, safari go here... */
+  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
+}
 .il-multi-line-cap-3 {
   position: relative;
   max-height: 4.5em;
@@ -22674,9 +22847,6 @@ div.ilFrame {
   height: 1.5em;
   background: linear-gradient(to right, rgba(255, 255, 255, 0), rgb(255, 255, 255) 80%);
 }
-.il-multi-line-cap-3 {
-  /* edge, chrome, safari go here... */
-}
 @supports (-webkit-line-clamp: 2) {
   .il-multi-line-cap-3 {
     overflow: hidden;
@@ -22688,9 +22858,6 @@ div.ilFrame {
   .il-multi-line-cap-3:after {
     display: none;
   }
-}
-.il-multi-line-cap-3 {
-  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
 }
 @supports (-moz-line-clamp: 2) {
   .il-multi-line-cap-3 {
@@ -22705,6 +22872,10 @@ div.ilFrame {
   }
 }
 
+.il-multi-line-cap-5 {
+  /* edge, chrome, safari go here... */
+  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
+}
 .il-multi-line-cap-5 {
   position: relative;
   max-height: 7.5em;
@@ -22721,9 +22892,6 @@ div.ilFrame {
   height: 1.5em;
   background: linear-gradient(to right, rgba(255, 255, 255, 0), rgb(255, 255, 255) 80%);
 }
-.il-multi-line-cap-5 {
-  /* edge, chrome, safari go here... */
-}
 @supports (-webkit-line-clamp: 2) {
   .il-multi-line-cap-5 {
     overflow: hidden;
@@ -22735,9 +22903,6 @@ div.ilFrame {
   .il-multi-line-cap-5:after {
     display: none;
   }
-}
-.il-multi-line-cap-5 {
-  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
 }
 @supports (-moz-line-clamp: 2) {
   .il-multi-line-cap-5 {
@@ -22752,6 +22917,10 @@ div.ilFrame {
   }
 }
 
+.il-multi-line-cap-10 {
+  /* edge, chrome, safari go here... */
+  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
+}
 .il-multi-line-cap-10 {
   position: relative;
   max-height: 15em;
@@ -22768,9 +22937,6 @@ div.ilFrame {
   height: 1.5em;
   background: linear-gradient(to right, rgba(255, 255, 255, 0), rgb(255, 255, 255) 80%);
 }
-.il-multi-line-cap-10 {
-  /* edge, chrome, safari go here... */
-}
 @supports (-webkit-line-clamp: 2) {
   .il-multi-line-cap-10 {
     overflow: hidden;
@@ -22782,9 +22948,6 @@ div.ilFrame {
   .il-multi-line-cap-10:after {
     display: none;
   }
-}
-.il-multi-line-cap-10 {
-  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
 }
 @supports (-moz-line-clamp: 2) {
   .il-multi-line-cap-10 {


### PR DESCRIPTION
This is a follow up of https://github.com/ILIAS-eLearning/ILIAS/pull/7837

This PR changes the Section View Control to allow Dropdowns as middle items.
<img width="321" alt="Bildschirmfoto 2024-07-22 um 13 45 21" src="https://github.com/user-attachments/assets/30cb5340-4767-4775-a40c-65ebbcc7f004">

Use cases are navigational elements like here:
https://docu.ilias.de/goto_docu_wiki_wpage_7518_1357.html

Docu Changes:
https://github.com/ILIAS-eLearning/ILIAS/pull/7837/files#diff-4cefcd552bb8e4cb0bf88461b0ea86defb16d82fe86477c3738bc0efcaea6697

Currently the Section View Control documentation includes "Split Buttons" which do not exist, so this part is removed. However the Month Buttons are already allows, so this is added.

This PR already includes an implementation. The correspdoning methods already allow to pass any component, the following check has been extended to check for the Dropdowns.
