### PR TITLE
T&A11 45372: Improves participant data export and import and also fixes inconsistent participant naming in different tables

### DIFF
--- a/components/ILIAS/Test/classes/class.ilObjTest.php
+++ b/components/ILIAS/Test/classes/class.ilObjTest.php
@@ -3286,7 +3286,7 @@ class ilObjTest extends ilObject
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "anonymity");
-        $a_xml_writer->xmlElement("fieldentry", null, sprintf("%d", $main_settings->getGeneralSettings()->getAnonymity()));
+        $a_xml_writer->xmlElement("fieldentry", null, $main_settings->getGeneralSettings()->getAnonymity() ? 1 : 0);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
@@ -3296,7 +3296,7 @@ class ilObjTest extends ilObject
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "sequence_settings");
-        $a_xml_writer->xmlElement("fieldentry", null, $main_settings->getParticipantFunctionalitySettings()->getPostponedQuestionsMoveToEnd());
+        $a_xml_writer->xmlElement("fieldentry", null, $main_settings->getParticipantFunctionalitySettings()->getPostponedQuestionsMoveToEnd() ? 1 : 0);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
@@ -3306,7 +3306,7 @@ class ilObjTest extends ilObject
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "reset_processing_time");
-        $a_xml_writer->xmlElement("fieldentry", null, (int) $main_settings->getTestBehaviourSettings()->getResetProcessingTime());
+        $a_xml_writer->xmlElement("fieldentry", null, $main_settings->getTestBehaviourSettings()->getResetProcessingTime() ? 1 : 0);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
@@ -3341,7 +3341,7 @@ class ilObjTest extends ilObject
 
         $a_xml_writer->xmlStartTag('qtimetadatafield');
         $a_xml_writer->xmlElement('fieldlabel', null, 'pass_deletion_allowed');
-        $a_xml_writer->xmlElement('fieldentry', null, (int) $this->isPassDeletionAllowed());
+        $a_xml_writer->xmlElement('fieldentry', null, $this->isPassDeletionAllowed() ? 1 : 0);
         $a_xml_writer->xmlEndTag('qtimetadatafield');
 
         if ($this->getScoreSettings()->getResultSummarySettings()->getReportingDate() !== null) {
@@ -3359,12 +3359,12 @@ class ilObjTest extends ilObject
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "nr_of_tries");
-        $a_xml_writer->xmlElement("fieldentry", null, sprintf("%d", $main_settings->getTestBehaviourSettings()->getNumberOfTries()));
+        $a_xml_writer->xmlElement("fieldentry", null, $main_settings->getTestBehaviourSettings()->getNumberOfTries());
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag('qtimetadatafield');
         $a_xml_writer->xmlElement('fieldlabel', null, 'block_after_passed');
-        $a_xml_writer->xmlElement('fieldentry', null, (int) $main_settings->getTestBehaviourSettings()->getBlockAfterPassedEnabled());
+        $a_xml_writer->xmlElement('fieldentry', null, $main_settings->getTestBehaviourSettings()->getBlockAfterPassedEnabled() ? 1 : 0);
         $a_xml_writer->xmlEndTag('qtimetadatafield');
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
@@ -3374,7 +3374,7 @@ class ilObjTest extends ilObject
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "kiosk");
-        $a_xml_writer->xmlElement("fieldentry", null, sprintf("%d", $main_settings->getTestBehaviourSettings()->getKioskMode()));
+        $a_xml_writer->xmlElement("fieldentry", null, $main_settings->getTestBehaviourSettings()->getKioskMode());
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag('qtimetadatafield');
@@ -3389,130 +3389,134 @@ class ilObjTest extends ilObject
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "use_previous_answers");
-        $a_xml_writer->xmlElement("fieldentry", null, (int) $main_settings->getParticipantFunctionalitySettings()->getUsePreviousAnswerAllowed());
+        $a_xml_writer->xmlElement("fieldentry", null, $main_settings->getParticipantFunctionalitySettings()->getUsePreviousAnswerAllowed() ? 1 : 0);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag('qtimetadatafield');
         $a_xml_writer->xmlElement('fieldlabel', null, 'question_list_enabled');
-        $a_xml_writer->xmlElement('fieldentry', null, (int) $main_settings->getParticipantFunctionalitySettings()->getQuestionListEnabled());
+        $a_xml_writer->xmlElement('fieldentry', null, $main_settings->getParticipantFunctionalitySettings()->getQuestionListEnabled() ? 1 : 0);
         $a_xml_writer->xmlEndTag('qtimetadatafield');
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "title_output");
-        $a_xml_writer->xmlElement("fieldentry", null, sprintf("%d", $main_settings->getQuestionBehaviourSettings()->getQuestionTitleOutputMode()));
+        $a_xml_writer->xmlElement("fieldentry", null, $main_settings->getQuestionBehaviourSettings()->getQuestionTitleOutputMode());
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "results_presentation");
-        $a_xml_writer->xmlElement("fieldentry", null, sprintf("%d", $this->getScoreSettings()->getResultDetailsSettings()->getResultsPresentation()));
+        $a_xml_writer->xmlElement("fieldentry", null, $this->getScoreSettings()->getResultDetailsSettings()->getResultsPresentation());
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "examid_in_test_pass");
-        $a_xml_writer->xmlElement("fieldentry", null, sprintf("%d", $main_settings->getTestBehaviourSettings()->getExamIdInTestAttemptEnabled()));
+        $a_xml_writer->xmlElement("fieldentry", null, $main_settings->getTestBehaviourSettings()->getExamIdInTestAttemptEnabled() ? 1 : 0);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "examid_in_test_res");
-        $a_xml_writer->xmlElement("fieldentry", null, sprintf("%d", $this->getScoreSettings()->getResultDetailsSettings()->getShowExamIdInTestResults()));
+        $a_xml_writer->xmlElement("fieldentry", null, $this->getScoreSettings()->getResultDetailsSettings()->getShowExamIdInTestResults() ? 1 : 0);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "usr_pass_overview_mode");
-        $a_xml_writer->xmlElement("fieldentry", null, sprintf("%d", $main_settings->getParticipantFunctionalitySettings()->getUsrPassOverviewMode()));
+        $a_xml_writer->xmlElement("fieldentry", null, $main_settings->getParticipantFunctionalitySettings()->getUsrPassOverviewMode());
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "score_reporting");
-        $a_xml_writer->xmlElement("fieldentry", null, sprintf("%d", $this->getScoreSettings()->getResultSummarySettings()->getScoreReporting()->value));
+        $a_xml_writer->xmlElement("fieldentry", null, $this->getScoreSettings()->getResultSummarySettings()->getScoreReporting()->value);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "show_solution_list_comparison");
-        $a_xml_writer->xmlElement("fieldentry", null, (int) $this->score_settings->getResultDetailsSettings()->getShowSolutionListComparison());
+        $a_xml_writer->xmlElement("fieldentry", null, $this->score_settings->getResultDetailsSettings()->getShowSolutionListComparison() ? 1 : 0);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "instant_verification");
-        $a_xml_writer->xmlElement("fieldentry", null, sprintf("%d", (int) $main_settings->getQuestionBehaviourSettings()->getInstantFeedbackSolutionEnabled()));
+        $a_xml_writer->xmlElement("fieldentry", null, $main_settings->getQuestionBehaviourSettings()->getInstantFeedbackSolutionEnabled() ? 1 : 0);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "answer_feedback");
-        $a_xml_writer->xmlElement("fieldentry", null, sprintf("%d", (int) $main_settings->getQuestionBehaviourSettings()->getInstantFeedbackGenericEnabled()));
+        $a_xml_writer->xmlElement("fieldentry", null, $main_settings->getQuestionBehaviourSettings()->getInstantFeedbackGenericEnabled() ? 1 : 0);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "instant_feedback_specific");
-        $a_xml_writer->xmlElement("fieldentry", null, sprintf("%d", (int) $main_settings->getQuestionBehaviourSettings()->getInstantFeedbackSpecificEnabled()));
+        $a_xml_writer->xmlElement("fieldentry", null, $main_settings->getQuestionBehaviourSettings()->getInstantFeedbackSpecificEnabled() ? 1 : 0);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "answer_feedback_points");
-        $a_xml_writer->xmlElement("fieldentry", null, sprintf("%d", (int) $main_settings->getQuestionBehaviourSettings()->getInstantFeedbackPointsEnabled()));
+        $a_xml_writer->xmlElement("fieldentry", null, $main_settings->getQuestionBehaviourSettings()->getInstantFeedbackPointsEnabled() ? 1 : 0);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "follow_qst_answer_fixation");
-        $a_xml_writer->xmlElement("fieldentry", null, (int) $main_settings->getQuestionBehaviourSettings()->getLockAnswerOnNextQuestionEnabled());
+        $a_xml_writer->xmlElement("fieldentry", null, $main_settings->getQuestionBehaviourSettings()->getLockAnswerOnNextQuestionEnabled() ? 1 : 0);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "instant_feedback_answer_fixation");
-        $a_xml_writer->xmlElement("fieldentry", null, (int) $main_settings->getQuestionBehaviourSettings()->getLockAnswerOnInstantFeedbackEnabled());
+        $a_xml_writer->xmlElement("fieldentry", null, $main_settings->getQuestionBehaviourSettings()->getLockAnswerOnInstantFeedbackEnabled() ? 1 : 0);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "force_instant_feedback");
-        $a_xml_writer->xmlElement("fieldentry", null, (int) $main_settings->getQuestionBehaviourSettings()->getForceInstantFeedbackOnNextQuestion());
+        $a_xml_writer->xmlElement("fieldentry", null, $main_settings->getQuestionBehaviourSettings()->getForceInstantFeedbackOnNextQuestion() ? 1 : 0);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $highscore_metadata = [
-            'highscore_enabled' => ['value' => $this->getHighscoreEnabled()],
-            'highscore_anon' => ['value' => $this->getHighscoreAnon()],
-            'highscore_achieved_ts' => ['value' => $this->getHighscoreAchievedTS()],
-            'highscore_score' => ['value' => $this->getHighscoreScore()],
-            'highscore_percentage' => ['value' => $this->getHighscorePercentage()],
-            'highscore_wtime' => ['value' => $this->getHighscoreWTime()],
-            'highscore_own_table' => ['value' => $this->getHighscoreOwnTable()],
-            'highscore_top_table' => ['value' => $this->getHighscoreTopTable()],
-            'highscore_top_num' => ['value' => $this->getHighscoreTopNum()],
+            'highscore_enabled' => $this->getHighscoreEnabled(),
+            'highscore_anon' => $this->getHighscoreAnon(),
+            'highscore_achieved_ts' => $this->getHighscoreAchievedTS(),
+            'highscore_score' => $this->getHighscoreScore(),
+            'highscore_percentage' => $this->getHighscorePercentage(),
+            'highscore_hints' => $this->getHighscoreHints(),
+            'highscore_wtime' => $this->getHighscoreWTime(),
+            'highscore_own_table' => $this->getHighscoreOwnTable(),
+            'highscore_top_table' => $this->getHighscoreTopTable(),
         ];
-        foreach ($highscore_metadata as $label => $data) {
+        foreach ($highscore_metadata as $label => $value) {
             $a_xml_writer->xmlStartTag("qtimetadatafield");
             $a_xml_writer->xmlElement("fieldlabel", null, $label);
-            $a_xml_writer->xmlElement("fieldentry", null, sprintf("%d", $data['value']));
+            $a_xml_writer->xmlElement("fieldentry", null, $value ? 1 : 0);
             $a_xml_writer->xmlEndTag("qtimetadatafield");
         }
+        $a_xml_writer->xmlStartTag("qtimetadatafield");
+        $a_xml_writer->xmlElement("fieldlabel", null, "highscore_top_num");
+        $a_xml_writer->xmlElement("fieldentry", null, $this->getHighscoreTopNum());
+        $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "suspend_test_allowed");
-        $a_xml_writer->xmlElement("fieldentry", null, sprintf("%d", (int) $main_settings->getParticipantFunctionalitySettings()->getSuspendTestAllowed()));
+        $a_xml_writer->xmlElement("fieldentry", null, $main_settings->getParticipantFunctionalitySettings()->getSuspendTestAllowed() ? 1 : 0);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "show_marker");
-        $a_xml_writer->xmlElement("fieldentry", null, sprintf("%d", (int) $main_settings->getParticipantFunctionalitySettings()->getQuestionMarkingEnabled()));
+        $a_xml_writer->xmlElement("fieldentry", null, $main_settings->getParticipantFunctionalitySettings()->getQuestionMarkingEnabled() ? 1 : 0);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "fixed_participants");
-        $a_xml_writer->xmlElement("fieldentry", null, sprintf("%d", (int) $main_settings->getAccessSettings()->getFixedParticipants()));
+        $a_xml_writer->xmlElement("fieldentry", null, $main_settings->getAccessSettings()->getFixedParticipants() ? 1 : 0);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "show_introduction");
-        $a_xml_writer->xmlElement("fieldentry", null, sprintf("%d", (int) $main_settings->getIntroductionSettings()->getIntroductionEnabled()));
+        $a_xml_writer->xmlElement("fieldentry", null, $main_settings->getIntroductionSettings()->getIntroductionEnabled() ? 1 : 0);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, 'exam_conditions');
-        $a_xml_writer->xmlElement("fieldentry", null, sprintf("%d", (int) $main_settings->getIntroductionSettings()->getExamConditionsCheckboxEnabled()));
+        $a_xml_writer->xmlElement("fieldentry", null, $main_settings->getIntroductionSettings()->getExamConditionsCheckboxEnabled() ? 1 : 0);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "show_concluding_remarks");
-        $a_xml_writer->xmlElement("fieldentry", null, sprintf("%d", (int) $main_settings->getFinishingSettings()->getConcludingRemarksEnabled()));
+        $a_xml_writer->xmlElement("fieldentry", null, $main_settings->getFinishingSettings()->getConcludingRemarksEnabled() ? 1 : 0);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
@@ -3522,7 +3526,7 @@ class ilObjTest extends ilObject
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "shuffle_questions");
-        $a_xml_writer->xmlElement("fieldentry", null, sprintf("%d", (int) $main_settings->getQuestionBehaviourSettings()->getShuffleQuestions()));
+        $a_xml_writer->xmlElement("fieldentry", null, $main_settings->getQuestionBehaviourSettings()->getShuffleQuestions() ? 1 : 0);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
@@ -3532,12 +3536,12 @@ class ilObjTest extends ilObject
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "enable_examview");
-        $a_xml_writer->xmlElement("fieldentry", null, (int) $main_settings->getFinishingSettings()->getShowAnswerOverview());
+        $a_xml_writer->xmlElement("fieldentry", null, $main_settings->getFinishingSettings()->getShowAnswerOverview() ? 1 : 0);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "skill_service");
-        $a_xml_writer->xmlElement("fieldentry", null, (int) $main_settings->getAdditionalSettings()->getSkillsServiceEnabled());
+        $a_xml_writer->xmlElement("fieldentry", null, $main_settings->getAdditionalSettings()->getSkillsServiceEnabled() ? 1 : 0);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         if ($this->getInstantFeedbackSolution() == 1) {
@@ -3551,17 +3555,17 @@ class ilObjTest extends ilObject
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "show_grading_status");
-        $a_xml_writer->xmlElement("fieldentry", null, (int) $this->isShowGradingStatusEnabled());
+        $a_xml_writer->xmlElement("fieldentry", null, $this->isShowGradingStatusEnabled() ? 1 : 0);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "show_grading_mark");
-        $a_xml_writer->xmlElement("fieldentry", null, (int) $this->isShowGradingMarkEnabled());
+        $a_xml_writer->xmlElement("fieldentry", null, $this->isShowGradingMarkEnabled() ? 1 : 0);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag('qtimetadatafield');
         $a_xml_writer->xmlElement('fieldlabel', null, 'hide_info_tab');
-        $a_xml_writer->xmlElement('fieldentry', null, (int) $this->getMainSettings()->getAdditionalSettings()->getHideInfoTab());
+        $a_xml_writer->xmlElement('fieldentry', null, $this->getMainSettings()->getAdditionalSettings()->getHideInfoTab() ? 1 : 0);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         if ($this->getStartingTime() > 0) {
@@ -3592,7 +3596,7 @@ class ilObjTest extends ilObject
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "autosave");
-        $a_xml_writer->xmlElement("fieldentry", null, (int) $main_settings->getQuestionBehaviourSettings()->getAutosaveEnabled());
+        $a_xml_writer->xmlElement("fieldentry", null, $main_settings->getQuestionBehaviourSettings()->getAutosaveEnabled() ? 1 : 0);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
@@ -3602,17 +3606,17 @@ class ilObjTest extends ilObject
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "instant_feedback_specific");
-        $a_xml_writer->xmlElement("fieldentry", null, (int) $main_settings->getQuestionBehaviourSettings()->getInstantFeedbackSpecificEnabled());
+        $a_xml_writer->xmlElement("fieldentry", null, $main_settings->getQuestionBehaviourSettings()->getInstantFeedbackSpecificEnabled() ? 1 : 0);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "instant_feedback_answer_fixation");
-        $a_xml_writer->xmlElement("fieldentry", null, (int) $main_settings->getQuestionBehaviourSettings()->getLockAnswerOnInstantFeedbackEnabled());
+        $a_xml_writer->xmlElement("fieldentry", null, $main_settings->getQuestionBehaviourSettings()->getLockAnswerOnInstantFeedbackEnabled() ? 1 : 0);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "enable_processing_time");
-        $a_xml_writer->xmlElement("fieldentry", null, (int) $main_settings->getTestBehaviourSettings()->getProcessingTimeEnabled());
+        $a_xml_writer->xmlElement("fieldentry", null, $main_settings->getTestBehaviourSettings()->getProcessingTimeEnabled() ? 1 : 0);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         foreach ($this->getMarkSchema()->getMarkSteps() as $index => $mark) {

--- a/components/ILIAS/Test/classes/class.ilTestParticipantList.php
+++ b/components/ILIAS/Test/classes/class.ilTestParticipantList.php
@@ -333,30 +333,25 @@ class ilTestParticipantList implements Iterator
         return $this->getTestObj()->_getLastAccess($active_id);
     }
 
-    protected function buildFullname(ilTestParticipant $participant): string
+    public function buildFullname(ilTestParticipant $participant): string
     {
-        if ($this->getTestObj()->getMainSettings()->getAccessSettings()->getFixedParticipants() && !$participant->getActiveId()) {
-            return $this->buildInviteeFullname($participant);
-        }
-
-        return $this->buildParticipantsFullname($participant);
+        $active_id = $participant->getActiveId();
+        $fixed_participants = $this->getTestObj()->getMainSettings()->getAccessSettings()->getFixedParticipants();
+        return $fixed_participants && !$active_id
+            ? $this->buildInviteeFullname($participant)
+            : ilObjTestAccess::_getParticipantData($active_id);
     }
 
     protected function buildInviteeFullname(ilTestParticipant $participant): string
     {
-        if (strlen($participant->getFirstname() . $participant->getLastname()) == 0) {
-            return $this->lng->txt("deleted_user");
+        if ("{$participant->getFirstname()}{$participant->getLastname()}" === '') {
+            return $this->lng->txt('deleted_user');
         }
 
         if ($this->getTestObj()->getAnonymity()) {
             return $this->lng->txt('anonymous');
         }
 
-        return trim($participant->getLastname() . ", " . $participant->getFirstname());
-    }
-
-    protected function buildParticipantsFullname(ilTestParticipant $participant): string
-    {
-        return ilObjTestAccess::_getParticipantData($participant->getActiveId());
+        return trim("{$participant->getLastname()}, {$participant->getFirstname()}");
     }
 }

--- a/components/ILIAS/Test/classes/class.ilTestResultsImportParser.php
+++ b/components/ILIAS/Test/classes/class.ilTestResultsImportParser.php
@@ -109,44 +109,44 @@ class ilTestResultsImportParser extends ilSaxParser
                     case 'tst_active':
                         if (!$this->user_criteria_checked) {
                             $this->user_criteria_checked = true;
-                            if (isset($a_attribs['user_criteria'])
-                                && $this->db->tableColumnExists('usr_data', $a_attribs['user_criteria'])) {
-                                $analyzer = new ilDBAnalyzer();
-                                $info = $analyzer->getFieldInformation('usr_data');
-                                $this->user_criteria_field = $a_attribs['user_criteria'];
-                                $this->user_criteria_type = $info[$a_attribs['user_criteria']]['type'];
+                            $user_criteria = $a_attribs['user_criteria'] ?? null;
+                            if (
+                                is_string($user_criteria)
+                                && $this->db->tableColumnExists('usr_data', $user_criteria)
+                            ) {
+                                $info = (new ilDBAnalyzer())->getFieldInformation('usr_data');
+                                $this->user_criteria_field = $user_criteria;
+                                $this->user_criteria_type = $info[$user_criteria]['type'];
                             }
                         }
                         $usr_id = ANONYMOUS_USER_ID;
                         if ($this->user_criteria_field !== '') {
                             $result = $this->db->queryF(
-                                'SELECT usr_id FROM usr_data WHERE '
-                                    . $this->user_criteria_field . ' =  %s',
+                                "SELECT usr_id FROM usr_data WHERE {$this->user_criteria_field} = %s",
                                 [$this->user_criteria_type],
                                 [$a_attribs[$this->user_criteria_field]]
                             );
                             if ($result->numRows()) {
-                                $row = $this->db->fetchAssoc($result);
-                                $usr_id = $row['usr_id'];
+                                $usr_id = $this->db->fetchAssoc($result)['usr_id'];
                             }
                         }
-                        $next_id = $this->db->nextId('tst_active');
 
+                        $next_id = $this->db->nextId('tst_active');
                         $this->db->insert('tst_active', [
-                            'active_id' => ['integer', $next_id],
-                            'user_fi' => ['integer', $usr_id],
-                            'anonymous_id' => ['text', strlen($a_attribs['anonymous_id']) ? $a_attribs['anonymous_id'] : null],
-                            'test_fi' => ['integer', $this->test_obj->getTestId()],
-                            'lastindex' => ['integer', $a_attribs['lastindex']],
-                            'tries' => ['integer', $a_attribs['tries']],
-                            'submitted' => ['integer', $a_attribs['submitted']],
-                            'submittimestamp' => ['timestamp', strlen($a_attribs['submittimestamp']) ? $a_attribs['submittimestamp'] : null],
-                            'tstamp' => ['integer', $a_attribs['tstamp']],
-                            'importname' => ['text', $a_attribs['fullname']],
-                            'last_finished_pass' => ['integer', $this->fetchLastFinishedPass($a_attribs)],
-                            'last_started_pass' => ['integer', $this->fetchLastStartedPass($a_attribs)],
-                            'answerstatusfilter' => ['integer', $this->fetchAttribute($a_attribs, 'answer_status_filter')],
-                            'objective_container' => ['integer', $this->fetchAttribute($a_attribs, 'objective_container')]
+                            'active_id' => [ilDBConstants::T_INTEGER, $next_id],
+                            'user_fi' => [ilDBConstants::T_INTEGER, $usr_id],
+                            'anonymous_id' => [ilDBConstants::T_TEXT, $a_attribs['anonymous_id'] ?: null],
+                            'test_fi' => [ilDBConstants::T_INTEGER, $this->test_obj->getTestId()],
+                            'lastindex' => [ilDBConstants::T_INTEGER, $a_attribs['lastindex']],
+                            'tries' => [ilDBConstants::T_INTEGER, $a_attribs['tries']],
+                            'submitted' => [ilDBConstants::T_INTEGER, $a_attribs['submitted']],
+                            'submittimestamp' => [ilDBConstants::T_TIMESTAMP, $a_attribs['submittimestamp'] ?: null],
+                            'tstamp' => [ilDBConstants::T_INTEGER, $a_attribs['tstamp']],
+                            'importname' => [ilDBConstants::T_TEXT, $a_attribs['fullname']],
+                            'last_finished_pass' => [ilDBConstants::T_INTEGER, $this->fetchLastFinishedPass($a_attribs)],
+                            'last_started_pass' => [ilDBConstants::T_INTEGER, $this->fetchLastStartedPass($a_attribs)],
+                            'answerstatusfilter' => [ilDBConstants::T_INTEGER, $this->fetchAttribute($a_attribs, 'answer_status_filter')],
+                            'objective_container' => [ilDBConstants::T_INTEGER, $this->fetchAttribute($a_attribs, 'objective_container')]
                         ]);
                         $this->active_id_mapping[$a_attribs['active_id']] = $next_id;
                         break;

--- a/components/ILIAS/Test/classes/class.ilTestResultsToXML.php
+++ b/components/ILIAS/Test/classes/class.ilTestResultsToXML.php
@@ -22,16 +22,17 @@ use ILIAS\ResourceStorage\Services as ResourceStorage;
 
 class ilTestResultsToXML extends ilXmlWriter
 {
-    private $active_ids;
+    private array $active_ids = [];
 
     protected bool $include_random_test_questions_enabled = false;
 
     public function __construct(
-        private int $test_id,
-        private ilDBInterface $db,
-        private ResourceStorage $irss,
-        private string $objects_export_directory,
-        private bool $anonymized = false
+        private readonly ilObjTest $test_obj,
+        private readonly ilDBInterface $db,
+        private readonly ResourceStorage $irss,
+        private readonly ilObjUser $user,
+        private readonly ilLanguage $lng,
+        private string $objects_export_directory
     ) {
         parent::__construct();
     }
@@ -48,30 +49,25 @@ class ilTestResultsToXML extends ilXmlWriter
 
     protected function exportActiveIDs(): void
     {
-        $assessment_setting = new ilSetting('assessment');
-        $user_criteria = $assessment_setting->get('user_criteria');
-        if ($user_criteria === null || $user_criteria === '') {
-            $user_criteria = 'usr_id';
-        }
+        $user_criteria = (new ilSetting('assessment'))->get('user_criteria', 'usr_id');
 
-        if ($this->anonymized) {
-            $result = $this->db->queryF(
-                'SELECT * FROM tst_active WHERE test_fi = %s',
-                ['integer'],
-                [$this->test_id]
-            );
-        } else {
-            $result = $this->db->queryF(
-                'SELECT tst_active.*, usr_data.' . $user_criteria . ' FROM tst_active, usr_data WHERE tst_active.test_fi = %s AND tst_active.user_fi = usr_data.usr_id',
-                ['integer'],
-                [$this->test_id]
-            );
-        }
+        $query = $this->test_obj->getAnonymity()
+            ? 'SELECT * FROM tst_active WHERE test_fi = %s'
+            : "SELECT tst_active.*, usr_data.{$user_criteria} FROM tst_active, usr_data WHERE tst_active.test_fi = %s AND tst_active.user_fi = usr_data.usr_id";
+        $result = $this->db->queryF($query, [ilDBConstants::T_INTEGER], [$this->test_obj->getTestId()]);
+
+        $test_participant_list = new ilTestParticipantList($this->test_obj, $this->user, $this->lng, $this->db);
+        $test_participant_list->initializeFromDbRows($this->test_obj->getTestParticipants());
+
         $this->xmlStartTag('tst_active', null);
         while ($row = $this->db->fetchAssoc($result)) {
+            $this->active_ids[] = $row['active_id'];
+            $participant = $test_participant_list->getParticipantByActiveId($row['active_id']);
+
             $attrs = [
                 'active_id' => $row['active_id'],
-                'user_fi' => $row['user_fi'] ?? '',
+                'user_fi' => $this->test_obj->getAnonymity() ? '' : ($row['user_fi'] ?? ''),
+                'fullname' => $participant ? $test_participant_list->buildFullname($participant) : '',
                 'anonymous_id' => $row['anonymous_id'] ?? '',
                 'test_fi' => $row['test_fi'],
                 'lastindex' => $row['lastindex'] ?? '',
@@ -82,12 +78,12 @@ class ilTestResultsToXML extends ilXmlWriter
                 'submittimestamp' => $row['submittimestamp'] ?? '',
                 'tstamp' => $row['tstamp'] ?? ''
             ];
-            $attrs['fullname'] = ilObjTestAccess::_getParticipantData($row['active_id']);
-            if (!$this->anonymized) {
+
+            if (!$this->test_obj->getAnonymity()) {
                 $attrs['user_criteria'] = $user_criteria;
                 $attrs[$user_criteria] = $row[$user_criteria];
             }
-            array_push($this->active_ids, $row['active_id']);
+
             $this->xmlElement('row', $attrs);
         }
         $this->xmlEndTag('tst_active');

--- a/components/ILIAS/Test/src/ExportImport/Export.php
+++ b/components/ILIAS/Test/src/ExportImport/Export.php
@@ -54,7 +54,7 @@ abstract class Export implements Exporter
     protected string $inst_id;
 
     public function __construct(
-        protected readonly Language $lng,
+        protected readonly \ilLanguage $lng,
         protected readonly \ilDBInterface $db,
         protected readonly \ilBenchmark $bench,
         protected readonly TestLogger $logger,
@@ -63,7 +63,8 @@ abstract class Export implements Exporter
         protected readonly GeneralQuestionPropertiesRepository $questionrepository,
         protected readonly FileDeliveryServices $file_delivery,
         protected readonly \ilObjTest $test_obj,
-        protected readonly ResourceStorage $irss
+        protected readonly ResourceStorage $irss,
+        protected readonly \ilObjUser $user
     ) {
         $this->inst_id = (string) IL_INST_ID;
         $this->export_dir = $test_obj->getExportDirectory();
@@ -166,11 +167,12 @@ abstract class Export implements Exporter
 
         if ($this->isResultExportingEnabled()) {
             $resultwriter = new \ilTestResultsToXML(
-                $this->test_obj->getTestId(),
+                $this->test_obj,
                 $this->db,
                 $this->irss,
-                $this->export_dir . "/" . $this->subdir . "/objects",
-                $this->test_obj->getAnonymity()
+                $this->user,
+                $this->lng,
+                "{$this->export_dir}/{$this->subdir}/objects"
             );
             $resultwriter->setIncludeRandomTestQuestionsEnabled($this->test_obj->isRandomTest());
             $this->bench->start('TestExport', 'write_results');

--- a/components/ILIAS/Test/src/ExportImport/Factory.php
+++ b/components/ILIAS/Test/src/ExportImport/Factory.php
@@ -85,10 +85,7 @@ class Factory
 
             case Types::XML:
             case Types::XML_WITH_RESULTS:
-                $export_class = ExportFixedQuestionSet::class;
-                if (!$test_obj->isFixedTest()) {
-                    $export_class = ExportRandomQuestionSet::class;
-                }
+                $export_class = $test_obj->isFixedTest() ? ExportFixedQuestionSet::class : ExportRandomQuestionSet::class;
 
                 $export = new $export_class(
                     $this->lng,
@@ -100,13 +97,11 @@ class Factory
                     $this->questionrepository,
                     $this->file_delivery,
                     $test_obj,
-                    $this->irss
+                    $this->irss,
+                    $this->current_user
                 );
 
-                if ($export_type === Types::XML_WITH_RESULTS) {
-                    return $export->withResultExportingEnabled(true);
-                }
-                return $export;
+                return $export->withResultExportingEnabled($export_type === Types::XML_WITH_RESULTS);
 
             case Types::PLUGIN:
                 if ($plugin_type === null) {

--- a/components/ILIAS/Test/tests/ExportImport/ExportFixedQuestionSetTest.php
+++ b/components/ILIAS/Test/tests/ExportImport/ExportFixedQuestionSetTest.php
@@ -39,7 +39,7 @@ class ExportFixedQuestionSetTest extends \ilTestBaseTestCase
         $this->addGlobal_resourceStorage();
 
         $this->testObj = new ExportFixedQuestionSet(
-            $this->createMock(\ILIAS\Language\Language::class),
+            $this->createMock(\ilLanguage::class),
             $this->createMock(\ilDBInterface::class),
             $this->createMock(\ilBenchmark::class),
             $this->createMock(\ILIAS\Test\Logging\TestLogger::class),
@@ -48,7 +48,8 @@ class ExportFixedQuestionSetTest extends \ilTestBaseTestCase
             $this->createMock(\ILIAS\TestQuestionPool\Questions\GeneralQuestionPropertiesRepository::class),
             $this->createMock(\ILIAS\FileDelivery\Services::class),
             $this->createMock(\ilObjTest::class),
-            $DIC['resource_storage']
+            $DIC['resource_storage'],
+            $DIC['ilUser']
         );
     }
 

--- a/components/ILIAS/Test/tests/ExportImport/ExportRandomQuestionSetTest.php
+++ b/components/ILIAS/Test/tests/ExportImport/ExportRandomQuestionSetTest.php
@@ -38,7 +38,7 @@ class ExportRandomQuestionSetTest extends \ilTestBaseTestCase
         $this->addGlobal_resourceStorage();
 
         $this->testObj = new ExportRandomQuestionSet(
-            $this->createMock(\ILIAS\Language\Language::class),
+            $this->createMock(\ilLanguage::class),
             $this->createMock(\ilDBInterface::class),
             $this->createmOck(\ilBenchmark::class),
             $this->createMock(\ILIAS\Test\Logging\TestLogger::class),
@@ -47,7 +47,8 @@ class ExportRandomQuestionSetTest extends \ilTestBaseTestCase
             $this->createMock(\ILIAS\TestQuestionPool\Questions\GeneralQuestionPropertiesRepository::class),
             $this->createMock(\ILIAS\FileDelivery\Services::class),
             $this->getTestObjMock(),
-            $DIC['resource_storage']
+            $DIC['resource_storage'],
+            $DIC['ilUser']
         );
     }
 

--- a/components/ILIAS/Test/tests/ilTestResultsToXMLTest.php
+++ b/components/ILIAS/Test/tests/ilTestResultsToXMLTest.php
@@ -32,11 +32,12 @@ class ilTestResultsToXMLTest extends ilTestBaseTestCase
         parent::setUp();
 
         $this->testObj = new ilTestResultsToXML(
-            0,
+            $this->createMock(ilObjTest::class),
             $DIC['ilDB'],
             $DIC['resource_storage'],
-            '',
-            false
+            $DIC['ilUser'],
+            $DIC['lng'],
+            ''
         );
     }
 


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45372

Aims to improve participant data export and import and also to fix inconsistent participant naming in different tables.

Already reviewed by @thojou.