### PR TITLE
Cron: fix lang vars and permission checks

### DIFF
--- a/components/ILIAS/Cron/src/class.ilObjCronGUI.php
+++ b/components/ILIAS/Cron/src/class.ilObjCronGUI.php
@@ -213,7 +213,7 @@ final class ilObjCronGUI extends ilObjectGUI
 
     public function executeCommand(): void
     {
-        if (!$this->rbac->system()->checkAccess('read', SYSTEM_FOLDER_ID)) {
+        if (!$this->rbac->system()->checkAccess('read', $this->ref_id)) {
             $this->error->raiseError($this->lng->txt('no_permission'), $this->error->WARNING);
         }
 
@@ -304,7 +304,7 @@ final class ilObjCronGUI extends ilObjectGUI
             $this->lng,
             $filtered_jobs,
             $this->cron_repository,
-            $this->rbac->system()->checkAccess('write', SYSTEM_FOLDER_ID)
+            $this->rbac->system()->checkAccess('write', $this->ref_id)
         );
 
         $this->tpl->setContent(
@@ -320,7 +320,7 @@ final class ilObjCronGUI extends ilObjectGUI
 
     public function edit(?ILIAS\UI\Component\Input\Container\Form\Form $form = null): void
     {
-        if (!$this->rbac->system()->checkAccess('write', SYSTEM_FOLDER_ID)) {
+        if (!$this->rbac->system()->checkAccess('write', $this->ref_id)) {
             $this->error->raiseError($this->lng->txt('no_permission'), $this->error->WARNING);
         }
 
@@ -345,7 +345,7 @@ final class ilObjCronGUI extends ilObjectGUI
 
     public function editLegacy(?ilPropertyFormGUI $a_form = null): void
     {
-        if (!$this->rbac->system()->checkAccess('write', SYSTEM_FOLDER_ID)) {
+        if (!$this->rbac->system()->checkAccess('write', $this->ref_id)) {
             $this->error->raiseError($this->lng->txt('no_permission'), $this->error->WARNING);
         }
 
@@ -571,7 +571,7 @@ final class ilObjCronGUI extends ilObjectGUI
 
     public function update(): void
     {
-        if (!$this->rbac->system()->checkAccess('write', SYSTEM_FOLDER_ID)) {
+        if (!$this->rbac->system()->checkAccess('write', $this->ref_id)) {
             $this->error->raiseError($this->lng->txt('no_permission'), $this->error->WARNING);
         }
 
@@ -631,7 +631,7 @@ final class ilObjCronGUI extends ilObjectGUI
     #[\Deprecated('Will be removed without any alternative, KS/UI forms will be expected', since: '12.0')]
     public function updateLegacy(): void
     {
-        if (!$this->rbac->system()->checkAccess('write', SYSTEM_FOLDER_ID)) {
+        if (!$this->rbac->system()->checkAccess('write', $this->ref_id)) {
             $this->error->raiseError($this->lng->txt('no_permission'), $this->error->WARNING);
         }
 
@@ -678,7 +678,7 @@ final class ilObjCronGUI extends ilObjectGUI
 
     public function confirmedRun(): void
     {
-        if (!$this->rbac->system()->checkAccess('write', SYSTEM_FOLDER_ID)) {
+        if (!$this->rbac->system()->checkAccess('write', $this->ref_id)) {
             $this->error->raiseError($this->lng->txt('no_permission'), $this->error->WARNING);
         }
 
@@ -704,7 +704,7 @@ final class ilObjCronGUI extends ilObjectGUI
 
     public function confirmedActivate(): void
     {
-        if (!$this->rbac->system()->checkAccess('write', SYSTEM_FOLDER_ID)) {
+        if (!$this->rbac->system()->checkAccess('write', $this->ref_id)) {
             $this->error->raiseError($this->lng->txt('no_permission'), $this->error->WARNING);
         }
 
@@ -731,7 +731,7 @@ final class ilObjCronGUI extends ilObjectGUI
 
     public function confirmedDeactivate(): void
     {
-        if (!$this->rbac->system()->checkAccess('write', SYSTEM_FOLDER_ID)) {
+        if (!$this->rbac->system()->checkAccess('write', $this->ref_id)) {
             $this->error->raiseError($this->lng->txt('no_permission'), $this->error->WARNING);
         }
 
@@ -758,7 +758,7 @@ final class ilObjCronGUI extends ilObjectGUI
 
     public function confirmedReset(): void
     {
-        if (!$this->rbac->system()->checkAccess('write', SYSTEM_FOLDER_ID)) {
+        if (!$this->rbac->system()->checkAccess('write', $this->ref_id)) {
             $this->error->raiseError($this->lng->txt('no_permission'), $this->error->WARNING);
         }
 
@@ -800,7 +800,7 @@ final class ilObjCronGUI extends ilObjectGUI
 
     protected function confirm(string $a_action): void
     {
-        if (!$this->rbac->system()->checkAccess('write', SYSTEM_FOLDER_ID)) {
+        if (!$this->rbac->system()->checkAccess('write', $this->ref_id)) {
             $this->error->raiseError($this->lng->txt('no_permission'), $this->error->WARNING);
         }
 

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -264,8 +264,6 @@ administration#:#nothing_to_restore#:#Nichts wiederherzustellen...
 administration#:#obj_blga#:#Blog
 administration#:#obj_blga_desc#:#Globale Blogeinstellungen
 administration#:#obj_chta_desc#:#Administration des Chat-Objekts und des Chat-Servers
-administration#:#obj_cron#:#Cron Jobs
-administration#:#obj_cron_desc#:#Liste aller Cron Jobs
 administration#:#obj_excs#:#Übung
 administration#:#obj_excs_desc#:#Globale Übungseinstellungen
 administration#:#obj_gsfo#:#Fußzeile
@@ -1364,7 +1362,7 @@ assessment#:#tst_answer_aggr_frequency_header#:#Häufigkeit
 assessment#:#tst_answer_details#:#Antwortdetails
 assessment#:#tst_answer_fixation#:#Antworten bei Anzeige der Rückmeldung und/oder Übergang zur nächsten Frage sperren
 assessment#:#tst_answer_fixation_handling#:#Antworten festschreiben
-assessment#:#tst_answer_fixation_none#:Antworten während des Testdurchlaufs nicht festschreiben
+assessment#:#tst_answer_fixation_none#:#Antworten während des Testdurchlaufs nicht festschreiben
 assessment#:#tst_answer_fixation_none_desc#:#Solange ein Testdurchlauf nicht beendet ist, können Teilnehmer ihre Antworten beliebig verändern.
 assessment#:#tst_answer_fixation_on_followup_question#:#Bei der Anzeige der Folgefrage
 assessment#:#tst_answer_fixation_on_followup_question_desc#:#Nach dem Anzeigen der Folgefrage können Teilnehmer die Antwort auf die vorherige Frage nicht mehr verändern.
@@ -1618,7 +1616,7 @@ assessment#:#tst_mark_minimum_level_invalid#:#Der Mindestprozentsatz muss zwisch
 assessment#:#tst_mark_official_form#:#Offizielle Bezeichnung
 assessment#:#tst_mark_passed#:#Bestanden
 assessment#:#tst_mark_reset_to_simple_mark_schema#:#Auf Einfaches Notenschema zurücksetzen
-assessment#:#tst_mark_reset_to_simple_mark_schema_confirmation#:Möchten Sie wirklich fortfahren? Das aktuelle Notenschema wird durch ein einfaches Notenschema mit den Stufen „bestanden“ und „nicht bestanden“ ersetzt. Alle lokalen Änderungen werden gelöscht.
+assessment#:#tst_mark_reset_to_simple_mark_schema_confirmation#:#Möchten Sie wirklich fortfahren? Das aktuelle Notenschema wird durch ein einfaches Notenschema mit den Stufen „bestanden“ und „nicht bestanden“ ersetzt. Alle lokalen Änderungen werden gelöscht.
 assessment#:#tst_mark_short_form#:#Kurzbezeichnung
 assessment#:#tst_max_comp_points#:#Maximale Kompetenz-Punkte
 assessment#:#tst_maximum_points#:#Maximale Punktezahl
@@ -4895,6 +4893,8 @@ common#:#obj_copa#:#Inhaltsseite
 common#:#obj_cpad#:#Inhaltsseiten
 common#:#obj_cpad#_desc#:#Administration Inhaltsseiten
 common#:#obj_cpad_desc#:#Administration der Inhaltsseiten
+common#:#obj_cron#:#Cron Jobs
+common#:#obj_cron_desc#:#Liste aller Cron Jobs
 common#:#obj_crs#:#Kurs
 common#:#obj_crs_duplicate#:#Kurs kopieren
 common#:#obj_crsr#:#Kurslink

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -264,8 +264,6 @@ administration#:#nothing_to_restore#:#Nothing to restore...
 administration#:#obj_blga#:#Blog
 administration#:#obj_blga_desc#:#Global Blog Settings
 administration#:#obj_chta_desc#:#Chat Administration
-administration#:#obj_cron#:#Cron Jobs
-administration#:#obj_cron_desc#:#List of all Cron Jobs
 administration#:#obj_excs#:#Exercise
 administration#:#obj_excs_desc#:#Global Exercise Settings
 administration#:#obj_gsfo#:#Footer
@@ -4895,6 +4893,8 @@ common#:#obj_copa#:#Content Page
 common#:#obj_cpad#:#Content Pages
 common#:#obj_cpad#_desc#:#Content Page Administration
 common#:#obj_cpad_desc#:#Content Page Administration
+common#:#obj_cron#:#Cron Jobs
+common#:#obj_cron_desc#:#List of all Cron Jobs
 common#:#obj_crs#:#Course
 common#:#obj_crs_duplicate#:#Copy Course
 common#:#obj_crsr#:#Course Link


### PR DESCRIPTION
This PR fixes two issues from the movement of the cron job adminstration to a separate admin node:

1. The language variables for title and description need to be moved to the "common" bodule because they are set by ilObjectGUI.
2. The  permission checks need to be done to the ref id of the cron admin node instead of the system folder

Additionally to malformed lang entries are fixes that prevented a refreshing o the language variables.