### PR TITLE
Fix: (Accessibility) replace 'Show More' glyph label with 'Menu' in mobile Metabar

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/MainControls/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/MainControls/Renderer.php
@@ -247,7 +247,7 @@ class Renderer extends AbstractComponentRenderer
         ];
         $entries = $component->getEntries();
 
-        $more_label = $this->txt('show_more');
+        $more_label = $this->txt('menu_label');
         $more_symbol = $f->symbol()->glyph()->disclosure()
             ->withCounter($f->counter()->novelty(0))
             ->withCounter($f->counter()->status(0));

--- a/components/ILIAS/UI/src/Implementation/Component/MainControls/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/MainControls/Renderer.php
@@ -247,7 +247,7 @@ class Renderer extends AbstractComponentRenderer
         ];
         $entries = $component->getEntries();
 
-        $more_label = $this->txt('menu_label');
+        $more_label = $this->txt('metabar_slate_label');
         $more_symbol = $f->symbol()->glyph()->disclosure()
             ->withCounter($f->counter()->novelty(0))
             ->withCounter($f->counter()->status(0));

--- a/components/ILIAS/UI/tests/Client/Item/Notification/NotificationItemTest.html
+++ b/components/ILIAS/UI/tests/Client/Item/Notification/NotificationItemTest.html
@@ -130,7 +130,7 @@
                     <span class="badge badge-notify il-counter-novelty" style="display:none">0</span>
                 </span>
             </span>
-            <span class="bulky-label">show_more</span>
+            <span class="bulky-label">menu_label</span>
         </button>
         <div class="il-metabar-slates">
             <div class="il-maincontrols-slate disengaged" id="id_10" role="menu">

--- a/components/ILIAS/UI/tests/Client/Item/Notification/NotificationItemTest.html
+++ b/components/ILIAS/UI/tests/Client/Item/Notification/NotificationItemTest.html
@@ -130,7 +130,7 @@
                     <span class="badge badge-notify il-counter-novelty" style="display:none">0</span>
                 </span>
             </span>
-            <span class="bulky-label">menu_label</span>
+            <span class="bulky-label">metabar_slate_label</span>
         </button>
         <div class="il-metabar-slates">
             <div class="il-maincontrols-slate disengaged" id="id_10" role="menu">

--- a/components/ILIAS/UI/tests/Component/MainControls/MetaBarTest.php
+++ b/components/ILIAS/UI/tests/Component/MainControls/MetaBarTest.php
@@ -188,7 +188,7 @@ class MetaBarTest extends ILIAS_UI_TestBase
                 <span class="il-counter"><span class="badge badge-notify il-counter-status" style="display:none">0</span></span>
                 <span class="il-counter"><span class="badge badge-notify il-counter-novelty" style="display:none">0</span></span>
              </span>
-             <span class="bulky-label">menu_label</span>
+             <span class="bulky-label">metabar_slate_label</span>
          </button>
          <div class="il-metabar-slates">
             <div class="il-maincontrols-slate disengaged" id="id_4" role="menu">

--- a/components/ILIAS/UI/tests/Component/MainControls/MetaBarTest.php
+++ b/components/ILIAS/UI/tests/Component/MainControls/MetaBarTest.php
@@ -188,7 +188,7 @@ class MetaBarTest extends ILIAS_UI_TestBase
                 <span class="il-counter"><span class="badge badge-notify il-counter-status" style="display:none">0</span></span>
                 <span class="il-counter"><span class="badge badge-notify il-counter-novelty" style="display:none">0</span></span>
              </span>
-             <span class="bulky-label">show_more</span>
+             <span class="bulky-label">menu_label</span>
          </button>
          <div class="il-metabar-slates">
             <div class="il-maincontrols-slate disengaged" id="id_4" role="menu">

--- a/lang/ilias_ar.lang
+++ b/lang/ilias_ar.lang
@@ -17413,6 +17413,7 @@ ui#:#label_fieldselection_refresh#:#Apply###26 08 2024 new variable
 ui#:#label_pagination_limit#:#Pagination Number of Rows###26 08 2024 new variable
 ui#:#label_pagination_offset#:#Pagination Offset###26 08 2024 new variable
 ui#:#label_sortation#:#Sortation###26 08 2024 new variable
+ui#:#metabar_slate_label#:#Menu###07 11 2025 new variable
 ui#:#order_option_alphabetical_ascending#:#A to Z###26 08 2024 new variable
 ui#:#order_option_alphabetical_descending#:#Z to A###26 08 2024 new variable
 ui#:#order_option_chronological_ascending#:#Earliest first###26 08 2024 new variable

--- a/lang/ilias_bg.lang
+++ b/lang/ilias_bg.lang
@@ -17413,6 +17413,7 @@ ui#:#label_fieldselection_refresh#:#Apply###26 08 2024 new variable
 ui#:#label_pagination_limit#:#Pagination Number of Rows###26 08 2024 new variable
 ui#:#label_pagination_offset#:#Pagination Offset###26 08 2024 new variable
 ui#:#label_sortation#:#Sortation###26 08 2024 new variable
+ui#:#metabar_slate_label#:#Menu###07 11 2025 new variable
 ui#:#order_option_alphabetical_ascending#:#A to Z###26 08 2024 new variable
 ui#:#order_option_alphabetical_descending#:#Z to A###26 08 2024 new variable
 ui#:#order_option_chronological_ascending#:#Earliest first###26 08 2024 new variable

--- a/lang/ilias_cs.lang
+++ b/lang/ilias_cs.lang
@@ -17413,6 +17413,7 @@ ui#:#label_fieldselection_refresh#:#Apply###26 08 2024 new variable
 ui#:#label_pagination_limit#:#Pagination Number of Rows###26 08 2024 new variable
 ui#:#label_pagination_offset#:#Pagination Offset###26 08 2024 new variable
 ui#:#label_sortation#:#Sortation###26 08 2024 new variable
+ui#:#metabar_slate_label#:#Menu###07 11 2025 new variable
 ui#:#order_option_alphabetical_ascending#:#A to Z###26 08 2024 new variable
 ui#:#order_option_alphabetical_descending#:#Z to A###26 08 2024 new variable
 ui#:#order_option_chronological_ascending#:#Earliest first###26 08 2024 new variable

--- a/lang/ilias_da.lang
+++ b/lang/ilias_da.lang
@@ -17413,6 +17413,7 @@ ui#:#label_fieldselection_refresh#:#Apply###26 08 2024 new variable
 ui#:#label_pagination_limit#:#Pagination Number of Rows###26 08 2024 new variable
 ui#:#label_pagination_offset#:#Pagination Offset###26 08 2024 new variable
 ui#:#label_sortation#:#Sortation###26 08 2024 new variable
+ui#:#metabar_slate_label#:#Menu###07 11 2025 new variable
 ui#:#order_option_alphabetical_ascending#:#A to Z###26 08 2024 new variable
 ui#:#order_option_alphabetical_descending#:#Z to A###26 08 2024 new variable
 ui#:#order_option_chronological_ascending#:#Earliest first###26 08 2024 new variable

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -4695,7 +4695,6 @@ common#:#member#:#Mitglied
 common#:#member_status#:#Status der Mitgliedschaft
 common#:#members#:#Mitglieder
 common#:#membership_leave#:#Abmelden
-common#:#menu_label#:#Menü
 common#:#mep#:#Medienpool
 common#:#mep_add#:#Medienpool anlegen
 common#:#mep_edit#:#Eigenschaften des Medienpools bearbeiten
@@ -17414,6 +17413,7 @@ ui#:#label_fieldselection_refresh#:#Anwenden
 ui#:#label_pagination_limit#:#Pagination - Anzahl der Zeilen
 ui#:#label_pagination_offset#:#Pagination - Start
 ui#:#label_sortation#:#Sortierung
+ui#:#metabar_slate_label#:#Menü
 ui#:#order_option_alphabetical_ascending#:#A bis Z
 ui#:#order_option_alphabetical_descending#:#Z bis A
 ui#:#order_option_chronological_ascending#:#Älteste zuerst

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -4695,6 +4695,7 @@ common#:#member#:#Mitglied
 common#:#member_status#:#Status der Mitgliedschaft
 common#:#members#:#Mitglieder
 common#:#membership_leave#:#Abmelden
+common#:#menu_label#:#Menü
 common#:#mep#:#Medienpool
 common#:#mep_add#:#Medienpool anlegen
 common#:#mep_edit#:#Eigenschaften des Medienpools bearbeiten

--- a/lang/ilias_el.lang
+++ b/lang/ilias_el.lang
@@ -17414,6 +17414,7 @@ ui#:#label_fieldselection_refresh#:#Apply###26 08 2024 new variable
 ui#:#label_pagination_limit#:#Pagination Number of Rows###26 08 2024 new variable
 ui#:#label_pagination_offset#:#Pagination Offset###26 08 2024 new variable
 ui#:#label_sortation#:#Sortation###26 08 2024 new variable
+ui#:#metabar_slate_label#:#Menu###07 11 2025 new variable
 ui#:#order_option_alphabetical_ascending#:#A to Z###26 08 2024 new variable
 ui#:#order_option_alphabetical_descending#:#Z to A###26 08 2024 new variable
 ui#:#order_option_chronological_ascending#:#Earliest first###26 08 2024 new variable

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -5706,7 +5706,7 @@ common#:#show_hidden_sections#:#Show More Information &raquo;
 common#:#show_less#:#Show less
 common#:#show_list#:#Show List
 common#:#show_members#:#Display Members
-common#:#show_more#:#Show More
+common#:#menu_label#:#Menu
 common#:#show_owner#:#Show Owner
 common#:#show_preview#:#Show Preview
 common#:#show_users_online#:#Show active users

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -4696,6 +4696,7 @@ common#:#member#:#Member
 common#:#member_status#:#Member Status
 common#:#members#:#Members
 common#:#membership_leave#:#Leave
+common#:#menu_label#:#Menu
 common#:#mep#:#Media Pool
 common#:#mep_add#:#Add Media Pool
 common#:#mep_edit#:#Edit Media Pool Properties
@@ -5706,7 +5707,6 @@ common#:#show_hidden_sections#:#Show More Information &raquo;
 common#:#show_less#:#Show less
 common#:#show_list#:#Show List
 common#:#show_members#:#Display Members
-common#:#menu_label#:#Menu
 common#:#show_more#:#Show More
 common#:#show_owner#:#Show Owner
 common#:#show_preview#:#Show Preview

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -5707,6 +5707,7 @@ common#:#show_less#:#Show less
 common#:#show_list#:#Show List
 common#:#show_members#:#Display Members
 common#:#menu_label#:#Menu
+common#:#show_more#:#Show More
 common#:#show_owner#:#Show Owner
 common#:#show_preview#:#Show Preview
 common#:#show_users_online#:#Show active users

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -4696,7 +4696,6 @@ common#:#member#:#Member
 common#:#member_status#:#Member Status
 common#:#members#:#Members
 common#:#membership_leave#:#Leave
-common#:#menu_label#:#Menu
 common#:#mep#:#Media Pool
 common#:#mep_add#:#Add Media Pool
 common#:#mep_edit#:#Edit Media Pool Properties
@@ -17415,6 +17414,7 @@ ui#:#label_fieldselection_refresh#:#Apply
 ui#:#label_pagination_limit#:#Pagination Number of Rows
 ui#:#label_pagination_offset#:#Pagination Offset
 ui#:#label_sortation#:#Sortation
+ui#:#metabar_slate_label#:#Menu
 ui#:#order_option_alphabetical_ascending#:#A to Z
 ui#:#order_option_alphabetical_descending#:#Z to A
 ui#:#order_option_chronological_ascending#:#Earliest First

--- a/lang/ilias_et.lang
+++ b/lang/ilias_et.lang
@@ -17413,6 +17413,7 @@ ui#:#label_fieldselection_refresh#:#Apply###26 08 2024 new variable
 ui#:#label_pagination_limit#:#Pagination Number of Rows###26 08 2024 new variable
 ui#:#label_pagination_offset#:#Pagination Offset###26 08 2024 new variable
 ui#:#label_sortation#:#Sortation###26 08 2024 new variable
+ui#:#metabar_slate_label#:#Menu###07 11 2025 new variable
 ui#:#order_option_alphabetical_ascending#:#A to Z###26 08 2024 new variable
 ui#:#order_option_alphabetical_descending#:#Z to A###26 08 2024 new variable
 ui#:#order_option_chronological_ascending#:#Earliest first###26 08 2024 new variable

--- a/lang/ilias_fa.lang
+++ b/lang/ilias_fa.lang
@@ -17413,6 +17413,7 @@ ui#:#label_fieldselection_refresh#:#Apply###26 08 2024 new variable
 ui#:#label_pagination_limit#:#Pagination Number of Rows###26 08 2024 new variable
 ui#:#label_pagination_offset#:#Pagination Offset###26 08 2024 new variable
 ui#:#label_sortation#:#Sortation###26 08 2024 new variable
+ui#:#metabar_slate_label#:#Menu###07 11 2025 new variable
 ui#:#order_option_alphabetical_ascending#:#A to Z###26 08 2024 new variable
 ui#:#order_option_alphabetical_descending#:#Z to A###26 08 2024 new variable
 ui#:#order_option_chronological_ascending#:#Earliest first###26 08 2024 new variable

--- a/lang/ilias_fr.lang
+++ b/lang/ilias_fr.lang
@@ -17398,6 +17398,7 @@ ui#:#label_fieldselection_refresh#:#Apply###31 10 2023 new variable
 ui#:#label_pagination_limit#:#Pagination Number of Rows###31 10 2023 new variable
 ui#:#label_pagination_offset#:#Pagination Offset###31 10 2023 new variable
 ui#:#label_sortation#:#Sortation###31 10 2023 new variable
+ui#:#metabar_slate_label#:#Menu###07 11 2025 new variable
 ui#:#order_option_alphabetical_ascending#:#A to Z###26 08 2024 new variable
 ui#:#order_option_alphabetical_descending#:#Z to A###26 08 2024 new variable
 ui#:#order_option_chronological_ascending#:#Earliest first###26 08 2024 new variable

--- a/lang/ilias_hr.lang
+++ b/lang/ilias_hr.lang
@@ -17413,6 +17413,7 @@ ui#:#label_fieldselection_refresh#:#Apply###26 08 2024 new variable
 ui#:#label_pagination_limit#:#Pagination Number of Rows###26 08 2024 new variable
 ui#:#label_pagination_offset#:#Pagination Offset###26 08 2024 new variable
 ui#:#label_sortation#:#Sortation###26 08 2024 new variable
+ui#:#metabar_slate_label#:#Menu###07 11 2025 new variable
 ui#:#order_option_alphabetical_ascending#:#A to Z###26 08 2024 new variable
 ui#:#order_option_alphabetical_descending#:#Z to A###26 08 2024 new variable
 ui#:#order_option_chronological_ascending#:#Earliest first###26 08 2024 new variable

--- a/lang/ilias_hu.lang
+++ b/lang/ilias_hu.lang
@@ -17413,6 +17413,7 @@ ui#:#label_fieldselection_refresh#:#Alkalmaz
 ui#:#label_pagination_limit#:#Sorok számozása
 ui#:#label_pagination_offset#:#Oldalszámozás kezdete
 ui#:#label_sortation#:#Rendezés
+ui#:#metabar_slate_label#:#Menu###07 11 2025 new variable
 ui#:#order_option_alphabetical_ascending#:#A → Z
 ui#:#order_option_alphabetical_descending#:#Z → A
 ui#:#order_option_chronological_ascending#:#Legkorábbi legelől

--- a/lang/ilias_it.lang
+++ b/lang/ilias_it.lang
@@ -17412,6 +17412,7 @@ ui#:#label_fieldselection_refresh#:#Apply###30 04 2024 new variable
 ui#:#label_pagination_limit#:#Pagination Number of Rows###30 04 2024 new variable
 ui#:#label_pagination_offset#:#Pagination Offset###30 04 2024 new variable
 ui#:#label_sortation#:#Sortation###30 04 2024 new variable
+ui#:#metabar_slate_label#:#Menu###07 11 2025 new variable
 ui#:#order_option_alphabetical_ascending#:#A to Z###30 04 2024 new variable
 ui#:#order_option_alphabetical_descending#:#Z to A###30 04 2024 new variable
 ui#:#order_option_chronological_ascending#:#Earliest first###30 04 2024 new variable

--- a/lang/ilias_ja.lang
+++ b/lang/ilias_ja.lang
@@ -17413,6 +17413,7 @@ ui#:#label_fieldselection_refresh#:#適用
 ui#:#label_pagination_limit#:#列のページ付け数
 ui#:#label_pagination_offset#:#ページ付けオフセット
 ui#:#label_sortation#:#仕分け
+ui#:#metabar_slate_label#:#Menu###07 11 2025 new variable
 ui#:#order_option_alphabetical_ascending#:#A to Z
 ui#:#order_option_alphabetical_descending#:#Z to A
 ui#:#order_option_chronological_ascending#:#先行順

--- a/lang/ilias_ka.lang
+++ b/lang/ilias_ka.lang
@@ -17413,6 +17413,7 @@ ui#:#label_fieldselection_refresh#:#Apply###26 08 2024 new variable
 ui#:#label_pagination_limit#:#Pagination Number of Rows###26 08 2024 new variable
 ui#:#label_pagination_offset#:#Pagination Offset###26 08 2024 new variable
 ui#:#label_sortation#:#Sortation###26 08 2024 new variable
+ui#:#metabar_slate_label#:#Menu###07 11 2025 new variable
 ui#:#order_option_alphabetical_ascending#:#A to Z###26 08 2024 new variable
 ui#:#order_option_alphabetical_descending#:#Z to A###26 08 2024 new variable
 ui#:#order_option_chronological_ascending#:#Earliest first###26 08 2024 new variable

--- a/lang/ilias_lt.lang
+++ b/lang/ilias_lt.lang
@@ -17413,6 +17413,7 @@ ui#:#label_fieldselection_refresh#:#Apply###26 08 2024 new variable
 ui#:#label_pagination_limit#:#Pagination Number of Rows###26 08 2024 new variable
 ui#:#label_pagination_offset#:#Pagination Offset###26 08 2024 new variable
 ui#:#label_sortation#:#Sortation###26 08 2024 new variable
+ui#:#metabar_slate_label#:#Menu###07 11 2025 new variable
 ui#:#order_option_alphabetical_ascending#:#A to Z###26 08 2024 new variable
 ui#:#order_option_alphabetical_descending#:#Z to A###26 08 2024 new variable
 ui#:#order_option_chronological_ascending#:#Earliest first###26 08 2024 new variable

--- a/lang/ilias_nl.lang
+++ b/lang/ilias_nl.lang
@@ -17413,6 +17413,7 @@ ui#:#label_fieldselection_refresh#:#Apply###26 08 2024 new variable
 ui#:#label_pagination_limit#:#Pagination Number of Rows###26 08 2024 new variable
 ui#:#label_pagination_offset#:#Pagination Offset###26 08 2024 new variable
 ui#:#label_sortation#:#Sortation###26 08 2024 new variable
+ui#:#metabar_slate_label#:#Menu###07 11 2025 new variable
 ui#:#order_option_alphabetical_ascending#:#A to Z###26 08 2024 new variable
 ui#:#order_option_alphabetical_descending#:#Z to A###26 08 2024 new variable
 ui#:#order_option_chronological_ascending#:#Earliest first###26 08 2024 new variable

--- a/lang/ilias_pl.lang
+++ b/lang/ilias_pl.lang
@@ -17413,6 +17413,7 @@ ui#:#label_fieldselection_refresh#:#Apply###26 08 2024 new variable
 ui#:#label_pagination_limit#:#Pagination Number of Rows###26 08 2024 new variable
 ui#:#label_pagination_offset#:#Pagination Offset###26 08 2024 new variable
 ui#:#label_sortation#:#Sortation###26 08 2024 new variable
+ui#:#metabar_slate_label#:#Menu###07 11 2025 new variable
 ui#:#order_option_alphabetical_ascending#:#A to Z###26 08 2024 new variable
 ui#:#order_option_alphabetical_descending#:#Z to A###26 08 2024 new variable
 ui#:#order_option_chronological_ascending#:#Earliest first###26 08 2024 new variable

--- a/lang/ilias_pt.lang
+++ b/lang/ilias_pt.lang
@@ -17413,6 +17413,7 @@ ui#:#label_fieldselection_refresh#:#Apply###26 08 2024 new variable
 ui#:#label_pagination_limit#:#Pagination Number of Rows###26 08 2024 new variable
 ui#:#label_pagination_offset#:#Pagination Offset###26 08 2024 new variable
 ui#:#label_sortation#:#Sortation###26 08 2024 new variable
+ui#:#metabar_slate_label#:#Menu###07 11 2025 new variable
 ui#:#order_option_alphabetical_ascending#:#A to Z###26 08 2024 new variable
 ui#:#order_option_alphabetical_descending#:#Z to A###26 08 2024 new variable
 ui#:#order_option_chronological_ascending#:#Earliest first###26 08 2024 new variable

--- a/lang/ilias_ro.lang
+++ b/lang/ilias_ro.lang
@@ -17413,6 +17413,7 @@ ui#:#label_fieldselection_refresh#:#Apply###26 08 2024 new variable
 ui#:#label_pagination_limit#:#Pagination Number of Rows###26 08 2024 new variable
 ui#:#label_pagination_offset#:#Pagination Offset###26 08 2024 new variable
 ui#:#label_sortation#:#Sortation###26 08 2024 new variable
+ui#:#metabar_slate_label#:#Menu###07 11 2025 new variable
 ui#:#order_option_alphabetical_ascending#:#A to Z###26 08 2024 new variable
 ui#:#order_option_alphabetical_descending#:#Z to A###26 08 2024 new variable
 ui#:#order_option_chronological_ascending#:#Earliest first###26 08 2024 new variable

--- a/lang/ilias_ru.lang
+++ b/lang/ilias_ru.lang
@@ -17413,6 +17413,7 @@ ui#:#label_fieldselection_refresh#:#Apply###26 08 2024 new variable
 ui#:#label_pagination_limit#:#Pagination Number of Rows###26 08 2024 new variable
 ui#:#label_pagination_offset#:#Pagination Offset###26 08 2024 new variable
 ui#:#label_sortation#:#Sortation###26 08 2024 new variable
+ui#:#metabar_slate_label#:#Menu###07 11 2025 new variable
 ui#:#order_option_alphabetical_ascending#:#A to Z###26 08 2024 new variable
 ui#:#order_option_alphabetical_descending#:#Z to A###26 08 2024 new variable
 ui#:#order_option_chronological_ascending#:#Earliest first###26 08 2024 new variable

--- a/lang/ilias_sk.lang
+++ b/lang/ilias_sk.lang
@@ -17413,6 +17413,7 @@ ui#:#label_fieldselection_refresh#:#Apply###26 08 2024 new variable
 ui#:#label_pagination_limit#:#Pagination Number of Rows###26 08 2024 new variable
 ui#:#label_pagination_offset#:#Pagination Offset###26 08 2024 new variable
 ui#:#label_sortation#:#Sortation###26 08 2024 new variable
+ui#:#metabar_slate_label#:#Menu###07 11 2025 new variable
 ui#:#order_option_alphabetical_ascending#:#A to Z###26 08 2024 new variable
 ui#:#order_option_alphabetical_descending#:#Z to A###26 08 2024 new variable
 ui#:#order_option_chronological_ascending#:#Earliest first###26 08 2024 new variable

--- a/lang/ilias_sl.lang
+++ b/lang/ilias_sl.lang
@@ -17413,6 +17413,7 @@ ui#:#label_fieldselection_refresh#:#Apply###26 08 2024 new variable
 ui#:#label_pagination_limit#:#Pagination Number of Rows###26 08 2024 new variable
 ui#:#label_pagination_offset#:#Pagination Offset###26 08 2024 new variable
 ui#:#label_sortation#:#Sortation###26 08 2024 new variable
+ui#:#metabar_slate_label#:#Menu###07 11 2025 new variable
 ui#:#order_option_alphabetical_ascending#:#A to Z###26 08 2024 new variable
 ui#:#order_option_alphabetical_descending#:#Z to A###26 08 2024 new variable
 ui#:#order_option_chronological_ascending#:#Earliest first###26 08 2024 new variable

--- a/lang/ilias_sq.lang
+++ b/lang/ilias_sq.lang
@@ -17413,6 +17413,7 @@ ui#:#label_fieldselection_refresh#:#Apply###26 08 2024 new variable
 ui#:#label_pagination_limit#:#Pagination Number of Rows###26 08 2024 new variable
 ui#:#label_pagination_offset#:#Pagination Offset###26 08 2024 new variable
 ui#:#label_sortation#:#Sortation###26 08 2024 new variable
+ui#:#metabar_slate_label#:#Menu###07 11 2025 new variable
 ui#:#order_option_alphabetical_ascending#:#A to Z###26 08 2024 new variable
 ui#:#order_option_alphabetical_descending#:#Z to A###26 08 2024 new variable
 ui#:#order_option_chronological_ascending#:#Earliest first###26 08 2024 new variable

--- a/lang/ilias_sr.lang
+++ b/lang/ilias_sr.lang
@@ -17413,6 +17413,7 @@ ui#:#label_fieldselection_refresh#:#Apply###26 08 2024 new variable
 ui#:#label_pagination_limit#:#Pagination Number of Rows###26 08 2024 new variable
 ui#:#label_pagination_offset#:#Pagination Offset###26 08 2024 new variable
 ui#:#label_sortation#:#Sortation###26 08 2024 new variable
+ui#:#metabar_slate_label#:#Menu###07 11 2025 new variable
 ui#:#order_option_alphabetical_ascending#:#A to Z###26 08 2024 new variable
 ui#:#order_option_alphabetical_descending#:#Z to A###26 08 2024 new variable
 ui#:#order_option_chronological_ascending#:#Earliest first###26 08 2024 new variable

--- a/lang/ilias_sv.lang
+++ b/lang/ilias_sv.lang
@@ -17413,6 +17413,7 @@ ui#:#label_fieldselection_refresh#:#Apply###21 11 2023 new variable
 ui#:#label_pagination_limit#:#Pagination Number of Rows###21 11 2023 new variable
 ui#:#label_pagination_offset#:#Pagination Offset###21 11 2023 new variable
 ui#:#label_sortation#:#Sortation###21 11 2023 new variable
+ui#:#metabar_slate_label#:#Menu###07 11 2025 new variable
 ui#:#order_option_alphabetical_ascending#:#A to Z###26 08 2024 new variable
 ui#:#order_option_alphabetical_descending#:#Z to A###26 08 2024 new variable
 ui#:#order_option_chronological_ascending#:#Earliest first###26 08 2024 new variable

--- a/lang/ilias_tr.lang
+++ b/lang/ilias_tr.lang
@@ -17413,6 +17413,7 @@ ui#:#label_fieldselection_refresh#:#Apply###26 08 2024 new variable
 ui#:#label_pagination_limit#:#Pagination Number of Rows###26 08 2024 new variable
 ui#:#label_pagination_offset#:#Pagination Offset###26 08 2024 new variable
 ui#:#label_sortation#:#Sortation###26 08 2024 new variable
+ui#:#metabar_slate_label#:#Menu###07 11 2025 new variable
 ui#:#order_option_alphabetical_ascending#:#A to Z###26 08 2024 new variable
 ui#:#order_option_alphabetical_descending#:#Z to A###26 08 2024 new variable
 ui#:#order_option_chronological_ascending#:#Earliest first###26 08 2024 new variable

--- a/lang/ilias_uk.lang
+++ b/lang/ilias_uk.lang
@@ -17413,6 +17413,7 @@ ui#:#label_fieldselection_refresh#:#Apply###26 08 2024 new variable
 ui#:#label_pagination_limit#:#Pagination Number of Rows###26 08 2024 new variable
 ui#:#label_pagination_offset#:#Pagination Offset###26 08 2024 new variable
 ui#:#label_sortation#:#Sortation###26 08 2024 new variable
+ui#:#metabar_slate_label#:#Menu###07 11 2025 new variable
 ui#:#order_option_alphabetical_ascending#:#A to Z###26 08 2024 new variable
 ui#:#order_option_alphabetical_descending#:#Z to A###26 08 2024 new variable
 ui#:#order_option_chronological_ascending#:#Earliest first###26 08 2024 new variable

--- a/lang/ilias_vi.lang
+++ b/lang/ilias_vi.lang
@@ -17415,6 +17415,7 @@ ui#:#label_fieldselection_refresh#:#Apply###26 08 2024 new variable
 ui#:#label_pagination_limit#:#Pagination Number of Rows###26 08 2024 new variable
 ui#:#label_pagination_offset#:#Pagination Offset###26 08 2024 new variable
 ui#:#label_sortation#:#Sortation###26 08 2024 new variable
+ui#:#metabar_slate_label#:#Menu###07 11 2025 new variable
 ui#:#order_option_alphabetical_ascending#:#A to Z###26 08 2024 new variable
 ui#:#order_option_alphabetical_descending#:#Z to A###26 08 2024 new variable
 ui#:#order_option_chronological_ascending#:#Earliest first###26 08 2024 new variable

--- a/lang/ilias_zh.lang
+++ b/lang/ilias_zh.lang
@@ -17412,6 +17412,7 @@ ui#:#label_fieldselection_refresh#:#Apply###26 08 2024 new variable
 ui#:#label_pagination_limit#:#Pagination Number of Rows###26 08 2024 new variable
 ui#:#label_pagination_offset#:#Pagination Offset###26 08 2024 new variable
 ui#:#label_sortation#:#Sortation###26 08 2024 new variable
+ui#:#metabar_slate_label#:#Menu###07 11 2025 new variable
 ui#:#order_option_alphabetical_ascending#:#A to Z###26 08 2024 new variable
 ui#:#order_option_alphabetical_descending#:#Z to A###26 08 2024 new variable
 ui#:#order_option_chronological_ascending#:#Earliest first###26 08 2024 new variable


### PR DESCRIPTION
The "Show More" glyph button in the mobile view of the Metabar has been replaced
with a descriptive text label "Menu".
This change improves accessibility and clarity for users, following the recommendations in ticket #[41471](https://mantis.ilias.de/view.php?id=41471).

The code for the tests in `NotificationItemTest.html` and `MetaBarTest.php` has also been modified by adapting the language variable.