### PR TITLE
ilCtrl: Fix removal of invalid elements when building structure

### DIFF
--- a/Services/UICore/classes/Structure/class.ilCtrlStructureMapper.php
+++ b/Services/UICore/classes/Structure/class.ilCtrlStructureMapper.php
@@ -1,12 +1,24 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 declare(strict_types=1);
 
-/* Copyright (c) 2021 Thibeau Fuhrer <thf@studer-raimann.ch> Extended GPL, see docs/LICENSE */
-
 /**
- * Class ilCtrlStructureMapper
- *
  * @author Thibeau Fuhrer <thf@studer-raimann.ch>
  */
 class ilCtrlStructureMapper
@@ -50,6 +62,8 @@ class ilCtrlStructureMapper
     private function addViseVersaMappingByClass(string $class_name, string $key_ref_from, string $key_ref_to): void
     {
         if (!empty($this->ctrl_structure[$class_name][$key_ref_from])) {
+            $invalid_indices = [];
+
             foreach ($this->ctrl_structure[$class_name][$key_ref_from] as $index => $reference) {
                 $is_reference_available = isset($this->ctrl_structure[$reference]);
                 $is_reference_valid = $this->isStructureEntryValid($reference);
@@ -71,9 +85,11 @@ class ilCtrlStructureMapper
                 // if the referenced class does not exist within the current
                 // structure, the reference is removed from the reference list.
                 if (!$is_reference_available || !$is_reference_valid) {
-                    $this->removeReference($this->ctrl_structure[$class_name][$key_ref_from], $index);
+                    $invalid_indices[] = $index;
                 }
             }
+
+            $this->removeInvalidReferences($invalid_indices, $class_name, $key_ref_from);
         }
     }
 
@@ -105,19 +121,20 @@ class ilCtrlStructureMapper
     }
 
     /**
-     * Removes an entry within the given reference list for the
-     * given index and re-indexes the reference list afterwards.
-     *
-     * @param array      $reference_list
-     * @param string|int $index
+     * @param list<int> $invalid_indices
      */
-    private function removeReference(array &$reference_list, $index): void
+    private function removeInvalidReferences(array $invalid_indices, string $class_name, string $key_ref_from): void
     {
-        // remove the reference of the current index.
-        unset($reference_list[$index]);
+        foreach ($invalid_indices as $index) {
+            unset($this->ctrl_structure[$class_name][$key_ref_from][$index]);
+        }
 
-        // re-index the reference list.
-        $reference_list = array_values($reference_list);
+        // Re-index the array once after all removals
+        if (!empty($invalid_indices)) {
+            $this->ctrl_structure[$class_name][$key_ref_from] = array_values(
+                $this->ctrl_structure[$class_name][$key_ref_from]
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
This PR fixes the removal of invalid elements from the parsed `ilCtrl` structure.

When `removeReference()` is called, it **modifies the array** (using `unset()` and `array_values()`) we are currently iterating over.

So the current removal mechnism re-indexes the array **during iteration**, causing (amongst potential other issues) wrong elements to be removed.

This can lead to issues like: https://mantis.ilias.de/view.php?id=46165

For all interested developers: Have a look at https://discord.com/channels/819582183290437642/938352958876286988/1438464095127863449