### PR TITLE
Search: Put Select-Option First

### DIFF
--- a/components/ILIAS/Search/classes/class.ilUserSearchOptions.php
+++ b/components/ILIAS/Search/classes/class.ilUserSearchOptions.php
@@ -118,14 +118,13 @@ class ilUserSearchOptions
 
                 case 'country':
                     $fields[$counter]['type'] = self::FIELD_TYPE_SELECT;
-                    $fields[$counter]['values'] = array(0 => $lng->txt('please_choose'));
 
                     // #7843 -- see ilCountrySelectInputGUI
                     $lng->loadLanguageModule('meta');
                     foreach (ilCountry::getCountryCodes() as $c) {
                         $fields[$counter]['values'][$c] = $lng->txt('meta_c_' . $c);
                     }
-                    asort($fields[$counter]['values']);
+                    array_unshift($fields[$counter]['values'], $lng->txt('please_choose'));
                     break;
 
                 case 'org_units':


### PR DESCRIPTION
Hi @smeyer-ilias 

This would put the unmarked option first in the country selection in advanced user search.

See: https://mantis.ilias.de/view.php?id=46103

Please pick back to ILIAS 10, if accepted.

Best,
@kergomard 