### PR TITLE
AuthApache/Init: Call legacy `entry_point`

### DIFF
--- a/components/ILIAS/Init/resources/sso/index.php
+++ b/components/ILIAS/Init/resources/sso/index.php
@@ -44,11 +44,13 @@ if (isset($_GET['client_id'])) {
     $_COOKIE['ilClientId'] = $_GET['client_id'];
 }
 
+define('IL_CERT_SSO', true);
 define('IL_COOKIE_PATH', $cookie_path);
 
 ilContext::init(ilContext::CONTEXT_APACHE_SSO);
 
-ilInitialisation::initILIAS();
+require_once __DIR__ . '/../../artifacts/bootstrap_default.php';
+entry_point('ILIAS Legacy Initialisation Adapter');
 
 ilStartUpGUI::setForcedCommand('doApacheAuthentication');
 $ilCtrl->callBaseClass(ilStartUpGUI::class);


### PR DESCRIPTION
The "./sso/index.php" script does not invoke the `entry_point` function, so the ILIAS initialization will fail.

If approved, this has to be picked to `release_11`.

Mantis Issue: https://mantis.ilias.de/view.php?id=46206