### PR TITLE
LegalDocuments: Check country criteria against `ilObjUser::getSelectedCountry` (9)

### DIFF
--- a/Services/LegalDocuments/classes/Condition/UserCountry.php
+++ b/Services/LegalDocuments/classes/Condition/UserCountry.php
@@ -48,7 +48,7 @@ class UserCountry implements Condition
 
     public function eval(ilObjUser $user): bool
     {
-        return strtoupper($user->getCountry()) === strtoupper($this->criterion->arguments()['country']);
+        return strtoupper($user->getSelectedCountry()) === strtoupper($this->criterion->arguments()['country']);
     }
 
     public function definition(): ConditionDefinition

--- a/Services/LegalDocuments/test/Condition/UserCountryTest.php
+++ b/Services/LegalDocuments/test/Condition/UserCountryTest.php
@@ -66,7 +66,7 @@ class UserCountryTest extends TestCase
             $this->mock(UIFactory::class)
         );
 
-        $this->assertTrue($instance->eval($this->mockTree(ilObjUser::class, ['getCountry' => 'foo'])));
+        $this->assertTrue($instance->eval($this->mockTree(ilObjUser::class, ['getSelectedCountry' => 'foo'])));
     }
 
     public function testDefinition(): void


### PR DESCRIPTION
This PR fixes Mantis Bug: https://mantis.ilias.de/view.php?id=45994

Instead of `ilObjUser::getCountry` now `ilObjUser::getSelectedCountry` is used to check against the criteria country.