### PR TITLE
10/legacy-ui/repository-object-list as actual ul/li tag list 33589

### DIFF
--- a/components/ILIAS/Container/templates/default/tpl.container_list_block.html
+++ b/components/ILIAS/Container/templates/default/tpl.container_list_block.html
@@ -15,30 +15,30 @@
 		<div class="pull-right">{CHR_COMMANDS}</div>
 	</div>
 	<!-- END container_header_row -->
-	<div class="ilContainerItemsContainer <!-- BEGIN container_items_hide -->ilNoDisplay<!-- END container_items_hide -->">
+	<ul class="ilContainerItemsContainer <!-- BEGIN container_items_hide -->ilNoDisplay<!-- END container_items_hide -->">
 		<!-- BEGIN tile_rows --><div class="ilContainerTileRows">{TILE_ROWS}</div><!-- END tile_rows -->
 		<!-- BEGIN container_row -->
 		<!-- BEGIN container_standard_row -->
 		<!-- BEGIN row -->
-		<div {ROW_ID} class="ilCLI ilObjListRow">
+		<li {ROW_ID} class="ilCLI ilObjListRow">
 		<!-- END row -->
 			{BLOCK_ROW_CONTENT}
-		</div>
+		</li>
 		<!-- END container_standard_row -->
 
 		<!-- BEGIN container_details_row -->
-		<div class="tblfooter row il_BlockInfo">
+		<li class="tblfooter row il_BlockInfo">
 			{TXT_DETAILS}:
 			<!-- BEGIN details_img -->
 			<a href="{DETAILS_LINK}"><img src="{DETAILS_SRC}" alt="{DETAILS_ALT}" title="{DETAILS_ALT}" /></a>
 			<!-- END details_img -->
-		</div>
+		</li>
 		<!-- END container_details_row -->
 		<!-- END container_row -->
 		<!-- BEGIN show_more -->
-			<div class="ilContainerShowMore">{SHOW_MORE_BUTTON}</div>
+			<li class="ilContainerShowMore">{SHOW_MORE_BUTTON}</li>
 		<!-- END show_more -->
-	</div>
+	</ul>
 	<!-- BEGIN select_all_row -->
 	<div class="tblfooter row ilContainerListFooter">
 		<input type="checkbox" name="{CHECKBOXNAME}" id="{CHECKBOXNAME}" value="1" onClick="javascript:il.Util.setChecked('{SEL_ALL_PARENT}', '{SEL_ALL_CB_NAME}', this.checked);" />

--- a/templates/default/070-components/legacy/Services/_component_container.scss
+++ b/templates/default/070-components/legacy/Services/_component_container.scss
@@ -29,6 +29,12 @@ div.ilContainerListItemOuter {
 	}
 }
 
+.ilContainerItemsContainer {
+	padding: 0;
+	margin: 0;
+	list-style: none;
+}
+
 div.tblfooter {
 	&.ilContainerListFooter {
 		font-size: $il-font-size-base;


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=33589

# Issue

Object list accessibility suffers because they are not actually marked as real html `<ul><li>`.

# Changes

Edited html template for a structure with `<ul>` and `<li>` elements

# Outlook

We have many more of these items and object lists not actually using list elements in the DOM.
But these UI components already do it correctly: Item Group, Listing Entity... so that's great :)