### PR TITLE
User: fix reading calendar period for default starting point (46106)

### DIFF
--- a/components/ILIAS/User/src/Settings/StartingPoint/Repository.php
+++ b/components/ILIAS/User/src/Settings/StartingPoint/Repository.php
@@ -528,7 +528,7 @@ class Repository
      */
     public function getSystemDefaultCalendarPeriod(): int
     {
-        return (int) $this->settings->get('user_cal_period');
+        return (int) $this->settings->get('user_calendar_period');
     }
 
     /**


### PR DESCRIPTION
This PR fixes [46106](https://mantis.ilias.de/view.php?id=46106) by fixing a typo when reading out the calendar period for the default starting point.

Looks like the same typo is also in 10, but I haven't tested this there.