### PR TITLE
add approval of testcase manager to assign authorities to curate test…

### DIFF
--- a/docs/development/maintenance.md
+++ b/docs/development/maintenance.md
@@ -50,7 +50,7 @@ say on new test cases and can ask for modifications. They will be the ones
 contacted if there are questions concerning the test cases for a component.
 4. **Authority to (De-)Assign Authorities**: The people listed here are
 authorised to assign and deassign other people to the authorities of a component
-They are the only ones allowed to modify the `maintanance.json` of a component.
+They are the only ones allowed to modify the `maintenance.json` of a component.
 
 Each of these authorities can be held by a different set of people. This means
 that the social organisation of different groups working on different parts of
@@ -91,6 +91,8 @@ assigned to PRs](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/docs/develo
 * The person/people holding the **Authority to (De-)Assign Authorities**
 coordinate assignments of authorities with the Product Manager and the Technical
 Board, who hold a vetoing power over these decisions.
+* If the person holding the **Authority to (De-)Assign Authorities** assigns 
+a new **Authority to Curate Test Cases** the Testcase Management needs to approve the PR. 
 
 # Additional Rules and Guidelines
 * Although the first decision on new features or feature removals in a unit of


### PR DESCRIPTION
… cases. 
This will make sure that the testcase manager is always notified about changes of testcase authorities.