### PR TITLE
release_10 - update the build process from StyleToRepo

### DIFF
--- a/.github/workflows/style-to-repo_trunk.yml
+++ b/.github/workflows/style-to-repo_trunk.yml
@@ -2,7 +2,7 @@ name: Build and deploy style files
 on:
   push:
     branches:
-      - "release_9"
+      - "release_10"
 
 jobs:
   style-to-repo:

--- a/scripts/Style-To-Repo/build.sh
+++ b/scripts/Style-To-Repo/build.sh
@@ -23,43 +23,30 @@ function build() {
     rm -rf ${BUILD_BASE_FOLDER}
   fi
 
-  mkdir -p ${BUILD_BASE_FOLDER}
+  mkdir -p ${BUILD_BASE_FOLDER}/delos
+  cp -r ./templates/default/* ${BUILD_BASE_FOLDER}/delos
 
-  mkdir ${BUILD_BASE_FOLDER}/UI
-  mkdir ${BUILD_BASE_FOLDER}/Services
-  mkdir ${BUILD_BASE_FOLDER}/Modules
+  mkdir -p ${BUILD_BASE_FOLDER}/fonts
+  cp -r ./components/ILIAS/UI/resources/fonts/* ${BUILD_BASE_FOLDER}/fonts
 
-  cp -r ./templates/default/* ${BUILD_BASE_FOLDER}
-  cp -r ./src/UI/templates/default/* ${BUILD_BASE_FOLDER}/UI
+  mkdir -p ${BUILD_BASE_FOLDER}/images
+  cp -r ./components/ILIAS/UI/resources/images/* ${BUILD_BASE_FOLDER}/images
 
-
-  declare -a SERVICES
-
-  SERVICES=($(find **/*/templates/default -type d | grep ^Services))
-
-  for SERVICE in "${SERVICES[@]}"
+  declare -a DEFAULT_TEMPLATE_FOLDERS
+  DEFAULT_TEMPLATE_FOLDERS=($(find ./components -type d -ipath '*templates/default*' | grep -v ^'./public/'))
+  for DEFAULT_TEMPLATE_FOLDER in "${DEFAULT_TEMPLATE_FOLDERS[@]}"
   do
-    NAME=$(echo ${SERVICE} | cut -d'/' -f2- | rev | cut -d'/' -f3- | rev)
-    if [[ "${NAME}" == *\/* ]]
-    then
-     continue
-    fi
-    mkdir -p ${BUILD_BASE_FOLDER}/Services/${NAME}
-    cp -r ${SERVICE}/* ${BUILD_BASE_FOLDER}/Services/${NAME}
+    NAME=$(echo "${DEFAULT_TEMPLATE_FOLDER}" | sed -e 's|/templates/default||')
+    mkdir -p "${BUILD_BASE_FOLDER}"/"${NAME}"
+    cp -r "${DEFAULT_TEMPLATE_FOLDER}"/*.html "${BUILD_BASE_FOLDER}"/"${NAME}" &> /dev/null
   done
 
-  declare -a MODULES
+  if [ -d ./components/ILIAS/Mail/templates/default/img && -d "${BUILD_BASE_FOLDER}"/Mail ]
+  them
+    cp -r ./components/ILIAS/Mail/templates/default/img "${BUILD_BASE_FOLDER}"/Mail &> /dev/null
+  fi
 
-  MODULES=($(find **/*/templates/default -type d | grep ^Modules))
+  mv ${BUILD_BASE_FOLDER}/delos/template.xml ${BUILD_BASE_FOLDER}/template.xml
 
-  for MODULE in "${MODULES[@]}"
-  do
-    NAME=$(echo ${MODULE} | cut -d'/' -f2- | rev | cut -d'/' -f3- | rev)
-    if [[ "${NAME}" == *\/* ]]
-    then
-     continue
-    fi
-    mkdir -p ${BUILD_BASE_FOLDER}/Modules/${NAME}
-    cp -r ${MODULE}/* ${BUILD_BASE_FOLDER}/Modules/${NAME}
-  done
+  sed -i 's/Delos/SkinRepoDelos/' ${BUILD_BASE_FOLDER}/template.xml
 }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=46153

# Issue

We have this useful template repository for creating your own skin design (custom system style) for your ILIAS instance: https://github.com/ILIAS-eLearning/delos

However, building the custom system style (skin) template to the delo repository failed for recent versions of ILIAS. The automation would not copy all html templates or not run at all.

# Changes

This PR adds the automation workflow to package delos as a custom system style into the delos skin repository.

* with this PR we suggest to mirror the directory structure from components/ILIAS/ into the custom system style
* Collecting the html tpl files is now a lot more general, collecting all templates in any templates/default directories within components/ILIAS/ regardless of nesting
* image files in random templates/default folders are deprecated but are still being collected
* images in /components/ILIAS/UI/resources/images are also copied over

# Important

This is only updating the build workflow.

The way how Custom System Styles override default assets and correctly load the new ones might still need to be tweaked and re-tested.