### PR TITLE
Mantis #45866: Fix plugin relative paths

### DIFF
--- a/components/ILIAS/Component/classes/class.ilPlugin.php
+++ b/components/ILIAS/Component/classes/class.ilPlugin.php
@@ -118,9 +118,14 @@ abstract class ilPlugin
      *     - Services/COPage/classes/class.ilPCPlugged.php
      *     - Modules/DataCollection/classes/Fields/class.ilDclFieldFactory.php
      */
-    public function getDirectory(): string
+    public function getDirectory(bool $relative = false): string
     {
-        return realpath($this->getPluginInfo()->getPath());
+        $path = realpath($this->getPluginInfo()->getPath());
+        if (!$relative) {
+            return $path;
+        }
+
+        return str_replace(ILIAS_ABSOLUTE_PATH . "/public/", "", realpath($this->getDirectory()));
     }
 
     /**

--- a/components/ILIAS/Component/classes/class.ilPlugin.php
+++ b/components/ILIAS/Component/classes/class.ilPlugin.php
@@ -120,7 +120,7 @@ abstract class ilPlugin
      */
     public function getDirectory(): string
     {
-        return $this->getPluginInfo()->getPath();
+        return realpath($this->getPluginInfo()->getPath());
     }
 
     /**

--- a/components/ILIAS/UICore/classes/class.ilTemplate.php
+++ b/components/ILIAS/UICore/classes/class.ilTemplate.php
@@ -356,7 +356,7 @@ class ilTemplate extends HTML_Template_ITX
         if (str_starts_with($a_tplname, $ilias_root)) {
             $a_tplname = str_replace($ilias_root, '', $a_tplname);
         }
-        if (strpos($a_tplname, 'public/Customizing/global/plugins')) {
+        if (str_starts_with($a_tplname, 'public/Customizing/global/plugins')) {
             $tpl_sub_path = '';
         }
 

--- a/components/ILIAS/UICore/classes/class.ilTemplate.php
+++ b/components/ILIAS/UICore/classes/class.ilTemplate.php
@@ -356,6 +356,11 @@ class ilTemplate extends HTML_Template_ITX
         if (str_starts_with($a_tplname, $ilias_root)) {
             $a_tplname = str_replace($ilias_root, '', $a_tplname);
         }
+
+        if (str_starts_with($a_tplname, 'Customizing/global/plugins/')) {
+            $a_tplname = "public/$a_tplname";
+        }
+
         if (str_starts_with($a_tplname, 'public/Customizing/global/plugins')) {
             $tpl_sub_path = '';
         }

--- a/components/ILIAS/UICore/tests/ilTemplateTest.php
+++ b/components/ILIAS/UICore/tests/ilTemplateTest.php
@@ -93,9 +93,9 @@ class ilTemplateTest extends TestCase
             ],
             'plugin template_file_no_component' => [
                 'skin' => 'default', 'style' => 'delos', 'file_exists' => true,
-                'tpl_filename' => $il_root . '/components/ILIAS/Component/classes/../../../../public/Customizing/global/plugins/Services/User/UDFDefinition/CascadingSelect/templates/tpl.prop_cascading_select.html',
+                'tpl_filename' => $il_root . '/public/Customizing/global/plugins/Services/User/UDFDefinition/CascadingSelect/templates/tpl.prop_cascading_select.html',
                 'component' => '',
-                'expected' => $il_root . '/components/ILIAS/Component/classes/../../../../public/Customizing/global/plugins/Services/User/UDFDefinition/CascadingSelect/templates/tpl.prop_cascading_select.html',
+                'expected' => $il_root . '/public/Customizing/global/plugins/Services/User/UDFDefinition/CascadingSelect/templates/tpl.prop_cascading_select.html',
             ],
             'custom skin' => [
                 'skin' => 'mySkin', 'style' => 'myStyle', 'file_exists' => true,


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45866

This pr fixes the following issues:

- If a path starting with "public/Customizing/..." is used in an ilTemplate, the path is not recognized as being from a plugin because **strpos** returns 0 when the haystack starts with the string
- cleanup path returned by ``plugin->getDirectory()`` using realpath
- Allow using both paths starting with ``public/Customizing/global/...`` & ``Customizing/global/...`` in ilTemplate creation
- Add a parameter to the ``plugin->getDirectory()`` method which returns the path as a relative path starting from **public**
  Example: ``Customizing/global/plugins/Services/Cron/CronHook/MyCronPlugin``


If accepted should be picked into **release_11** & **trunk**