### PR TITLE
Admin: Copy perms to new objects & delete perms from adm

### DIFF
--- a/components/ILIAS/Administration/classes/Setup/Objective/CopyPermissions.php
+++ b/components/ILIAS/Administration/classes/Setup/Objective/CopyPermissions.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Administration\Setup\Objective;
+
+use ILIAS\Setup\Environment;
+use ilDatabaseInitializedObjective;
+use ilDBInterface;
+use ilAccessRBACOperationDeletedObjective;
+use ILIAS\Setup\Objective;
+use ilDBConstants;
+
+/**
+ * ALL permissions are copied from the $src_type and all existing permissions are first deleted from $dest_type.
+ * Only rbac_pa is modified.
+ */
+readonly class CopyPermissions implements Objective
+{
+    /**
+     * @param Objective[] $additional_preconditions
+     */
+    public function __construct(private string $src_type, private string $dest_type, private array $additional_preconditions)
+    {
+    }
+
+    public function getHash(): string
+    {
+        return hash("sha256", self::class . $this->src_type . ',' . $this->dest_type);
+    }
+
+    public function getLabel(): string
+    {
+        return sprintf('Copy permissions from %s to %s', $this->src_type, $this->dest_type);
+    }
+
+    public function isNotable(): bool
+    {
+        return true;
+    }
+
+    public function getPreconditions(Environment $environment): array
+    {
+        return [new ilDatabaseInitializedObjective(), ...$this->additional_preconditions];
+    }
+
+    public function achieve(Environment $environment): Environment
+    {
+        $db = $environment->getResource(Environment::RESOURCE_DATABASE);
+        $src_ref_id = $this->firstRefIdOfType($db, $this->src_type);
+        $dest_ref_id = $this->firstRefIdOfType($db, $this->dest_type);
+
+        if (!$src_ref_id || !$dest_ref_id) {
+            return $environment;
+        }
+
+        $db->queryF(
+            'DELETE FROM rbac_pa WHERE ref_id = %s',
+            [ilDBConstants::T_INTEGER],
+            [$dest_ref_id]
+        );
+        $db->manipulateF(
+            'INSERT INTO rbac_pa (ref_id, ops_id, rol_id) SELECT %s AS ref_id, ops_id, rol_id FROM rbac_pa WHERE ref_id = %s',
+            [ilDBConstants::T_INTEGER, ilDBConstants::T_INTEGER],
+            [$dest_ref_id, $src_ref_id]
+        );
+
+        return $environment;
+    }
+
+    public function isApplicable(Environment $environment): bool
+    {
+        $db = $environment->getResource(Environment::RESOURCE_DATABASE);
+        $src_ref = $this->firstRefIdOfType($db, $this->src_type);
+        $ret = null !== $db->fetchAssoc($db->queryF('select 1 from rbac_pa where ref_id = %s', [ilDBConstants::T_INTEGER], [$src_ref]));
+
+        return $ret;
+    }
+
+    private function firstRefIdOfType(ilDBInterface $db, string $type): int
+    {
+        $ref_query = 'SELECT ref_id FROM object_reference AS r INNER JOIN object_data AS o ON r.obj_id = o.obj_id where type = %s';
+        return (int) ($db->fetchAssoc($db->queryF($ref_query, [ilDBConstants::T_TEXT], [$type]))['ref_id'] ?? 0);
+    }
+}

--- a/components/ILIAS/Administration/classes/Setup/Objective/DropPermissions.php
+++ b/components/ILIAS/Administration/classes/Setup/Objective/DropPermissions.php
@@ -80,7 +80,7 @@ readonly class DropPermissions implements Objective
         }
 
         // rbac_pa is not cleanup by ilAccessRBACOperationDeletedObjective::class.
-        $update_row = $db->prepare('UPDATE rbac_pa SET ops_id = ? WHERE ref_id = ?', [ilDBConstants::T_TEXT, ilDBConstants::T_INTEGER]);
+        $update_row = $db->prepare('UPDATE rbac_pa SET ops_id = ? WHERE rol_id = ? AND ref_id = ?', [ilDBConstants::T_TEXT, ilDBConstants::T_INTEGER]);
         $delete_row = $db->prepare('DELETE FROM rbac_pa WHERE rol_id = ? AND ref_id = ?', [ilDBConstants::T_INTEGER, ilDBConstants::T_INTEGER]);
         foreach ($db->fetchAll($db->queryF('SELECT * FROM rbac_pa WHERE ref_id = %s', [ilDBConstants::T_INTEGER], [$ref_id])) as $row) {
             $ops_id = unserialize($row['ops_id'], ['allowed_classes' => false]);
@@ -88,7 +88,7 @@ readonly class DropPermissions implements Objective
             if ($ops_id === []) {
                 $db->execute($delete_row, [$row['rol_id'], $ref_id]);
             } else {
-                $db->execute($update_row, [serialize($ops_id), $ref_id]);
+                $db->execute($update_row, [serialize($ops_id), $row['rol_id'], $ref_id]);
             }
         }
 

--- a/components/ILIAS/Administration/classes/Setup/Objective/DropPermissions.php
+++ b/components/ILIAS/Administration/classes/Setup/Objective/DropPermissions.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Administration\Setup\Objective;
+
+use ILIAS\Setup\Environment;
+use ilIniFilesLoadedObjective;
+use ilDatabaseInitializedObjective;
+use ilIniFile;
+use ilDBInterface;
+use ilAccessRBACOperationDeletedObjective;
+use ILIAS\Setup\Objective;
+use ilDBConstants;
+
+readonly class DropPermissions implements Objective
+{
+    /**
+     * @param int[] $operations
+     * @param Objective[] $additional_preconditions
+     */
+    public function __construct(
+        private string $type,
+        private array $operations,
+        private array $additional_preconditions = []
+    ) {
+    }
+
+    public function getHash(): string
+    {
+        return hash("sha256", self::class . $this->type . ',' . join(',', $this->operations));
+    }
+
+    public function getLabel(): string
+    {
+        return 'Drop permissions ' . join(', ', $this->operations) . ' from ' . $this->type;
+    }
+
+    public function isNotable(): bool
+    {
+        return true;
+    }
+
+    public function getPreconditions(Environment $environment): array
+    {
+        return [
+            new ilDatabaseInitializedObjective(),
+            ...$this->additional_preconditions,
+        ];
+    }
+
+    public function achieve(Environment $environment): Environment
+    {
+        $db = $environment->getResource(Environment::RESOURCE_DATABASE);
+        $operations = $this->operations($environment);
+        $ref_id = $this->firstRefIdOfType($db, $this->type);
+        if (!$ref_id) {
+            return $environment;
+        }
+
+        foreach ($operations as $operation) {
+            $objective = new ilAccessRBACOperationDeletedObjective($this->type, $operation);
+            $objective->achieve($environment);
+        }
+
+        // rbac_pa is not cleanup by ilAccessRBACOperationDeletedObjective::class.
+        $update_row = $db->prepare('UPDATE rbac_pa SET ops_id = ? WHERE ref_id = ?', [ilDBConstants::T_TEXT, ilDBConstants::T_INTEGER]);
+        $delete_row = $db->prepare('DELETE FROM rbac_pa WHERE rol_id = ? AND ref_id = ?', [ilDBConstants::T_INTEGER, ilDBConstants::T_INTEGER]);
+        foreach ($db->fetchAll($db->queryF('SELECT * FROM rbac_pa WHERE ref_id = %s', [ilDBConstants::T_INTEGER], [$ref_id])) as $row) {
+            $ops_id = unserialize($row['ops_id'], ['allowed_classes' => false]);
+            $ops_id = array_values(array_filter($ops_id, fn($op) => !in_array($op, $operations, false)));
+            if ($ops_id === []) {
+                $db->execute($delete_row, [$row['rol_id'], $ref_id]);
+            } else {
+                $db->execute($update_row, [serialize($ops_id), $ref_id]);
+            }
+        }
+
+        return $environment;
+    }
+
+    public function isApplicable(Environment $environment): bool
+    {
+        return $this->operations($environment) !== [];
+    }
+
+    /**
+     * @return int[]
+     */
+    private function operations(Environment $environment): array
+    {
+        $db = $environment->getResource(Environment::RESOURCE_DATABASE);
+
+        $s = $db->query(
+            'SELECT ops_id FROM rbac_ta WHERE ' .
+            $db->in('ops_id', $this->operations, false, ilDBConstants::T_INTEGER) .
+            ' AND typ_id IN (SELECT obj_id FROM object_data WHERE title = ' .
+            $db->quote($this->type, ilDBConstants::T_TEXT) .
+            ' AND type = "typ")'
+        );
+
+        return array_map('intval', array_column($db->fetchAll($s), 'ops_id'));
+    }
+
+    private function firstRefIdOfType(ilDBInterface $db, string $type): int
+    {
+        $ref_query = 'SELECT ref_id FROM object_reference AS r INNER JOIN object_data AS o ON r.obj_id = o.obj_id where type = %s';
+        return (int) ($db->fetchAssoc($db->queryF($ref_query, [ilDBConstants::T_TEXT], [$type]))['ref_id'] ?? 0);
+    }
+}

--- a/components/ILIAS/Administration/classes/Setup/class.ilAdministrationSetupAgent.php
+++ b/components/ILIAS/Administration/classes/Setup/class.ilAdministrationSetupAgent.php
@@ -30,6 +30,10 @@ use ILIAS\Setup\ObjectiveCollection;
 use ilObjGeneralSettings;
 use ilTreeAdminNodeAddedObjective;
 use ilObjServerInfo;
+use ilAccessRBACOperationDeletedObjective;
+use ILIAS\Administration\Setup\Objective\DropPermissions;
+use ILIAS\Administration\Setup\Objective\CopyPermissions;
+use ilObjBenchmark;
 
 /**
  * Class ilAdministrationSetupAgent
@@ -37,8 +41,15 @@ use ilObjServerInfo;
  */
 class ilAdministrationSetupAgent extends NullAgent
 {
+    private const DROP_PERMISSIONS = [
+        1, // ilTreeAdminNodeAddedObjective::RBAC_OP_EDIT_PERMISSIONS,
+        2, // ilTreeAdminNodeAddedObjective::RBAC_OP_VISIBLE,
+        4, // ilTreeAdminNodeAddedObjective::RBAC_OP_WRITE,
+    ];
+
     public function getUpdateObjective(?Config $config = null): Objective
     {
+        $drop_visible = new DropPermissions('adm', [2]); // ilTreeAdminNodeAddedObjective::RBAC_OP_VISIBLE
         return new ObjectiveCollection(
             'Administration',
             true,
@@ -46,7 +57,14 @@ class ilAdministrationSetupAgent extends NullAgent
             new ilTreeAdminNodeAddedObjective(ilObjGeneralSettings::TYPE, 'General Settings'),
             new ilTreeAdminNodeAddedObjective(ilObjServerInfo::TYPE, 'Server Info'),
             new AdminNodesVisibilityRemovedObjective(),
-            new ExternalToolsRemovedObjective()
+            new ExternalToolsRemovedObjective(),
+            // First drop visible then copy permissions then drop all except READ.
+            new DropPermissions('adm', self::DROP_PERMISSIONS, [
+                new CopyPermissions('adm', ilObjGeneralSettings::TYPE, [$drop_visible]),
+                new CopyPermissions('adm', ilObjServerInfo::TYPE, [$drop_visible]),
+                new CopyPermissions('adm', 'cron', [$drop_visible]),
+                new CopyPermissions('adm', ilObjBenchmark::TYPE, [$drop_visible]),
+            ]),
         );
     }
 


### PR DESCRIPTION
This PR is part of the feature request [Unbundling of Admin Permissions](https://docu.ilias.de/go/wiki/wpage_8648_1357).

This PR copies the existing permissions of the system folder to the newly created admin nodes (cron, benchmark, server & system settings).
Additionally all permissions except READ are dropped from the system folder.