### PR TITLE
T&A 45906: Fixes ilTestException thrown when submitting an answer while already locked by a previous submit

### DIFF
--- a/Modules/Test/classes/class.ilTestOutputGUI.php
+++ b/Modules/Test/classes/class.ilTestOutputGUI.php
@@ -724,7 +724,8 @@ abstract class ilTestOutputGUI extends ilTestPlayerAbstractGUI
 
             if ($this->isParticipantsAnswerFixed($q_id)) {
                 // should only be reached by firebugging the disabled form in ui
-                throw new ilTestException('not allowed request');
+                $this->tpl->setOnScreenMessage(ilGlobalTemplateInterface::MESSAGE_TYPE_FAILURE, $this->lng->txt('tst_player_answer_saved_and_locked'), true);
+                $this->ctrl->redirect($this, ilTestPlayerCommands::SHOW_QUESTION);
             }
 
             if (is_numeric($q_id) && (int) $q_id) {


### PR DESCRIPTION
This PR attempts to fix https://mantis.ilias.de/view.php?id=45906.

If "Lock Answers After Moving to Next Question" is enabled, a fatal crash occurs when clicking "Next" a second time in another tab. Apart from the fact that this is a bad move to begin with, with these changes a proper error message is now displayed.

Kind regards,
@bidzanaaron 