### PR TITLE
Update maintenance.md – Update TB members

### DIFF
--- a/docs/development/maintenance.md
+++ b/docs/development/maintenance.md
@@ -9,7 +9,7 @@ contributors.
 # Special Roles
 
 * **Product Management**: [Matthias Kunkel](https://docu.ilias.de/go/usr/115)
-* **Technical Board**: [Rob Falkenstein](https://docu.ilias.de/go/usr/63946), [Marvin Hackfort](https://docu.ilias.de/go/usr/50523), [Michael Jansen](https://docu.ilias.de/go/usr/8784), [Richard Klees](https://docu.ilias.de/go/usr/34047), [Franziska Wandelmaier](https://docu.ilias.de/go/usr/33833)
+* **Technical Board**: [Rob Falkenstein](https://docu.ilias.de/go/usr/63946), [Marvin Hackfort](https://docu.ilias.de/go/usr/50523), [Michael Jansen](https://docu.ilias.de/go/usr/8784), [Franziska Wandelmaier](https://docu.ilias.de/go/usr/33833), [one vacant position]
 * **Testcase Management**: [Fabian Kruse](https://docu.ilias.de/go/usr/27631)
 * **Release Management**: [Fabian Wolf](https://docu.ilias.de/go/usr/29018)
 * **Technical Documentation**: [Ann-Christin Gruber](https://docu.ilias.de/go/usr/94025)


### PR DESCRIPTION
In accordance with the communication from the board and administration of the ILIAS Association and CaT Concepts and Training, this PR removes Richard from TB membership. 
We would like to take this opportunity to thank him and CaT once again for their many years of cooperation.

Oliver Samoila on behalf of the ILIAS Association Board