### PR TITLE
ECS: Fix Input Labels in Participant Import Settings

### DIFF
--- a/components/ILIAS/WebServices/ECS/classes/class.ilECSParticipantSettingsGUI.php
+++ b/components/ILIAS/WebServices/ECS/classes/class.ilECSParticipantSettingsGUI.php
@@ -55,6 +55,7 @@ class ilECSParticipantSettingsGUI
         $this->mid = $a_mid;
 
         $this->lng->loadLanguageModule('ecs');
+        $this->lng->loadLanguageModule('auth');
 
         $this->participant = new ilECSParticipantSetting($this->getServerId(), $this->getMid());
         $this->auth_factory = new ilECSAuthFactory();
@@ -272,8 +273,13 @@ class ilECSParticipantSettingsGUI
         $user_credentials->setValue($this->getParticipant()->getOutgoingAuthModes());
         $import->addSubItem($user_credentials);
         foreach ($this->parseAvailableAuthModes() as $option_name => $option_text) {
+            // default login does not need a placeholder
+            if ($option_name === 'ilias') {
+                continue;
+            }
+
             $option = new ilCheckboxOption(
-                $this->lng->txt('ecs_import_auth_mode') . ' ' . $option_text,
+                sprintf($this->lng->txt('ecs_import_auth_mode'), $option_text),
                 $option_name
             );
             $user_credentials->addOption($option);


### PR DESCRIPTION
Hi everyone,

In this PR I am submitting a follow-up to #10252. As mentioned in the comments, the labels in the import section of the ECS-Participant settings are not displayed correctly. The changes in this PR resolve this issue. The actual import logic was not affected by this issue; we tested the settings during development and as part of our quality assurance measures.

Thank you for the note @Akumatic and Best,
@lukas-heinrich 