### PR TITLE
Test/Certificate: Fix flaky unit test

### DIFF
--- a/components/ILIAS/Certificate/classes/Gui/class.ilCertificateGUIFactory.php
+++ b/components/ILIAS/Certificate/classes/Gui/class.ilCertificateGUIFactory.php
@@ -30,7 +30,7 @@ use ILIAS\StudyProgramme\Certificate\ilStudyProgrammePlaceholderDescription;
 use ILIAS\StudyProgramme\Certificate\ilCertificateSettingsStudyProgrammeFormRepository;
 use ILIAS\Test\Certificate\TestPlaceholderValues;
 use ILIAS\Test\Certificate\TestPlaceholderDescription;
-use ILIAS\Course\Certificate\CertificateTestTemplateDeleteAction;
+use ILIAS\Test\Certificate\CertificateTestTemplateDeleteAction;
 use ILIAS\Test\Certificate\CertificateSettingsTestFormRepository;
 
 /**

--- a/components/ILIAS/Test/src/Certificate/CertificateTestTemplateDeleteAction.php
+++ b/components/ILIAS/Test/src/Certificate/CertificateTestTemplateDeleteAction.php
@@ -18,11 +18,8 @@
 
 declare(strict_types=1);
 
-namespace ILIAS\Course\Certificate;
+namespace ILIAS\Test\Certificate;
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
 class CertificateTestTemplateDeleteAction implements \ilCertificateDeleteAction
 {
     public function __construct(private readonly \ilCertificateDeleteAction $deleteAction)

--- a/components/ILIAS/Test/tests/Certificate/CertificateTestTemplateDeleteActionTest.php
+++ b/components/ILIAS/Test/tests/Certificate/CertificateTestTemplateDeleteActionTest.php
@@ -21,31 +21,15 @@ declare(strict_types=1);
 namespace ILIAS\Test\Certificate;
 
 use PHPUnit\Framework\TestCase;
-use ILIAS\Course\Certificate\CertificateTestTemplateDeleteAction;
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
 class CertificateTestTemplateDeleteActionTest extends TestCase
 {
-    public function testDelete(): void
+    public function testDeletionIsDelegatedToWrappedAction(): void
     {
-        $delete_action = $this->getMockBuilder(\ilCertificateDeleteAction::class)
-            ->getMock();
-
+        $delete_action = $this->createMock(\ilCertificateDeleteAction::class);
         $delete_action
             ->expects($this->once())
             ->method('delete');
-
-        $object_helper = $this->getMockBuilder(\ilCertificateObjectHelper::class)
-            ->getMock();
-
-        $object = $this->getMockBuilder(\ilObjTest::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $object_helper->method('getInstanceByObjId')
-            ->willReturn($object);
 
         $action = new CertificateTestTemplateDeleteAction(
             $delete_action


### PR DESCRIPTION
One test-certificate-related unit test seems to randomly fail: https://github.com/ILIAS-eLearning/ILIAS/actions/runs/19264415560/job/55076635597#step:7:241

If approved, this should also be picked to `release_11`.