### PR TITLE
fix/46236 Call to undefined method ilDBPdoMySQLInnoDB::fetch()

### DIFF
--- a/components/ILIAS/User/src/Setup/DBUpdateSteps11.php
+++ b/components/ILIAS/User/src/Setup/DBUpdateSteps11.php
@@ -71,7 +71,7 @@ class DBUpdateSteps11 implements \ilDatabaseUpdateSteps
         string $new_value
     ): void {
         $query = $this->db->query("SELECT id, conf FROM badge_badge WHERE type_id='user/profile' AND conf LIKE '%$old_value%'");
-        while (($badge = $this->db->fetch($query)) !== null) {
+        while (($badge = $this->db->fetchObject($query)) !== null) {
             $config_array = unserialize($badge['conf'], ['allowed_classes' => false]);
             if (!array_key_exists('profile', $config_array)) {
                 continue;


### PR DESCRIPTION
replace fetch() with fetchObject()