### PR TITLE
StudyProgramme: Fix Display of UDFs

### DIFF
--- a/components/ILIAS/StudyProgramme/classes/model/Assignments/class.ilPRGAssignmentDBRepository.php
+++ b/components/ILIAS/StudyProgramme/classes/model/Assignments/class.ilPRGAssignmentDBRepository.php
@@ -631,8 +631,8 @@ class ilPRGAssignmentDBRepository implements PRGAssignmentRepository
                     $user_data_values[$field] = $this->interimOrguLookup((int) $row[self::ASSIGNMENT_FIELD_USR_ID]);
                     break;
                 case str_starts_with($field, 'udf_'):
-                    $udf_field_id = str_replace('udf_', 'f_', $field);
-                    $user_data_values[$field] = $udf_data->getAdditionalFieldByIdentifier($udf_field_id);
+                    $udf_field_id = mb_substr($field, 4);
+                    $user_data_values[$field] = implode(', ', $udf_data->getAdditionalFieldByIdentifier($udf_field_id) ?? []);
                     break;
                 default:
                     $user_data_values[$field] = $row[$field];


### PR DESCRIPTION
Hi @klees 

Please find a small fix for the presentation of the assignments in the Study Programme here.

I put everything (including the conversion from `array` to `string`) into the `repository`, as I do not believe that the Study Programme cares one little bit about the internal structure of the user fields, but if you would like to push this closer to the interface I can clearly adapt the PR accordingly.

See: https://mantis.ilias.de/view.php?id=46152

Best,
@kergomard 