### PR TITLE
Saml: stringify `ILIAS\Data\URI`

### DIFF
--- a/components/ILIAS/Saml/classes/class.ilSamlAppEventListener.php
+++ b/components/ILIAS/Saml/classes/class.ilSamlAppEventListener.php
@@ -29,7 +29,7 @@ class ilSamlAppEventListener implements ilAppEventListener
             isset($a_parameter['used_external_auth_mode']) && $a_parameter['used_external_auth_mode']) {
             if ((int) $a_parameter['used_external_auth_mode'] === ilAuthUtils::AUTH_SAML) {
                 $url = $a_parameter['logout_target'] ?? ILIAS_HTTP_PATH . '/login.php';
-                $DIC->ctrl()->redirectToURL('saml.php?action=logout&logout_url=' . urlencode($url));
+                $DIC->ctrl()->redirectToURL('saml.php?action=logout&logout_url=' . urlencode((string) $url));
             }
         }
     }


### PR DESCRIPTION
Fix TypeError: `urlencode(): Argument #1 ($string) must be of type string, ILIAS\Data\URI given`.

`$a_parameter['logout_target']` is not a string but a `ILIAS\Data\URI` (see https://github.com/ILIAS-eLearning/ILIAS/blob/release_10/components/ILIAS/Init/classes/class.ilStartUpGUI.php#L1347).

`ILIAS\Data\URI` must be cast to a string explicitly.