### PR TITLE
Fix: Values in WhoIsOnline & AllowContactRequests

### DIFF
--- a/components/ILIAS/Chatroom/src/UserSettings/AllowOnScreenChatConversations.php
+++ b/components/ILIAS/Chatroom/src/UserSettings/AllowOnScreenChatConversations.php
@@ -141,6 +141,10 @@ class AllowOnScreenChatConversations implements SettingDefinition
             return $user;
         }
 
+        if ($input === '1' || $input === '0') {
+            $input = $input === '1';
+        }
+
         if (\is_bool($input)) {
             $user->setPref($this->getIdentifier(), $input ? 'y' : 'n');
             $this->updateChatServer($user->getId(), $input);

--- a/components/ILIAS/Contact/src/UserSettings/AllowContactRequest.php
+++ b/components/ILIAS/Contact/src/UserSettings/AllowContactRequest.php
@@ -101,7 +101,9 @@ class AllowContactRequest implements SettingDefinition
         \ilSetting $settings,
         \ilObjUser $user
     ): bool {
-        return $this->retrieveValueFromUser($user) !== $settings->get('bs_allow_to_contact_me');
+        $user_value = $this->retrieveValueFromUser($user);
+        $settings_value = $settings->get('bs_allow_to_contact_me') === 'y';
+        return $user_value !== null && $user_value !== $settings_value;
     }
 
     public function persistUserInput(


### PR DESCRIPTION
Hi @mjansenDatabay 

I've produced a little bit of a confusion in different user settings as types of return values are different depending on the input type and where the information comes from. The issue below is wider than that and this is only part of it.

See: https://mantis.ilias.de/view.php?id=46069

Thank you very much and best,
@kergomard 