### PR TITLE
T&A Generate question pool filter id based on ref_id

### DIFF
--- a/components/ILIAS/Test/classes/Tables/class.ilTestQuestionBrowserTableGUI.php
+++ b/components/ILIAS/Test/classes/Tables/class.ilTestQuestionBrowserTableGUI.php
@@ -115,11 +115,12 @@ class ilTestQuestionBrowserTableGUI
 
     private function getQuestionsBrowserFilterComponent(string $parent_title = '', string $action = ''): Filter
     {
+        $ref_id = $this->testrequest->getRefId();
         return (new QuestionsBrowserFilter(
             $this->ui_service,
             $this->lng,
             $this->ui_factory,
-            'question_browser_filter',
+            "question_browser_filter_$ref_id",
             $parent_title
         ))->getComponent($action, $this->http_state->request());
     }

--- a/components/ILIAS/Test/src/Logging/LogTable.php
+++ b/components/ILIAS/Test/src/Logging/LogTable.php
@@ -98,7 +98,7 @@ class LogTable implements Table\DataRetrieval
     {
         return $this->ui_factory->table()->data(
             $this->lng->txt('history'),
-            $this->getColums(),
+            $this->getColumns(),
             $this
         )->withActions($this->getActions());
     }
@@ -150,7 +150,7 @@ class LogTable implements Table\DataRetrieval
         $active = array_fill(0, count($filter_inputs), true);
 
         $this->filter = $this->ui_service->filter()->standard(
-            'log_table_filter_id',
+            "log_table_filter_id_$this->ref_id",
             $this->unmaskCmdNodesFromBuilder($this->url_builder->buildURI()->__toString()),
             $filter_inputs,
             $active,
@@ -160,7 +160,7 @@ class LogTable implements Table\DataRetrieval
     }
 
 
-    private function getColums(): array
+    private function getColumns(): array
     {
         $f = $this->ui_factory->table()->column();
 

--- a/components/ILIAS/Test/src/Participants/ParticipantTable.php
+++ b/components/ILIAS/Test/src/Participants/ParticipantTable.php
@@ -258,8 +258,9 @@ class ParticipantTable implements DataRetrieval
             [$filter_inputs[$filter_id], $is_input_initially_rendered[$filter_id]] = $filter;
         }
 
+        $ref_id = $this->test_request->getRefId();
         return $this->ui_service->filter()->standard(
-            'participant_filter',
+            "participant_filter_$ref_id",
             $action,
             $filter_inputs,
             $is_input_initially_rendered,

--- a/components/ILIAS/Test/src/Scoring/Manual/ScoringByQuestionTable.php
+++ b/components/ILIAS/Test/src/Scoring/Manual/ScoringByQuestionTable.php
@@ -48,7 +48,8 @@ class ScoringByQuestionTable
         private readonly URLBuilder $url_builder,
         private URLBuilderToken $action_parameter_token,
         private URLBuilderToken $row_id_token,
-        private readonly UIFactory $ui_factory
+        private readonly UIFactory $ui_factory,
+        private readonly string $filter_id
     ) {
     }
 
@@ -141,7 +142,7 @@ class ScoringByQuestionTable
         $active = array_fill(0, count($filter_inputs), true);
 
         $filter = $ui_service->filter()->standard(
-            'scoring_by_qst_filter_id',
+            $this->filter_id,
             $target_url,
             $filter_inputs,
             $active,

--- a/components/ILIAS/Test/src/Scoring/Manual/class.TestScoringByQuestionGUI.php
+++ b/components/ILIAS/Test/src/Scoring/Manual/class.TestScoringByQuestionGUI.php
@@ -117,7 +117,8 @@ class TestScoringByQuestionGUI extends TestScoringByParticipantGUI
             $this->url_builder,
             $this->action_parameter_token,
             $this->row_id_token,
-            $this->ui_factory
+            $this->ui_factory,
+            "scoring_by_qst_filter_id_$question_id"
         );
 
         if ($this->testrequest->strVal($this->action_parameter_token->getName()) === ScoringByQuestionTable::ACTION_SCORING) {

--- a/components/ILIAS/TestQuestionPool/src/Questions/Presentation/QuestionTable.php
+++ b/components/ILIAS/TestQuestionPool/src/Questions/Presentation/QuestionTable.php
@@ -62,7 +62,7 @@ class QuestionTable extends \ilAssQuestionList implements Table\DataRetrieval
     {
         return $this->ui_factory->table()->data(
             $this->lng->txt('questions'),
-            $this->getColums(),
+            $this->getColumns(),
             $this
         )
         ->withActions($this->getActions())
@@ -147,7 +147,7 @@ class QuestionTable extends \ilAssQuestionList implements Table\DataRetrieval
     }
 
 
-    public function getColums(): array
+    public function getColumns(): array
     {
         $f = $this->ui_factory->table()->column();
         $df = $this->data_factory->dateFormat();

--- a/components/ILIAS/TestQuestionPool/src/Questions/Presentation/QuestionTable.php
+++ b/components/ILIAS/TestQuestionPool/src/Questions/Presentation/QuestionTable.php
@@ -136,7 +136,7 @@ class QuestionTable extends \ilAssQuestionList implements Table\DataRetrieval
         $active = array_fill(0, count($filter_inputs), true);
 
         $filter = $ui_service->filter()->standard(
-            'question_table_filter_id',
+            "question_table_filter_$this->request_ref_id",
             $action,
             $filter_inputs,
             $active,


### PR DESCRIPTION
Hey,

This PR addresses an issue observed during testing.
The filter state for question pool tables was shared across all question pools, leading to unexpected behavior.
With this PR, a unique ID is used per ref_id to separate the filter state for each repository object.

Best Regards,
@thojou 