### PR TITLE
MainMenu: change check for admin top item

### DIFF
--- a/components/ILIAS/GlobalScreen/classes/Helper/BasicAccessCheckClosures.php
+++ b/components/ILIAS/GlobalScreen/classes/Helper/BasicAccessCheckClosures.php
@@ -109,10 +109,14 @@ class BasicAccessCheckClosures
     public function hasAdministrationAccess(?Closure $additional = null): Closure
     {
         if (!isset($this->access_cache['has_admin_access'])) {
-            $this->access_cache['has_admin_access'] = ($this->dic->rbac()->system()->checkAccess(
-                'visible',
-                \SYSTEM_FOLDER_ID
-            ));
+            $access = false;
+            foreach ($this->dic->repositoryTree()->getChildIds(SYSTEM_FOLDER_ID) as $child_id) {
+                if ($this->dic->rbac()->system()->checkAccess('read', $child_id)) {
+                    $access = true;
+                    break;
+                }
+            }
+            $this->access_cache['has_admin_access'] = $access;
         }
         return $this->getClosureWithOptinalClosure(fn(): bool => $this->access_cache['has_admin_access'], $additional);
     }

--- a/components/ILIAS/GlobalScreen/tests/ilServicesGlobalScreenTest.php
+++ b/components/ILIAS/GlobalScreen/tests/ilServicesGlobalScreenTest.php
@@ -27,6 +27,7 @@ class ilServicesGlobalScreenTest extends TestCase
     private ?Container $dic_backup = null;
     private int $SYSTEM_FOLDER_ID;
     private int $ROOT_FOLDER_ID;
+    private int $ONE_ADMIN_NODE_ID = 123;
 
     protected function setUp(): void
     {
@@ -52,12 +53,18 @@ class ilServicesGlobalScreenTest extends TestCase
     public function testAdminAccessTrue(): void
     {
         global $DIC;
+        $DIC['tree'] = $tree_mock = $this->createMock(ilTree::class);
         $DIC['rbacsystem'] = $rbac_mock = $this->createMock(ilRbacSystem::class);
         $class = new BasicAccessCheckClosures($DIC);
 
+        $tree_mock->expects($this->once())
+                  ->method('getChildIds')
+                  ->with($this->SYSTEM_FOLDER_ID)
+                  ->willReturn([$this->ONE_ADMIN_NODE_ID]);
+
         $rbac_mock->expects($this->once())
                   ->method('checkAccess')
-                  ->with('visible', $this->SYSTEM_FOLDER_ID)
+                  ->with('read', $this->ONE_ADMIN_NODE_ID)
                   ->willReturn(true);
 
         $this->assertTrue($class->hasAdministrationAccess()());
@@ -69,12 +76,18 @@ class ilServicesGlobalScreenTest extends TestCase
     public function testAdminAccessFalse(): void
     {
         global $DIC;
+        $DIC['tree'] = $tree_mock = $this->createMock(ilTree::class);
         $DIC['rbacsystem'] = $rbac_mock = $this->createMock(ilRbacSystem::class);
         $class = new BasicAccessCheckClosures($DIC);
 
+        $tree_mock->expects($this->once())
+                  ->method('getChildIds')
+                  ->with($this->SYSTEM_FOLDER_ID)
+                  ->willReturn([$this->ONE_ADMIN_NODE_ID]);
+
         $rbac_mock->expects($this->once())
                   ->method('checkAccess')
-                  ->with('visible', $this->SYSTEM_FOLDER_ID)
+                  ->with('read', $this->ONE_ADMIN_NODE_ID)
                   ->willReturn(false);
 
         $this->assertFalse($class->hasAdministrationAccess()());
@@ -86,12 +99,18 @@ class ilServicesGlobalScreenTest extends TestCase
     public function testAdminAcessTrueButWithClosure(): void
     {
         global $DIC;
+        $DIC['tree'] = $tree_mock = $this->createMock(ilTree::class);
         $DIC['rbacsystem'] = $rbac_mock = $this->createMock(ilRbacSystem::class);
         $class = new BasicAccessCheckClosures($DIC);
 
+        $tree_mock->expects($this->once())
+                  ->method('getChildIds')
+                  ->with($this->SYSTEM_FOLDER_ID)
+                  ->willReturn([$this->ONE_ADMIN_NODE_ID]);
+
         $rbac_mock->expects($this->once())
                   ->method('checkAccess')
-                  ->with('visible', $this->SYSTEM_FOLDER_ID)
+                  ->with('read', $this->ONE_ADMIN_NODE_ID)
                   ->willReturn(true);
 
         $closure_returning_false = fn(): bool => false;

--- a/components/ILIAS/MainMenu/tests/ilServicesMainMenuTest.php
+++ b/components/ILIAS/MainMenu/tests/ilServicesMainMenuTest.php
@@ -142,6 +142,7 @@ class ilServicesMainMenuTest extends TestCase
     public function testStandardTopItems(): void
     {
         $this->dic_mock['lng'] = $this->createMock(ilLanguage::class);
+        $this->dic_mock['tree'] = $this->createMock(ilTree::class);
         $standard_top_items = new StandardTopItemsProvider($this->dic_mock);
         $items = $standard_top_items->getStaticTopItems();
         $item_identifications = array_map(


### PR DESCRIPTION
This PR is part of the feature request [Unbundling of Admin Permissions](https://docu.ilias.de/go/wiki/wpage_8648_1357).

According to the FR, the "visible" permission will be removed from the system folder and permissions to nodes in the administration menu can be set independently from the system folder.

Therefore the top item of the administration menu should be shown to all users that have "read" access to at least one child node of the system folder. 

The permission checks in `ilAdministrationGUI` will be changed accordingly with the PR [Admin: change base permission check](https://github.com/ILIAS-eLearning/ILIAS/pull/10302)