### PR TITLE
45958 fix: remove deleted languages from multilingual

### DIFF
--- a/Services/Object/classes/Translation/class.ilObjectTranslation.php
+++ b/Services/Object/classes/Translation/class.ilObjectTranslation.php
@@ -234,6 +234,11 @@ class ilObjectTranslation
     public function removeLanguage(string $lang): void
     {
         if ($lang != $this->getMasterLanguage()) {
+            $this->db->manipulateF(
+                "DELETE FROM page_object WHERE parent_id = %s AND lang = %s",
+                ["integer", "text"],
+                [$this->getObjId(), $lang]
+            );
             unset($this->languages[$lang]);
         }
     }


### PR DESCRIPTION
Fix for Mantis #45958

Problem
A removed language remains visible and editable in the page editor even after being deleted from the module's multilingual settings. This causes confusion, as the interface continues to show the removed language as the current one.

Solution
Removed multilingual settings logic from class.ilObjectTranslation.php to ensure that deleted languages are fully excluded from translation selection and editing.