### PR TITLE
Branch: 10/UI/Mainbar/OffsetHeight/45615 - Fixing calculation of top offset of mainbar

### DIFF
--- a/components/ILIAS/UI/resources/js/MainControls/dist/mainbar.js
+++ b/components/ILIAS/UI/resources/js/MainControls/dist/mainbar.js
@@ -867,7 +867,7 @@ var persistence = function() {
                 return $('.' + css.mainbar);
             },
             getOffsetTop: function() {
-                return this.getElement().offset().top;
+                return (document.querySelector('.il-system-infos').clientHeight + document.querySelector('.header').clientHeight);
             }
         }
     },

--- a/components/ILIAS/UI/resources/js/MainControls/src/mainbar.renderer.js
+++ b/components/ILIAS/UI/resources/js/MainControls/src/mainbar.renderer.js
@@ -160,7 +160,7 @@
                 return $('.' + css.mainbar);
             },
             getOffsetTop: function() {
-                return this.getElement().offset().top;
+                return (document.querySelector('.il-system-infos').clientHeight + document.querySelector('.header').clientHeight);
             }
         }
     },


### PR DESCRIPTION
**Mantis:** https://mantis.ilias.de/view.php?id=45615

**Bug-Description:**
If the screensize height is significant lower than the main menu on the left (...more is displayed), and a request is using an anchor "#anchor" reference in the url. The main menu + content area will be moved underneath the header area. It is not possible to click the top menu items and it is not possible to scroll back to the top of the content.

I set this to major, since on some devices this might make the use, e.g. of the tests, very difficult, e.g. tablets in landscape that are not able to show the full main menu on the left.

**Fix-Description:**
Fixing the calculation in function getOffsetTop() by using the clientHeight of all top elements (header and system-infos)

The fix is ​​identical for all ILIAS branches. I recommend applying the fix to all currently available ILIAS versions.

**Larger Scope**
The fix was implemented using plain JavaScript to avoid using jQuery.