### PR TITLE
LegalDocuments: Move modal out of table (11)

### DIFF
--- a/components/ILIAS/LegalDocuments/classes/Table/DocumentModal.php
+++ b/components/ILIAS/LegalDocuments/classes/Table/DocumentModal.php
@@ -28,6 +28,11 @@ use Closure;
 class DocumentModal
 {
     /**
+     * @var Component[]
+     */
+    private array $components = [];
+
+    /**
      * @param Closure(DocumentContent): Component $content_as_component
      */
     public function __construct(
@@ -52,6 +57,16 @@ class DocumentModal
             $modal->getShowSignal()
         );
 
-        return [$link, $modal];
+        $this->components[] = $modal;
+
+        return [$link];
+    }
+
+    /**
+     * @return Component[]
+     */
+    public function components(): array
+    {
+        return $this->components;
     }
 }

--- a/components/ILIAS/LegalDocuments/classes/Table/DocumentTable.php
+++ b/components/ILIAS/LegalDocuments/classes/Table/DocumentTable.php
@@ -181,7 +181,11 @@ class DocumentTable implements OrderingRetrieval
 
     public function render(): string
     {
-        return $this->ui_renderer->render($this->table);
+        // This MUST be rendered BEFORE $this->modal->components(),
+        // because the components are filled within the rendering process.
+        $html = $this->ui_renderer->render($this->table);
+
+        return $html . $this->ui_renderer->render($this->modal->components());
     }
 
     /**

--- a/components/ILIAS/LegalDocuments/tests/Table/DocumentModalTest.php
+++ b/components/ILIAS/LegalDocuments/tests/Table/DocumentModalTest.php
@@ -71,6 +71,7 @@ class DocumentModalTest extends TestCase
             return $component;
         });
 
-        $this->assertSame([$button_component, $modal_component], $instance->create($content));
+        $this->assertSame([$button_component], $instance->create($content));
+        $this->assertSame([$modal_component], $instance->components($content));
     }
 }


### PR DESCRIPTION
Fix Mantis Bug: https://mantis.ilias.de/view.php?id=46118

The UI Tables as well as the lightbox Modals use forms, which produces invalid HTML (nested forms). This PR renders all modals AFTER the table itself to circumvent this.