### PR TITLE
Access: fix display options in advmd admin for active plugin (33207)

### DIFF
--- a/Services/AccessControl/classes/class.ilClaimingPermissionHelper.php
+++ b/Services/AccessControl/classes/class.ilClaimingPermissionHelper.php
@@ -231,7 +231,7 @@ abstract class ilClaimingPermissionHelper
             $a_action_sub_id = is_null($a_action_sub_id)
                 ? ilAdvancedMDPermissionHelper::SUBACTION_UNDEFINED
                 : $a_action_sub_id;
-            if (!$plugin->checkPermission($this->getUserId(), $a_context_type, $a_context_id, $a_action_id, $a_action_sub_id)) {
+            if (!$plugin->checkPermission($this->getUserId(), $a_context_type, (int) $a_context_id, $a_action_id, $a_action_sub_id)) {
                 $valid = false;
                 break;
             }


### PR DESCRIPTION
This PR fixes [33207](https://mantis.ilias.de/view.php?id=33207) for releases 9 and 10. It is a (much much) smaller version of #10431 for 11 and trunk, so no need to pick this past 10.