### PR TITLE
UI 45579: Automatically opens back exam modal when test password is wrong

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Launcher/Inline.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Launcher/Inline.php
@@ -135,17 +135,21 @@ class Inline implements C\Launcher\Inline
     {
         $clone = clone $this;
         $clone->request = $request;
+
+        if ($request->getMethod() === 'POST') {
+            $clone->modal = $clone->modal->withRequest($request);
+        }
+
         return $clone;
     }
 
     public function getResult(): ?Result
     {
-        if ($this->request && $this->request->getMethod() == "POST") {
-            $modal = $this->modal->withRequest($this->request);
-            $result = $modal->getForm()->getInputGroup()->getContent();
-            return $result;
+        try {
+            return $this->modal?->getForm()?->getInputGroup()?->getContent();
+        } catch (\Throwable) {
+            return null;
         }
-        return null;
     }
 
     public function getModal(): ?Modal\Roundtrip

--- a/components/ILIAS/UI/src/Implementation/Component/Launcher/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Launcher/Renderer.php
@@ -52,6 +52,10 @@ class Renderer extends AbstractComponentRenderer
         $start_button = $ui_factory->button()->bulky($launch_glyph, $label, (string) $target);
 
         if ($modal = $component->getModal()) {
+            if ($result?->isError()) {
+                $modal = $modal->withOnLoad($modal->getShowSignal());
+            }
+
             if ($modal_submit_lable = $component->getModalSubmitLabel()) {
                 $modal = $modal->withSubmitLabel($modal_submit_lable);
             }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45579

We kindly request these changes as part of the issue mentioned above.

The modal inside of the launcher component also needs to get the current request when calling `withRequest` on the launcher itself. As the modal is an internal property of the launcher there is no other way to pass the current request to it. The request should not be assigned to the modal when calling `getResult` on the launcher because it leads to some side effects. 

Also when the result of a launcher component leads to an error, the modal should be rendered open to display the issue to the user.

If you have any questions regarding the proposed changes please fell free to ask.

These changes are highly related to the following [PR](https://github.com/ILIAS-eLearning/ILIAS/pull/10201).

Best regards
@matheuszych 