### PR TITLE
Refinery: Fix wrong types in "Logical Group"

### DIFF
--- a/components/ILIAS/Refinery/src/Logical/Group.php
+++ b/components/ILIAS/Refinery/src/Logical/Group.php
@@ -21,8 +21,7 @@ declare(strict_types=1);
 namespace ILIAS\Refinery\Logical;
 
 use ILIAS\Data\Factory;
-use ILIAS\Refinery\Custom\Constraint;
-use ILIAS\Refinery\Constraint as ConstraintInterface;
+use ILIAS\Refinery\Constraint;
 
 class Group
 {
@@ -37,32 +36,29 @@ class Group
 
     /**
      * @param Constraint[] $other
-     * @return ConstraintInterface
      */
-    public function logicalOr(array $other): ConstraintInterface
+    public function logicalOr(array $other): Constraint
     {
         return new LogicalOr($other, $this->dataFactory, $this->language);
     }
 
-    public function not(Constraint $constraint): ConstraintInterface
+    public function not(Constraint $constraint): Constraint
     {
         return new Not($constraint, $this->dataFactory, $this->language);
     }
 
     /**
      * @param Constraint[] $constraints
-     * @return ConstraintInterface
      */
-    public function parallel(array $constraints): ConstraintInterface
+    public function parallel(array $constraints): Constraint
     {
         return new Parallel($constraints, $this->dataFactory, $this->language);
     }
 
     /**
      * @param Constraint[] $constraints
-     * @return ConstraintInterface
      */
-    public function sequential(array $constraints): ConstraintInterface
+    public function sequential(array $constraints): Constraint
     {
         return new Sequential($constraints, $this->dataFactory, $this->language);
     }

--- a/components/ILIAS/Refinery/src/Logical/LogicalOr.php
+++ b/components/ILIAS/Refinery/src/Logical/LogicalOr.php
@@ -20,16 +20,14 @@ declare(strict_types=1);
 
 namespace ILIAS\Refinery\Logical;
 
-use ILIAS\Refinery\Custom\Constraint;
+use ILIAS\Refinery\Constraint;
+use ILIAS\Refinery\Custom\Constraint as CustomConstraint;
 use ILIAS\Data;
 
-class LogicalOr extends Constraint
+class LogicalOr extends CustomConstraint
 {
     /**
-     * LogicalOr constructor.
      * @param Constraint[] $other
-     * @param Data\Factory $data_factory
-     * @param \ILIAS\Language\Language $lng
      */
     public function __construct(array $other, Data\Factory $data_factory, \ILIAS\Language\Language $lng)
     {

--- a/components/ILIAS/Refinery/src/Logical/Not.php
+++ b/components/ILIAS/Refinery/src/Logical/Not.php
@@ -20,19 +20,23 @@ declare(strict_types=1);
 
 namespace ILIAS\Refinery\Logical;
 
-use ILIAS\Refinery\Custom\Constraint;
+use ILIAS\Refinery\Constraint;
+use ILIAS\Refinery\Custom\Constraint as CustomConstraint;
 use ILIAS\Data;
 
-class Not extends Constraint
+class Not extends CustomConstraint
 {
-    public function __construct(Constraint $constraint, Data\Factory $data_factory, \ILIAS\Language\Language $lng)
-    {
+    public function __construct(
+        Constraint $constraint,
+        Data\Factory $data_factory,
+        \ILIAS\Language\Language $lng
+    ) {
         parent::__construct(
             static function ($value) use ($constraint) {
                 return !$constraint->accepts($value);
             },
             static function ($txt, $value) use ($constraint): string {
-                return (string) $txt("not_generic", $constraint->getErrorMessage($value));
+                return (string) $txt('not_generic', $constraint->getErrorMessage($value));
             },
             $data_factory,
             $lng

--- a/components/ILIAS/Refinery/src/Logical/Parallel.php
+++ b/components/ILIAS/Refinery/src/Logical/Parallel.php
@@ -20,23 +20,21 @@ declare(strict_types=1);
 
 namespace ILIAS\Refinery\Logical;
 
-use ILIAS\Refinery\Custom\Constraint;
+use ILIAS\Refinery\Constraint;
+use ILIAS\Refinery\Custom\Constraint as CustomConstraint;
 use ILIAS\Data;
 
-class Parallel extends Constraint
+class Parallel extends CustomConstraint
 {
     /**
      * There's a test to show this state will never be visible
      * ParallelTest::testCorrectErrorMessagesAfterMultiAccept
-     *
      * @var Constraint[]
      */
     protected array $failed_constraints;
 
     /**
      * @param Constraint[] $constraints
-     * @param Data\Factory $data_factory
-     * @param \ILIAS\Language\Language $lng
      */
     public function __construct(array $constraints, Data\Factory $data_factory, \ILIAS\Language\Language $lng)
     {
@@ -59,7 +57,7 @@ class Parallel extends Constraint
                     $messages[] = $constraint->getErrorMessage($value);
                 }
 
-                return implode(" ", $messages);
+                return implode(' ', $messages);
             },
             $data_factory,
             $lng

--- a/components/ILIAS/Refinery/src/Logical/Sequential.php
+++ b/components/ILIAS/Refinery/src/Logical/Sequential.php
@@ -29,15 +29,11 @@ class Sequential extends CustomConstraint
     /**
      * There's a test to show this state will never be visible
      * SequentialTest::testCorrectErrorMessagesAfterMultiAccept
-     *
-     * @var Constraint
      */
     private Constraint $failed_constraint;
 
     /**
      * @param Constraint[] $constraints
-     * @param Data\Factory $data_factory
-     * @param \ILIAS\Language\Language $lng
      */
     public function __construct(array $constraints, Data\Factory $data_factory, \ILIAS\Language\Language $lng)
     {


### PR DESCRIPTION
This PR fixes some explicit and implicit (documented) types in the "Logical Group" of the "Refinery".