### PR TITLE
AccessControl: Return true for ilObjSystemFolder read permission

### DIFF
--- a/components/ILIAS/AccessControl/classes/class.ilAccess.php
+++ b/components/ILIAS/AccessControl/classes/class.ilAccess.php
@@ -274,6 +274,11 @@ class ilAccess implements ilAccessHandler
             return false;
         }
 
+        // As of FR: https://docu.ilias.de/go/wiki/wpage_8648_1357#ilPageTocA248
+        // the ilObjSystemFolderGUI is always readable.
+        if ($a_ref_id === SYSTEM_FOLDER_ID && 'read' === $a_permission) {
+            return true;
+        }
         // rbac check for current object
         if (!$this->doRBACCheck($a_permission, $a_cmd, $a_ref_id, $a_user_id, $a_type)) {
             $this->current_info->addInfoItem(ilAccessInfo::IL_NO_PERMISSION, $this->getLanguage()->txt("status_no_permission"));


### PR DESCRIPTION
This PR is part of the following Feature Requests: https://docu.ilias.de/go/wiki/wpage_8648_1357 specifically Section 2.2 (https://docu.ilias.de/go/wiki/wpage_8648_1357#ilPageTocA248)

As the `ilObjSystemFolder` will only serve as a parent and won't have it's own page (implemented in other PR's), the `read` permission should always return true, so that `ilAccess` checks can be used for the children.

Sadly this requires a special case in the `ilAccess` class.