### PR TITLE
Mantis #45743: Redirect to dashboard when user has no access to exercise

### DIFF
--- a/Modules/Exercise/PermanentLink/StaticUrlHandler.php
+++ b/Modules/Exercise/PermanentLink/StaticUrlHandler.php
@@ -20,6 +20,8 @@ declare(strict_types=1);
 
 namespace ILIAS\Exercise\PermanentLink;
 
+use ilDashboardGUI;
+use ilGlobalTemplateInterface;
 use ILIAS\StaticURL\Response\Response;
 use ILIAS\StaticURL\Response\Factory;
 use ILIAS\StaticURL\Handler\BaseHandler;
@@ -141,7 +143,12 @@ class StaticURLHandler extends BaseHandler implements Handler
             if ($exc_domain->user()->isAnonymous() || $exc_domain->user()->getId() == 0) {
                 return $response_factory->loginFirst();
             } else {
-                return $response_factory->cannot();
+                $main_tpl->setOnScreenMessage(
+                    ilGlobalTemplateInterface::MESSAGE_TYPE_FAILURE,
+                    $lng->txt('permission_denied'),
+                    true
+                );
+                $uri = $ctrl->getLinkTargetByClass(ilDashboardGUI::class);
             }
         }
         return $response_factory->can($uri);


### PR DESCRIPTION
This pr fixes https://mantis.ilias.de/view.php?id=45743

When the user has no access to an exercise the user is redirected to the dashboard with a **permission denied** message.

If accepted should be picked into **release_10**, **release_11** & **trunk**.