### PR TITLE
T&A 46065: Numeric value out of range "ILIAS\Test\Setup\TestSetupAgent.MoveTestSettingsMigration"

### DIFF
--- a/components/ILIAS/Test/src/Setup/MoveTestSettingsMigration.php
+++ b/components/ILIAS/Test/src/Setup/MoveTestSettingsMigration.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace ILIAS\Test\Setup;
 
 use ILIAS\Setup;
+use ILIAS\Setup\CLI\IOWrapper;
 use ILIAS\Setup\Environment;
 use ILIAS\Setup\Migration;
 
@@ -29,6 +30,7 @@ class MoveTestSettingsMigration implements Migration
     use TestSettingsSetup;
 
     private \ilDBInterface $db;
+    private IOWrapper $io;
 
     public function getLabel(): string
     {
@@ -48,6 +50,7 @@ class MoveTestSettingsMigration implements Migration
     public function prepare(Environment $environment): void
     {
         $this->db = $environment->getResource(Setup\Environment::RESOURCE_DATABASE);
+        $this->io = $environment->getResource(Setup\Environment::RESOURCE_ADMIN_INTERACTION);
     }
 
     public function step(Environment $environment): void
@@ -66,6 +69,12 @@ class MoveTestSettingsMigration implements Migration
 
                 if ($column_name === 'reporting_date') {
                     $value = $this->convertLegacyDate($value);
+                }
+                if ($column_name === 'nr_of_tries' && $value > 127) {
+                    $this->io->inform(
+                        "ID {$settings_id}: Tried to set nr_of_tries to {$value}, which is too high. Setting it to 127 instead."
+                    );
+                    $value = 127;
                 }
 
                 // Convert legacy null values to 0

--- a/components/ILIAS/Test/src/Setup/Test11DBUpdateSteps.php
+++ b/components/ILIAS/Test/src/Setup/Test11DBUpdateSteps.php
@@ -147,4 +147,12 @@ class Test11DBUpdateSteps implements \ilDatabaseUpdateSteps
             );
         }
     }
+
+    public function step_3(): void
+    {
+        $columns = ['reporting_date', 'starting_time', 'ending_time'];
+        foreach ($columns as $column) {
+            $this->db->modifyTableColumn('tst_test_settings', $column, ['length' => 8]);
+        }
+    }
 }

--- a/components/ILIAS/Test/src/Setup/TestSettingsSetup.php
+++ b/components/ILIAS/Test/src/Setup/TestSettingsSetup.php
@@ -39,7 +39,7 @@ trait TestSettingsSetup
         'fixed_participants' => [T_BOOLEAN, 'fixed_participants'],
         'suspend_test_allowed' => [T_BOOLEAN, 'ShowCancel'],
         'anonymity' => [T_BOOLEAN, 'Anonymity'],
-        'nr_of_tries' => [T_BIGINT, 'NrOfTries'],
+        'nr_of_tries' => [T_TINYINT, 'NrOfTries'],
         'use_previous_answers' => [T_BOOLEAN, 'use_previous_answers'],
         'title_output' => [T_TINYINT, 'TitleOutput'],
         'processing_time' => [['type' => \ilDBConstants::T_TEXT, 'length' => 8, 'default' => null], 'ProcessingTime'],

--- a/components/ILIAS/Test/src/Setup/TestSettingsSetup.php
+++ b/components/ILIAS/Test/src/Setup/TestSettingsSetup.php
@@ -22,7 +22,8 @@ namespace ILIAS\Test\Setup;
 
 const T_BOOLEAN = ['type' => \ilDBConstants::T_INTEGER, 'length' => 1, 'default' => 0];
 const T_TINYINT = ['type' => \ilDBConstants::T_INTEGER, 'length' => 4, 'default' => 0];
-const T_BIGINT = ['type' => \ilDBConstants::T_INTEGER, 'default' => 0];
+const T_INT = ['type' => \ilDBConstants::T_INTEGER, 'default' => 0];
+const T_BIGINT = ['type' => \ilDBConstants::T_INTEGER, 'default' => 0, 'length' => 8];
 
 const LEGACY_STORAGE_DATE_FORMAT = 'YmdHis';
 
@@ -38,7 +39,7 @@ trait TestSettingsSetup
         'fixed_participants' => [T_BOOLEAN, 'fixed_participants'],
         'suspend_test_allowed' => [T_BOOLEAN, 'ShowCancel'],
         'anonymity' => [T_BOOLEAN, 'Anonymity'],
-        'nr_of_tries' => [['type' => \ilDBConstants::T_INTEGER, 'length' => 8, 'default' => 0], 'NrOfTries'],
+        'nr_of_tries' => [T_BIGINT, 'NrOfTries'],
         'use_previous_answers' => [T_BOOLEAN, 'use_previous_answers'],
         'title_output' => [T_TINYINT, 'TitleOutput'],
         'processing_time' => [['type' => \ilDBConstants::T_TEXT, 'length' => 8, 'default' => null], 'ProcessingTime'],
@@ -51,12 +52,12 @@ trait TestSettingsSetup
         'pass_scoring' => [T_TINYINT, 'PassScoring'],
         'password' => [['type' => \ilDBConstants::T_TEXT, 'length' => 20, 'default' => null], 'password'],
         'results_presentation' => [['type' => \ilDBConstants::T_INTEGER, 'default' => 3], 'ResultsPresentation'],
-        'usr_pass_overview_mode' => [T_BIGINT, 'ListOfQuestionsSettings'],
+        'usr_pass_overview_mode' => [T_INT, 'ListOfQuestionsSettings'],
         'show_marker' => [T_BOOLEAN, 'ShowMarker'],
-        'kiosk' => [T_BIGINT, 'Kiosk'],
+        'kiosk' => [T_INT, 'Kiosk'],
         'finalstatement' => [['type' => \ilDBConstants::T_TEXT, 'length' => 4000, 'default' => null], null],
         'showfinalstatement' => [T_BOOLEAN, 'ShowFinalStatement'],
-        'exportsettings' => [T_BIGINT, null],
+        'exportsettings' => [T_INT, null],
         'print_bs_with_res' => [['type' => \ilDBConstants::T_INTEGER, 'length' => 1, 'default' => 0], 'show_solution_list_comparison'],
         'highscore_enabled' => [T_BOOLEAN, 'highscore_enabled'],
         'highscore_anon' => [T_BOOLEAN, 'highscore_anon'],
@@ -66,10 +67,10 @@ trait TestSettingsSetup
         'highscore_wtime' => [T_BOOLEAN, 'highscore_wtime'],
         'highscore_own_table' => [T_BOOLEAN, 'highscore_own_table'],
         'highscore_top_table' => [T_BOOLEAN, 'highscore_top_table'],
-        'highscore_top_num' => [T_BIGINT, 'highscore_top_num'],
+        'highscore_top_num' => [T_INT, 'highscore_top_num'],
         'specific_feedback' => [T_BOOLEAN, 'SpecificAnswerFeedback'],
         'autosave' => [T_BOOLEAN, 'autosave'],
-        'autosave_ival' => [T_BIGINT, 'autosave_ival'],
+        'autosave_ival' => [T_INT, 'autosave_ival'],
         'pass_deletion_allowed' => [T_BOOLEAN, 'pass_deletion_allowed'],
         'redirection_mode' => [T_TINYINT, 'redirection_mode'],
         'redirection_url' => [['type' => \ilDBConstants::T_TEXT, 'length' => 4000, 'default' => null], 'redirection_url'],


### PR DESCRIPTION
Hi everyone,

In this PR, I am addressing the issue described in [46065](https://mantis.ilias.de/view.php?id=46065), where migrations for the test settings are failing. I suspect that this is caused by an overflow in the `reporting_date` column. The problem could be related to Y2038 and occur when the Unix timestamp to store becomes too large. To counteract this problem, I introduced the [BIGINT](https://mariadb.com/docs/server/reference/data-types/numeric-data-types/bigint) data type for all timestamp-related columns.

I look forward to your review and feedback on this proposal.

Best
@lukas-heinrich 