### PR TITLE
[LTI] Fix: Correct order of arguments in LTI tables

### DIFF
--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeSynchronizationTableGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeSynchronizationTableGUI.php
@@ -93,7 +93,7 @@ class ilLTIConsumerGradeSynchronizationTableGUI implements DataRetrieval
     public function getHTML(): string
     {
         $table = $this->ui_factory->table()
-            ->data("", $this->getColumns(), $this)
+            ->data($this, "", $this->getColumns())
             ->withOrder(new Order("lti_timestamp", Order::DESC))
             ->withRequest($this->request);
 

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerProviderTableGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerProviderTableGUI.php
@@ -149,7 +149,7 @@ class ilLTIConsumerProviderTableGUI implements DataRetrieval
     public function getHTML(bool $hasWriteAccess = false): string
     {
         $table = $this->ui_factory->table()
-            ->data($this->lng->txt('tbl_provider_header'), $this->getColumns(), $this)
+            ->data($this, $this->lng->txt('tbl_provider_header'), $this->getColumns())
             ->withOrder(new Order('title', Order::ASC))
             ->withRequest($this->request);
 

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerProviderUsageTableGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerProviderUsageTableGUI.php
@@ -101,7 +101,7 @@ class ilLTIConsumerProviderUsageTableGUI implements DataRetrieval
     public function getHTML(): string
     {
         $table = $this->ui_factory->table()
-            ->data($this->lng->txt('tbl_provider_usage_header'), $this->getColumns(), $this)
+            ->data($this, $this->lng->txt('tbl_provider_usage_header'), $this->getColumns())
             ->withOrder(new Order('title', Order::ASC))
             ->withRequest($this->request);
 

--- a/components/ILIAS/LTIProvider/classes/Consumer/class.ilObjectConsumerTableGUI.php
+++ b/components/ILIAS/LTIProvider/classes/Consumer/class.ilObjectConsumerTableGUI.php
@@ -218,7 +218,7 @@ class ilObjectConsumerTableGUI implements DataRetrieval
     public function getHtml(): string
     {
         $table = $this->ui_factory->table()
-            ->data($this->lng->txt('lti_object_consumer'), $this->getColumns(), $this)
+            ->data($this, $this->lng->txt('lti_object_consumer'), $this->getColumns())
             ->withOrder(new Order('title', Order::ASC))
             ->withActions($this->getActions())
             ->withRequest($this->request);

--- a/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilLTIProviderReleasedObjectsTableGUI.php
+++ b/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilLTIProviderReleasedObjectsTableGUI.php
@@ -147,7 +147,7 @@ class ilLTIProviderReleasedObjectsTableGUI implements DataRetrieval
     public function getHtml(): string
     {
         $table = $this->ui_factory->table()
-            ->data($this->lng->txt('lti_released_objects'), $this->getColumns(), $this)
+            ->data($this, $this->lng->txt('lti_released_objects'), $this->getColumns())
             ->withOrder(new Order('title', Order::ASC))
             ->withRequest($this->request);
 


### PR DESCRIPTION
The order of some parameters that caused a crash when accessing the LTI section in the administration panel has been modified to fix the issue reported in ticket [#45978](https://mantis.ilias.de/view.php?id=45978).