### PR TITLE
10/UI/Panel and Item Listing dl, dt, dd html tags 43814

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Item/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Item/Renderer.php
@@ -326,7 +326,6 @@ class Renderer extends AbstractComponentRenderer
     {
         $props = $component->getProperties();
         if (count($props) > 0) {
-            $cnt = 0;
             foreach ($props as $name => $value) {
                 $name = htmlentities($name);
                 if ($value instanceof Button\Shy || $value instanceof \ILIAS\UI\Component\Symbol\Icon\Icon) {
@@ -336,18 +335,10 @@ class Renderer extends AbstractComponentRenderer
                     //should introduce here htmlentities
                     $value = $value;
                 }
-                $cnt++;
-                if ($cnt % 2 == 1) {
-                    $tpl->setCurrentBlock("property_row");
-                    $tpl->setVariable("PROP_NAME_A", $name);
-                    $tpl->setVariable("PROP_VAL_A", $value);
-                } else {
-                    $tpl->setVariable("PROP_NAME_B", $name);
-                    $tpl->setVariable("PROP_VAL_B", $value);
-                    $tpl->parseCurrentBlock();
-                }
-            }
-            if ($cnt % 2 == 1) {
+
+                $tpl->setCurrentBlock("property_row");
+                $tpl->setVariable("PROP_NAME_A", $name);
+                $tpl->setVariable("PROP_VAL_A", $value);
                 $tpl->parseCurrentBlock();
             }
             $tpl->setCurrentBlock("properties");

--- a/components/ILIAS/UI/src/templates/default/Item/tpl.item_standard.html
+++ b/components/ILIAS/UI/src/templates/default/Item/tpl.item_standard.html
@@ -48,16 +48,11 @@
 			<div class="il-item-audio">{AUDIO}</div><!-- END audio -->
 			<!-- BEGIN properties -->
 			<hr class="il-item-divider" />
+			<dl class="il-item-property-list">
 			<!-- BEGIN property_row -->
-			<div class="row">
-				<div class="col-md-6 il-multi-line-cap-3">
-					<span class="il-item-property-name">{PROP_NAME_A}</span><span class="il-item-property-value">{PROP_VAL_A}</span>
-				</div>
-				<div class="col-md-6 il-multi-line-cap-3">
-					<span class="il-item-property-name">{PROP_NAME_B}</span><span class="il-item-property-value">{PROP_VAL_B}</span>
-				</div>
-			</div>
+				<dt class="il-item-property-name">{PROP_NAME_A}</dt><dd class="il-item-property-value">{PROP_VAL_A}</dd>
 			<!-- END property_row -->
+			</dl>
 			<!-- END properties -->
 			<!-- BEGIN progress_end_with_lead_icon -->
 		</div>

--- a/templates/default/050-layout/_layout_grid-paired-key-value-columns.scss
+++ b/templates/default/050-layout/_layout_grid-paired-key-value-columns.scss
@@ -1,0 +1,49 @@
+////
+/// Create column layouts with multiple unnested pairs of key and value columns in one row
+/// Needed to layout definition lists like <dl><dt></dt><dd></dd>...</dl> where nesting is prohibited.
+/// @group layout-tools
+////
+
+@use "sass:string";
+@use "sass:math";
+@use "../010-settings" as s;
+@use "../050-layout/basics" as l;
+@use "../050-layout/layout_breakpoints" as l-brk;
+
+///
+/// Make container grid (e.g. <dl>)
+/// MUST be the direct parent of the columns
+/// children MUST be pairs of alternating key and value columns
+///
+@mixin make-grid-for-key-value-pairs($number-of-col-pairs-in-row) {
+  display: grid;
+  grid-template-columns: repeat($number-of-col-pairs-in-row, minmax(auto, auto) minmax(math.div(100%, $number-of-col-pairs-in-row * 2), 1fr));
+  column-gap: l.$il-margin-small-horizontal;
+  @include l-brk.on-screen-size(small) {
+    grid-template-columns: minmax(auto, auto) minmax(50%, 1fr);
+  }
+}
+
+///
+/// Make key column (e.g. for <dt>)
+/// Next sibling MUST be value column
+///
+@mixin make-key-column($add-colon: true) {
+  text-align: right;
+  @if $add-colon {
+    &:not(:empty)::after {
+      content: ": "
+    }
+  }
+}
+
+///
+/// Make value column (e.g. for <dd>)
+/// Next sibling (if any) MUST be key column
+///
+@mixin make-value-column($number-of-col-pairs-in-row) {
+  padding-right: l.$il-margin-xxlarge-horizontal; // nudge next pair further away
+  &:nth-of-type(#{string.unquote(#{$number-of-col-pairs-in-row}n)}) {
+    padding-right: 0; // stay flush at the end of the row
+  }
+}

--- a/templates/default/070-components/UI-framework/Item/_ui-component_item.scss
+++ b/templates/default/070-components/UI-framework/Item/_ui-component_item.scss
@@ -1,8 +1,10 @@
+@use "sass:string";
 @use "../../../010-settings/" as *;
 @use "../../../010-settings/legacy-settings/legacy-settings_panel" as *;
 @use "../../../010-settings/legacy-settings/legacy-settings_chart" as *;
 @use "../../../010-settings/legacy-settings/legacy-settings_symbol" as *;
 @use "../../../030-tools/tool_rem-conversion" as *;
+@use "../../../050-layout/layout_grid-paired-key-value-columns" as l-kv-grid;
 @use "../../../050-layout/basics" as *;
 
 //== Item
@@ -36,7 +38,7 @@ $il-item-gap-xs: 1px;
 		.btn-link, a {
 			font-size: inherit;
 			line-height: $il-line-height-base;
-			
+
 			&:focus-visible {
 				display: block;
 			}
@@ -71,18 +73,18 @@ $il-item-gap-xs: 1px;
 		clear: both;
 	}
 
-	.il-item-property-name {
-		font-size: $il-font-size-small;
-		color: $il-text-light-color;
-		overflow: hidden;
-		&:not(:empty):after {
-			content: ": "
+	$pairs-in-row: 2;
+	.il-item-property-list {
+		@include l-kv-grid.make-grid-for-key-value-pairs($pairs-in-row);
+		.il-item-property-name {
+			@include l-kv-grid.make-key-column();
+			font-size: $il-font-size-small;
+			color: $il-text-light-color;
 		}
-	}
-
-	.il-item-property-value {
-		font-size: $il-font-size-small;
-		overflow: hidden;
+		.il-item-property-value {
+			@include l-kv-grid.make-value-column($pairs-in-row);
+			font-size: $il-font-size-small;
+		}
 	}
 
 	.il-chart-progressmeter-box {

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -4952,17 +4952,30 @@ hr.il-divider-with-label {
   font-size: 0.75rem;
   clear: both;
 }
-.il-item .il-item-property-name {
+.il-item .il-item-property-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(auto, auto) minmax(25%, 1fr));
+  column-gap: 6px;
+}
+@media screen and (max-width: 768px) {
+  .il-item .il-item-property-list {
+    grid-template-columns: minmax(auto, auto) minmax(50%, 1fr);
+  }
+}
+.il-item .il-item-property-list .il-item-property-name {
+  text-align: right;
   font-size: 0.75rem;
   color: #6f6f6f;
-  overflow: hidden;
 }
-.il-item .il-item-property-name:not(:empty):after {
+.il-item .il-item-property-list .il-item-property-name:not(:empty)::after {
   content: ": ";
 }
-.il-item .il-item-property-value {
+.il-item .il-item-property-list .il-item-property-value {
+  padding-right: 15px;
   font-size: 0.75rem;
-  overflow: hidden;
+}
+.il-item .il-item-property-list .il-item-property-value:nth-of-type(2n) {
+  padding-right: 0;
 }
 .il-item .il-chart-progressmeter-box {
   max-width: 80px;


### PR DESCRIPTION
# Issue

https://mantis.ilias.de/view.php?id=43814

Properties in UI Items (used in many places e.g the UI Panel) are not accessibly marked as definition pairs in the DOM.

# Changes

* simplified DOM and php rendering to get the most clear, best practice DOM structure
```html
<dl>
  <dt>Key 1</dt>
  <dd>Value 1</dd>
  <dt>Key 2</dt>
  <dd>Value 2</dd>
  <dt>Key 4</dt>
  <dd>Value 4</dd>
</dl>
``` 
* this is a huge problem for styling as a pair cannot be nested. This makes it hard for CSS to know which two columns belong together and can't be seperated by a line break. Therefor, I introduced a new layout tool which does the heavy lifting of layouting everything in individual columns of a CSS grid, but keeps pairs always together.

This is how it looks now:
<img width="896" height="164" alt="image" src="https://github.com/user-attachments/assets/14db2083-1f72-43ce-85d9-50d6e1f5ba9d" />

Mobile
<img width="352" height="190" alt="image" src="https://github.com/user-attachments/assets/6faac1bf-ffd4-4775-9fe3-65ee4ec0fc21" />


Some edge cases:
<img width="707" height="238" alt="image" src="https://github.com/user-attachments/assets/c1820e63-a502-4cc4-b912-97610098dc81" />

<img width="897" height="243" alt="image" src="https://github.com/user-attachments/assets/f96ff6e6-f5f3-47a7-a33e-8386d69293e2" />

# Outlook

* All key value properties in columns in ILIAS should probably be moved to use this DOM structure and layouting tool
* More property locations should be able to not render keys visibly (Status: offline) but still optionally serve them as aria labels.
* I will fix the Unit Tests if this approach is approved