### PR TITLE
[FIX] read other components that components/ILIAS

### DIFF
--- a/components/ILIAS/Component/classes/Setup/class.ilComponentInfoDefinitionProcessor.php
+++ b/components/ILIAS/Component/classes/Setup/class.ilComponentInfoDefinitionProcessor.php
@@ -60,6 +60,8 @@ class ilComponentInfoDefinitionProcessor implements ilComponentDefinitionProcess
             $type = "components/ILIAS";
         } elseif ($name === "pluginslot") {
             $type = null;
+        } elseif ($name === "component") {
+            $type = $attributes["type"] ?? null;
         } else {
             return;
         }

--- a/components/ILIAS/Component/classes/class.ilComponentDefinitionReader.php
+++ b/components/ILIAS/Component/classes/class.ilComponentDefinitionReader.php
@@ -114,11 +114,17 @@ class ilComponentDefinitionReader
      */
     protected function getComponents(): \Iterator
     {
-        foreach ($this->getComponentInfo("components/ILIAS", "module.xml") as $i) {
-            yield $i;
-        }
-        foreach ($this->getComponentInfo("components/ILIAS", "service.xml") as $i) {
-            yield $i;
+        foreach (glob("components/*") as $component_namespace) {
+            $short_namespace = basename($component_namespace);
+            foreach ($this->getComponentInfo("components/" . $short_namespace, "module.xml") as $i) {
+                yield $i;
+            }
+            foreach ($this->getComponentInfo("components/" . $short_namespace, "service.xml") as $i) {
+                yield $i;
+            }
+            foreach ($this->getComponentInfo("components/" . $short_namespace, "component.xml") as $i) {
+                yield $i;
+            }
         }
     }
 

--- a/components/ILIAS/Component/classes/class.ilComponentInfo.php
+++ b/components/ILIAS/Component/classes/class.ilComponentInfo.php
@@ -43,7 +43,7 @@ class ilComponentInfo
         string $name,
         array &$pluginslots
     ) {
-        if (!in_array($type, self::TYPES)) {
+        if (!in_array($type, self::TYPES) && preg_match('/components\/(.+)/', $type) !== 1) {
             throw new \InvalidArgumentException(
                 "Invalid component type: $type"
             );


### PR DESCRIPTION
We are experimenting with rewriting the first plugins as components, possibly already for ILIAS 10. At present, however, this is still quite limited because, for example, information that is currently still in service.xml or module.xml in ILIAS 10 cannot be read. I know that these are supposed to be phased out, but I believe that they will still be with us for a while...

The following PR would make this possible. However, it introduces a component.xml (or rather, it takes one into account). Unfortunately, I have not been able to get it to work any other way because a lot of things are still ‘hard-wired’.