### PR TITLE
User/NewAccountMail: Fix encoding of `{{` and `}}`

### DIFF
--- a/components/ILIAS/User/src/Settings/NewAccountMail/class.SettingsGUI.php
+++ b/components/ILIAS/User/src/Settings/NewAccountMail/class.SettingsGUI.php
@@ -165,9 +165,7 @@ class SettingsGUI
                             $this->buildConvertCurlyBracesTrafo()
                         )->withAdditionalTransformation(
                             $this->buildValidateMailBodyConstraint()
-                        )->withValue(
-                            $this->convertCurlyBracesForFormOutput($account_mail->getSubject())
-                        ),
+                        )->withValue($this->convertCurlyBracesForFormOutput($account_mail->getSubject())),
                     'salutation_none_specific' => $ff->text($this->lng->txt('mail_salutation_general'))
                         ->withValue($account_mail->getSalutationNoneSpecific()),
                     'salutation_female' => $ff->text($this->lng->txt('mail_salutation_female'))
@@ -179,9 +177,7 @@ class SettingsGUI
                             $this->buildConvertCurlyBracesTrafo()
                         )->withAdditionalTransformation(
                             $this->buildValidateMailBodyConstraint()
-                        )->withValue(
-                            $this->convertCurlyBracesForFormOutput($account_mail->getBody())
-                        ),
+                        )->withValue($account_mail->getBody()),
                     'attachment' => $ff->file($this->upload_handler_gui, $this->lng->txt('attachment'))
                         ->withValue(
                             $account_mail->getAttachmentRid() === null
@@ -210,7 +206,7 @@ class SettingsGUI
                 try {
                     $this->mail_mustache_factory->getBasicEngine()->render($v, []);
                     return true;
-                } catch (Exception) {
+                } catch (\Exception) {
                     return false;
                 }
             },


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=46142

If approved, this must be picked to `release_11` as well.