### PR TITLE
Performance: optimize admin menu check

### DIFF
--- a/components/ILIAS/AccessControl/classes/class.ilRbacSystem.php
+++ b/components/ILIAS/AccessControl/classes/class.ilRbacSystem.php
@@ -230,7 +230,7 @@ class ilRbacSystem
             $r = $this->db->query($q);
 
             while ($row = $r->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-                if($row->ops_id === ':') {
+                if ($row->ops_id === ':') {
                     continue;
                 }
                 if (in_array($row->rol_id, $roles[(int) $row->ref_id])) {
@@ -380,5 +380,43 @@ class ilRbacSystem
     {
         $paCacheKey = $a_usr_id . ':' . $a_ref_id;
         unset(self::$_paCache[$paCacheKey]);
+    }
+
+    /**
+     * Check if the current user has read permission to any sub node of the system folder
+     * This is used by th main menu to decide if the Administration top item is shown
+     * @see self::checkAccessOfUser() for deserialisation
+     */
+    public function hasAnyAdminReadPermission(): bool
+    {
+
+        $roles = $this->fetchAssignedRoles($this->user->getId(), ROLE_FOLDER_ID);
+        if (in_array(SYSTEM_ROLE_ID, $roles)) {
+            return true;
+        }
+
+        $read_id = ilRbacReview::_getOperationIdByName('read');
+
+        $result = $this->db->queryF(
+            "
+            SELECT pa.ops_id
+            FROM tree t
+            JOIN rbac_pa pa ON pa.ref_id = t.child
+            JOIN rbac_ua ua ON ua.rol_id = pa.rol_id AND ua.usr_id = %s
+            WHERE t.parent = %s
+            ",
+            [ilDBConstants::T_INTEGER, ilDBConstants::T_INTEGER],
+            [$this->user->getId(), SYSTEM_FOLDER_ID]
+        );
+
+        while ($row = $result->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
+            if ($row->ops_id !== ':') {
+                $ops = unserialize(stripslashes($row->ops_id));
+                if (in_array($read_id, $ops)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 } // END class.RbacSystem

--- a/components/ILIAS/GlobalScreen/classes/Helper/BasicAccessCheckClosures.php
+++ b/components/ILIAS/GlobalScreen/classes/Helper/BasicAccessCheckClosures.php
@@ -109,14 +109,7 @@ class BasicAccessCheckClosures
     public function hasAdministrationAccess(?Closure $additional = null): Closure
     {
         if (!isset($this->access_cache['has_admin_access'])) {
-            $access = false;
-            foreach ($this->dic->repositoryTree()->getChildIds(SYSTEM_FOLDER_ID) as $child_id) {
-                if ($this->dic->rbac()->system()->checkAccess('read', $child_id)) {
-                    $access = true;
-                    break;
-                }
-            }
-            $this->access_cache['has_admin_access'] = $access;
+            $this->access_cache['has_admin_access'] = $this->dic->rbac()->system()->hasAnyAdminReadPermission();
         }
         return $this->getClosureWithOptinalClosure(fn(): bool => $this->access_cache['has_admin_access'], $additional);
     }

--- a/components/ILIAS/GlobalScreen/tests/ilServicesGlobalScreenTest.php
+++ b/components/ILIAS/GlobalScreen/tests/ilServicesGlobalScreenTest.php
@@ -27,7 +27,6 @@ class ilServicesGlobalScreenTest extends TestCase
     private ?Container $dic_backup = null;
     private int $SYSTEM_FOLDER_ID;
     private int $ROOT_FOLDER_ID;
-    private int $ONE_ADMIN_NODE_ID = 123;
 
     protected function setUp(): void
     {
@@ -53,18 +52,11 @@ class ilServicesGlobalScreenTest extends TestCase
     public function testAdminAccessTrue(): void
     {
         global $DIC;
-        $DIC['tree'] = $tree_mock = $this->createMock(ilTree::class);
         $DIC['rbacsystem'] = $rbac_mock = $this->createMock(ilRbacSystem::class);
         $class = new BasicAccessCheckClosures($DIC);
 
-        $tree_mock->expects($this->once())
-                  ->method('getChildIds')
-                  ->with($this->SYSTEM_FOLDER_ID)
-                  ->willReturn([$this->ONE_ADMIN_NODE_ID]);
-
         $rbac_mock->expects($this->once())
-                  ->method('checkAccess')
-                  ->with('read', $this->ONE_ADMIN_NODE_ID)
+                  ->method('hasAnyAdminReadPermission')
                   ->willReturn(true);
 
         $this->assertTrue($class->hasAdministrationAccess()());
@@ -76,18 +68,11 @@ class ilServicesGlobalScreenTest extends TestCase
     public function testAdminAccessFalse(): void
     {
         global $DIC;
-        $DIC['tree'] = $tree_mock = $this->createMock(ilTree::class);
         $DIC['rbacsystem'] = $rbac_mock = $this->createMock(ilRbacSystem::class);
         $class = new BasicAccessCheckClosures($DIC);
 
-        $tree_mock->expects($this->once())
-                  ->method('getChildIds')
-                  ->with($this->SYSTEM_FOLDER_ID)
-                  ->willReturn([$this->ONE_ADMIN_NODE_ID]);
-
         $rbac_mock->expects($this->once())
-                  ->method('checkAccess')
-                  ->with('read', $this->ONE_ADMIN_NODE_ID)
+                  ->method('hasAnyAdminReadPermission')
                   ->willReturn(false);
 
         $this->assertFalse($class->hasAdministrationAccess()());
@@ -99,18 +84,11 @@ class ilServicesGlobalScreenTest extends TestCase
     public function testAdminAcessTrueButWithClosure(): void
     {
         global $DIC;
-        $DIC['tree'] = $tree_mock = $this->createMock(ilTree::class);
         $DIC['rbacsystem'] = $rbac_mock = $this->createMock(ilRbacSystem::class);
         $class = new BasicAccessCheckClosures($DIC);
 
-        $tree_mock->expects($this->once())
-                  ->method('getChildIds')
-                  ->with($this->SYSTEM_FOLDER_ID)
-                  ->willReturn([$this->ONE_ADMIN_NODE_ID]);
-
         $rbac_mock->expects($this->once())
-                  ->method('checkAccess')
-                  ->with('read', $this->ONE_ADMIN_NODE_ID)
+                  ->method('hasAnyAdminReadPermission')
                   ->willReturn(true);
 
         $closure_returning_false = fn(): bool => false;


### PR DESCRIPTION
This PR optimizes the performance of the decision whether the "Administration" main menu entry is shown to a user.

With acceptance of [MainMenu: change check for admin top item](https://github.com/ILIAS-eLearning/ILIAS/pull/10301) the main menu now shows the "Administration" top item if at least one sub node of the system folder has "read" permission. This is done in a straightforward way which results in around 70 permission checks for a non-admin user.

This PR adds a new shortcut function `\ilRbacSystem::hasAnyAdminReadPermission` that needs only one database query for this check. It is implemented in ilRbacSystem because it needs knowledge on how the permissions are stored in the table `rbac_pa`. 