### PR TITLE
Saml: Keep entity ID after save & stringify `ILIAS\Data\URI`

### DIFF
--- a/components/ILIAS/Saml/classes/class.ilSamlAppEventListener.php
+++ b/components/ILIAS/Saml/classes/class.ilSamlAppEventListener.php
@@ -29,7 +29,7 @@ class ilSamlAppEventListener implements ilAppEventListener
             isset($a_parameter['used_external_auth_mode']) && $a_parameter['used_external_auth_mode']) {
             if ((int) $a_parameter['used_external_auth_mode'] === ilAuthUtils::AUTH_SAML) {
                 $url = $a_parameter['logout_target'] ?? ILIAS_HTTP_PATH . '/login.php';
-                $DIC->ctrl()->redirectToURL('saml.php?action=logout&logout_url=' . urlencode($url));
+                $DIC->ctrl()->redirectToURL('saml.php?action=logout&logout_url=' . urlencode((string) $url));
             }
         }
     }

--- a/components/ILIAS/Saml/classes/class.ilSamlIdp.php
+++ b/components/ILIAS/Saml/classes/class.ilSamlIdp.php
@@ -166,8 +166,8 @@ final class ilSamlIdp
     public function bindForm(StandardForm $form): void
     {
         $data = $form->getData();
-        $this->setUidClaim((string) ($data[self::PROP_UID_CLAIM] ?? ''));
-        $this->setEntityId((string) ($data[self::PROP_ENTITY_ID] ?? ''));
+        $this->setUidClaim((string) ($data[self::PROP_UID_CLAIM] ?? $this->getUidClaim()));
+        $this->setEntityId((string) ($data[self::PROP_ENTITY_ID] ?? $this->getEntityId()));
         $this->setLocalLocalAuthenticationStatus((bool) ($data[self::PROP_ALLOW_LOCAL_AUTH] ?? false));
         $this->setSynchronizationStatus(($data[self::PROP_SYNC_STATUS] ?? null) !== null);
 


### PR DESCRIPTION
This PR fixes #10455 for ILIAS 11.

Additionally this PR fixes an empty entity ID when saving a saml IDP (when changing e.g. the UID Claim not in the initial save).

When saving the initial entity ID is not given (see https://github.com/ILIAS-eLearning/ILIAS/blob/release_11/components/ILIAS/Saml/classes/class.ilSamlSettingsGUI.php#L712 no `$data` argument given) and as the entity ID is disabled, it is also not send with the request, which causes the entity ID to be changed to `''`.

This results in an endless redirect when trying to use this IDP.