### PR TITLE
PHPUnit: remove/adjust PHPUnit functions as they are deprecated an…

### DIFF
--- a/components/ILIAS/Component/src/Dependencies/Reader.php
+++ b/components/ILIAS/Component/src/Dependencies/Reader.php
@@ -360,8 +360,6 @@ class Reader
         return $mock_builder
             ->disableOriginalConstructor()
             ->disableOriginalClone()
-            ->disableArgumentCloning()
-            ->disallowMockingUnknownTypes()
             ->getMock();
     }
 }

--- a/components/ILIAS/Data/tests/Description/DListTest.php
+++ b/components/ILIAS/Data/tests/Description/DListTest.php
@@ -113,7 +113,7 @@ class DListTest extends TestCase
 
         $this->v
             ->method("getPrimitiveRepresentation")
-            ->will($this->returnCallback(fn($v) => $v));
+            ->willReturnCallback(fn($v) => $v);
 
         $res = $this->l->getPrimitiveRepresentation($data);
 

--- a/components/ILIAS/EventHandling/tests/EventTest.php
+++ b/components/ILIAS/EventHandling/tests/EventTest.php
@@ -45,14 +45,12 @@ class EventTest extends TestCase
 
         $db_mock = $this->createMock(ilDBInterface::class);
         $db_mock->method("fetchAssoc")
-            ->will(
-                $this->onConsecutiveCalls(
-                    [
-                     "component" => "components/ILIAS/EventHandling",
-                     "id" => "MyTestComponent"
+            ->willReturn(
+                [
+                    "component" => "components/ILIAS/EventHandling",
+                    "id" => "MyTestComponent"
                  ],
-                    null
-                )
+                null
             );
 
 

--- a/components/ILIAS/LearningSequence/tests/IliasMocks.php
+++ b/components/ILIAS/LearningSequence/tests/IliasMocks.php
@@ -36,7 +36,7 @@ trait IliasMocks
     {
         $ui_reflection = new ReflectionClass(UIFactory::class);
         $methods = array_map(
-            fn ($m) => $m->getName(),
+            fn($m) => $m->getName(),
             $ui_reflection->getMethods()
         );
 
@@ -50,10 +50,10 @@ trait IliasMocks
         $ui_factory->method('viewControl')
             ->willReturn(new CImpl\ViewControl\Factory($signal_generator));
         $ui_factory->method('breadcrumbs')
-            ->will(
-                $this->returnCallback(function ($crumbs) {
+            ->willReturnCallback(
+                function ($crumbs) {
                     return new CImpl\Breadcrumbs\Breadcrumbs($crumbs);
-                })
+                }
             );
         $ui_factory->method('link')
             ->willReturn(new CImpl\Link\Factory());

--- a/components/ILIAS/Setup/tests/AgentCollectionTest.php
+++ b/components/ILIAS/Setup/tests/AgentCollectionTest.php
@@ -473,10 +473,10 @@ class AgentCollectionTest extends TestCase
         $seen_config = null;
         $agent
             ->method("getNamedObjectives")
-            ->will($this->returnCallback(function ($config) use (&$seen_config) {
+            ->willReturnCallback(function ($config) use (&$seen_config) {
                 $seen_config = $config;
                 return [];
-            }));
+            });
 
         $collection = new Setup\AgentCollection(
             $refinery,

--- a/components/ILIAS/Setup/tests/CLI/AchieveCommandTest.php
+++ b/components/ILIAS/Setup/tests/CLI/AchieveCommandTest.php
@@ -223,7 +223,7 @@ class AchieveCommandTest extends TestCase
         $agent
             ->expects($this->once())
             ->method("getNamedObjectives")
-            ->will($this->returnCallback(function ($config) use (&$seen_config, $objective) {
+            ->willReturnCallback(function ($config) use (&$seen_config, $objective) {
                 $seen_config = $config;
                 return [
                     "my.objective" => new Setup\ObjectiveConstructor(
@@ -233,7 +233,7 @@ class AchieveCommandTest extends TestCase
                         }
                     )
                 ];
-            }));
+            });
 
         $objective
             ->expects($this->once())

--- a/components/ILIAS/Setup/tests/CLI/BuildCommandTest.php
+++ b/components/ILIAS/Setup/tests/CLI/BuildCommandTest.php
@@ -52,9 +52,9 @@ class BuildCommandTest extends TestCase
         $objective
             ->expects($this->once())
             ->method("achieve")
-            ->will($this->returnCallback(function (Setup\Environment $e) {
+            ->willReturnCallback(function (Setup\Environment $e) {
                 return $e;
-            }));
+            });
 
         $objective
             ->expects($this->once())

--- a/components/ILIAS/Setup/tests/CLI/HasAgentTest.php
+++ b/components/ILIAS/Setup/tests/CLI/HasAgentTest.php
@@ -79,10 +79,10 @@ class HasAgentTest extends TestCase
 
         $ii
             ->method("getOption")
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ["no-legacy-plugins", true],
                 ["skip-legacy-plugin", null]
-            ]));
+            ]);
 
         $this->agent_finder
             ->expects($this->once())
@@ -107,11 +107,11 @@ class HasAgentTest extends TestCase
 
         $ii
             ->method("getOption")
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ["no-legacy-plugins", null],
                 ["legacy-plugin", "foobar"],
                 ["skip-legacy-plugin", null]
-            ]));
+            ]);
 
         $this->agent_finder
             ->expects($this->once())

--- a/components/ILIAS/Setup/tests/Objective/AdminConfirmedObjectiveTest.php
+++ b/components/ILIAS/Setup/tests/Objective/AdminConfirmedObjectiveTest.php
@@ -71,9 +71,9 @@ class AdminConfirmedObjectiveTest extends TestCase
 
         $env
             ->method("getResource")
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 [Setup\Environment::RESOURCE_ADMIN_INTERACTION, $admin_interaction]
-            ]));
+            ]);
 
         $admin_interaction
             ->expects($this->once())
@@ -94,9 +94,9 @@ class AdminConfirmedObjectiveTest extends TestCase
 
         $env
             ->method("getResource")
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 [Setup\Environment::RESOURCE_ADMIN_INTERACTION, $admin_interaction]
-            ]));
+            ]);
 
         $admin_interaction
             ->expects($this->once())

--- a/components/ILIAS/StudyProgramme/tests/cron/ilPrgRestartAssignmentsCronJobTest.php
+++ b/components/ILIAS/StudyProgramme/tests/cron/ilPrgRestartAssignmentsCronJobTest.php
@@ -194,7 +194,7 @@ class ilPrgRestartAssignmentsCronJobTest extends TestCase
         $this->prg
             ->expects($this->exactly(2))
             ->method('assignUser')
-            ->will($this->onConsecutiveCalls($ass1, $ass2));
+            ->willReturn($ass1, $ass2);
 
         $job = new ilPrgRestartAssignmentsCronJobMock($this->assignment_repo, $this->real_adapter, $this->prg);
         $job->run();

--- a/components/ILIAS/UI/tests/Component/Input/Field/DurationInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/DurationInputTest.php
@@ -50,7 +50,7 @@ class DurationInputTest extends ILIAS_UI_TestBase
     {
         $this->lng = $this->createMock(Language::class);
         $this->lng->method("txt")
-            ->will($this->returnArgument(0));
+            ->willReturnArgument(0);
 
         return $this->lng;
     }

--- a/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlPaginationTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlPaginationTest.php
@@ -137,9 +137,7 @@ class ViewControlPaginationTest extends ViewControlTestBase
         $input = $this->createMock(InputData::class);
         $input->expects($this->exactly(2))
             ->method("getOr")
-            ->will(
-                $this->onConsecutiveCalls($v[Pagination::FNAME_OFFSET], $v[Pagination::FNAME_LIMIT])
-            );
+            ->willReturn($v[Pagination::FNAME_OFFSET], $v[Pagination::FNAME_LIMIT]);
 
         $vc = $this->buildVCFactory()->pagination()
             ->withNameFrom($this->getNamesource())

--- a/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlSortationTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlSortationTest.php
@@ -65,9 +65,7 @@ class ViewControlSortationTest extends ViewControlTestBase
         $input = $this->createMock(InputData::class);
         $input->expects($this->exactly(2))
             ->method("getOr")
-            ->will(
-                $this->onConsecutiveCalls($v[0], $v[1])
-            );
+            ->willReturn($v[0], $v[1]);
 
         $vc = $this->buildVCFactory()->sortation($options)
             ->withNameFrom($this->getNamesource())

--- a/components/ILIAS/UI/tests/Component/TriggererTest.php
+++ b/components/ILIAS/UI/tests/Component/TriggererTest.php
@@ -72,8 +72,6 @@ class ILIAS_UI_Component_TriggererTest extends TestCase
         return $this
             ->getMockBuilder(Component\Signal::class)
             ->disableOriginalClone()
-            ->disableArgumentCloning()
-            ->disallowMockingUnknownTypes()
             ->setMockClassName("Signal_" . ((string) self::$signal_mock_counter))
             ->getMock();
     }


### PR DESCRIPTION
…d will be exchanged or removed with PHPUnit v12.

1. remove `MockBuilder::disableArgumentCloning()`
2. remove `MockBuilder::disallowMockingUnknownTypes()`
3. exchange `->will($this->returnCallback())` with `->willReturnCallback()`
4. exchange `->will($this->onConsecutiveCalls())` with `->willReturn()`
5. exchange `->will($this->returnValueMap())` with `->willReturnMap()`
6. exchange `->will($this->returnArgument())` with `->willReturnArgument()`

Regarding following components:

1. Component
2. Data
3. EventHandling
4. LearningSequence
5. Setup
6. StudyProgramme
7. UI