### PR TITLE
AdvMD/Access: remove substitution context from adv md claiming plugin (33207)

### DIFF
--- a/components/ILIAS/AccessControl/classes/class.ilClaimingPermissionHelper.php
+++ b/components/ILIAS/AccessControl/classes/class.ilClaimingPermissionHelper.php
@@ -99,7 +99,7 @@ abstract class ilClaimingPermissionHelper
      */
     protected function isValidContextAndAction(
         int $a_context_type,
-        string $a_context_id,
+        int $a_context_id,
         int $a_action_id,
         ?int $a_action_sub_id = null
     ): bool {
@@ -149,7 +149,7 @@ abstract class ilClaimingPermissionHelper
      */
     public function hasPermission(
         int $a_context_type,
-        string $a_context_id,
+        int $a_context_id,
         int $a_action_id,
         ?int $a_action_sub_id = null
     ): bool {
@@ -163,7 +163,7 @@ abstract class ilClaimingPermissionHelper
     /**
      * Check permissions
      */
-    public function hasPermissions(int $a_context_type, string $a_context_id, array $a_action_ids): array
+    public function hasPermissions(int $a_context_type, int $a_context_id, array $a_action_ids): array
     {
         $res = [];
 
@@ -186,12 +186,12 @@ abstract class ilClaimingPermissionHelper
      */
     protected function checkPermission(
         int $a_context_type,
-        string $a_context_id,
+        int $a_context_id,
         int $a_action_id,
         ?int $a_action_sub_id = null
     ): bool {
         return ($this->checkRBAC() &&
-            $this->checkPlugins($a_context_type, (string) $a_context_id, $a_action_id, $a_action_sub_id));
+            $this->checkPlugins($a_context_type, $a_context_id, $a_action_id, $a_action_sub_id));
     }
 
     /**
@@ -216,7 +216,7 @@ abstract class ilClaimingPermissionHelper
      */
     protected function checkPlugins(
         int $a_context_type,
-        string $a_context_id,
+        int $a_context_id,
         int $a_action_id,
         ?int $a_action_sub_id = null
     ): bool {
@@ -237,25 +237,5 @@ abstract class ilClaimingPermissionHelper
         }
 
         return $valid;
-    }
-
-    /**
-     * @return array of object type strings
-     */
-    public function getAllowedObjectTypes(): array
-    {
-        $accepted_types = ['cat','crs','sess','grp','iass','exc','file'];
-
-        $obj_def = new ilObjectDefinition();
-        $adv_md_types = $obj_def->getAdvancedMetaDataTypes();
-
-        $valid_accepted_types = [];
-        foreach ($adv_md_types as $value) {
-            if (in_array($value['obj_type'], $accepted_types) || in_array($value['sub_type'], $accepted_types)) {
-                array_push($valid_accepted_types, $value['obj_type']);
-            }
-        }
-
-        return $valid_accepted_types;
     }
 }

--- a/components/ILIAS/AdvancedMetaData/classes/class.ilAdvancedMDFieldDefinition.php
+++ b/components/ILIAS/AdvancedMetaData/classes/class.ilAdvancedMDFieldDefinition.php
@@ -573,7 +573,7 @@ abstract class ilAdvancedMDFieldDefinition
 
         $perm = $a_permissions->hasPermissions(
             ilAdvancedMDPermissionHelper::CONTEXT_FIELD,
-            (string) $this->getFieldId(),
+            (int) $this->getFieldId(),
             array(
                 array(ilAdvancedMDPermissionHelper::ACTION_FIELD_EDIT_PROPERTY,
                       ilAdvancedMDPermissionHelper::SUBACTION_FIELD_TITLE
@@ -685,7 +685,7 @@ abstract class ilAdvancedMDFieldDefinition
 
         if ($a_permissions->hasPermission(
             ilAdvancedMDPermissionHelper::CONTEXT_FIELD,
-            (string) $this->getFieldId(),
+            (int) $this->getFieldId(),
             ilAdvancedMDPermissionHelper::ACTION_FIELD_EDIT_PROPERTY,
             ilAdvancedMDPermissionHelper::SUBACTION_FIELD_PROPERTIES
         )) {

--- a/components/ILIAS/AdvancedMetaData/classes/class.ilAdvancedMDFieldTableGUI.php
+++ b/components/ILIAS/AdvancedMetaData/classes/class.ilAdvancedMDFieldTableGUI.php
@@ -139,7 +139,7 @@ class ilAdvancedMDFieldTableGUI extends ilTable2GUI
 
             $tmp_arr['perm'] = $this->permissions->hasPermissions(
                 ilAdvancedMDPermissionHelper::CONTEXT_FIELD,
-                (string) $definition->getFieldId(),
+                (int) $definition->getFieldId(),
                 array(
                     ilAdvancedMDPermissionHelper::ACTION_FIELD_EDIT
                     ,

--- a/components/ILIAS/AdvancedMetaData/classes/class.ilAdvancedMDPermissionHelper.php
+++ b/components/ILIAS/AdvancedMetaData/classes/class.ilAdvancedMDPermissionHelper.php
@@ -26,80 +26,35 @@ declare(strict_types=1);
  */
 class ilAdvancedMDPermissionHelper extends ilClaimingPermissionHelper
 {
-    public const CONTEXT_MD = 1;
-    public const CONTEXT_RECORD = 2;
-    public const CONTEXT_FIELD = 3;
-    public const CONTEXT_SUBSTITUTION = 4;
-    public const CONTEXT_SUBSTITUTION_COURSE = 5;
-    public const CONTEXT_SUBSTITUTION_CATEGORY = 6;
-    public const CONTEXT_SUBSTITUTION_SESSION = 7;
-    public const CONTEXT_SUBSTITUTION_IASS = 8;
-    public const CONTEXT_SUBSTITUTION_GROUP = 9;
-    public const CONTEXT_SUBSTITUTION_EXERCISE = 10;
+    public const int CONTEXT_MD = 1;
+    public const int CONTEXT_RECORD = 2;
+    public const int CONTEXT_FIELD = 3;
 
-    public const CONTEXT_SUBSTITUTION_FILE = 11;
-    public const CONTEXT_SUBSTITUTION_PRG = 12;
-    public const CONTEXT_SUBSTITUTION_ORG_UNIT = 13;
+    public const int ACTION_MD_CREATE_RECORD = 1;
+    public const int ACTION_MD_IMPORT_RECORDS = 2;
 
-    public const ACTION_MD_CREATE_RECORD = 1;
-    public const ACTION_MD_IMPORT_RECORDS = 2;
+    public const int ACTION_RECORD_EDIT = 5;
+    public const int ACTION_RECORD_DELETE = 6;
+    public const int ACTION_RECORD_EXPORT = 7;
+    public const int ACTION_RECORD_TOGGLE_ACTIVATION = 8;
+    public const int ACTION_RECORD_EDIT_PROPERTY = 9;
+    public const int ACTION_RECORD_EDIT_FIELDS = 10;
+    public const int ACTION_RECORD_CREATE_FIELD = 11;
+    public const int ACTION_RECORD_FIELD_POSITIONS = 12;
 
-    public const ACTION_RECORD_EDIT = 5;
-    public const ACTION_RECORD_DELETE = 6;
-    public const ACTION_RECORD_EXPORT = 7;
-    public const ACTION_RECORD_TOGGLE_ACTIVATION = 8;
-    public const ACTION_RECORD_EDIT_PROPERTY = 9;
-    public const ACTION_RECORD_EDIT_FIELDS = 10;
-    public const ACTION_RECORD_CREATE_FIELD = 11;
-    public const ACTION_RECORD_FIELD_POSITIONS = 12;
+    public const int ACTION_FIELD_EDIT = 13;
+    public const int ACTION_FIELD_DELETE = 14;
+    public const int ACTION_FIELD_EDIT_PROPERTY = 15;
 
-    public const ACTION_FIELD_EDIT = 13;
-    public const ACTION_FIELD_DELETE = 14;
-    public const ACTION_FIELD_EDIT_PROPERTY = 15;
+    public const int SUBACTION_UNDEFINED = 0;
+    public const int SUBACTION_RECORD_TITLE = 1;
+    public const int SUBACTION_RECORD_DESCRIPTION = 2;
+    public const int SUBACTION_RECORD_OBJECT_TYPES = 3;
 
-    public const ACTION_SUBSTITUTION_SHOW_DESCRIPTION = 16;
-    public const ACTION_SUBSTITUTION_SHOW_FIELDNAMES = 17;
-    public const ACTION_SUBSTITUTION_FIELD_POSITIONS = 18;
-
-    public const ACTION_SUBSTITUTION_COURSE_SHOW_FIELD = 19;
-    public const ACTION_SUBSTITUTION_COURSE_EDIT_FIELD_PROPERTY = 20;
-
-    public const ACTION_SUBSTITUTION_CATEGORY_SHOW_FIELD = 21;
-    public const ACTION_SUBSTITUTION_CATEGORY_EDIT_FIELD_PROPERTY = 22;
-
-    public const ACTION_SUBSTITUTION_SESSION_SHOW_FIELD = 23;
-    public const ACTION_SUBSTITUTION_SESSION_EDIT_FIELD_PROPERTY = 24;
-
-    public const ACTION_SUBSTITUTION_GROUP_SHOW_FIELD = 25;
-    public const ACTION_SUBSTITUTION_GROUP_EDIT_FIELD_PROPERTY = 26;
-
-    public const ACTION_SUBSTITUTION_IASS_SHOW_FIELD = 27;
-    public const ACTION_SUBSTITUTION_IASS_EDIT_FIELD_PROPERTY = 28;
-
-    public const ACTION_SUBSTITUTION_EXERCISE_SHOW_FIELD = 29;
-    public const ACTION_SUBSTITUTION_EXERCISE_EDIT_FIELD_PROPERTY = 30;
-
-    public const ACTION_SUBSTITUTION_FILE_SHOW_FIELD = 31;
-    public const ACTION_SUBSTITUTION_FILE_EDIT_FIELD_PROPERTY = 32;
-
-    public const ACTION_SUBSTITUTION_PRG_SHOW_FIELD = 33;
-    public const ACTION_SUBSTITUTION_PRG_EDIT_FIELD_PROPERTY = 34;
-
-    public const ACTION_SUBSTITUTION_ORG_UNIT_SHOW_FIELD = 35;
-    public const ACTION_SUBSTITUTION_ORG_UNIT_EDIT_FIELD_PROPERTY = 36;
-
-    public const SUBACTION_UNDEFINED = 0;
-    public const SUBACTION_RECORD_TITLE = 1;
-    public const SUBACTION_RECORD_DESCRIPTION = 2;
-    public const SUBACTION_RECORD_OBJECT_TYPES = 3;
-
-    public const SUBACTION_FIELD_TITLE = 4;
-    public const SUBACTION_FIELD_DESCRIPTION = 5;
-    public const SUBACTION_FIELD_SEARCHABLE = 6;
-    public const SUBACTION_FIELD_PROPERTIES = 7;
-
-    public const SUBACTION_SUBSTITUTION_BOLD = 8;
-    public const SUBACTION_SUBSTITUTION_NEWLINE = 9;
+    public const int SUBACTION_FIELD_TITLE = 4;
+    public const int SUBACTION_FIELD_DESCRIPTION = 5;
+    public const int SUBACTION_FIELD_SEARCHABLE = 6;
+    public const int SUBACTION_FIELD_PROPERTIES = 7;
 
     protected function readContextIds(int $a_context_type): array
     {
@@ -117,21 +72,9 @@ class ilAdvancedMDPermissionHelper extends ilClaimingPermissionHelper
                 break;
 
             case self::CONTEXT_FIELD:
-            case self::CONTEXT_SUBSTITUTION_COURSE:
-            case self::CONTEXT_SUBSTITUTION_GROUP:
-            case self::CONTEXT_SUBSTITUTION_SESSION:
-            case self::CONTEXT_SUBSTITUTION_CATEGORY:
-            case self::CONTEXT_SUBSTITUTION_IASS:
-            case self::CONTEXT_SUBSTITUTION_EXERCISE:
-            case self::CONTEXT_SUBSTITUTION_FILE:
-            case self::CONTEXT_SUBSTITUTION_PRG:
-            case self::CONTEXT_SUBSTITUTION_ORG_UNIT:
                 $set = $ilDB->query("SELECT field_id id" .
                     " FROM adv_mdf_definition");
                 break;
-
-            case self::CONTEXT_SUBSTITUTION:
-                return $this->getAllowedObjectTypes();
 
             default:
                 return array();
@@ -200,133 +143,7 @@ class ilAdvancedMDPermissionHelper extends ilClaimingPermissionHelper
                             self::SUBACTION_FIELD_PROPERTIES
                         )
                 )
-            ),
-            self::CONTEXT_SUBSTITUTION => array(
-                "actions" => array(
-                    self::ACTION_SUBSTITUTION_SHOW_DESCRIPTION
-                    ,
-                    self::ACTION_SUBSTITUTION_SHOW_FIELDNAMES
-                    ,
-                    self::ACTION_SUBSTITUTION_FIELD_POSITIONS
-                )
-            ),
-            self::CONTEXT_SUBSTITUTION_COURSE => array(
-                "actions" => array(
-                    self::ACTION_SUBSTITUTION_COURSE_SHOW_FIELD
-                ),
-                "subactions" => array(
-                    self::ACTION_SUBSTITUTION_COURSE_EDIT_FIELD_PROPERTY =>
-                        array(
-                            self::SUBACTION_SUBSTITUTION_BOLD
-                            ,
-                            self::SUBACTION_SUBSTITUTION_NEWLINE
-                        )
-                )
-            ),
-            self::CONTEXT_SUBSTITUTION_CATEGORY => array(
-                "actions" => array(
-                    self::ACTION_SUBSTITUTION_CATEGORY_SHOW_FIELD
-                ),
-                "subactions" => array(
-                    self::ACTION_SUBSTITUTION_CATEGORY_EDIT_FIELD_PROPERTY =>
-                        array(
-                            self::SUBACTION_SUBSTITUTION_BOLD
-                            ,
-                            self::SUBACTION_SUBSTITUTION_NEWLINE
-                        )
-                )
-            ),
-            self::CONTEXT_SUBSTITUTION_SESSION => array(
-                "actions" => array(
-                    self::ACTION_SUBSTITUTION_SESSION_SHOW_FIELD
-                ),
-                "subactions" => array(
-                    self::ACTION_SUBSTITUTION_SESSION_EDIT_FIELD_PROPERTY =>
-                        array(
-                            self::SUBACTION_SUBSTITUTION_BOLD
-                            ,
-                            self::SUBACTION_SUBSTITUTION_NEWLINE
-                        )
-                )
-            ),
-            self::CONTEXT_SUBSTITUTION_GROUP => array(
-                "actions" => array(
-                    self::ACTION_SUBSTITUTION_GROUP_SHOW_FIELD
-                ),
-                "subactions" => array(
-                    self::ACTION_SUBSTITUTION_GROUP_EDIT_FIELD_PROPERTY =>
-                        array(
-                            self::SUBACTION_SUBSTITUTION_BOLD
-                            ,
-                            self::SUBACTION_SUBSTITUTION_NEWLINE
-                        )
-                )
-            ),
-            self::CONTEXT_SUBSTITUTION_IASS => array(
-                "actions" => array(
-                    self::ACTION_SUBSTITUTION_IASS_SHOW_FIELD
-                ),
-                "subactions" => array(
-                    self::ACTION_SUBSTITUTION_IASS_EDIT_FIELD_PROPERTY =>
-                        array(
-                            self::SUBACTION_SUBSTITUTION_BOLD
-                            ,
-                            self::SUBACTION_SUBSTITUTION_NEWLINE
-                        )
-                )
-            ),
-            self::CONTEXT_SUBSTITUTION_EXERCISE => array(
-                "actions" => array(
-                    self::ACTION_SUBSTITUTION_EXERCISE_SHOW_FIELD
-                ),
-                "subactions" => array(
-                    self::ACTION_SUBSTITUTION_EXERCISE_EDIT_FIELD_PROPERTY =>
-                        array(
-                            self::SUBACTION_SUBSTITUTION_BOLD
-                            ,
-                            self::SUBACTION_SUBSTITUTION_NEWLINE
-                        )
-                )
-            ),
-            self::CONTEXT_SUBSTITUTION_FILE => array(
-                "actions" => array(
-                    self::ACTION_SUBSTITUTION_FILE_SHOW_FIELD
-                ),
-                "subactions" => array(
-                    self::ACTION_SUBSTITUTION_FILE_EDIT_FIELD_PROPERTY =>
-                        array(
-                            self::SUBACTION_SUBSTITUTION_BOLD
-                            ,
-                            self::SUBACTION_SUBSTITUTION_NEWLINE
-                        )
-                )
-            ),
-            self::CONTEXT_SUBSTITUTION_PRG => array(
-                "actions" => array(
-                    self::ACTION_SUBSTITUTION_PRG_SHOW_FIELD
-                ),
-                "subactions" => array(
-                    self::ACTION_SUBSTITUTION_PRG_EDIT_FIELD_PROPERTY =>
-                        array(
-                            self::SUBACTION_SUBSTITUTION_BOLD
-                            ,
-                            self::SUBACTION_SUBSTITUTION_NEWLINE
-                        )
-                )
-            ),
-            self::CONTEXT_SUBSTITUTION_ORG_UNIT => [
-                "actions" => [
-                    self::ACTION_SUBSTITUTION_ORG_UNIT_SHOW_FIELD
-                ],
-                "subactions" => [
-                    self::ACTION_SUBSTITUTION_ORG_UNIT_EDIT_FIELD_PROPERTY =>
-                        [
-                            self::SUBACTION_SUBSTITUTION_BOLD
-                            ,
-                            self::SUBACTION_SUBSTITUTION_NEWLINE
-                        ]
-                ]
-            ]
+            )
         );
     }
 
@@ -342,7 +159,7 @@ class ilAdvancedMDPermissionHelper extends ilClaimingPermissionHelper
 
     protected function checkPermission(
         int $a_context_type,
-        string $a_context_id,
+        int $a_context_id,
         int $a_action_id,
         ?int $a_action_sub_id = null
     ): bool {

--- a/components/ILIAS/AdvancedMetaData/classes/class.ilAdvancedMDSettingsGUI.php
+++ b/components/ILIAS/AdvancedMetaData/classes/class.ilAdvancedMDSettingsGUI.php
@@ -60,6 +60,7 @@ class ilAdvancedMDSettingsGUI
     protected ilToolbarGUI $toolbar;
     protected ilLogger $logger;
     protected ilObjUser $user;
+    protected ilAccess $access;
 
     protected ilAdvancedMDPermissionHelper $permissions;
     protected ?ilAdvancedMDRecord $record = null;
@@ -95,6 +96,7 @@ class ilAdvancedMDSettingsGUI
         $this->http = $DIC->http();
         $this->db = $DIC->database();
         $this->user = $DIC->user();
+        $this->access = $DIC->access();
 
         /** @noinspection PhpUndefinedMethodInspection */
         $this->logger = $DIC->logger()->amet();
@@ -290,16 +292,11 @@ class ilAdvancedMDSettingsGUI
 
     public function showRecords(): void
     {
-        global $DIC;
-
-        $ilToolbar = $DIC['ilToolbar'];
-        $ilAccess = $DIC['ilAccess'];
-
         $this->setSubTabs($this->context);
 
         $perm = $this->getPermissions()->hasPermissions(
             ilAdvancedMDPermissionHelper::CONTEXT_MD,
-            (string) $this->ref_id,
+            $this->ref_id,
             array(
                 ilAdvancedMDPermissionHelper::ACTION_MD_CREATE_RECORD,
                 ilAdvancedMDPermissionHelper::ACTION_MD_IMPORT_RECORDS
@@ -311,10 +308,10 @@ class ilAdvancedMDSettingsGUI
                 $this->lng->txt('add'),
                 $this->ctrl->getLinkTargetByClass(strtolower(self::class), "createRecord")
             );
-            $ilToolbar->addComponent($button);
+            $this->toolbar->addComponent($button);
 
             if ($perm[ilAdvancedMDPermissionHelper::ACTION_MD_IMPORT_RECORDS]) {
-                $ilToolbar->addSeparator();
+                $this->toolbar->addSeparator();
             }
         }
 
@@ -323,7 +320,7 @@ class ilAdvancedMDSettingsGUI
                 $this->lng->txt('import'),
                 $this->ctrl->getLinkTargetByClass(strtolower(self::class), "importRecords")
             );
-            $ilToolbar->addComponent($button);
+            $this->toolbar->addComponent($button);
         }
 
         $obj_type_context = ($this->obj_id > 0)
@@ -343,12 +340,12 @@ class ilAdvancedMDSettingsGUI
         $table_gui->addMultiCommand("exportRecords", $this->lng->txt('export'));
         $table_gui->setSelectAllCheckbox("record_id");
 
-        if ($ilAccess->checkAccess('write', '', $this->ref_id)) {
+        if ($this->access->checkAccess('write', '', $this->ref_id)) {
             $table_gui->addMultiCommand("confirmDeleteRecords", $this->lng->txt("delete"));
             $table_gui->addCommandButton("updateRecords", $this->lng->txt("save"));
         }
 
-        $DIC->ui()->mainTemplate()->setContent($table_gui->getHTML());
+        $this->tpl->setContent($table_gui->getHTML());
     }
 
     protected function showPresentation(): void
@@ -369,11 +366,7 @@ class ilAdvancedMDSettingsGUI
      */
     public function updateSubstitutions(): void
     {
-        global $DIC;
-
-        $ilAccess = $DIC['ilAccess'];
-
-        if (!$ilAccess->checkAccess('write', '', $this->ref_id)) {
+        if (!$this->access->checkAccess('write', '', $this->ref_id)) {
             $this->ctrl->redirect($this, "showPresentation");
         }
 
@@ -392,29 +385,9 @@ class ilAdvancedMDSettingsGUI
         }
 
         foreach ($visible_records as $obj_type => $record) {
-            $perm = null;
-
-            if (in_array($obj_type, $this->permissions->getAllowedObjectTypes())) {
-                $perm = $this->getPermissions()->hasPermissions(
-                    ilAdvancedMDPermissionHelper::CONTEXT_SUBSTITUTION,
-                    "0",
-                    array(
-                        ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_SHOW_DESCRIPTION
-                        ,
-                        ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_SHOW_FIELDNAMES
-                        ,
-                        ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_FIELD_POSITIONS
-                    )
-                );
-            }
             $sub = ilAdvancedMDSubstitution::_getInstanceByObjectType($obj_type);
-            if ($perm && $perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_SHOW_DESCRIPTION]) {
-                $sub->enableDescription((bool) $form->getInput('enabled_desc_' . $obj_type));
-            }
-
-            if ($perm && $perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_SHOW_FIELDNAMES]) {
-                $sub->enableFieldNames((bool) $form->getInput('enabled_field_names_' . $obj_type));
-            }
+            $sub->enableDescription((bool) $form->getInput('enabled_desc_' . $obj_type));
+            $sub->enableFieldNames((bool) $form->getInput('enabled_field_names_' . $obj_type));
 
             $definitions = ilAdvancedMDFieldDefinition::getInstancesByObjType($obj_type);
             $definitions = $sub->sortDefinitions($definitions);
@@ -439,23 +412,13 @@ class ilAdvancedMDSettingsGUI
                 $field_id = $def->getFieldId();
                 $old = $old_sub[$field_id];
 
-                $perm_def = $this->getSubstitutionFieldPermissions($obj_type, $field_id);
-                if ($perm_def["show"] ?? false) {
-                    $active = (bool) $form->getInput('show_' . $obj_type . '_' . $field_id);
-                } else {
-                    $active = $old["active"] ?? false;
-                }
+                $active = (bool) $form->getInput('show_' . $obj_type . '_' . $field_id);
+
                 if ($active) {
                     $new_sub[$field_id] = $old;
-                    if ($perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_FIELD_POSITIONS]) {
-                        $new_sub[$field_id]['pos'] = (int) $form->getInput('position_' . $obj_type . '_' . $field_id);
-                    }
-                    if ($perm_def["bold"] ?? false) {
-                        $new_sub[$field_id]['bold'] = (bool) $form->getInput('bold_' . $obj_type . '_' . $field_id);
-                    }
-                    if ($perm_def["newline"] ?? false) {
-                        $new_sub[$field_id]['newline'] = (bool) $form->getInput('newline_' . $obj_type . '_' . $field_id);
-                    }
+                    $new_sub[$field_id]['pos'] = (int) $form->getInput('position_' . $obj_type . '_' . $field_id);
+                    $new_sub[$field_id]['bold'] = (bool) $form->getInput('bold_' . $obj_type . '_' . $field_id);
+                    $new_sub[$field_id]['newline'] = (bool) $form->getInput('newline_' . $obj_type . '_' . $field_id);
                 }
             }
 
@@ -490,7 +453,7 @@ class ilAdvancedMDSettingsGUI
         foreach ($record_ids as $record_id) {
             if (!$this->getPermissions()->hasPermission(
                 ilAdvancedMDPermissionHelper::CONTEXT_RECORD,
-                (string) $record_id,
+                (int) $record_id,
                 ilAdvancedMDPermissionHelper::ACTION_RECORD_EXPORT
             )) {
                 $record = ilAdvancedMDRecord::_getInstanceByRecordId($record_id);
@@ -690,7 +653,7 @@ class ilAdvancedMDSettingsGUI
 
             if (!$this->getPermissions()->hasPermission(
                 ilAdvancedMDPermissionHelper::CONTEXT_RECORD,
-                (string) $record_id,
+                (int) $record_id,
                 ilAdvancedMDPermissionHelper::ACTION_RECORD_DELETE
             )) {
                 $record = ilAdvancedMDRecord::_getInstanceByRecordId($record_id);
@@ -746,7 +709,7 @@ class ilAdvancedMDSettingsGUI
 
             $perm = $this->getPermissions()->hasPermissions(
                 ilAdvancedMDPermissionHelper::CONTEXT_RECORD,
-                (string) $item['id'],
+                (int) $item['id'],
                 [
                     ilAdvancedMDPermissionHelper::ACTION_RECORD_TOGGLE_ACTIVATION,
                     [
@@ -875,7 +838,7 @@ class ilAdvancedMDSettingsGUI
         foreach ($field_ids as $field_id) {
             if (!$this->getPermissions()->hasPermission(
                 ilAdvancedMDPermissionHelper::CONTEXT_FIELD,
-                (string) $field_id,
+                (int) $field_id,
                 ilAdvancedMDPermissionHelper::ACTION_FIELD_DELETE
             )) {
                 $field = ilAdvancedMDFieldDefinition::getInstance($field_id);
@@ -915,8 +878,6 @@ class ilAdvancedMDSettingsGUI
 
     protected function editFields(): void
     {
-        global $DIC;
-
         $record_id = $this->getRecordIdFromQuery();
         if (!$record_id) {
             $this->ctrl->redirect($this, 'showRecords');
@@ -929,7 +890,7 @@ class ilAdvancedMDSettingsGUI
 
         $perm = $this->getPermissions()->hasPermissions(
             ilAdvancedMDPermissionHelper::CONTEXT_RECORD,
-            (string) $this->record->getRecordId(),
+            (int) $this->record->getRecordId(),
             array(
                 ilAdvancedMDPermissionHelper::ACTION_RECORD_CREATE_FIELD
                 ,
@@ -1019,7 +980,7 @@ class ilAdvancedMDSettingsGUI
 
         if ($this->getPermissions()->hasPermission(
             ilAdvancedMDPermissionHelper::CONTEXT_RECORD,
-            (string) $record_id,
+            $record_id,
             ilAdvancedMDPermissionHelper::ACTION_RECORD_FIELD_POSITIONS
         )) {
             $positions_flipped = array_flip(array_keys($positions));
@@ -1032,7 +993,7 @@ class ilAdvancedMDSettingsGUI
         foreach ($fields as $field) {
             if ($this->getPermissions()->hasPermission(
                 ilAdvancedMDPermissionHelper::CONTEXT_FIELD,
-                (string) $field->getFieldId(),
+                (int) $field->getFieldId(),
                 ilAdvancedMDPermissionHelper::ACTION_FIELD_EDIT_PROPERTY,
                 ilAdvancedMDPermissionHelper::SUBACTION_FIELD_SEARCHABLE
             )) {
@@ -1451,7 +1412,7 @@ class ilAdvancedMDSettingsGUI
         }
         $perm = $this->getPermissions()->hasPermissions(
             ilAdvancedMDPermissionHelper::CONTEXT_RECORD,
-            (string) $this->record->getRecordId(),
+            $this->record->getRecordId(),
             array(
                 array(ilAdvancedMDPermissionHelper::ACTION_RECORD_EDIT_PROPERTY,
                       ilAdvancedMDPermissionHelper::SUBACTION_RECORD_TITLE
@@ -1633,231 +1594,12 @@ class ilAdvancedMDSettingsGUI
         return $this->form;
     }
 
-    protected function getSubstitutionFieldPermissions(string $a_obj_type, int $a_field_id): array
-    {
-        if ($a_obj_type == "crs") {
-            $perm = $this->getPermissions()->hasPermissions(
-                ilAdvancedMDPermissionHelper::CONTEXT_SUBSTITUTION_COURSE,
-                (string) $a_field_id,
-                array(
-                    ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_COURSE_SHOW_FIELD
-                    ,
-                    array(ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_COURSE_EDIT_FIELD_PROPERTY,
-                          ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_BOLD
-                    )
-                    ,
-                    array(ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_COURSE_EDIT_FIELD_PROPERTY,
-                          ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_NEWLINE
-                    )
-                )
-            );
-            return array(
-                "show" => $perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_COURSE_SHOW_FIELD]
-                ,
-                "bold" => $perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_COURSE_EDIT_FIELD_PROPERTY][ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_BOLD]
-                ,
-                "newline" => $perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_COURSE_EDIT_FIELD_PROPERTY][ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_NEWLINE]
-            );
-        } elseif ($a_obj_type == "cat") {
-            $perm = $this->getPermissions()->hasPermissions(
-                ilAdvancedMDPermissionHelper::CONTEXT_SUBSTITUTION_CATEGORY,
-                (string) $a_field_id,
-                array(
-                    ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_CATEGORY_SHOW_FIELD
-                    ,
-                    array(ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_CATEGORY_EDIT_FIELD_PROPERTY,
-                          ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_BOLD
-                    )
-                    ,
-                    array(ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_CATEGORY_EDIT_FIELD_PROPERTY,
-                          ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_NEWLINE
-                    )
-                )
-            );
-            return array(
-                "show" => $perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_CATEGORY_SHOW_FIELD]
-                ,
-                "bold" => $perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_CATEGORY_EDIT_FIELD_PROPERTY][ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_BOLD]
-                ,
-                "newline" => $perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_CATEGORY_EDIT_FIELD_PROPERTY][ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_NEWLINE]
-            );
-        } elseif ($a_obj_type == "sess") {
-            $perm = $this->getPermissions()->hasPermissions(
-                ilAdvancedMDPermissionHelper::CONTEXT_SUBSTITUTION_SESSION,
-                (string) $a_field_id,
-                array(
-                    ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_SESSION_SHOW_FIELD
-                    ,
-                    array(ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_SESSION_EDIT_FIELD_PROPERTY,
-                          ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_BOLD
-                    )
-                    ,
-                    array(ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_SESSION_EDIT_FIELD_PROPERTY,
-                          ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_NEWLINE
-                    )
-                )
-            );
-            return array(
-                "show" => $perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_SESSION_SHOW_FIELD]
-                ,
-                "bold" => $perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_SESSION_EDIT_FIELD_PROPERTY][ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_BOLD]
-                ,
-                "newline" => $perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_SESSION_EDIT_FIELD_PROPERTY][ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_NEWLINE]
-            );
-        } elseif ($a_obj_type == "grp") {
-            $perm = $this->getPermissions()->hasPermissions(
-                ilAdvancedMDPermissionHelper::CONTEXT_SUBSTITUTION_GROUP,
-                (string) $a_field_id,
-                array(
-                    ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_GROUP_SHOW_FIELD
-                    ,
-                    array(ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_GROUP_EDIT_FIELD_PROPERTY,
-                          ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_BOLD
-                    )
-                    ,
-                    array(ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_GROUP_EDIT_FIELD_PROPERTY,
-                          ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_NEWLINE
-                    )
-                )
-            );
-            return array(
-                "show" => $perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_GROUP_SHOW_FIELD]
-                ,
-                "bold" => $perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_GROUP_EDIT_FIELD_PROPERTY][ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_BOLD]
-                ,
-                "newline" => $perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_GROUP_EDIT_FIELD_PROPERTY][ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_NEWLINE]
-            );
-        } elseif ($a_obj_type == "iass") {
-            $perm = $this->getPermissions()->hasPermissions(
-                ilAdvancedMDPermissionHelper::CONTEXT_SUBSTITUTION_IASS,
-                (string) $a_field_id,
-                array(
-                    ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_IASS_SHOW_FIELD
-                    ,
-                    array(ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_IASS_EDIT_FIELD_PROPERTY,
-                          ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_BOLD
-                    )
-                    ,
-                    array(ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_IASS_EDIT_FIELD_PROPERTY,
-                          ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_NEWLINE
-                    )
-                )
-            );
-            return array(
-                "show" => $perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_IASS_SHOW_FIELD]
-                ,
-                "bold" => $perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_IASS_EDIT_FIELD_PROPERTY][ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_BOLD]
-                ,
-                "newline" => $perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_IASS_EDIT_FIELD_PROPERTY][ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_NEWLINE]
-            );
-        } elseif ($a_obj_type == "exc") {
-            $perm = $this->getPermissions()->hasPermissions(
-                ilAdvancedMDPermissionHelper::CONTEXT_SUBSTITUTION_EXERCISE,
-                (string) $a_field_id,
-                array(
-                    ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_EXERCISE_SHOW_FIELD
-                    ,
-                    array(ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_EXERCISE_EDIT_FIELD_PROPERTY,
-                          ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_BOLD
-                    )
-                    ,
-                    array(ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_EXERCISE_EDIT_FIELD_PROPERTY,
-                          ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_NEWLINE
-                    )
-                )
-            );
-            return array(
-                "show" => $perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_EXERCISE_SHOW_FIELD]
-                ,
-                "bold" => $perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_EXERCISE_EDIT_FIELD_PROPERTY][ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_BOLD]
-                ,
-                "newline" => $perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_EXERCISE_EDIT_FIELD_PROPERTY][ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_NEWLINE]
-            );
-        } elseif ($a_obj_type == "file") {
-            $perm = $this->getPermissions()->hasPermissions(
-                ilAdvancedMDPermissionHelper::CONTEXT_SUBSTITUTION_FILE,
-                (string) $a_field_id,
-                array(
-                    ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_FILE_SHOW_FIELD
-                    ,
-                    array(ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_FILE_EDIT_FIELD_PROPERTY,
-                          ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_BOLD
-                    )
-                    ,
-                    array(ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_FILE_EDIT_FIELD_PROPERTY,
-                          ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_NEWLINE
-                    )
-                )
-            );
-            return array(
-                "show" => $perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_FILE_SHOW_FIELD]
-                ,
-                "bold" => $perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_FILE_EDIT_FIELD_PROPERTY][ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_BOLD]
-                ,
-                "newline" => $perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_FILE_EDIT_FIELD_PROPERTY][ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_NEWLINE]
-            );
-        } elseif ($a_obj_type == "prg") {
-            $perm = $this->getPermissions()->hasPermissions(
-                ilAdvancedMDPermissionHelper::CONTEXT_SUBSTITUTION_PRG,
-                (string) $a_field_id,
-                [
-                    ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_PRG_SHOW_FIELD,
-                    [
-                        ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_PRG_EDIT_FIELD_PROPERTY,
-                        ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_BOLD
-                    ],
-                    [
-                        ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_PRG_EDIT_FIELD_PROPERTY,
-                        ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_NEWLINE
-                    ]
-                ]
-            );
-            return array(
-                "show" => $perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_PRG_SHOW_FIELD]
-                ,
-                "bold" => $perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_PRG_EDIT_FIELD_PROPERTY][ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_BOLD]
-                ,
-                "newline" => $perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_PRG_EDIT_FIELD_PROPERTY][ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_NEWLINE]
-            );
-        } elseif ($a_obj_type == "orgu") {
-            $perm = $this->getPermissions()->hasPermissions(
-                ilAdvancedMDPermissionHelper::CONTEXT_SUBSTITUTION_ORG_UNIT,
-                (string) $a_field_id,
-                [
-                    ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_ORG_UNIT_SHOW_FIELD
-                    ,
-                    [
-                        ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_ORG_UNIT_EDIT_FIELD_PROPERTY,
-                        ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_BOLD
-                    ]
-                    ,
-                    [
-                        ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_ORG_UNIT_EDIT_FIELD_PROPERTY,
-                        ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_NEWLINE
-                    ]
-                ]
-            );
-            return [
-                "show" => $perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_ORG_UNIT_SHOW_FIELD]
-                ,
-                "bold" => $perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_ORG_UNIT_EDIT_FIELD_PROPERTY][ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_BOLD]
-                ,
-                "newline" => $perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_ORG_UNIT_EDIT_FIELD_PROPERTY][ilAdvancedMDPermissionHelper::SUBACTION_SUBSTITUTION_NEWLINE]
-            ];
-        }
-        return [];
-    }
-
     /**
      * init form table 'substitutions'
      * @access protected
      */
     protected function initFormSubstitutions(): ?ilPropertyFormGUI
     {
-        global $DIC;
-
-        $ilAccess = $DIC['ilAccess'];
-
         if (!$visible_records = ilAdvancedMDRecord::_getAllRecordsByObjectType()) {
             return null;
         }
@@ -1868,21 +1610,8 @@ class ilAdvancedMDSettingsGUI
 
         // substitution
         foreach ($visible_records as $obj_type => $records) {
-            $perm = null;
-
-            if (in_array($obj_type, $this->permissions->getAllowedObjectTypes())) {
-                $perm = $this->getPermissions()->hasPermissions(
-                    ilAdvancedMDPermissionHelper::CONTEXT_SUBSTITUTION,
-                    (string) $obj_type,
-                    array(
-                        ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_SHOW_DESCRIPTION
-                        ,
-                        ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_SHOW_FIELDNAMES
-                        ,
-                        ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_FIELD_POSITIONS
-                    )
-                );
-            }
+            $read_only = !$this->access->checkAccess('write', '', $this->ref_id);
+            ;
 
             $sub = ilAdvancedMDSubstitution::_getInstanceByObjectType($obj_type);
 
@@ -1897,7 +1626,7 @@ class ilAdvancedMDSettingsGUI
             $check->setChecked($sub->isDescriptionEnabled());
             $this->form->addItem($check);
 
-            if ($perm && !$perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_SHOW_DESCRIPTION]) {
+            if ($read_only) {
                 $check->setDisabled(true);
             }
 
@@ -1907,13 +1636,8 @@ class ilAdvancedMDSettingsGUI
             $check->setChecked($sub->enabledFieldNames());
             $this->form->addItem($check);
 
-            if ($perm && !$perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_SHOW_FIELDNAMES]) {
+            if ($read_only) {
                 $check->setDisabled(true);
-            }
-
-            $perm_pos = null;
-            if ($perm) {
-                $perm_pos = $perm[ilAdvancedMDPermissionHelper::ACTION_SUBSTITUTION_FIELD_POSITIONS];
             }
 
             $definitions = ilAdvancedMDFieldDefinition::getInstancesByObjType($obj_type);
@@ -1923,8 +1647,6 @@ class ilAdvancedMDSettingsGUI
             foreach ($definitions as $def) {
                 $definition_id = $def->getFieldId();
 
-                $perm = $this->getSubstitutionFieldPermissions($obj_type, $definition_id);
-
                 $title = ilAdvancedMDRecord::_lookupTitle((int) $def->getRecordId());
                 $title = $def->getTitle() . ' (' . $title . ')';
 
@@ -1933,7 +1655,7 @@ class ilAdvancedMDSettingsGUI
                 $check->setOptionTitle($this->lng->txt('md_adv_show'));
                 $check->setChecked($sub->isSubstituted($definition_id));
 
-                if ($perm && !$perm["show"]) {
+                if ($read_only) {
                     $check->setDisabled(true);
                 }
 
@@ -1947,7 +1669,7 @@ class ilAdvancedMDSettingsGUI
                 $pos->setValue(sprintf('%.1f', $counter++));
                 $check->addSubItem($pos);
 
-                if ($perm && !$perm_pos) {
+                if ($read_only) {
                     $pos->setDisabled(true);
                 }
 
@@ -1959,7 +1681,7 @@ class ilAdvancedMDSettingsGUI
                 $bold->setChecked($sub->isBold($definition_id));
                 $check->addSubItem($bold);
 
-                if ($perm && !$perm["bold"]) {
+                if ($read_only) {
                     $bold->setDisabled(true);
                 }
 
@@ -1971,7 +1693,7 @@ class ilAdvancedMDSettingsGUI
                 $bold->setChecked($sub->hasNewline($definition_id));
                 $check->addSubItem($bold);
 
-                if ($perm && !$perm["newline"]) {
+                if ($read_only) {
                     $bold->setDisabled(true);
                 }
 
@@ -1980,7 +1702,7 @@ class ilAdvancedMDSettingsGUI
         }
         $this->form->setTitle($this->lng->txt('md_adv_substitution_table'));
 
-        if ($ilAccess->checkAccess('write', '', $this->ref_id)) {
+        if ($this->access->checkAccess('write', '', $this->ref_id)) {
             $this->form->addCommandButton('updateSubstitutions', $this->lng->txt('save'));
         }
         return $this->form;
@@ -1992,7 +1714,7 @@ class ilAdvancedMDSettingsGUI
 
         $perm = $this->getPermissions()->hasPermissions(
             ilAdvancedMDPermissionHelper::CONTEXT_RECORD,
-            (string) $this->record->getRecordId(),
+            $this->record->getRecordId(),
             array(
                 array(ilAdvancedMDPermissionHelper::ACTION_RECORD_EDIT_PROPERTY,
                       ilAdvancedMDPermissionHelper::SUBACTION_RECORD_TITLE
@@ -2200,7 +1922,7 @@ class ilAdvancedMDSettingsGUI
 
             $tmp_arr['perm'] = $this->permissions->hasPermissions(
                 ilAdvancedMDPermissionHelper::CONTEXT_RECORD,
-                (string) $record->getRecordId(),
+                $record->getRecordId(),
                 array(
                     ilAdvancedMDPermissionHelper::ACTION_RECORD_EDIT
                     ,


### PR DESCRIPTION
This PR fixes [33207](https://mantis.ilias.de/view.php?id=33207) by removing the substitution context from the `ilAdvancedMDClaimingPlugin` (and changing the type of the `context_id` parameter from string to int in `ilClaimingPermissionHelper`), as discussed in the last JF.

I'll provide a separate PR with a smaller fix for 9 and 10.
