### PR TITLE
[FIX] #46031 UI: update `Component\Triggerer` JS binding order.

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Button/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Button/Renderer.php
@@ -37,6 +37,9 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
+        if ($component instanceof Component\Triggerer) {
+            $component = $this->addTriggererOnLoadCode($component);
+        }
         if ($component instanceof Component\Button\Close) {
             return $this->renderClose($component);
         } elseif ($component instanceof Component\Button\Minimize) {

--- a/components/ILIAS/UI/src/Implementation/Component/Card/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Card/Renderer.php
@@ -39,6 +39,9 @@ class Renderer extends AbstractComponentRenderer
             $this->cannotHandleComponent($component);
         }
 
+        /** @var $component Component\Card\Card */
+        $component = $this->addTriggererOnLoadCode($component);
+
         $tpl = $this->getTemplate("tpl.card.html", true, true);
 
         $title = $component->getTitle();

--- a/components/ILIAS/UI/src/Implementation/Component/Dropdown/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Dropdown/Renderer.php
@@ -34,6 +34,9 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
+        if ($component instanceof Component\Triggerer) {
+            $component = $this->addTriggererOnLoadCode($component);
+        }
         if ($component instanceof Component\Dropdown\Dropdown) {
             return $this->renderDropdown($component, $default_renderer);
         }

--- a/components/ILIAS/UI/src/Implementation/Component/Dropzone/File/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Dropzone/File/Renderer.php
@@ -37,6 +37,9 @@ class Renderer extends AbstractComponentRenderer
 {
     public function render(Component $component, RenderInterface $default_renderer): string
     {
+        if ($component instanceof \ILIAS\UI\Component\Triggerer) {
+            $component = $this->addTriggererOnLoadCode($component);
+        }
         if ($component instanceof \ILIAS\UI\Component\Dropzone\File\Wrapper) {
             return $this->renderWrapper($component, $default_renderer);
         }

--- a/components/ILIAS/UI/src/Implementation/Component/Image/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Image/Renderer.php
@@ -40,6 +40,9 @@ class Renderer extends AbstractComponentRenderer
             $this->cannotHandleComponent($component);
         }
 
+        /** @var $component Component\Image\Image */
+        $component = $this->addTriggererOnLoadCode($component);
+
         $tpl = $this->getTemplate("tpl.image.html", true, true);
 
         if (($sources = $component->getAdditionalHighResSources()) !== []) {

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/FilterContextRenderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/FilterContextRenderer.php
@@ -42,6 +42,9 @@ class FilterContextRenderer extends Renderer
 
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
+        if ($component instanceof Component\Triggerer) {
+            $component = $this->addTriggererOnLoadCode($component);
+        }
         if ($component instanceof FilterInput) {
             $component = $this->setSignals($component);
         }

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
@@ -87,6 +87,10 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
+        if ($component instanceof Component\Triggerer) {
+            $component = $this->addTriggererOnLoadCode($component);
+        }
+
         $component = $this->setSignals($component);
 
         switch (true) {

--- a/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/Renderer.php
@@ -37,6 +37,10 @@ class Renderer extends AbstractComponentRenderer
 
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
+        if ($component instanceof Component\Triggerer) {
+            $component = $this->addTriggererOnLoadCode($component);
+        }
+
         switch (true) {
             case ($component instanceof FieldSelection):
                 return $this->renderFieldSelection($component, $default_renderer);

--- a/components/ILIAS/UI/src/Implementation/Component/MainControls/Slate/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/MainControls/Slate/Renderer.php
@@ -34,6 +34,9 @@ class Renderer extends AbstractComponentRenderer
             $this->cannotHandleComponent($component);
         }
 
+        /** @var $component ISlate\slate */
+        $component = $this->addTriggererOnLoadCode($component);
+
         switch (true) {
             case ($component instanceof ISlate\Notification):
                 return $this->renderNotificationSlate($component, $default_renderer);

--- a/components/ILIAS/UI/src/Implementation/Component/Modal/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Modal/Renderer.php
@@ -44,6 +44,9 @@ class Renderer extends AbstractComponentRenderer
             $this->cannotHandleComponent($component);
         }
 
+        /** @var $component Component\Modal\Modal */
+        $component = $this->addTriggererOnLoadCode($component);
+
         // If the modal is rendered async, we just create a fake container which will be
         // replaced by the modal upon successful ajax request
         if ($component->getAsyncRenderUrl()) {

--- a/components/ILIAS/UI/src/Implementation/Component/Progress/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Progress/Renderer.php
@@ -40,6 +40,9 @@ class Renderer extends AbstractComponentRenderer
 
     public function render(Component $component, RendererInterface $default_renderer): string
     {
+        if ($component instanceof \ILIAS\UI\Component\Triggerer) {
+            $component = $this->addTriggererOnLoadCode($component);
+        }
         if ($component instanceof Bar) {
             return $this->renderProgressBar($component, $default_renderer);
         }

--- a/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/Renderer.php
@@ -43,6 +43,9 @@ class Renderer extends AbstractComponentRenderer
             $this->cannotHandleComponent($component);
         }
 
+        /** @var $component Component\Symbol\Glyph\Glyph */
+        $component = $this->addTriggererOnLoadCode($component);
+
         $tpl_file = $this->getTemplateFilename();
         $tpl = $this->getTemplate($tpl_file, true, true);
 

--- a/components/ILIAS/UI/src/Implementation/Component/Tree/Node/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Tree/Node/Renderer.php
@@ -38,6 +38,9 @@ class Renderer extends AbstractComponentRenderer
             $this->cannotHandleComponent($component);
         }
 
+        /** @var $component Component\Button\Button */
+        $component = $this->addTriggererOnLoadCode($component);
+
         $tpl_name = "tpl.node.html";
         $tpl = $this->getTemplate($tpl_name, true, true);
 

--- a/components/ILIAS/UI/src/Implementation/Component/ViewControl/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/ViewControl/Renderer.php
@@ -38,6 +38,9 @@ class Renderer extends AbstractComponentRenderer
 
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
+        if ($component instanceof Component\Triggerer) {
+            $component = $this->addTriggererOnLoadCode($component);
+        }
         if ($component instanceof Component\ViewControl\Mode) {
             return $this->renderMode($component, $default_renderer);
         }

--- a/components/ILIAS/UI/src/Implementation/Render/AbstractComponentRenderer.php
+++ b/components/ILIAS/UI/src/Implementation/Render/AbstractComponentRenderer.php
@@ -153,9 +153,6 @@ abstract class AbstractComponentRenderer implements ComponentRenderer, HelpTextR
      */
     final protected function bindJavaScript(JavaScriptBindable $component): ?string
     {
-        if ($component instanceof Triggerer) {
-            $component = $this->addTriggererOnLoadCode($component);
-        }
         return $this->bindOnloadCode($component);
     }
 
@@ -201,7 +198,7 @@ abstract class AbstractComponentRenderer implements ComponentRenderer, HelpTextR
     /**
      * Add onload-code for triggerer.
      */
-    private function addTriggererOnLoadCode(Triggerer $triggerer): JavaScriptBindable
+    final protected function addTriggererOnLoadCode(Triggerer $triggerer): Triggerer
     {
         $triggered_signals = $triggerer->getTriggeredSignals();
         if (count($triggered_signals) == 0) {


### PR DESCRIPTION
Hi @klees

This fixes https://mantis.ilias.de/view.php?id=46031 by making all `Render\ComponentRenderer` add the JS binding of a `Component\Triggerer` (explicitly) before rendering their component(s).

Until now this happened when `Render\AbstractComponentRenderer::bindJavaScript()` was called. However, due to the reversed order of rendering the bound JS, triggerer on load code must be added **before** the initialisation code now, otherwise JS facilities will not usable then. I think this is only a problem for modals and form inputs, but I updated all of the triggerer anyways now.

Kind regards,
@thibsy 