### PR TITLE
T&A 45598: Fixes entering non-numeric characters for 'Points' results in Whoops error

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssAnswerCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssAnswerCorrectionsInputGUI.php
@@ -41,6 +41,10 @@ class ilAssAnswerCorrectionsInputGUI extends ilAnswerWizardInputGUI
     public function setValue($a_value): void
     {
         foreach ($this->forms_helper->transformPoints($a_value) as $index => $value) {
+            if ($value === null) {
+                return;
+            }
+
             $this->values[$index]->setPoints($value);
         }
     }

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssClozeTestCombinationVariantsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssClozeTestCombinationVariantsInputGUI.php
@@ -29,6 +29,10 @@ class ilAssClozeTestCombinationVariantsInputGUI extends ilAnswerWizardInputGUI
     public function setValue($a_value): void
     {
         foreach ($this->forms_helper->transformPoints($a_value) as $index => $value) {
+            if ($value === null) {
+                return;
+            }
+
             $this->values[$index]['points'] = $value;
         }
     }

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssErrorTextCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssErrorTextCorrectionsInputGUI.php
@@ -29,6 +29,10 @@ class ilAssErrorTextCorrectionsInputGUI extends ilErrorTextWizardInputGUI
     public function setValue($a_value): void
     {
         foreach ($this->forms_helper->transformPoints($a_value) as $index => $points) {
+            if ($points === null) {
+                return;
+            }
+
             $this->values[$index] = $this->values[$index]->withPoints($points);
         }
     }

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssMatchingPairCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssMatchingPairCorrectionsInputGUI.php
@@ -40,6 +40,10 @@ class ilAssMatchingPairCorrectionsInputGUI extends ilMatchingPairWizardInputGUI
     public function setValue($a_value): void
     {
         foreach ($this->forms_helper->transformPoints($a_value) as $index => $value) {
+            if ($value === null) {
+                return;
+            }
+
             $this->pairs[$index] = $this->pairs[$index]->withPoints($value);
         }
     }

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssMultipleChoiceCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssMultipleChoiceCorrectionsInputGUI.php
@@ -37,6 +37,10 @@ class ilAssMultipleChoiceCorrectionsInputGUI extends ilMultipleChoiceWizardInput
         $points_unchecked = $this->forms_helper->transformPoints($a_value, 'points_unchecked');
 
         foreach ($this->values as $index => $value) {
+            if ($value === null) {
+                return;
+            }
+
             $this->values[$index]->setPoints($points[$index] ?? 0.0);
             $this->values[$index]->setPointsUnchecked($points_unchecked[$index] ?? 0.0);
         }

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssSingleChoiceCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssSingleChoiceCorrectionsInputGUI.php
@@ -34,6 +34,10 @@ class ilAssSingleChoiceCorrectionsInputGUI extends ilSingleChoiceWizardInputGUI
     public function setValue($a_value): void
     {
         foreach ($this->forms_helper->transformPoints($a_value) as $index => $value) {
+            if ($value === null) {
+                return;
+            }
+
             $this->values[$index]->setPoints($value);
         }
     }

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilImagemapCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilImagemapCorrectionsInputGUI.php
@@ -37,6 +37,10 @@ class ilImagemapCorrectionsInputGUI extends ilImagemapFileInputGUI
         $points_unchecked = $this->forms_helper->transformPoints($a_areas, 'points_unchecked');
 
         foreach (array_keys($this->areas) as $index) {
+            if ($points[$index] === null) {
+                return;
+            }
+
             $points_unchecked[$index] = $this->getPointsUncheckedFieldEnabled() && isset($points_unchecked[$index])
                 ? $points_unchecked[$index] : 0.0;
 


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45598

This PR aims to resolve the problem that non-numeric input values submitted in the correction of points GUI result in an error.

I'm not entirely happy with the solution because putting `is_numeric` checks in each problematic `foreach` doesn't seem like the right place to me. I haven't found any better central place to do this either. The `string_replace` which is the part that causes the crash, gets executed in `->setPoints` and before the form even has the chance to check if the value provided is non-numeric. Feedback is greatly appreciated.

Kind Regards,
@bidzanaaron 