### PR TITLE
Fix: update aria-label from “Mainbar” to “Main navigation bar” for clarity

### DIFF
--- a/lang/ilias_ar.lang
+++ b/lang/ilias_ar.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#الرسائل
 common#:#mails_at_the_ilias_installation#:#You received %1$s new mails at the ILIAS-Installation %2$s
 common#:#mails_pl#:#البريد
 common#:#main_menu#:#Main Menu
-common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###01 02 2026 changed content
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#المدخلات المعينة

--- a/lang/ilias_ar.lang
+++ b/lang/ilias_ar.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#الرسائل
 common#:#mails_at_the_ilias_installation#:#You received %1$s new mails at the ILIAS-Installation %2$s
 common#:#mails_pl#:#البريد
 common#:#main_menu#:#Main Menu
-common#:#mainbar_aria_label#:#Mainbar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#المدخلات المعينة

--- a/lang/ilias_bg.lang
+++ b/lang/ilias_bg.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Поща
 common#:#mails_at_the_ilias_installation#:#You received %1$s new mails at the ILIAS-Installation %2$s###10 09 2010 new variable
 common#:#mails_pl#:#Mail(s)###25 02 2007 new variable
 common#:#main_menu#:#Main Menu###30 04 2009 new variable
-common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###01 02 2026 changed content
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#Marked Entries###25 02 2007 new variable

--- a/lang/ilias_bg.lang
+++ b/lang/ilias_bg.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Поща
 common#:#mails_at_the_ilias_installation#:#You received %1$s new mails at the ILIAS-Installation %2$s###10 09 2010 new variable
 common#:#mails_pl#:#Mail(s)###25 02 2007 new variable
 common#:#main_menu#:#Main Menu###30 04 2009 new variable
-common#:#mainbar_aria_label#:#Mainbar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#Marked Entries###25 02 2007 new variable

--- a/lang/ilias_cs.lang
+++ b/lang/ilias_cs.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Pošta
 common#:#mails_at_the_ilias_installation#:#Obdržel(a) jste %1$s nových e-mailů v instalaci ILIAS %2$s
 common#:#mails_pl#:#Pošta
 common#:#main_menu#:#Hlavní menu
-common#:#mainbar_aria_label#:#Mainbar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Správa členů
 common#:#marked_entries#:#Označené vstupy

--- a/lang/ilias_cs.lang
+++ b/lang/ilias_cs.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Pošta
 common#:#mails_at_the_ilias_installation#:#Obdržel(a) jste %1$s nových e-mailů v instalaci ILIAS %2$s
 common#:#mails_pl#:#Pošta
 common#:#main_menu#:#Hlavní menu
-common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###01 02 2026 changed content
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Správa členů
 common#:#marked_entries#:#Označené vstupy

--- a/lang/ilias_da.lang
+++ b/lang/ilias_da.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Mail
 common#:#mails_at_the_ilias_installation#:#You received %1$s new mails at the ILIAS-Installation %2$s###10 09 2010 new variable
 common#:#mails_pl#:#Mail(s)
 common#:#main_menu#:#Hovedmenu
-common#:#mainbar_aria_label#:#Mainbar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#Marked Entries###25 02 2007 new variable

--- a/lang/ilias_da.lang
+++ b/lang/ilias_da.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Mail
 common#:#mails_at_the_ilias_installation#:#You received %1$s new mails at the ILIAS-Installation %2$s###10 09 2010 new variable
 common#:#mails_pl#:#Mail(s)
 common#:#main_menu#:#Hovedmenu
-common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###01 02 2026 changed content
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#Marked Entries###25 02 2007 new variable

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -4655,7 +4655,7 @@ common#:#mails#:#Mails
 common#:#mails_at_the_ilias_installation#:#Auf der ILIAS-Installation %2$s haben Sie %1$s neue Mail(s) erhalten
 common#:#mails_pl#:#Mail(s)
 common#:#main_menu#:#Hauptmenü
-common#:#mainbar_aria_label#:#Hauptnavigationsleiste
+common#:#mainbar_aria_label#:#Hauptnavigationsleiste###01 02 2026 changed content
 common#:#mainbar_more_label#:#Mehr
 common#:#manage_members#:#Mitglieder verwalten
 common#:#marked_entries#:#Markierte Einträge

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -4655,7 +4655,7 @@ common#:#mails#:#Mails
 common#:#mails_at_the_ilias_installation#:#Auf der ILIAS-Installation %2$s haben Sie %1$s neue Mail(s) erhalten
 common#:#mails_pl#:#Mail(s)
 common#:#main_menu#:#Hauptmenü
-common#:#mainbar_aria_label#:#Hauptleiste
+common#:#mainbar_aria_label#:#Hauptnavigationsleiste
 common#:#mainbar_more_label#:#Mehr
 common#:#manage_members#:#Mitglieder verwalten
 common#:#marked_entries#:#Markierte Einträge

--- a/lang/ilias_el.lang
+++ b/lang/ilias_el.lang
@@ -4654,7 +4654,7 @@ common#:#mails#:#Email
 common#:#mails_at_the_ilias_installation#:#You received %1$s new mails at the ILIAS-Installation %2$s###10 09 2010 new variable
 common#:#mails_pl#:#Μηνύματα
 common#:#main_menu#:#Main Menu###30 04 2009 new variable
-common#:#mainbar_aria_label#:#Mainbar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#Marked Entries

--- a/lang/ilias_el.lang
+++ b/lang/ilias_el.lang
@@ -4654,7 +4654,7 @@ common#:#mails#:#Email
 common#:#mails_at_the_ilias_installation#:#You received %1$s new mails at the ILIAS-Installation %2$s###10 09 2010 new variable
 common#:#mails_pl#:#Μηνύματα
 common#:#main_menu#:#Main Menu###30 04 2009 new variable
-common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###01 02 2026 changed content
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#Marked Entries

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -4656,7 +4656,7 @@ common#:#mails#:#Mails
 common#:#mails_at_the_ilias_installation#:#You received %1$s new mails at the ILIAS-Installation %2$s
 common#:#mails_pl#:#Mail(s)
 common#:#main_menu#:#Main Menu
-common#:#mainbar_aria_label#:#Mainbar
+common#:#mainbar_aria_label#:#Main navigation bar
 common#:#mainbar_more_label#:#More
 common#:#manage_members#:#Manage Members
 common#:#marked_entries#:#Marked Entries

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -4656,7 +4656,7 @@ common#:#mails#:#Mails
 common#:#mails_at_the_ilias_installation#:#You received %1$s new mails at the ILIAS-Installation %2$s
 common#:#mails_pl#:#Mail(s)
 common#:#main_menu#:#Main Menu
-common#:#mainbar_aria_label#:#Main navigation bar
+common#:#mainbar_aria_label#:#Main navigation bar###01 02 2026 changed content
 common#:#mainbar_more_label#:#More
 common#:#manage_members#:#Manage Members
 common#:#marked_entries#:#Marked Entries

--- a/lang/ilias_es.lang
+++ b/lang/ilias_es.lang
@@ -4655,7 +4655,7 @@ common#:#mails#:#correos
 common#:#mails_at_the_ilias_installation#:#Has recibido %1$s nuevos correos en la instalación de ILIAS %2$s
 common#:#mails_pl#:#Correo(s)
 common#:#main_menu#:#Menú Principal
-common#:#mainbar_aria_label#:#Barra de navegación principal
+common#:#mainbar_aria_label#:#Barra de navegación principal###01 02 2026 changed content
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Gestionar miembros
 common#:#marked_entries#:#Entradas marcadas

--- a/lang/ilias_es.lang
+++ b/lang/ilias_es.lang
@@ -4655,7 +4655,7 @@ common#:#mails#:#correos
 common#:#mails_at_the_ilias_installation#:#Has recibido %1$s nuevos correos en la instalación de ILIAS %2$s
 common#:#mails_pl#:#Correo(s)
 common#:#main_menu#:#Menú Principal
-common#:#mainbar_aria_label#:#Mainbar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Barra de navegación principal
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Gestionar miembros
 common#:#marked_entries#:#Entradas marcadas

--- a/lang/ilias_et.lang
+++ b/lang/ilias_et.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Postkast
 common#:#mails_at_the_ilias_installation#:#You received %1$s new mails at the ILIAS-Installation %2$s
 common#:#mails_pl#:#Kirjad
 common#:#main_menu#:#Põhimenüü
-common#:#mainbar_aria_label#:#Mainbar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#Märgistatud sisestused

--- a/lang/ilias_et.lang
+++ b/lang/ilias_et.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Postkast
 common#:#mails_at_the_ilias_installation#:#You received %1$s new mails at the ILIAS-Installation %2$s
 common#:#mails_pl#:#Kirjad
 common#:#main_menu#:#Põhimenüü
-common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###01 02 2026 changed content
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#Märgistatud sisestused

--- a/lang/ilias_fa.lang
+++ b/lang/ilias_fa.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Mails
 common#:#mails_at_the_ilias_installation#:#You received %1$s new mails at the ILIAS-Installation %2$s
 common#:#mails_pl#:#ایمیل
 common#:#main_menu#:#Main Menu
-common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###01 02 2026 changed content
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#موارد علامت گذاری شده

--- a/lang/ilias_fa.lang
+++ b/lang/ilias_fa.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Mails
 common#:#mails_at_the_ilias_installation#:#You received %1$s new mails at the ILIAS-Installation %2$s
 common#:#mails_pl#:#ایمیل
 common#:#main_menu#:#Main Menu
-common#:#mainbar_aria_label#:#Mainbar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#موارد علامت گذاری شده

--- a/lang/ilias_fr.lang
+++ b/lang/ilias_fr.lang
@@ -4638,7 +4638,7 @@ common#:#mails#:#Messages
 common#:#mails_at_the_ilias_installation#:#Vous avez reçu %1$s nouveaux mails à  l'installation-ILIAS %2$s
 common#:#mails_pl#:#Message(s)
 common#:#main_menu#:#Menu Principal
-common#:#mainbar_aria_label#:#Barre principale
+common#:#mainbar_aria_label#:#Barre de navigation principale
 common#:#mainbar_more_label#:#Plus
 common#:#manage_members#:#Gérer les membres
 common#:#marked_entries#:#Entrées Marquées

--- a/lang/ilias_fr.lang
+++ b/lang/ilias_fr.lang
@@ -4638,7 +4638,7 @@ common#:#mails#:#Messages
 common#:#mails_at_the_ilias_installation#:#Vous avez reçu %1$s nouveaux mails à  l'installation-ILIAS %2$s
 common#:#mails_pl#:#Message(s)
 common#:#main_menu#:#Menu Principal
-common#:#mainbar_aria_label#:#Barre de navigation principale
+common#:#mainbar_aria_label#:#Barre de navigation principale###01 02 2026 changed content
 common#:#mainbar_more_label#:#Plus
 common#:#manage_members#:#Gérer les membres
 common#:#marked_entries#:#Entrées Marquées

--- a/lang/ilias_hr.lang
+++ b/lang/ilias_hr.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#E-pošte
 common#:#mails_at_the_ilias_installation#:#Primili ste %1$s novu poštu na ILIAS-instalaciji %2$s
 common#:#mails_pl#:#E-pošta(e)
 common#:#main_menu#:#Glavni izbornik
-common#:#mainbar_aria_label#:#Mainbar###04 06 2021 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###04 06 2021 new variable
 common#:#mainbar_more_label#:#More###04 06 2021 new variable
 common#:#manage_members#:#Upravljanje članovima
 common#:#marked_entries#:#Označeni unosi

--- a/lang/ilias_hr.lang
+++ b/lang/ilias_hr.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#E-pošte
 common#:#mails_at_the_ilias_installation#:#Primili ste %1$s novu poštu na ILIAS-instalaciji %2$s
 common#:#mails_pl#:#E-pošta(e)
 common#:#main_menu#:#Glavni izbornik
-common#:#mainbar_aria_label#:#Main navigation bar###04 06 2021 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###01 02 2026 changed content
 common#:#mainbar_more_label#:#More###04 06 2021 new variable
 common#:#manage_members#:#Upravljanje članovima
 common#:#marked_entries#:#Označeni unosi

--- a/lang/ilias_hu.lang
+++ b/lang/ilias_hu.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Levelek
 common#:#mails_at_the_ilias_installation#:#%1$s új levelet kapott a(z) %2$s ILIAS-ban.
 common#:#mails_pl#:#levél/levelek
 common#:#main_menu#:#Főmenü
-common#:#mainbar_aria_label#:#Fő navigációs sáv
+common#:#mainbar_aria_label#:#Fő navigációs sáv###01 02 2026 changed content
 common#:#mainbar_more_label#:#Több
 common#:#manage_members#:#Tagok kezelése
 common#:#marked_entries#:#Megjelölt bejegyzések

--- a/lang/ilias_hu.lang
+++ b/lang/ilias_hu.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Levelek
 common#:#mails_at_the_ilias_installation#:#%1$s új levelet kapott a(z) %2$s ILIAS-ban.
 common#:#mails_pl#:#levél/levelek
 common#:#main_menu#:#Főmenü
-common#:#mainbar_aria_label#:#Főmenü
+common#:#mainbar_aria_label#:#Fő navigációs sáv
 common#:#mainbar_more_label#:#Több
 common#:#manage_members#:#Tagok kezelése
 common#:#marked_entries#:#Megjelölt bejegyzések

--- a/lang/ilias_it.lang
+++ b/lang/ilias_it.lang
@@ -4652,7 +4652,7 @@ common#:#mails#:#eMail
 common#:#mails_at_the_ilias_installation#:#Riceverai %1$s nuove mail durante l’installazione di ILIAS %2$s
 common#:#mails_pl#:#Mail
 common#:#main_menu#:#Menu principale
-common#:#mainbar_aria_label#:#Barra principale
+common#:#mainbar_aria_label#:#Barra principale###01 02 2026 changed content
 common#:#mainbar_more_label#:#More
 common#:#manage_members#:#Gestisci membri
 common#:#marked_entries#:#Voci contrassegnate

--- a/lang/ilias_it.lang
+++ b/lang/ilias_it.lang
@@ -4653,7 +4653,7 @@ common#:#mails_at_the_ilias_installation#:#Riceverai %1$s nuove mail durante lâ€
 common#:#mails_pl#:#Mail
 common#:#main_menu#:#Menu principale
 common#:#mainbar_aria_label#:#Barra principale###01 02 2026 changed content
-common#:#mainbar_more_label#:#More
+common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Gestisci membri
 common#:#marked_entries#:#Voci contrassegnate
 common#:#matriculation#:#Numero di matricola

--- a/lang/ilias_it.lang
+++ b/lang/ilias_it.lang
@@ -4652,8 +4652,8 @@ common#:#mails#:#eMail
 common#:#mails_at_the_ilias_installation#:#Riceverai %1$s nuove mail durante l’installazione di ILIAS %2$s
 common#:#mails_pl#:#Mail
 common#:#main_menu#:#Menu principale
-common#:#mainbar_aria_label#:#Barra principale###01 02 2026 changed content
-common#:#mainbar_more_label#:#More###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Barra principale
+common#:#mainbar_more_label#:#More
 common#:#manage_members#:#Gestisci membri
 common#:#marked_entries#:#Voci contrassegnate
 common#:#matriculation#:#Numero di matricola

--- a/lang/ilias_ja.lang
+++ b/lang/ilias_ja.lang
@@ -4659,7 +4659,7 @@ common#:#mails#:#メール
 common#:#mails_at_the_ilias_installation#:#ILIASインストレーション%2$sに%1$s個の新規メールがあります。
 common#:#mails_pl#:#メール
 common#:#main_menu#:#メインメニュー
-common#:#mainbar_aria_label#:#メインバー
+common#:#mainbar_aria_label#:#メインナビゲーションバー
 common#:#mainbar_more_label#:#More
 common#:#manage_members#:#メンバーを管理
 common#:#marked_entries#:#マークしたエントリー

--- a/lang/ilias_ja.lang
+++ b/lang/ilias_ja.lang
@@ -4659,7 +4659,7 @@ common#:#mails#:#メール
 common#:#mails_at_the_ilias_installation#:#ILIASインストレーション%2$sに%1$s個の新規メールがあります。
 common#:#mails_pl#:#メール
 common#:#main_menu#:#メインメニュー
-common#:#mainbar_aria_label#:#メインナビゲーションバー
+common#:#mainbar_aria_label#:#メインナビゲーションバー###01 02 2026 changed content
 common#:#mainbar_more_label#:#More
 common#:#manage_members#:#メンバーを管理
 common#:#marked_entries#:#マークしたエントリー

--- a/lang/ilias_ka.lang
+++ b/lang/ilias_ka.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#ემაილები
 common#:#mails_at_the_ilias_installation#:#თქვენ მიირეთ %s1$ ახალი ემაილები ილიასის დაყენებაში %s2$
 common#:#mails_pl#:#ემაილები
 common#:#main_menu#:#ემაილის მენიუ
-common#:#mainbar_aria_label#:#Mainbar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#მონიშნული შენატანები

--- a/lang/ilias_ka.lang
+++ b/lang/ilias_ka.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#ემაილები
 common#:#mails_at_the_ilias_installation#:#თქვენ მიირეთ %s1$ ახალი ემაილები ილიასის დაყენებაში %s2$
 common#:#mails_pl#:#ემაილები
 common#:#main_menu#:#ემაილის მენიუ
-common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###01 02 2026 changed content
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#მონიშნული შენატანები

--- a/lang/ilias_lt.lang
+++ b/lang/ilias_lt.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Paštas
 common#:#mails_at_the_ilias_installation#:#You received %1$s new mails at the ILIAS-Installation %2$s###10 09 2010 new variable
 common#:#mails_pl#:#Laiškas(-ai)
 common#:#main_menu#:#Main Menu###30 04 2009 new variable
-common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###01 02 2026 changed content
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#Marked Entries###25 02 2007 new variable

--- a/lang/ilias_lt.lang
+++ b/lang/ilias_lt.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Paštas
 common#:#mails_at_the_ilias_installation#:#You received %1$s new mails at the ILIAS-Installation %2$s###10 09 2010 new variable
 common#:#mails_pl#:#Laiškas(-ai)
 common#:#main_menu#:#Main Menu###30 04 2009 new variable
-common#:#mainbar_aria_label#:#Mainbar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#Marked Entries###25 02 2007 new variable

--- a/lang/ilias_nl.lang
+++ b/lang/ilias_nl.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#E-mail
 common#:#mails_at_the_ilias_installation#:#Je hebt %1$s nieuwe e-mails op ILIAS installatie %2$s
 common#:#mails_pl#:#E-mail(s)
 common#:#main_menu#:#Main Menu
-common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###01 02 2026 changed content
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#Gemarkeerde invoer

--- a/lang/ilias_nl.lang
+++ b/lang/ilias_nl.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#E-mail
 common#:#mails_at_the_ilias_installation#:#Je hebt %1$s nieuwe e-mails op ILIAS installatie %2$s
 common#:#mails_pl#:#E-mail(s)
 common#:#main_menu#:#Main Menu
-common#:#mainbar_aria_label#:#Mainbar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#Gemarkeerde invoer

--- a/lang/ilias_pl.lang
+++ b/lang/ilias_pl.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Wiadomości
 common#:#mails_at_the_ilias_installation#:#W programie ILIAS %2$s otrzymałeś %1$s nowych maili
 common#:#mails_pl#:#Maile
 common#:#main_menu#:#Menu główne
-common#:#mainbar_aria_label#:#Mainbar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Zarządzaj członkami
 common#:#marked_entries#:#Pozycje zaznaczone

--- a/lang/ilias_pl.lang
+++ b/lang/ilias_pl.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Wiadomości
 common#:#mails_at_the_ilias_installation#:#W programie ILIAS %2$s otrzymałeś %1$s nowych maili
 common#:#mails_pl#:#Maile
 common#:#main_menu#:#Menu główne
-common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###01 02 2026 changed content
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Zarządzaj członkami
 common#:#marked_entries#:#Pozycje zaznaczone

--- a/lang/ilias_pt.lang
+++ b/lang/ilias_pt.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Editar
 common#:#mails_at_the_ilias_installation#:#Recebeu %1$s novos mails na instalação ILIAS %2$s
 common#:#mails_pl#:#Definições de administração para editor de páginas ILIAS e TinyMCE.
 common#:#main_menu#:#Pasta
-common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###01 02 2026 changed content
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Gerir membros
 common#:#marked_entries#:#Fórum

--- a/lang/ilias_pt.lang
+++ b/lang/ilias_pt.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Editar
 common#:#mails_at_the_ilias_installation#:#Recebeu %1$s novos mails na instalação ILIAS %2$s
 common#:#mails_pl#:#Definições de administração para editor de páginas ILIAS e TinyMCE.
 common#:#main_menu#:#Pasta
-common#:#mainbar_aria_label#:#Mainbar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Gerir membros
 common#:#marked_entries#:#Fórum

--- a/lang/ilias_ro.lang
+++ b/lang/ilias_ro.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Mail
 common#:#mails_at_the_ilias_installation#:#You received %1$s new mails at the ILIAS-Installation %2$s###10 09 2010 new variable
 common#:#mails_pl#:#Mail(s)###25 02 2007 new variable
 common#:#main_menu#:#Main Menu###30 04 2009 new variable
-common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###01 02 2026 changed content
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#Marked Entries###25 02 2007 new variable

--- a/lang/ilias_ro.lang
+++ b/lang/ilias_ro.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Mail
 common#:#mails_at_the_ilias_installation#:#You received %1$s new mails at the ILIAS-Installation %2$s###10 09 2010 new variable
 common#:#mails_pl#:#Mail(s)###25 02 2007 new variable
 common#:#main_menu#:#Main Menu###30 04 2009 new variable
-common#:#mainbar_aria_label#:#Mainbar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#Marked Entries###25 02 2007 new variable

--- a/lang/ilias_ru.lang
+++ b/lang/ilias_ru.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Почта
 common#:#mails_at_the_ilias_installation#:#You received %1$s new mails at the ILIAS-Installation %2$s
 common#:#mails_pl#:#Письмо(а)
 common#:#main_menu#:#Main Menu
-common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###01 02 2026 changed content
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#Marked Entries

--- a/lang/ilias_ru.lang
+++ b/lang/ilias_ru.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Почта
 common#:#mails_at_the_ilias_installation#:#You received %1$s new mails at the ILIAS-Installation %2$s
 common#:#mails_pl#:#Письмо(а)
 common#:#main_menu#:#Main Menu
-common#:#mainbar_aria_label#:#Mainbar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#Marked Entries

--- a/lang/ilias_sk.lang
+++ b/lang/ilias_sk.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Pošta
 common#:#mails_at_the_ilias_installation#:#You received %1$s new mails at the ILIAS-Installation %2$s###28 10 2010 new variable
 common#:#mails_pl#:#Pošta
 common#:#main_menu#:#Hlavní menu
-common#:#mainbar_aria_label#:#Mainbar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#Označené vstupy

--- a/lang/ilias_sk.lang
+++ b/lang/ilias_sk.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Pošta
 common#:#mails_at_the_ilias_installation#:#You received %1$s new mails at the ILIAS-Installation %2$s###28 10 2010 new variable
 common#:#mails_pl#:#Pošta
 common#:#main_menu#:#Hlavní menu
-common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###01 02 2026 changed content
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#Označené vstupy

--- a/lang/ilias_sl.lang
+++ b/lang/ilias_sl.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#E-pošta
 common#:#mails_at_the_ilias_installation#:#Na namestitvi ILIAS %2$s ste prejeli %1$s novih sporočil
 common#:#mails_pl#:#E-pošta
 common#:#main_menu#:#Glavni meni
-common#:#mainbar_aria_label#:#Main navigation bar
+common#:#mainbar_aria_label#:#Main navigation bar###01 02 2026 changed content
 common#:#mainbar_more_label#:#More###19 08 2022 new variable
 common#:#manage_members#:#Upravljanje članov
 common#:#marked_entries#:#Označeni vnosi

--- a/lang/ilias_sl.lang
+++ b/lang/ilias_sl.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#E-pošta
 common#:#mails_at_the_ilias_installation#:#Na namestitvi ILIAS %2$s ste prejeli %1$s novih sporočil
 common#:#mails_pl#:#E-pošta
 common#:#main_menu#:#Glavni meni
-common#:#mainbar_aria_label#:#Mainbar
+common#:#mainbar_aria_label#:#Main navigation bar
 common#:#mainbar_more_label#:#More###19 08 2022 new variable
 common#:#manage_members#:#Upravljanje članov
 common#:#marked_entries#:#Označeni vnosi

--- a/lang/ilias_sq.lang
+++ b/lang/ilias_sq.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#E-Mail
 common#:#mails_at_the_ilias_installation#:#You received %1$s new mails at the ILIAS-Installation %2$s###10 09 2010 new variable
 common#:#mails_pl#:#Mail(s)###25 02 2007 new variable
 common#:#main_menu#:#Main Menu###30 04 2009 new variable
-common#:#mainbar_aria_label#:#Mainbar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#Marked Entries###25 02 2007 new variable

--- a/lang/ilias_sq.lang
+++ b/lang/ilias_sq.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#E-Mail
 common#:#mails_at_the_ilias_installation#:#You received %1$s new mails at the ILIAS-Installation %2$s###10 09 2010 new variable
 common#:#mails_pl#:#Mail(s)###25 02 2007 new variable
 common#:#main_menu#:#Main Menu###30 04 2009 new variable
-common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###01 02 2026 changed content
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#Marked Entries###25 02 2007 new variable

--- a/lang/ilias_sr.lang
+++ b/lang/ilias_sr.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Pošta
 common#:#mails_at_the_ilias_installation#:#You received %1$s new mails at the ILIAS-Installation %2$s###10 09 2010 new variable
 common#:#mails_pl#:#Mail(s)###25 02 2007 new variable
 common#:#main_menu#:#Main Menu###30 04 2009 new variable
-common#:#mainbar_aria_label#:#Mainbar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#Marked Entries###25 02 2007 new variable

--- a/lang/ilias_sr.lang
+++ b/lang/ilias_sr.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Pošta
 common#:#mails_at_the_ilias_installation#:#You received %1$s new mails at the ILIAS-Installation %2$s###10 09 2010 new variable
 common#:#mails_pl#:#Mail(s)###25 02 2007 new variable
 common#:#main_menu#:#Main Menu###30 04 2009 new variable
-common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###01 02 2026 changed content
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#Marked Entries###25 02 2007 new variable

--- a/lang/ilias_sv.lang
+++ b/lang/ilias_sv.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Mails
 common#:#mails_at_the_ilias_installation#:#På ILIAS-installationen %2$s har du fått %1$s nya mail(s)
 common#:#mails_pl#:#Mail(s)
 common#:#main_menu#:#Huvudmeny
-common#:#mainbar_aria_label#:#Main navigation bar
+common#:#mainbar_aria_label#:#Main navigation bar###01 02 2026 changed content
 common#:#mainbar_more_label#:#Mer
 common#:#manage_members#:#Hantera medlemmar
 common#:#marked_entries#:# Markerade poster

--- a/lang/ilias_sv.lang
+++ b/lang/ilias_sv.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Mails
 common#:#mails_at_the_ilias_installation#:#På ILIAS-installationen %2$s har du fått %1$s nya mail(s)
 common#:#mails_pl#:#Mail(s)
 common#:#main_menu#:#Huvudmeny
-common#:#mainbar_aria_label#:#Mainbar
+common#:#mainbar_aria_label#:#Main navigation bar
 common#:#mainbar_more_label#:#Mer
 common#:#manage_members#:#Hantera medlemmar
 common#:#marked_entries#:# Markerade poster

--- a/lang/ilias_tr.lang
+++ b/lang/ilias_tr.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Postalar
 common#:#mails_at_the_ilias_installation#:#ILIAS yüklemesi %2$s tarafından %1$s yeni posta aldınız
 common#:#mails_pl#:#Posta
 common#:#main_menu#:#Ana Menü
-common#:#mainbar_aria_label#:#Mainbar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#İşaretli Girdiler

--- a/lang/ilias_tr.lang
+++ b/lang/ilias_tr.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Postalar
 common#:#mails_at_the_ilias_installation#:#ILIAS yüklemesi %2$s tarafından %1$s yeni posta aldınız
 common#:#mails_pl#:#Posta
 common#:#main_menu#:#Ana Menü
-common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###01 02 2026 changed content
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#İşaretli Girdiler

--- a/lang/ilias_uk.lang
+++ b/lang/ilias_uk.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Пошта
 common#:#mails_at_the_ilias_installation#:#You received %1$s new mails at the ILIAS-Installation %2$s###10 09 2010 new variable
 common#:#mails_pl#:#Mail(s)###25 02 2007 new variable
 common#:#main_menu#:#Main Menu###30 04 2009 new variable
-common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###01 02 2026 changed content
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#Marked Entries###25 02 2007 new variable

--- a/lang/ilias_uk.lang
+++ b/lang/ilias_uk.lang
@@ -4653,7 +4653,7 @@ common#:#mails#:#Пошта
 common#:#mails_at_the_ilias_installation#:#You received %1$s new mails at the ILIAS-Installation %2$s###10 09 2010 new variable
 common#:#mails_pl#:#Mail(s)###25 02 2007 new variable
 common#:#main_menu#:#Main Menu###30 04 2009 new variable
-common#:#mainbar_aria_label#:#Mainbar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#Marked Entries###25 02 2007 new variable

--- a/lang/ilias_vi.lang
+++ b/lang/ilias_vi.lang
@@ -4655,7 +4655,7 @@ common#:#mails#:#Thư
 common#:#mails_at_the_ilias_installation#:#You received %1$s new mails at the ILIAS-Installation %2$s###10 09 2010 new variable
 common#:#mails_pl#:#Mail(s)###25 02 2007 new variable
 common#:#main_menu#:#Main Menu###30 04 2009 new variable
-common#:#mainbar_aria_label#:#Mainbar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#Marked Entries###25 02 2007 new variable

--- a/lang/ilias_vi.lang
+++ b/lang/ilias_vi.lang
@@ -4655,7 +4655,7 @@ common#:#mails#:#Thư
 common#:#mails_at_the_ilias_installation#:#You received %1$s new mails at the ILIAS-Installation %2$s###10 09 2010 new variable
 common#:#mails_pl#:#Mail(s)###25 02 2007 new variable
 common#:#main_menu#:#Main Menu###30 04 2009 new variable
-common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###01 02 2026 changed content
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#Marked Entries###25 02 2007 new variable

--- a/lang/ilias_zh.lang
+++ b/lang/ilias_zh.lang
@@ -4652,7 +4652,7 @@ common#:#mails#:#邮件
 common#:#mails_at_the_ilias_installation#:#您在ILIAS安装过程中已收到 %1$s 封新邮件
 common#:#mails_pl#:#邮件
 common#:#main_menu#:#主菜单
-common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###01 02 2026 changed content
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#已标记条目

--- a/lang/ilias_zh.lang
+++ b/lang/ilias_zh.lang
@@ -4652,7 +4652,7 @@ common#:#mails#:#邮件
 common#:#mails_at_the_ilias_installation#:#您在ILIAS安装过程中已收到 %1$s 封新邮件
 common#:#mails_pl#:#邮件
 common#:#main_menu#:#主菜单
-common#:#mainbar_aria_label#:#Mainbar###29 07 2022 new variable
+common#:#mainbar_aria_label#:#Main navigation bar###29 07 2022 new variable
 common#:#mainbar_more_label#:#More###29 07 2022 new variable
 common#:#manage_members#:#Manage Members###30 08 2015 new variable
 common#:#marked_entries#:#已标记条目


### PR DESCRIPTION
Replaced the aria-label `Mainbar` used for the main navigation with `Main navigation bar` to improve clarity and accessibility for
screen reader users, as requested in ticket [#43945](https://mantis.ilias.de/view.php?id=43945).

Additionally, we have included the modification in all languages and it has been specifically translated for:
- German
- Spanish
- French
- Hungarian
- Japanese
- Slovenian
