### PR TITLE
FIX 0045992: Breadcrumb: Missing Expand Glyph for small screens

### DIFF
--- a/templates/default/070-components/UI-framework/Layout/_ui-component_standardpage.scss
+++ b/templates/default/070-components/UI-framework/Layout/_ui-component_standardpage.scss
@@ -363,6 +363,7 @@ footer {
 			white-space: nowrap;
 			overflow: hidden;
 			text-overflow: ellipsis;
+			display: inline-block;
 			&:before {
 			    content: " \e606";
 			    font-family: "il-icons";

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -5036,6 +5036,7 @@ footer {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    display: inline-block;
   }
   .il-header-locator .dropdown-toggle:before {
     content: " \e606";


### PR DESCRIPTION
This PR resolves https://mantis.ilias.de/view.php?id=45992 by correcting the display of the expand glyph and ellipse.

<img width="857" height="364" alt="Bildschirmfoto 2025-11-05 um 17 43 10" src="https://github.com/user-attachments/assets/98b91428-bf36-4420-86d6-da3ff9d7c083" />
