### PR TITLE
T&A 45954: Removes many orphaned assessment language variables

### DIFF
--- a/lang/ilias_ar.lang
+++ b/lang/ilias_ar.lang
@@ -693,12 +693,10 @@ assessment#:#examid_in_test_res#:#ILIAS Testpass ID###27 01 2015 new variable
 assessment#:#examid_in_test_res_desc#:#The ILIAS Testpass ID will be included in the test results.###27 01 2015 new variable
 assessment#:#exp_all_test_runs#:#All test attempts###26 08 2024 new variable
 assessment#:#exp_eval_data#:#Export evaluation data as
-assessment#:#exp_file_created#:#Export file created.###24 10 2013 new variable
 assessment#:#exp_grammar_as#:#as###26 08 2024 new variable
 assessment#:#exp_scored_test_attempt#:#Scored Test Attempt###28 10 2024 new variable
 assessment#:#exp_type_certificate#:# (PDF) شهادة
 assessment#:#exp_type_excel#:#Microsoft Excel
-assessment#:#exp_type_spss#:#Comma Separated Value (CSV)
 assessment#:#expected_result_type#:#Expected result type###24 10 2013 new variable
 assessment#:#export_cert_failed_for_users_p#:#No certificate file could be generated and added for the following %s accounts: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
 assessment#:#export_cert_failed_for_users_s#:#No certificate file could be generated and added to the archive for the following account: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
@@ -1434,7 +1432,6 @@ assessment#:#tst_delete_missing_mark#:#Please select at least one mark step to d
 assessment#:#tst_derive_new_pool#:#Derive New Question Pool###25 10 2016 new variable
 assessment#:#tst_derive_new_pools#:#Derive New Question Pools###25 10 2016 new variable
 assessment#:#tst_dont_show_msg_again_in_current_session#:#Don't show this message again in my current session.###10 11 2018 new variable
-assessment#:#tst_dont_use_previous_answers#:#Your previous answers will not be used as default values in future test passes
 assessment#:#tst_edit_competence_assign#:#Edit Assignment Properties###30 08 2015 new variable
 assessment#:#tst_edit_scoring#:#Edit Scoring
 assessment#:#tst_enable_questionlist#:#Show 'List of Questions’###26 08 2024 new variable
@@ -1494,7 +1491,6 @@ assessment#:#tst_finish_notification#:#Mail on completion
 assessment#:#tst_finish_notification_advanced#:#Send complete test result to test owner
 assessment#:#tst_finish_notification_content_type#:#Content of e-mail###27 01 2015 new variable
 assessment#:#tst_finish_notification_desc#:#Sends an e-mail to the test owner for every user that has completed the test.###27 01 2015 new variable
-assessment#:#tst_finish_notification_no#:#No e-mail###06 02 2015 new variable
 assessment#:#tst_finish_notification_simple#:#Send user name and finish date to test owner
 assessment#:#tst_finished#:#Finished
 assessment#:#tst_form_dynamic_question_set_config#:#Continues Question Selection###24 10 2013 new variable
@@ -1508,7 +1504,6 @@ assessment#:#tst_hide_info_tab#:#Hide Info Tab###26 08 2024 new variable
 assessment#:#tst_hide_info_tab_desc#:#Hides the tab ‘Info’ of the test.###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents#:#Hide page content###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents_desc#:#ILIAS content placed before and after the actual question text via the "Edit Page" button will not be displayed in the result views and print output.###26 08 2024 new variable
-assessment#:#tst_hide_side_list#:#Hide question list
 assessment#:#tst_highscore_achieved_ts#:#Show date of test
 assessment#:#tst_highscore_achieved_ts_description#:#Controls, if a column with the test date should be shown.
 assessment#:#tst_highscore_all_tables#:#All Rankings###07 11 2014 new variable
@@ -1528,7 +1523,6 @@ assessment#:#tst_highscore_score#:#Show score
 assessment#:#tst_highscore_score_description#:#Controls, if a column with the score should be shown.
 assessment#:#tst_highscore_top_num#:#Number of ranks
 assessment#:#tst_highscore_top_num_description#:#Controls, how many ranks should be included in the top ranking table.
-assessment#:#tst_highscore_top_num_unit#:#entries
 assessment#:#tst_highscore_top_table#:#Show table 'top ranking'
 assessment#:#tst_highscore_top_table_description#:#Controls, if the table 'top ranking' should be shown.
 assessment#:#tst_highscore_wtime#:#Show working time
@@ -1924,10 +1918,6 @@ assessment#:#tst_show_results#:#Show Test Results
 assessment#:#tst_show_side_list#:#Show question list aside
 assessment#:#tst_show_solution_answers_only#:#Results print view (answers only)
 assessment#:#tst_show_solution_answers_only_desc#:#If is selected, the ILIAS content you place around a question using the "Edit content" tab page will not be visible in a print-out. If you want to save some paper space, select this option.###07 11 2014 new variable
-assessment#:#tst_show_solution_compare#:#Compare Answer with Solution in List of Answers###24 10 2013 new variable
-assessment#:#tst_show_solution_compare_desc#:#Participants are presented with an overview comparing their own answers with the best solutions. Please note that this view will be displayed in the ‘Detailed Results’ that can be accessed via the ‘Show Test Results‘-button on the ‘Info’-tab. It will not be displayed in the printable ‘List of Answers’ even though the setting is made here.###06 02 2015 new variable
-assessment#:#tst_show_solution_details#:#Show Solutions in Test Results
-assessment#:#tst_show_solution_details_desc#:#If selected, the detailed question solution is available to participants in the test results presentation. This includes the exact scoring of every answer, otherwise only an overview with the question titles and the reached points is shown.###07 11 2014 new variable
 assessment#:#tst_show_solution_details_singlepage#:#Scored Answers on single pages###26 08 2024 new variable
 assessment#:#tst_show_solution_details_singlepage_desc#:#Participants can access each question individually and see if their answers were correct and how many points they scored.###26 08 2024 new variable
 assessment#:#tst_show_solution_feedback#:#Show Answer-Specific Feedback in Test Results
@@ -1950,7 +1940,6 @@ assessment#:#tst_skill_triggerings_num_req_answers_desc#:#Competences aren't tri
 assessment#:#tst_skill_triggerings_num_req_answers_not_reached_warn#:#At least one of the competences addressed by this test is not triggered by the minimal required amount of questions.<br />The required amount of questions: %s###10 11 2018 new variable
 assessment#:#tst_skl_level_thresholds_link#:#Configure Competence-Thresholds###30 08 2015 new variable
 assessment#:#tst_skl_level_thresholds_missing#:#There are missing thresholds for the relevant competences!###30 08 2015 new variable
-assessment#:#tst_skl_res_interpretation_hint_msg#:#Please consider that competence results from a single test has a limited significance. The more information is collected per competence, the merrier valid the significance will be. Should there are single competences without any entry, there is to less information collected.###30 08 2015 new variable
 assessment#:#tst_skl_sub_tab_thresholds#:#Competence Thresholds###26 09 2014 new variable
 assessment#:#tst_sol_comp_expressions#:#Comparison Expressions###30 08 2015 new variable
 assessment#:#tst_solution_compare_cfg#:#Configuration for Solution Compare###30 08 2015 new variable
@@ -2012,7 +2001,6 @@ assessment#:#tst_unchanged_answer_is_correct#:#The preset answer is correct###fa
 assessment#:#tst_unchanged_order_is_correct#:#The preset order is correct###fau: testNav
 assessment#:#tst_use_previous_answers#:#Use Previous Answers
 assessment#:#tst_use_previous_answers_description#:#If checked, a participant may choose to use the previous answers as default values in future test passes, otherwise the previous answers are not shown in future test passes.
-assessment#:#tst_use_previous_answers_user#:#Use my previous answers as default values in future test passes
 assessment#:#tst_user_finished_test#:#User finished test (%s)
 assessment#:#tst_view_competence_assign#:#View Assignment Properties###30 08 2015 new variable
 assessment#:#tst_virtual_pass_header_lo_initial#:#Initial Test Results for the Learning Objectives<br />%s###30 08 2015 new variable

--- a/lang/ilias_bg.lang
+++ b/lang/ilias_bg.lang
@@ -693,12 +693,10 @@ assessment#:#examid_in_test_res#:#ILIAS Testpass ID###27 01 2015 new variable
 assessment#:#examid_in_test_res_desc#:#The ILIAS Testpass ID will be included in the test results.###27 01 2015 new variable
 assessment#:#exp_all_test_runs#:#All test attempts###26 08 2024 new variable
 assessment#:#exp_eval_data#:#Експортиране на данните за оценяването като
-assessment#:#exp_file_created#:#Export file created.###24 10 2013 new variable
 assessment#:#exp_grammar_as#:#as###26 08 2024 new variable
 assessment#:#exp_scored_test_attempt#:#Scored Test Attempt###28 10 2024 new variable
 assessment#:#exp_type_certificate#:#Certificate (PDF)###25 02 2007 new variable
 assessment#:#exp_type_excel#:#Microsoft Excel###23 Mar 2006 content changed
-assessment#:#exp_type_spss#:#Стойност отделена със запетая (CSV)
 assessment#:#expected_result_type#:#Expected result type###24 10 2013 new variable
 assessment#:#export_cert_failed_for_users_p#:#No certificate file could be generated and added for the following %s accounts: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
 assessment#:#export_cert_failed_for_users_s#:#No certificate file could be generated and added to the archive for the following account: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
@@ -1434,7 +1432,6 @@ assessment#:#tst_delete_missing_mark#:#Моля, изберете поне ед�
 assessment#:#tst_derive_new_pool#:#Derive New Question Pool###25 10 2016 new variable
 assessment#:#tst_derive_new_pools#:#Derive New Question Pools###25 10 2016 new variable
 assessment#:#tst_dont_show_msg_again_in_current_session#:#Don't show this message again in my current session.###10 11 2018 new variable
-assessment#:#tst_dont_use_previous_answers#:#Your previous answers will not be used as default values in future test passes###25 02 2007 new variable
 assessment#:#tst_edit_competence_assign#:#Edit Assignment Properties###30 08 2015 new variable
 assessment#:#tst_edit_scoring#:#Edit Scoring###28 08 2012 new variable
 assessment#:#tst_enable_questionlist#:#Show 'List of Questions’###26 08 2024 new variable
@@ -1494,7 +1491,6 @@ assessment#:#tst_finish_notification#:#Mail on completion###24 07 2009 new varia
 assessment#:#tst_finish_notification_advanced#:#Send complete test result to test owner###24 07 2009 new variable
 assessment#:#tst_finish_notification_content_type#:#Content of e-mail###27 01 2015 new variable
 assessment#:#tst_finish_notification_desc#:#Sends an e-mail to the test owner for every user that has completed the test.###27 01 2015 new variable
-assessment#:#tst_finish_notification_no#:#No e-mail###06 02 2015 new variable
 assessment#:#tst_finish_notification_simple#:#Send user name and finish date to test owner###24 07 2009 new variable
 assessment#:#tst_finished#:#Finished###06 09 2006 new variable
 assessment#:#tst_form_dynamic_question_set_config#:#Continues Question Selection###24 10 2013 new variable
@@ -1508,7 +1504,6 @@ assessment#:#tst_hide_info_tab#:#Hide Info Tab###26 08 2024 new variable
 assessment#:#tst_hide_info_tab_desc#:#Hides the tab ‘Info’ of the test.###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents#:#Hide page content###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents_desc#:#ILIAS content placed before and after the actual question text via the "Edit Page" button will not be displayed in the result views and print output.###26 08 2024 new variable
-assessment#:#tst_hide_side_list#:#Hide question list###24 07 2009 new variable
 assessment#:#tst_highscore_achieved_ts#:#Show date of test###28 08 2012 new variable
 assessment#:#tst_highscore_achieved_ts_description#:#Controls, if a column with the test date should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_all_tables#:#All Rankings###07 11 2014 new variable
@@ -1528,7 +1523,6 @@ assessment#:#tst_highscore_score#:#Show score###28 08 2012 new variable
 assessment#:#tst_highscore_score_description#:#Controls, if a column with the score should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_top_num#:#Number of ranks###28 08 2012 new variable
 assessment#:#tst_highscore_top_num_description#:#Controls, how many ranks should be included in the top ranking table.###28 08 2012 new variable
-assessment#:#tst_highscore_top_num_unit#:#entries###28 08 2012 new variable
 assessment#:#tst_highscore_top_table#:#Show table 'top ranking'###28 08 2012 new variable
 assessment#:#tst_highscore_top_table_description#:#Controls, if the table 'top ranking' should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_wtime#:#Show working time###28 08 2012 new variable
@@ -1924,10 +1918,6 @@ assessment#:#tst_show_results#:#Показване на резултатите �
 assessment#:#tst_show_side_list#:#Show question list aside###24 07 2009 new variable
 assessment#:#tst_show_solution_answers_only#:#Results print view (answers only)###14 11 2007 new variable
 assessment#:#tst_show_solution_answers_only_desc#:#If is selected, the ILIAS content you place around a question using the "Edit content" tab page will not be visible in a print-out. If you want to save some paper space, select this option.###07 11 2014 new variable
-assessment#:#tst_show_solution_compare#:#Compare Answer with Solution in List of Answers###24 10 2013 new variable
-assessment#:#tst_show_solution_compare_desc#:#Participants are presented with an overview comparing their own answers with the best solutions. Please note that this view will be displayed in the ‘Detailed Results’ that can be accessed via the ‘Show Test Results‘-button on the ‘Info’-tab. It will not be displayed in the printable ‘List of Answers’ even though the setting is made here.###06 02 2015 new variable
-assessment#:#tst_show_solution_details#:#Show Solutions in Test Results###25 02 2007 new variable
-assessment#:#tst_show_solution_details_desc#:#If selected, the detailed question solution is available to participants in the test results presentation. This includes the exact scoring of every answer, otherwise only an overview with the question titles and the reached points is shown.###07 11 2014 new variable
 assessment#:#tst_show_solution_details_singlepage#:#Scored Answers on single pages###26 08 2024 new variable
 assessment#:#tst_show_solution_details_singlepage_desc#:#Participants can access each question individually and see if their answers were correct and how many points they scored.###26 08 2024 new variable
 assessment#:#tst_show_solution_feedback#:#Show Answer-Specific Feedback in Test Results###10 05 2007 new variable
@@ -1950,7 +1940,6 @@ assessment#:#tst_skill_triggerings_num_req_answers_desc#:#Competences aren't tri
 assessment#:#tst_skill_triggerings_num_req_answers_not_reached_warn#:#At least one of the competences addressed by this test is not triggered by the minimal required amount of questions.<br />The required amount of questions: %s###10 11 2018 new variable
 assessment#:#tst_skl_level_thresholds_link#:#Configure Competence-Thresholds###30 08 2015 new variable
 assessment#:#tst_skl_level_thresholds_missing#:#There are missing thresholds for the relevant competences!###30 08 2015 new variable
-assessment#:#tst_skl_res_interpretation_hint_msg#:#Please consider that competence results from a single test has a limited significance. The more information is collected per competence, the merrier valid the significance will be. Should there are single competences without any entry, there is to less information collected.###30 08 2015 new variable
 assessment#:#tst_skl_sub_tab_thresholds#:#Competence Thresholds###26 09 2014 new variable
 assessment#:#tst_sol_comp_expressions#:#Comparison Expressions###30 08 2015 new variable
 assessment#:#tst_solution_compare_cfg#:#Configuration for Solution Compare###30 08 2015 new variable
@@ -2012,7 +2001,6 @@ assessment#:#tst_unchanged_answer_is_correct#:#The preset answer is correct###fa
 assessment#:#tst_unchanged_order_is_correct#:#The preset order is correct###fau: testNav
 assessment#:#tst_use_previous_answers#:#Use Previous Answers###25 02 2007 new variable
 assessment#:#tst_use_previous_answers_description#:#If checked, a participant may choose to use the previous answers as default values in future test passes, otherwise the previous answers are not shown in future test passes###25 02 2007 new variable
-assessment#:#tst_use_previous_answers_user#:#Use my previous answers as default values in future test passes###25 02 2007 new variable
 assessment#:#tst_user_finished_test#:#User finished test (%s)###24 07 2009 new variable
 assessment#:#tst_view_competence_assign#:#View Assignment Properties###30 08 2015 new variable
 assessment#:#tst_virtual_pass_header_lo_initial#:#Initial Test Results for the Learning Objectives<br />%s###30 08 2015 new variable

--- a/lang/ilias_cs.lang
+++ b/lang/ilias_cs.lang
@@ -693,12 +693,10 @@ assessment#:#examid_in_test_res#:#ILIAS ID průchodu testem
 assessment#:#examid_in_test_res_desc#:#ILIAS ID průchodu testem bude zahrnuto do výsledků testu.
 assessment#:#exp_all_test_runs#:#All test attempts###26 08 2024 new variable
 assessment#:#exp_eval_data#:#Exportovat data hodnocení jako
-assessment#:#exp_file_created#:#Exportní soubor vytvořen
 assessment#:#exp_grammar_as#:#as###26 08 2024 new variable
 assessment#:#exp_scored_test_attempt#:#Scored Test Attempt###28 10 2024 new variable
 assessment#:#exp_type_certificate#:#Certifikát (PDF)
 assessment#:#exp_type_excel#:#Microsoft Excel
-assessment#:#exp_type_spss#:#Desetinnou čárkou oddělená hodnota (CSV)
 assessment#:#expected_result_type#:#Očekávaný typ výsledku
 assessment#:#export_cert_failed_for_users_p#:#No certificate file could be generated and added for the following %s accounts: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
 assessment#:#export_cert_failed_for_users_s#:#No certificate file could be generated and added to the archive for the following account: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
@@ -1434,7 +1432,6 @@ assessment#:#tst_delete_missing_mark#:#Vyberte alespoň jednu známku kroku ke s
 assessment#:#tst_derive_new_pool#:#Odvodit nový zásobník otázek
 assessment#:#tst_derive_new_pools#:#Odvodit nové zásobníky otázek
 assessment#:#tst_dont_show_msg_again_in_current_session#:#Znovu nezobrazovat tuto zprávu v mé aktuální relaci.
-assessment#:#tst_dont_use_previous_answers#:#Vaše předchozí odpovědi nebudou použity jako výchozí hodnoty v budoucích průchodech testem
 assessment#:#tst_edit_competence_assign#:#Upravit vlastnosti přiřazení
 assessment#:#tst_edit_scoring#:#Upravit hodnocení
 assessment#:#tst_enable_questionlist#:#Show 'List of Questions’###26 08 2024 new variable
@@ -1494,7 +1491,6 @@ assessment#:#tst_finish_notification#:#E-mail při dokončení
 assessment#:#tst_finish_notification_advanced#:#Poslat kompletní výsledky testu jeho vlastníkovi
 assessment#:#tst_finish_notification_content_type#:#Obsah e-mailu
 assessment#:#tst_finish_notification_desc#:#Odešle e-mail vlastníkovi testu pro každého uživatele, který dokončil test.
-assessment#:#tst_finish_notification_no#:#Žádný e-mail
 assessment#:#tst_finish_notification_simple#:#Poslat uživatelské jméno a finální datum vlastníkovi testu
 assessment#:#tst_finished#:#Ukončeno
 assessment#:#tst_form_dynamic_question_set_config#:#Pokračuje výběr otázek
@@ -1508,7 +1504,6 @@ assessment#:#tst_hide_info_tab#:#Hide Info Tab###26 08 2024 new variable
 assessment#:#tst_hide_info_tab_desc#:#Hides the tab ‘Info’ of the test.###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents#:#Hide page content###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents_desc#:#ILIAS content placed before and after the actual question text via the "Edit Page" button will not be displayed in the result views and print output.###26 08 2024 new variable
-assessment#:#tst_hide_side_list#:#Skrýt seznam otázek
 assessment#:#tst_highscore_achieved_ts#:#Zobrazit datum testu
 assessment#:#tst_highscore_achieved_ts_description#:#Kontroluje, zda sloupec s datem testu má být zobrazen.
 assessment#:#tst_highscore_all_tables#:#Všechna hodnocení
@@ -1528,7 +1523,6 @@ assessment#:#tst_highscore_score#:#Zobrazit hodnocení
 assessment#:#tst_highscore_score_description#:#Řídí, zda sloupec s hodnocením má být zobrazen.
 assessment#:#tst_highscore_top_num#:#Číslo umístění
 assessment#:#tst_highscore_top_num_description#:#Řídí, kolik pořadí má být zahrnuto v tabulce nejlepších umístění.
-assessment#:#tst_highscore_top_num_unit#:#vstupy
 assessment#:#tst_highscore_top_table#:#Zobrazit tabulku 'nejlepší umístění'
 assessment#:#tst_highscore_top_table_description#:#Řídí, zda tabulka 'nejlepší umístění' má být zobrazena.
 assessment#:#tst_highscore_wtime#:#Zobrazit pracovní čas
@@ -1924,10 +1918,6 @@ assessment#:#tst_show_results#:#Zobrazit výsledky testu
 assessment#:#tst_show_side_list#:#Zobrazit boční seznam otázek
 assessment#:#tst_show_solution_answers_only#:#Přehled výsledků (jen odpovědi)
 assessment#:#tst_show_solution_answers_only_desc#:#Je-li vybráno, obsah ILIAS, který umístíte kolem otázky pomocí stránky záložky „Upravit obsah“, nebude viditelný ve výtisku. Pokud chcete ušetřit místo na papíru, vyberte tuto možnost.
-assessment#:#tst_show_solution_compare#:#Porovnat odpovědi s řešením v seznamu odpovědí.
-assessment#:#tst_show_solution_compare_desc#:#Účastníkům je představen přehled srovnávající jejich vlastní odpovědi s nejlepšími řešeními. Povšimněte si, že toto zobrazení se zobrazí v „Podrobných výsledcích“, ke kterým lze přistupovat pomocí tlačítka „Zobrazit výsledky testu“ v záložce „Informace“. Nebude zobrazen v tisknutelném „seznamu odpovědí“, i když je zde provedeno nastavení.
-assessment#:#tst_show_solution_details#:#Zobrazit řešení ve výsledcích testu
-assessment#:#tst_show_solution_details_desc#:#Je-li vybráno, je účastníkům v prezentaci výsledků testů k dispozici podrobné řešení otázek. To zahrnuje přesné bodování každé odpovědi, jinak je zobrazen pouze přehled s nadpisy otázek a dosažené body.
 assessment#:#tst_show_solution_details_singlepage#:#Scored Answers on single pages###26 08 2024 new variable
 assessment#:#tst_show_solution_details_singlepage_desc#:#Participants can access each question individually and see if their answers were correct and how many points they scored.###26 08 2024 new variable
 assessment#:#tst_show_solution_feedback#:#Zobrazit odpovědi-specifický ohlas ve výsledcích testu
@@ -1950,7 +1940,6 @@ assessment#:#tst_skill_triggerings_num_req_answers_desc#:#Způsobilosti nejsou s
 assessment#:#tst_skill_triggerings_num_req_answers_not_reached_warn#:#Nejméně jedna ze způsobilostí, kterou se zabývá tento test, není aktivována minimálním požadovaným počtem otázek.<br />Požadovaný počet otázek: %s
 assessment#:#tst_skl_level_thresholds_link#:#Konfigurace prahových hodnot způsobilosti
 assessment#:#tst_skl_level_thresholds_missing#:#Chybí prahové hodnoty pro příslušné způsobilosti!
-assessment#:#tst_skl_res_interpretation_hint_msg#:#Mějte na paměti, že výsledky způsobilosti z jednoho testu mají omezený význam. Čím více informací je shromážděno ke způsobilosti, tím platnější bude význam. Pokud existují jednotlivé způsobilosti bez jakéhokoli vstupu, je možné shromáždit méně informací.
 assessment#:#tst_skl_sub_tab_thresholds#:#Prahové hodnoty způsobilosti
 assessment#:#tst_sol_comp_expressions#:#Srovnávací výrazy
 assessment#:#tst_solution_compare_cfg#:#Konfigurace pro porovnání řešení
@@ -2012,7 +2001,6 @@ assessment#:#tst_unchanged_answer_is_correct#:#Předem nastavená odpověď je s
 assessment#:#tst_unchanged_order_is_correct#:#Předem nastavené uspořádání je správné
 assessment#:#tst_use_previous_answers#:#Použít předchozí odpovědi
 assessment#:#tst_use_previous_answers_description#:#Pokud je vybráno, účastník může zvolit použití předchozích odpovědí jako výchozích hodnot v dalších průchodech testem, jinak předchozí odpovědi nebudou v dalších průchodech testem zobrazeny.
-assessment#:#tst_use_previous_answers_user#:#Použít mé předchozí odpovědi jako výchozí hodnoty v budoucích průchodech testem
 assessment#:#tst_user_finished_test#:#Uživatel ukončil test (%s)
 assessment#:#tst_view_competence_assign#:#Zobrazit vlastnosti přiřazení
 assessment#:#tst_virtual_pass_header_lo_initial#:#Výsledky počátečního testu pro cíle učení<br />%s

--- a/lang/ilias_da.lang
+++ b/lang/ilias_da.lang
@@ -693,12 +693,10 @@ assessment#:#examid_in_test_res#:#ILIAS Testpass ID###27 01 2015 new variable
 assessment#:#examid_in_test_res_desc#:#The ILIAS Testpass ID will be included in the test results.###27 01 2015 new variable
 assessment#:#exp_all_test_runs#:#All test attempts###26 08 2024 new variable
 assessment#:#exp_eval_data#:#Eksporter evalueringsdata som
-assessment#:#exp_file_created#:#Export file created.###16 09 2013 new variable
 assessment#:#exp_grammar_as#:#as###26 08 2024 new variable
 assessment#:#exp_scored_test_attempt#:#Scored Test Attempt###28 10 2024 new variable
 assessment#:#exp_type_certificate#:#Diplom (PDF)
 assessment#:#exp_type_excel#:#Microsoft Excel
-assessment#:#exp_type_spss#:#komma separerede værdier (CSV)
 assessment#:#expected_result_type#:#Expected result type###16 09 2013 new variable
 assessment#:#export_cert_failed_for_users_p#:#No certificate file could be generated and added for the following %s accounts: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
 assessment#:#export_cert_failed_for_users_s#:#No certificate file could be generated and added to the archive for the following account: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
@@ -1434,7 +1432,6 @@ assessment#:#tst_delete_missing_mark#:#Vælg venligst mindst en karakter for at 
 assessment#:#tst_derive_new_pool#:#Derive New Question Pool###25 10 2016 new variable
 assessment#:#tst_derive_new_pools#:#Derive New Question Pools###25 10 2016 new variable
 assessment#:#tst_dont_show_msg_again_in_current_session#:#Don't show this message again in my current session.###10 11 2018 new variable
-assessment#:#tst_dont_use_previous_answers#:#Dine tidligere svar bruges som standardværdier i fremtidige besvarelser.
 assessment#:#tst_edit_competence_assign#:#Edit Assignment Properties###30 08 2015 new variable
 assessment#:#tst_edit_scoring#:#Edit Scoring###28 08 2012 new variable
 assessment#:#tst_enable_questionlist#:#Show 'List of Questions’###26 08 2024 new variable
@@ -1494,7 +1491,6 @@ assessment#:#tst_finish_notification#:#Mail ved afslutning
 assessment#:#tst_finish_notification_advanced#:#Send komplet testresultat til testens ejer.
 assessment#:#tst_finish_notification_content_type#:#Content of e-mail###27 01 2015 new variable
 assessment#:#tst_finish_notification_desc#:#Sends an e-mail to the test owner for every user that has completed the test.###27 01 2015 new variable
-assessment#:#tst_finish_notification_no#:#No e-mail###06 02 2015 new variable
 assessment#:#tst_finish_notification_simple#:#Send navn og afslutningstidspunkt til testens ejer
 assessment#:#tst_finished#:#Afsluttet
 assessment#:#tst_form_dynamic_question_set_config#:#Continues Question Selection###16 09 2013 new variable
@@ -1508,7 +1504,6 @@ assessment#:#tst_hide_info_tab#:#Hide Info Tab###26 08 2024 new variable
 assessment#:#tst_hide_info_tab_desc#:#Hides the tab ‘Info’ of the test.###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents#:#Hide page content###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents_desc#:#ILIAS content placed before and after the actual question text via the "Edit Page" button will not be displayed in the result views and print output.###26 08 2024 new variable
-assessment#:#tst_hide_side_list#:#Skjul listen med spørgsmål
 assessment#:#tst_highscore_achieved_ts#:#Show date of test###28 08 2012 new variable
 assessment#:#tst_highscore_achieved_ts_description#:#Controls, if a column with the test date should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_all_tables#:#All Rankings###07 11 2014 new variable
@@ -1528,7 +1523,6 @@ assessment#:#tst_highscore_score#:#Vis scoring
 assessment#:#tst_highscore_score_description#:#Controls, if a column with the score should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_top_num#:#Number of ranks###28 08 2012 new variable
 assessment#:#tst_highscore_top_num_description#:#Controls, how many ranks should be included in the top ranking table.###28 08 2012 new variable
-assessment#:#tst_highscore_top_num_unit#:#entries###28 08 2012 new variable
 assessment#:#tst_highscore_top_table#:#Show table 'top ranking'###28 08 2012 new variable
 assessment#:#tst_highscore_top_table_description#:#Controls, if the table 'top ranking' should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_wtime#:#Show working time###28 08 2012 new variable
@@ -1924,10 +1918,6 @@ assessment#:#tst_show_results#:#Vis testresultat
 assessment#:#tst_show_side_list#:#Show question list aside###24 07 2009 new variable
 assessment#:#tst_show_solution_answers_only#:#Udskriftsvisning af resultater (kun svar)
 assessment#:#tst_show_solution_answers_only_desc#:#If is selected, the ILIAS content you place around a question using the "Edit content" tab page will not be visible in a print-out. If you want to save some paper space, select this option.###07 11 2014 new variable
-assessment#:#tst_show_solution_compare#:#Compare Answer with Solution in List of Answers###16 09 2013 new variable
-assessment#:#tst_show_solution_compare_desc#:#Participants are presented with an overview comparing their own answers with the best solutions. Please note that this view will be displayed in the ‘Detailed Results’ that can be accessed via the ‘Show Test Results‘-button on the ‘Info’-tab. It will not be displayed in the printable ‘List of Answers’ even though the setting is made here.###06 02 2015 new variable
-assessment#:#tst_show_solution_details#:#Pointdetaljer
-assessment#:#tst_show_solution_details_desc#:#If selected, the detailed question solution is available to participants in the test results presentation. This includes the exact scoring of every answer, otherwise only an overview with the question titles and the reached points is shown.###07 11 2014 new variable
 assessment#:#tst_show_solution_details_singlepage#:#Scored Answers on single pages###26 08 2024 new variable
 assessment#:#tst_show_solution_details_singlepage_desc#:#Participants can access each question individually and see if their answers were correct and how many points they scored.###26 08 2024 new variable
 assessment#:#tst_show_solution_feedback#:#Vis besvarelsesafhængingt feedback i resultater
@@ -1950,7 +1940,6 @@ assessment#:#tst_skill_triggerings_num_req_answers_desc#:#Competences aren't tri
 assessment#:#tst_skill_triggerings_num_req_answers_not_reached_warn#:#At least one of the competences addressed by this test is not triggered by the minimal required amount of questions.<br />The required amount of questions: %s###10 11 2018 new variable
 assessment#:#tst_skl_level_thresholds_link#:#Configure Competence-Thresholds###30 08 2015 new variable
 assessment#:#tst_skl_level_thresholds_missing#:#There are missing thresholds for the relevant competences!###30 08 2015 new variable
-assessment#:#tst_skl_res_interpretation_hint_msg#:#Please consider that competence results from a single test has a limited significance. The more information is collected per competence, the merrier valid the significance will be. Should there are single competences without any entry, there is to less information collected.###30 08 2015 new variable
 assessment#:#tst_skl_sub_tab_thresholds#:#Competence Thresholds###26 09 2014 new variable
 assessment#:#tst_sol_comp_expressions#:#Comparison Expressions###30 08 2015 new variable
 assessment#:#tst_solution_compare_cfg#:#Configuration for Solution Compare###30 08 2015 new variable
@@ -2012,7 +2001,6 @@ assessment#:#tst_unchanged_answer_is_correct#:#The preset answer is correct###fa
 assessment#:#tst_unchanged_order_is_correct#:#The preset order is correct###fau: testNav
 assessment#:#tst_use_previous_answers#:#Tidligere svar
 assessment#:#tst_use_previous_answers_description#:#Hvis afkrydset anvendes de tidligere svar som standardværdier når testen tages igen.
-assessment#:#tst_use_previous_answers_user#:#Brug mine tidligere svar som standardværdier i fremtidige forsøg.
 assessment#:#tst_user_finished_test#:#User finished test (%s)###24 07 2009 new variable
 assessment#:#tst_view_competence_assign#:#View Assignment Properties###30 08 2015 new variable
 assessment#:#tst_virtual_pass_header_lo_initial#:#Initial Test Results for the Learning Objectives<br />%s###30 08 2015 new variable

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -694,12 +694,10 @@ assessment#:#examid_in_test_res#:#ILIAS-Test-ID anzeigen
 assessment#:#examid_in_test_res_desc#:#Die ILIAS-Test-ID wird in den Ansichten „Detaillierte Ergebnisse“ und   „Druckbare Liste der Antworten“ angezeigt sowie in den über den Reiter „Teilnehmer“ exportierten Tabellenkalkulationsdateien.
 assessment#:#exp_all_test_runs#:#Alle Durchläufe
 assessment#:#exp_eval_data#:#Daten exportieren
-assessment#:#exp_file_created#:#Exportdatei erzeugt.
 assessment#:#exp_grammar_as#:#als
 assessment#:#exp_scored_test_attempt#:#Bewerteter Durchlauf
 assessment#:#exp_type_certificate#:#Zertifikat (PDF)
 assessment#:#exp_type_excel#:#Microsoft Excel
-assessment#:#exp_type_spss#:#durch Komma getrennte Werte (CSV)
 assessment#:#expected_result_type#:#Erwarteter Ergebnistyp
 assessment#:#export_cert_failed_for_users_p#:#Für die folgenden %s Konten konnte kein Zertifikats-Dokument generiert und in das Archiv gelegt werden: %s. Bitte kontaktieren Sie einen Administrator zur Sichtung der Protokolldateien.
 assessment#:#export_cert_failed_for_users_s#:#Für das folgende Konto konnte kein Zertifikats-Dokument generiert und in das Archiv gelegt werden: %s. Bitte kontaktieren Sie einen Administrator zur Sichtung der Protokolldateien.
@@ -1440,7 +1438,6 @@ assessment#:#tst_delete_missing_mark#:#Bitte wählen Sie mindestens eine Notenst
 assessment#:#tst_derive_new_pool#:#Neuen Fragenpool ableiten
 assessment#:#tst_derive_new_pools#:#Neue Fragenpools ableiten
 assessment#:#tst_dont_show_msg_again_in_current_session#:#Diese Meldung in meiner aktuellen Sitzung nicht mehr anzeigen.
-assessment#:#tst_dont_use_previous_answers#:#Ihre vorherigen Antworten werden in zukünftigen Testdurchläufen nicht als vorgegebene Werte verwendet
 assessment#:#tst_edit_competence_assign#:#Bearbeite Zuordnungs-Eigenschaften
 assessment#:#tst_edit_scoring#:#Ändere Bewertung
 assessment#:#tst_enable_questionlist#:#Fragenliste
@@ -1500,7 +1497,6 @@ assessment#:#tst_finish_notification#:#Benachrichtigung
 assessment#:#tst_finish_notification_advanced#:#Komplettes Testergebnis pro Benutzer
 assessment#:#tst_finish_notification_content_type#:#Inhalt der Benachrichtigung
 assessment#:#tst_finish_notification_desc#:#Für jede Person, die einen Test beendet, wird eine Mail an die Person die für den Test verantwortlich ist, versendet. Diese Person wird in dem Unterreiter „Im Besitz von“ des Reiters „Rechte“ aufgeführt.
-assessment#:#tst_finish_notification_no#:#Keine Benachrichtigung
 assessment#:#tst_finish_notification_simple#:#Nur Anmeldename und Datum des Beendens
 assessment#:#tst_finished#:#Beendet
 assessment#:#tst_form_dynamic_question_set_config#:#Fortlaufende Fragenauswahl
@@ -1514,7 +1510,6 @@ assessment#:#tst_hide_info_tab#:#Info-Tab ausblenden
 assessment#:#tst_hide_info_tab_desc#:#Blendet den Tab „Info“ des Tests aus.
 assessment#:#tst_hide_pagecontents#:#Seiteninhalte ausblenden
 assessment#:#tst_hide_pagecontents_desc#:#Inhalte, die über den Button „Seite bearbeiten" vor und hinter dem eigentlichen Fragentext platziert wurden, werden in den Ergebnisansichten und der Druckausgabe nicht angezeigt.
-assessment#:#tst_hide_side_list#:#Fragenliste aus
 assessment#:#tst_highscore_achieved_ts#:#Datum / Uhrzeit
 assessment#:#tst_highscore_achieved_ts_description#:#Es wird eine zusätzliche Spalte eingeblendet, die anzeigt, wann der Test beendet wurde.
 assessment#:#tst_highscore_all_tables#:#Eigener Rang und Bestenliste
@@ -1534,7 +1529,6 @@ assessment#:#tst_highscore_score#:#Punkte
 assessment#:#tst_highscore_score_description#:#Es wird einen zusätzliche Spalte mit der Angabe der erreichten Punkte eingeblendet.
 assessment#:#tst_highscore_top_num#:#Länge der Bestenliste
 assessment#:#tst_highscore_top_num_description#:#Bestimmt, wie viele Einträge in der Bestenliste angezeigt werden.
-assessment#:#tst_highscore_top_num_unit#:#Platzierungen
 assessment#:#tst_highscore_top_table#:#Bestenliste
 assessment#:#tst_highscore_top_table_description#:#Teilnehmerinnen und Teilnehmern wird eine Tabelle mit den besten Platzierungen angezeigt.
 assessment#:#tst_highscore_wtime#:#Bearbeitungsdauer
@@ -1929,10 +1923,6 @@ assessment#:#tst_show_results#:#Testergebnisse
 assessment#:#tst_show_side_list#:#Fragenliste an
 assessment#:#tst_show_solution_answers_only#:#Druckausgabe der Ergebnisse (nur Antworten)
 assessment#:#tst_show_solution_answers_only_desc#:#Wenn „Druckausgabe der Ergebnisse (nur Antworten)“ ausgewählt ist, werden ILIAS-Inhalte, die Sie über den „Inhalt bearbeiten“-Reiter der Fragen vor und hinter dem eigentlichen Fragentext platzieren können, in einem Ausdruck nicht angezeigt.
-assessment#:#tst_show_solution_compare#:#Zeige bestmögliche Lösung in „Tabelle mit detaillierten Testergebnissen“
-assessment#:#tst_show_solution_compare_desc#:#Teilnehmern wird als Teil der Tabelle „Detallierte Testergebnisse“ eine Ansicht präsentiert, welche ihre eigenen Antworten und die bestmögliche Lösung gegenüberstellt. <br> Diese Ansicht wird nicht im Unterreiter „Bewertete Antworten“ des „Meine Ergebnisse“-Reiters angezeigt, auch wenn diese Einstellung hier vorgenommen wird.
-assessment#:#tst_show_solution_details#:#Bewertete Antworten als Liste
-assessment#:#tst_show_solution_details_desc#:#Die Tabelle „Detallierte Testergebnisse“ wird um eine Liste der eigenen Antworten ergänzt.
 assessment#:#tst_show_solution_details_singlepage#:#Bewertete Antworten auf Einzelseiten
 assessment#:#tst_show_solution_details_singlepage_desc#:#Teilnehmerinnen und Teilnehmer können jede Frage einzeln aufrufen und sehen, ob ihre Antworten richtig waren und wie viele Punkte sie damit erreicht haben.
 assessment#:#tst_show_solution_feedback#:#Rückmeldungen
@@ -1955,7 +1945,6 @@ assessment#:#tst_skill_triggerings_num_req_answers_desc#:#Kompetenzen werden ers
 assessment#:#tst_skill_triggerings_num_req_answers_not_reached_warn#:#Mindestens eine im Test adressierte Kompetenz ist nicht ausreichend vielen Fragen zugeordnet. Für diese Kompetenzen werden keine Kompetenzeinträge für Teilnehmer erfasst.<br />Die Mindestanzahl für zugewiesene Fragen: %s
 assessment#:#tst_skl_level_thresholds_link#:#Kompetenz-Schwellenwerte konfigurieren
 assessment#:#tst_skl_level_thresholds_missing#:#Es sind noch nicht für alle relevanten Kompetenzen Schwellenwerte definiert worden!
-assessment#:#tst_skl_res_interpretation_hint_msg#:#Beachten Sie, dass die Kompetenzergebnisse eines einzelnen Tests nur bedingt aussagekräftig sind. Je mehr Informationen zu den einzelnen Kompetenzen gesammelt werden, desto valider die Aussage. Sollten einzelne Kompetenzen keinen Eintrag erhalten haben, standen für diese Kompetenz zu wenig Informationen zur Verfügung.
 assessment#:#tst_skl_sub_tab_thresholds#:#Kompetenz-Schwellenwerte
 assessment#:#tst_sol_comp_expressions#:#Vergleichsausdrücke
 assessment#:#tst_solution_compare_cfg#:#Konfiguration für Antwortvergleich
@@ -2017,7 +2006,6 @@ assessment#:#tst_unchanged_answer_is_correct#:#Die vorgegebene Antwort ist korre
 assessment#:#tst_unchanged_order_is_correct#:#Die vorgegebene Anordnung ist korrekt.
 assessment#:#tst_use_previous_answers#:#Verwendung vorheriger Lösungen
 assessment#:#tst_use_previous_answers_description#:#Zeigt Teilnehmern die Antworten aus dem vorherigen Testdurchlauf an. Die Übernahme der Lösungen muss vom Teilnehmer vor Beginn des Testdurchlaufs in einem Modal per Checkbox aktiviert werden.
-assessment#:#tst_use_previous_answers_user#:#Meine Lösungen aus einem vorherigen Testdurchlauf als vorgegebene Werte verwenden
 assessment#:#tst_user_finished_test#:#Ein Teilnehmer hat den Test beendet (%s)
 assessment#:#tst_view_competence_assign#:#Zeige Zuordnungs-Eigenschaften
 assessment#:#tst_virtual_pass_header_lo_initial#:#Einstiegsergebnisse zum Lernziel<br />%s

--- a/lang/ilias_el.lang
+++ b/lang/ilias_el.lang
@@ -694,12 +694,10 @@ assessment#:#examid_in_test_res#:#ILIAS Testpass ID###27 01 2015 new variable
 assessment#:#examid_in_test_res_desc#:#The ILIAS Testpass ID will be included in the test results.###27 01 2015 new variable
 assessment#:#exp_all_test_runs#:#All test attempts###26 08 2024 new variable
 assessment#:#exp_eval_data#:#Εξαγωγή των δεδομένων αξιολόγησης ως
-assessment#:#exp_file_created#:#Export file created.###24 10 2013 new variable
 assessment#:#exp_grammar_as#:#as###26 08 2024 new variable
 assessment#:#exp_scored_test_attempt#:#Scored Test Attempt###28 10 2024 new variable
 assessment#:#exp_type_certificate#:#Πιστοποιητικό (PDF)
 assessment#:#exp_type_excel#:#Microsoft Excel (Intel x86)
-assessment#:#exp_type_spss#:#Τιμή διαχωρισμένη με κόμμα (CSV)
 assessment#:#expected_result_type#:#Expected result type###24 10 2013 new variable
 assessment#:#export_cert_failed_for_users_p#:#No certificate file could be generated and added for the following %s accounts: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
 assessment#:#export_cert_failed_for_users_s#:#No certificate file could be generated and added to the archive for the following account: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
@@ -1435,7 +1433,6 @@ assessment#:#tst_delete_missing_mark#:#Παρακαλώ επιλέξτε του�
 assessment#:#tst_derive_new_pool#:#Derive New Question Pool###25 10 2016 new variable
 assessment#:#tst_derive_new_pools#:#Derive New Question Pools###25 10 2016 new variable
 assessment#:#tst_dont_show_msg_again_in_current_session#:#Don't show this message again in my current session.###10 11 2018 new variable
-assessment#:#tst_dont_use_previous_answers#:#Οι προηγούμενες απαντήσεις σας δεν θα χρησιμοποιηθούν ώς προκαθορισμένες τιμές σε μελλοντικά τέστ
 assessment#:#tst_edit_competence_assign#:#Edit Assignment Properties###30 08 2015 new variable
 assessment#:#tst_edit_scoring#:#Edit Scoring###28 08 2012 new variable
 assessment#:#tst_enable_questionlist#:#Show 'List of Questions’###26 08 2024 new variable
@@ -1495,7 +1492,6 @@ assessment#:#tst_finish_notification#:#Mail on completion###24 07 2009 new varia
 assessment#:#tst_finish_notification_advanced#:#Send complete test result to test owner###24 07 2009 new variable
 assessment#:#tst_finish_notification_content_type#:#Content of e-mail###27 01 2015 new variable
 assessment#:#tst_finish_notification_desc#:#Sends an e-mail to the test owner for every user that has completed the test.###27 01 2015 new variable
-assessment#:#tst_finish_notification_no#:#No e-mail###06 02 2015 new variable
 assessment#:#tst_finish_notification_simple#:#Send user name and finish date to test owner###24 07 2009 new variable
 assessment#:#tst_finished#:#Ολοκληρώθηκε
 assessment#:#tst_form_dynamic_question_set_config#:#Continues Question Selection###24 10 2013 new variable
@@ -1509,7 +1505,6 @@ assessment#:#tst_hide_info_tab#:#Hide Info Tab###26 08 2024 new variable
 assessment#:#tst_hide_info_tab_desc#:#Hides the tab ‘Info’ of the test.###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents#:#Hide page content###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents_desc#:#ILIAS content placed before and after the actual question text via the "Edit Page" button will not be displayed in the result views and print output.###26 08 2024 new variable
-assessment#:#tst_hide_side_list#:#Hide question list###24 07 2009 new variable
 assessment#:#tst_highscore_achieved_ts#:#Show date of test###28 08 2012 new variable
 assessment#:#tst_highscore_achieved_ts_description#:#Controls, if a column with the test date should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_all_tables#:#All Rankings###07 11 2014 new variable
@@ -1529,7 +1524,6 @@ assessment#:#tst_highscore_score#:#Show score###28 08 2012 new variable
 assessment#:#tst_highscore_score_description#:#Controls, if a column with the score should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_top_num#:#Number of ranks###28 08 2012 new variable
 assessment#:#tst_highscore_top_num_description#:#Controls, how many ranks should be included in the top ranking table.###28 08 2012 new variable
-assessment#:#tst_highscore_top_num_unit#:#entries###28 08 2012 new variable
 assessment#:#tst_highscore_top_table#:#Show table 'top ranking'###28 08 2012 new variable
 assessment#:#tst_highscore_top_table_description#:#Controls, if the table 'top ranking' should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_wtime#:#Show working time###28 08 2012 new variable
@@ -1925,10 +1919,6 @@ assessment#:#tst_show_results#:#Προβολή αποτελεσμάτων δια
 assessment#:#tst_show_side_list#:#Show question list aside###24 07 2009 new variable
 assessment#:#tst_show_solution_answers_only#:#Results print view (answers only)
 assessment#:#tst_show_solution_answers_only_desc#:#If is selected, the ILIAS content you place around a question using the "Edit content" tab page will not be visible in a print-out. If you want to save some paper space, select this option.###07 11 2014 new variable
-assessment#:#tst_show_solution_compare#:#Compare Answer with Solution in List of Answers###24 10 2013 new variable
-assessment#:#tst_show_solution_compare_desc#:#Participants are presented with an overview comparing their own answers with the best solutions. Please note that this view will be displayed in the ‘Detailed Results’ that can be accessed via the ‘Show Test Results‘-button on the ‘Info’-tab. It will not be displayed in the printable ‘List of Answers’ even though the setting is made here.###06 02 2015 new variable
-assessment#:#tst_show_solution_details#:#Λεπτομέρειες βαθμολογίας
-assessment#:#tst_show_solution_details_desc#:#If selected, the detailed question solution is available to participants in the test results presentation. This includes the exact scoring of every answer, otherwise only an overview with the question titles and the reached points is shown.###07 11 2014 new variable
 assessment#:#tst_show_solution_details_singlepage#:#Scored Answers on single pages###26 08 2024 new variable
 assessment#:#tst_show_solution_details_singlepage_desc#:#Participants can access each question individually and see if their answers were correct and how many points they scored.###26 08 2024 new variable
 assessment#:#tst_show_solution_feedback#:#Show Answer-Specific Feedback in Test Results
@@ -1951,7 +1941,6 @@ assessment#:#tst_skill_triggerings_num_req_answers_desc#:#Competences aren't tri
 assessment#:#tst_skill_triggerings_num_req_answers_not_reached_warn#:#At least one of the competences addressed by this test is not triggered by the minimal required amount of questions.<br />The required amount of questions: %s###10 11 2018 new variable
 assessment#:#tst_skl_level_thresholds_link#:#Configure Competence-Thresholds###30 08 2015 new variable
 assessment#:#tst_skl_level_thresholds_missing#:#There are missing thresholds for the relevant competences!###30 08 2015 new variable
-assessment#:#tst_skl_res_interpretation_hint_msg#:#Please consider that competence results from a single test has a limited significance. The more information is collected per competence, the merrier valid the significance will be. Should there are single competences without any entry, there is to less information collected.###30 08 2015 new variable
 assessment#:#tst_skl_sub_tab_thresholds#:#Competence Thresholds###26 09 2014 new variable
 assessment#:#tst_sol_comp_expressions#:#Comparison Expressions###30 08 2015 new variable
 assessment#:#tst_solution_compare_cfg#:#Configuration for Solution Compare###30 08 2015 new variable
@@ -2013,7 +2002,6 @@ assessment#:#tst_unchanged_answer_is_correct#:#The preset answer is correct###fa
 assessment#:#tst_unchanged_order_is_correct#:#The preset order is correct###fau: testNav
 assessment#:#tst_use_previous_answers#:#Use Previous Answers
 assessment#:#tst_use_previous_answers_description#:#If checked, the previous answers of a participant will be used as default values in future test passes
-assessment#:#tst_use_previous_answers_user#:#Use my previous answers as default values in future test passes
 assessment#:#tst_user_finished_test#:#User finished test (%s)###24 07 2009 new variable
 assessment#:#tst_view_competence_assign#:#View Assignment Properties###30 08 2015 new variable
 assessment#:#tst_virtual_pass_header_lo_initial#:#Initial Test Results for the Learning Objectives<br />%s###30 08 2015 new variable

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -694,12 +694,10 @@ assessment#:#examid_in_test_res#:#Display ILIAS Test ID
 assessment#:#examid_in_test_res_desc#:#The ILIAS Test ID will be included in the test results and the Excel-Export-File.
 assessment#:#exp_all_test_runs#:#All test attempts
 assessment#:#exp_eval_data#:#Export data
-assessment#:#exp_file_created#:#Export file created.
 assessment#:#exp_grammar_as#:#as
 assessment#:#exp_scored_test_attempt#:#Scored Test Attempt
 assessment#:#exp_type_certificate#:#Certificate (PDF)
 assessment#:#exp_type_excel#:#Microsoft Excel
-assessment#:#exp_type_spss#:#Comma Separated Values (CSV)
 assessment#:#expected_result_type#:#Expected result type
 assessment#:#export_cert_failed_for_users_p#:#No certificate file could be generated and added for the following %s accounts: %s. Please contact an administrator to check the log file.
 assessment#:#export_cert_failed_for_users_s#:#No certificate file could be generated and added to the archive for the following account: %s. Please contact an administrator to check the log file.
@@ -1440,7 +1438,6 @@ assessment#:#tst_delete_missing_mark#:#Please select at least one mark step to r
 assessment#:#tst_derive_new_pool#:#Derive New Question Pool
 assessment#:#tst_derive_new_pools#:#Derive New Question Pools
 assessment#:#tst_dont_show_msg_again_in_current_session#:#Don't show this message again in my current session.
-assessment#:#tst_dont_use_previous_answers#:#Your previous answers will not be used as default values in future test attempts
 assessment#:#tst_edit_competence_assign#:#Edit Assignment Properties
 assessment#:#tst_edit_scoring#:#Edit Scoring
 assessment#:#tst_enable_questionlist#:#Show 'List of Questions’
@@ -1500,7 +1497,6 @@ assessment#:#tst_finish_notification#:#Notification
 assessment#:#tst_finish_notification_advanced#:#Send complete test result
 assessment#:#tst_finish_notification_content_type#:#Content of e-mail
 assessment#:#tst_finish_notification_desc#:#Sends an e-mail to the test owner for every user that has completed the test.
-assessment#:#tst_finish_notification_no#:#No e-mail
 assessment#:#tst_finish_notification_simple#:#Send username and finish date
 assessment#:#tst_finished#:#Finished
 assessment#:#tst_form_dynamic_question_set_config#:#Continues Question Selection
@@ -1514,7 +1510,6 @@ assessment#:#tst_hide_info_tab#:#Hide Info Tab
 assessment#:#tst_hide_info_tab_desc#:#Hides the tab ‘Info’ of the test.
 assessment#:#tst_hide_pagecontents#:#Hide page content
 assessment#:#tst_hide_pagecontents_desc#:#ILIAS content placed before and after the actual question text via the "Edit Page" button will not be displayed in the result views and print output.
-assessment#:#tst_hide_side_list#:#Hide List of Questions
 assessment#:#tst_highscore_achieved_ts#:#Date
 assessment#:#tst_highscore_achieved_ts_description#:#A column containing the test date will be included in the ranking.
 assessment#:#tst_highscore_all_tables#:#Participant's Own Rank and Top Ranking
@@ -1534,7 +1529,6 @@ assessment#:#tst_highscore_score#:#Score
 assessment#:#tst_highscore_score_description#:#A column containing the score will be included in the ranking.
 assessment#:#tst_highscore_top_num#:#Length of Top Ranking
 assessment#:#tst_highscore_top_num_description#:#Specify how many ranks are to be included in the top ranking list.
-assessment#:#tst_highscore_top_num_unit#:#entries
 assessment#:#tst_highscore_top_table#:#Top Ranking
 assessment#:#tst_highscore_top_table_description#:#Participants are presented with a table containing the top rankings.
 assessment#:#tst_highscore_wtime#:#Duration of Test
@@ -1930,10 +1924,6 @@ assessment#:#tst_show_results#:#Test Results
 assessment#:#tst_show_side_list#:#Show List of Questions
 assessment#:#tst_show_solution_answers_only#:#Print View of Results (Answers Only)
 assessment#:#tst_show_solution_answers_only_desc#:#If is selected, the ILIAS content you place around a question using the ‘Edit content’ tab page will not be visible in a print-out. If you want to save some paper space, select this option.
-assessment#:#tst_show_solution_compare#:#Show Best Solution in ‘Detailed Results’
-assessment#:#tst_show_solution_compare_desc#:#Participants are presented with an overview comparing their own answers with the best solutions. Please note that this view will be displayed in the 'Detailed Results' that can be accessed via the 'Show Test Results'-button on the 'Info'-tab. It will not be displayed in the printable 'List of Answers' even though the setting is made here.
-assessment#:#tst_show_solution_details#:#Scored Answers of Participant
-assessment#:#tst_show_solution_details_desc#:#The ‘Table of Detailed Test Results’ will be added by a list of answers.
 assessment#:#tst_show_solution_details_singlepage#:#Scored Answers on single pages
 assessment#:#tst_show_solution_details_singlepage_desc#:#Participants can access each question individually and see if their answers were correct and how many points they scored.
 assessment#:#tst_show_solution_feedback#:#Feedback
@@ -1956,7 +1946,6 @@ assessment#:#tst_skill_triggerings_num_req_answers_desc#:#Competences aren't tri
 assessment#:#tst_skill_triggerings_num_req_answers_not_reached_warn#:#At least one of the competences addressed by this test is not triggered by the minimal required amount of questions. No competence records will be written for these competences.<br />The required amount of questions: %s
 assessment#:#tst_skl_level_thresholds_link#:#Configure Competence Thresholds
 assessment#:#tst_skl_level_thresholds_missing#:#There are missing thresholds for the relevant competences!
-assessment#:#tst_skl_res_interpretation_hint_msg#:#Please consider that competence results from a single test has a limited significance. The more information is collected per competence, the merrier valid the significance will be. Should there are single competences without any entry, there is to less information collected.
 assessment#:#tst_skl_sub_tab_thresholds#:#Competence Thresholds
 assessment#:#tst_sol_comp_expressions#:#Comparison Expressions
 assessment#:#tst_solution_compare_cfg#:#Configuration for Solution Compare
@@ -2018,7 +2007,6 @@ assessment#:#tst_unchanged_answer_is_correct#:#The preset answer is correct###fa
 assessment#:#tst_unchanged_order_is_correct#:#The preset order is correct###fau: testNav
 assessment#:#tst_use_previous_answers#:#Use Previous Answers
 assessment#:#tst_use_previous_answers_description#:#Participants will be presented with their answers from previous test attempts. This option has to be activated by individual participants on a modal before starting a test attempt.
-assessment#:#tst_use_previous_answers_user#:#Use my previous answers as default values in future test attempts
 assessment#:#tst_user_finished_test#:#User finished test (%s)
 assessment#:#tst_view_competence_assign#:#View Assignment Properties
 assessment#:#tst_virtual_pass_header_lo_initial#:#Initial Test Results for the Learning Objective<br />%s

--- a/lang/ilias_es.lang
+++ b/lang/ilias_es.lang
@@ -695,12 +695,10 @@ assessment#:#examid_in_test_res#:#Mostrar id del examen en resultados
 assessment#:#examid_in_test_res_desc#:#Mostrar id del examen al finalizar el test
 assessment#:#exp_all_test_runs#:#All test attempts###26 08 2024 new variable
 assessment#:#exp_eval_data#:#Exportar Datos de Evaluación.
-assessment#:#exp_file_created#:#Archivo de exportación creado.
 assessment#:#exp_grammar_as#:#as###26 08 2024 new variable
 assessment#:#exp_scored_test_attempt#:#Scored Test Attempt###28 10 2024 new variable
 assessment#:#exp_type_certificate#:#Informe (PDF)
 assessment#:#exp_type_excel#:#Excel
-assessment#:#exp_type_spss#:#SPSS
 assessment#:#expected_result_type#:#Tipo de resultado esperado
 assessment#:#export_cert_failed_for_users_p#:#No certificate file could be generated and added for the following %s accounts: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
 assessment#:#export_cert_failed_for_users_s#:#No certificate file could be generated and added to the archive for the following account: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
@@ -1436,7 +1434,6 @@ assessment#:#tst_delete_missing_mark#:#Por favor seleccione al menos un rango de
 assessment#:#tst_derive_new_pool#:#Obtener nuevo banco de preguntas
 assessment#:#tst_derive_new_pools#:#Obtener nuevos bancos de preguntas
 assessment#:#tst_dont_show_msg_again_in_current_session#:#Don't show this message again in my current session.
-assessment#:#tst_dont_use_previous_answers#:#Sus respuestas previas no serán usadas como valores por defecto en futuras ejecuciones del test
 assessment#:#tst_edit_competence_assign#:#Editar propiedades de asignación
 assessment#:#tst_edit_scoring#:#Editar puntuación
 assessment#:#tst_enable_questionlist#:#Show 'List of Questions’###26 08 2024 new variable
@@ -1496,7 +1493,6 @@ assessment#:#tst_finish_notification#:#Correo al terminar
 assessment#:#tst_finish_notification_advanced#:#Enviar resultado completo del test al propietario del test
 assessment#:#tst_finish_notification_content_type#:#Contenido del e-mail
 assessment#:#tst_finish_notification_desc#:#Envía un e-mail al propietario del test para cada usuario que se ha completado el test.
-assessment#:#tst_finish_notification_no#:#No enviar correo electrónico
 assessment#:#tst_finish_notification_simple#:#Enviar nombre de usuario y fecha de finalización para poner al propietario del test
 assessment#:#tst_finished#:#Terminado
 assessment#:#tst_form_dynamic_question_set_config#:#Selección continua de preguntas
@@ -1510,7 +1506,6 @@ assessment#:#tst_hide_info_tab#:#Hide Info Tab###26 08 2024 new variable
 assessment#:#tst_hide_info_tab_desc#:#Hides the tab ‘Info’ of the test.###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents#:#Hide page content###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents_desc#:#ILIAS content placed before and after the actual question text via the "Edit Page" button will not be displayed in the result views and print output.###26 08 2024 new variable
-assessment#:#tst_hide_side_list#:#Ocultar lista de preguntas
 assessment#:#tst_highscore_achieved_ts#:#Mostrar fecha del test
 assessment#:#tst_highscore_achieved_ts_description#:#Controla si debe mostrarse una columna con la fecha del test.
 assessment#:#tst_highscore_all_tables#:#Todas las puntuaciones
@@ -1530,7 +1525,6 @@ assessment#:#tst_highscore_score#:#Mostrar puntuación
 assessment#:#tst_highscore_score_description#:#Controla si debe mostrarse una columna con la puntuación.
 assessment#:#tst_highscore_top_num#:#Número de entradas
 assessment#:#tst_highscore_top_num_description#:#Controla cuantas entradas deben mostrarse en la tabla de puntuaciones más altas.
-assessment#:#tst_highscore_top_num_unit#:#entradas
 assessment#:#tst_highscore_top_table#:#Mostrar tabla 'clasificaciones más altas'
 assessment#:#tst_highscore_top_table_description#:#Controla si debe mostrarse la tabla 'clasificaciones más altas'.
 assessment#:#tst_highscore_wtime#:#Mostrar tiempo de trabajo
@@ -1926,10 +1920,6 @@ assessment#:#tst_show_results#:#Mostrar resultados del test
 assessment#:#tst_show_side_list#:#Mostrar lista de preguntas en el lateral
 assessment#:#tst_show_solution_answers_only#:#Vista de impresión de resultados (respuestas sólo)
 assessment#:#tst_show_solution_answers_only_desc#:#Si se marca no se muestra el contenido ILIAS que se puede crear con la pestaña "Editar Página" antes y después de la pregunta cuando se edita. Permite ahorrar papel.
-assessment#:#tst_show_solution_compare#:#Comparar respuesta con la solución en la Lista de Respuestas
-assessment#:#tst_show_solution_compare_desc#:#A los participantes se les muestra una comparativa de sus respuestas con las mejores soluciones. El resumen se mostará en "Resultados Detallados" a los que se accede con el botón "Mostrar resultados del test" en la pestaña de "Información". No se mostrará en la versión de impresión de la "Lista de respuestas" aunque esté activo aquí.
-assessment#:#tst_show_solution_details#:#Detalles de puntuación
-assessment#:#tst_show_solution_details_desc#:#Si se marca muestra al participante la solución detallada de cada pregunta en los resultados del test (para cada opción de respuesta si la hubiera). Si no está activa, sólo se muestra un resumen con el título y la puntuación total alcanzada en cada pregunta. Esta lista se mostrará en la pestaña "Info" y al finalizar la ejecución de un test, antes del envío final.
 assessment#:#tst_show_solution_details_singlepage#:#Scored Answers on single pages###26 08 2024 new variable
 assessment#:#tst_show_solution_details_singlepage_desc#:#Participants can access each question individually and see if their answers were correct and how many points they scored.###26 08 2024 new variable
 assessment#:#tst_show_solution_feedback#:#Mostrar explicaciones específicas por respuesta en los resultados del test
@@ -1952,7 +1942,6 @@ assessment#:#tst_skill_triggerings_num_req_answers_desc#:#Las competencias no so
 assessment#:#tst_skill_triggerings_num_req_answers_not_reached_warn#:#Al menos una de las competencias evaluadas en este test no se aborda con la cantidad mínima necesaria de preguntas.<br />Cantidad necesaria de preguntas: %s
 assessment#:#tst_skl_level_thresholds_link#:#Configurar umbrales de competencia
 assessment#:#tst_skl_level_thresholds_missing#:#Faltan umbrales para competencias relevantes!
-assessment#:#tst_skl_res_interpretation_hint_msg#:#Por favor, considere que los resultados de competencia de un único test tienen una significación limitada. Cuanto más información se recolecte por competencia, mejor será la significación. En caso de que hubiera competencias individuales sin ninguna entrada, hay menos información recopilada.
 assessment#:#tst_skl_sub_tab_thresholds#:#Umbrales de competencias
 assessment#:#tst_sol_comp_expressions#:#Expresión de comparación
 assessment#:#tst_solution_compare_cfg#:#Configuración por comparación de solución
@@ -2014,7 +2003,6 @@ assessment#:#tst_unchanged_answer_is_correct#:#La respuesta preestablecida es co
 assessment#:#tst_unchanged_order_is_correct#:#El orden preestablecido es correcto
 assessment#:#tst_use_previous_answers#:#Usar respuestas previas
 assessment#:#tst_use_previous_answers_description#:#Si se activa, se usarán las respuestas previas de un participante como valores por defecto en futuras ejecuciones del test
-assessment#:#tst_use_previous_answers_user#:#Usar mis respuestas previas como valores por defecto en futuras ejecuciones del test
 assessment#:#tst_user_finished_test#:#Test finalizado de usuario (%s)
 assessment#:#tst_view_competence_assign#:#Ver propiedades de asignación
 assessment#:#tst_virtual_pass_header_lo_initial#:#Resultados del test inicial para los objetivos de aprendizaje<br />%s

--- a/lang/ilias_et.lang
+++ b/lang/ilias_et.lang
@@ -693,12 +693,10 @@ assessment#:#examid_in_test_res#:#ILIAS Testpass ID
 assessment#:#examid_in_test_res_desc#:#The ILIAS Testpass ID will be included in the test results.
 assessment#:#exp_all_test_runs#:#All test attempts###26 08 2024 new variable
 assessment#:#exp_eval_data#:#Ekspordi tulemused
-assessment#:#exp_file_created#:#Export file created.
 assessment#:#exp_grammar_as#:#as###26 08 2024 new variable
 assessment#:#exp_scored_test_attempt#:#Scored Test Attempt###28 10 2024 new variable
 assessment#:#exp_type_certificate#:#Sertifikaat (PDF)
 assessment#:#exp_type_excel#:#Microsoft Excel
-assessment#:#exp_type_spss#:#Komaga eraldatud andmete faili formaat (CSV)
 assessment#:#expected_result_type#:#Expected result type
 assessment#:#export_cert_failed_for_users_p#:#No certificate file could be generated and added for the following %s accounts: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
 assessment#:#export_cert_failed_for_users_s#:#No certificate file could be generated and added to the archive for the following account: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
@@ -1434,7 +1432,6 @@ assessment#:#tst_delete_missing_mark#:#Valige kustutamiseks vähemalt üks hinne
 assessment#:#tst_derive_new_pool#:#Derive New Question Pool###25 10 2016 new variable
 assessment#:#tst_derive_new_pools#:#Derive New Question Pools###25 10 2016 new variable
 assessment#:#tst_dont_show_msg_again_in_current_session#:#Don't show this message again in my current session.###10 11 2018 new variable
-assessment#:#tst_dont_use_previous_answers#:#Sinu varasemaid vastuseid ei kasutata järgnevates testides vaikeväärtustena
 assessment#:#tst_edit_competence_assign#:#Edit Assignment Properties###30 08 2015 new variable
 assessment#:#tst_edit_scoring#:#Edit Scoring
 assessment#:#tst_enable_questionlist#:#Show 'List of Questions’###26 08 2024 new variable
@@ -1494,7 +1491,6 @@ assessment#:#tst_finish_notification#:#Kiri lõpetamise kohta
 assessment#:#tst_finish_notification_advanced#:#Saada testitulemus testi omanikule
 assessment#:#tst_finish_notification_content_type#:#Content of e-mail
 assessment#:#tst_finish_notification_desc#:#Sends an e-mail to the test owner for every user that has completed the test.
-assessment#:#tst_finish_notification_no#:#No e-mail###06 02 2015 new variable
 assessment#:#tst_finish_notification_simple#:#Saada kasutajanimi ja lõpetamise aeg testi omanikule
 assessment#:#tst_finished#:#Lõpetatud
 assessment#:#tst_form_dynamic_question_set_config#:#Continues Question Selection
@@ -1508,7 +1504,6 @@ assessment#:#tst_hide_info_tab#:#Hide Info Tab###26 08 2024 new variable
 assessment#:#tst_hide_info_tab_desc#:#Hides the tab ‘Info’ of the test.###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents#:#Hide page content###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents_desc#:#ILIAS content placed before and after the actual question text via the "Edit Page" button will not be displayed in the result views and print output.###26 08 2024 new variable
-assessment#:#tst_hide_side_list#:#Peida küsimuste nimestik
 assessment#:#tst_highscore_achieved_ts#:#Show date of test
 assessment#:#tst_highscore_achieved_ts_description#:#Controls, if a column with the test date should be shown.
 assessment#:#tst_highscore_all_tables#:#All Rankings
@@ -1528,7 +1523,6 @@ assessment#:#tst_highscore_score#:#Show score
 assessment#:#tst_highscore_score_description#:#Controls, if a column with the score should be shown.
 assessment#:#tst_highscore_top_num#:#Number of ranks
 assessment#:#tst_highscore_top_num_description#:#Controls, how many ranks should be included in the top ranking table.
-assessment#:#tst_highscore_top_num_unit#:#entries
 assessment#:#tst_highscore_top_table#:#Show table 'top ranking'
 assessment#:#tst_highscore_top_table_description#:#Controls, if the table 'top ranking' should be shown.
 assessment#:#tst_highscore_wtime#:#Show working time
@@ -1924,10 +1918,6 @@ assessment#:#tst_show_results#:#Näita testitulemusi
 assessment#:#tst_show_side_list#:#Näita kõrval küsimuste loendit
 assessment#:#tst_show_solution_answers_only#:#Tulemuste printvaade (ainult vastused)
 assessment#:#tst_show_solution_answers_only_desc#:#If is selected, the ILIAS content you place around a question using the "Edit content" tab page will not be visible in a print-out. If you want to save some paper space, select this option.
-assessment#:#tst_show_solution_compare#:#Compare Answer with Solution in List of Answers
-assessment#:#tst_show_solution_compare_desc#:#Participants are presented with an overview comparing their own answers with the best solutions. Please note that this view will be displayed in the ‘Detailed Results’ that can be accessed via the ‘Show Test Results‘-button on the ‘Info’-tab. It will not be displayed in the printable ‘List of Answers’ even though the setting is made here.###06 02 2015 new variable
-assessment#:#tst_show_solution_details#:#Näita testitulemustes enese vastuseid
-assessment#:#tst_show_solution_details_desc#:#If selected, the detailed question solution is available to participants in the test results presentation. This includes the exact scoring of every answer, otherwise only an overview with the question titles and the reached points is shown.
 assessment#:#tst_show_solution_details_singlepage#:#Scored Answers on single pages###26 08 2024 new variable
 assessment#:#tst_show_solution_details_singlepage_desc#:#Participants can access each question individually and see if their answers were correct and how many points they scored.###26 08 2024 new variable
 assessment#:#tst_show_solution_feedback#:#Näita testitulemustes vastustekeskset tagasisidet
@@ -1950,7 +1940,6 @@ assessment#:#tst_skill_triggerings_num_req_answers_desc#:#Competences aren't tri
 assessment#:#tst_skill_triggerings_num_req_answers_not_reached_warn#:#At least one of the competences addressed by this test is not triggered by the minimal required amount of questions.<br />The required amount of questions: %s###10 11 2018 new variable
 assessment#:#tst_skl_level_thresholds_link#:#Configure Competence-Thresholds###30 08 2015 new variable
 assessment#:#tst_skl_level_thresholds_missing#:#There are missing thresholds for the relevant competences!###30 08 2015 new variable
-assessment#:#tst_skl_res_interpretation_hint_msg#:#Please consider that competence results from a single test has a limited significance. The more information is collected per competence, the merrier valid the significance will be. Should there are single competences without any entry, there is to less information collected.###30 08 2015 new variable
 assessment#:#tst_skl_sub_tab_thresholds#:#Competence Thresholds
 assessment#:#tst_sol_comp_expressions#:#Comparison Expressions###30 08 2015 new variable
 assessment#:#tst_solution_compare_cfg#:#Configuration for Solution Compare###30 08 2015 new variable
@@ -2012,7 +2001,6 @@ assessment#:#tst_unchanged_answer_is_correct#:#The preset answer is correct###fa
 assessment#:#tst_unchanged_order_is_correct#:#The preset order is correct###fau: testNav
 assessment#:#tst_use_previous_answers#:#Kasuta varasemaid vastuseid
 assessment#:#tst_use_previous_answers_description#:#Kui märgistatud, võib osaleja kasutada varasemaid vastuseid vaikimis tulevastes testides, vastasel juhul ei näidata varasemaid vastuseid tulevastes testides
-assessment#:#tst_use_previous_answers_user#:#Kasuta mu varasemaid vastuseid tuleviku testides
 assessment#:#tst_user_finished_test#:#Kasutaja lõpetas testi (%s)
 assessment#:#tst_view_competence_assign#:#View Assignment Properties###30 08 2015 new variable
 assessment#:#tst_virtual_pass_header_lo_initial#:#Initial Test Results for the Learning Objectives<br />%s###30 08 2015 new variable

--- a/lang/ilias_fa.lang
+++ b/lang/ilias_fa.lang
@@ -693,12 +693,10 @@ assessment#:#examid_in_test_res#:#ILIAS Testpass ID###27 01 2015 new variable
 assessment#:#examid_in_test_res_desc#:#The ILIAS Testpass ID will be included in the test results.###27 01 2015 new variable
 assessment#:#exp_all_test_runs#:#All test attempts###26 08 2024 new variable
 assessment#:#exp_eval_data#:#صدور داده ارزیابی به
-assessment#:#exp_file_created#:#Export file created.###24 10 2013 new variable
 assessment#:#exp_grammar_as#:#as###26 08 2024 new variable
 assessment#:#exp_scored_test_attempt#:#Scored Test Attempt###28 10 2024 new variable
 assessment#:#exp_type_certificate#:#Certificate (PDF)
 assessment#:#exp_type_excel#:#Microsoft Excel
-assessment#:#exp_type_spss#:#مقادیر جدا شده با کاما (CSV)
 assessment#:#expected_result_type#:#Expected result type###24 10 2013 new variable
 assessment#:#export_cert_failed_for_users_p#:#No certificate file could be generated and added for the following %s accounts: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
 assessment#:#export_cert_failed_for_users_s#:#No certificate file could be generated and added to the archive for the following account: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
@@ -1434,7 +1432,6 @@ assessment#:#tst_delete_missing_mark#:#Please select at least one mark step to d
 assessment#:#tst_derive_new_pool#:#Derive New Question Pool###25 10 2016 new variable
 assessment#:#tst_derive_new_pools#:#Derive New Question Pools###25 10 2016 new variable
 assessment#:#tst_dont_show_msg_again_in_current_session#:#Don't show this message again in my current session.###10 11 2018 new variable
-assessment#:#tst_dont_use_previous_answers#:#Your previous answers will not be used as default values in future test passes
 assessment#:#tst_edit_competence_assign#:#Edit Assignment Properties###30 08 2015 new variable
 assessment#:#tst_edit_scoring#:#Edit Scoring###28 08 2012 new variable
 assessment#:#tst_enable_questionlist#:#Show 'List of Questions’###26 08 2024 new variable
@@ -1494,7 +1491,6 @@ assessment#:#tst_finish_notification#:#ارسال ایمیل بعد از تکم�
 assessment#:#tst_finish_notification_advanced#:#ارسال کامل نتیجه تست به مالک تست
 assessment#:#tst_finish_notification_content_type#:#Content of e-mail###27 01 2015 new variable
 assessment#:#tst_finish_notification_desc#:#Sends an e-mail to the test owner for every user that has completed the test.###27 01 2015 new variable
-assessment#:#tst_finish_notification_no#:#No e-mail###06 02 2015 new variable
 assessment#:#tst_finish_notification_simple#:#اراسال نام کاربری و تاریخ اتمام به مالک
 assessment#:#tst_finished#:#پایان یافت
 assessment#:#tst_form_dynamic_question_set_config#:#Continues Question Selection###24 10 2013 new variable
@@ -1508,7 +1504,6 @@ assessment#:#tst_hide_info_tab#:#Hide Info Tab###26 08 2024 new variable
 assessment#:#tst_hide_info_tab_desc#:#Hides the tab ‘Info’ of the test.###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents#:#Hide page content###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents_desc#:#ILIAS content placed before and after the actual question text via the "Edit Page" button will not be displayed in the result views and print output.###26 08 2024 new variable
-assessment#:#tst_hide_side_list#:#Hide question list
 assessment#:#tst_highscore_achieved_ts#:#Show date of test###28 08 2012 new variable
 assessment#:#tst_highscore_achieved_ts_description#:#Controls, if a column with the test date should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_all_tables#:#All Rankings###07 11 2014 new variable
@@ -1528,7 +1523,6 @@ assessment#:#tst_highscore_score#:#Show score###28 08 2012 new variable
 assessment#:#tst_highscore_score_description#:#Controls, if a column with the score should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_top_num#:#Number of ranks###28 08 2012 new variable
 assessment#:#tst_highscore_top_num_description#:#Controls, how many ranks should be included in the top ranking table.###28 08 2012 new variable
-assessment#:#tst_highscore_top_num_unit#:#entries###28 08 2012 new variable
 assessment#:#tst_highscore_top_table#:#Show table 'top ranking'###28 08 2012 new variable
 assessment#:#tst_highscore_top_table_description#:#Controls, if the table 'top ranking' should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_wtime#:#Show working time###28 08 2012 new variable
@@ -1924,10 +1918,6 @@ assessment#:#tst_show_results#:#نمایش نتایج تست
 assessment#:#tst_show_side_list#:#Show question list aside
 assessment#:#tst_show_solution_answers_only#:#نمای چاپ نتایج - فقط پاسخ ها
 assessment#:#tst_show_solution_answers_only_desc#:#If is selected, the ILIAS content you place around a question using the "Edit content" tab page will not be visible in a print-out. If you want to save some paper space, select this option.###07 11 2014 new variable
-assessment#:#tst_show_solution_compare#:#Compare Answer with Solution in List of Answers###24 10 2013 new variable
-assessment#:#tst_show_solution_compare_desc#:#Participants are presented with an overview comparing their own answers with the best solutions. Please note that this view will be displayed in the ‘Detailed Results’ that can be accessed via the ‘Show Test Results‘-button on the ‘Info’-tab. It will not be displayed in the printable ‘List of Answers’ even though the setting is made here.###06 02 2015 new variable
-assessment#:#tst_show_solution_details#:#نمایش راه حل ها درنتیج تست
-assessment#:#tst_show_solution_details_desc#:#If selected, the detailed question solution is available to participants in the test results presentation. This includes the exact scoring of every answer, otherwise only an overview with the question titles and the reached points is shown.###07 11 2014 new variable
 assessment#:#tst_show_solution_details_singlepage#:#Scored Answers on single pages###26 08 2024 new variable
 assessment#:#tst_show_solution_details_singlepage_desc#:#Participants can access each question individually and see if their answers were correct and how many points they scored.###26 08 2024 new variable
 assessment#:#tst_show_solution_feedback#:#نمایش بازخورد متناسب با پاسخ در نتایج تست
@@ -1950,7 +1940,6 @@ assessment#:#tst_skill_triggerings_num_req_answers_desc#:#Competences aren't tri
 assessment#:#tst_skill_triggerings_num_req_answers_not_reached_warn#:#At least one of the competences addressed by this test is not triggered by the minimal required amount of questions.<br />The required amount of questions: %s###10 11 2018 new variable
 assessment#:#tst_skl_level_thresholds_link#:#Configure Competence-Thresholds###30 08 2015 new variable
 assessment#:#tst_skl_level_thresholds_missing#:#There are missing thresholds for the relevant competences!###30 08 2015 new variable
-assessment#:#tst_skl_res_interpretation_hint_msg#:#Please consider that competence results from a single test has a limited significance. The more information is collected per competence, the merrier valid the significance will be. Should there are single competences without any entry, there is to less information collected.###30 08 2015 new variable
 assessment#:#tst_skl_sub_tab_thresholds#:#Competence Thresholds###26 09 2014 new variable
 assessment#:#tst_sol_comp_expressions#:#Comparison Expressions###30 08 2015 new variable
 assessment#:#tst_solution_compare_cfg#:#Configuration for Solution Compare###30 08 2015 new variable
@@ -2012,7 +2001,6 @@ assessment#:#tst_unchanged_answer_is_correct#:#The preset answer is correct###fa
 assessment#:#tst_unchanged_order_is_correct#:#The preset order is correct###fau: testNav
 assessment#:#tst_use_previous_answers#:#جوابهای قبلی را استفاده کن
 assessment#:#tst_use_previous_answers_description#:#اگر انتخاب شده باشد، شرکت کننده می تواند پاسخهای قبلی را به عنوان مقادیر پیش فرض برای دوره تست های بعدی انتخاب کند.
-assessment#:#tst_use_previous_answers_user#:#جوابهای قبلی را من را به عنوان مقادیر پیش فرض برای تستهای آتی استفاده کن
 assessment#:#tst_user_finished_test#:#User finished test (%s)
 assessment#:#tst_view_competence_assign#:#View Assignment Properties###30 08 2015 new variable
 assessment#:#tst_virtual_pass_header_lo_initial#:#Initial Test Results for the Learning Objectives<br />%s###30 08 2015 new variable

--- a/lang/ilias_fr.lang
+++ b/lang/ilias_fr.lang
@@ -678,12 +678,10 @@ assessment#:#examid_in_test_res#:#ILIAS Testpass ID
 assessment#:#examid_in_test_res_desc#:#The ILIAS Testpass ID will be included in the test results.
 assessment#:#exp_all_test_runs#:#All test runs###31 10 2023 new variable
 assessment#:#exp_eval_data#:#Exporter les résultats
-assessment#:#exp_file_created#:#Fichier d'export créé.
 assessment#:#exp_grammar_as#:#as###26 08 2024 new variable
 assessment#:#exp_scored_test_attempt#:#Scored test Attempt
 assessment#:#exp_type_certificate#:#Certificat (PDF)
 assessment#:#exp_type_excel#:# Excel
-assessment#:#exp_type_spss#:#  SPSS
 assessment#:#expected_result_type#:#Type de résultat attendu
 assessment#:#export_cert_failed_for_users_p#:#No certificate file could be generated and added for the following %s accounts: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
 assessment#:#export_cert_failed_for_users_s#:#No certificate file could be generated and added to the archive for the following account: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
@@ -1419,7 +1417,6 @@ assessment#:#tst_delete_missing_mark#:#Veuillez sélectionner au moins une étap
 assessment#:#tst_derive_new_pool#:#Obtenir un nouveau pool de questions
 assessment#:#tst_derive_new_pools#:#Obtenir de nouveaux pools de questions
 assessment#:#tst_dont_show_msg_again_in_current_session#:#Don't show this message again in my current session.
-assessment#:#tst_dont_use_previous_answers#:#Vos réponses antérieures ne seront pas affichées par défaut lorsque vous repasserez le test
 assessment#:#tst_edit_competence_assign#:#Éditer les propriétés de la tâche
 assessment#:#tst_edit_scoring#:#Notation Manuelle
 assessment#:#tst_enable_questionlist#:#Show 'List of Questions’###31 10 2023 new variable
@@ -1479,7 +1476,6 @@ assessment#:#tst_finish_notification#:#Notification par Email en fin de test
 assessment#:#tst_finish_notification_advanced#:#Envoyer résultat complet du test au propriétaire du test
 assessment#:#tst_finish_notification_content_type#:#Content of e-mail###31 10 2023 new variable
 assessment#:#tst_finish_notification_desc#:#Envoie un mail au propriétaire du test pour chaque utilisateur qui a terminé le test.
-assessment#:#tst_finish_notification_no#:#Ne pas envoyer de notification par email lorsqu'un utilisateur achève un test
 assessment#:#tst_finish_notification_simple#:#Envoyer nom de l'utilisateur et date d'achèvement au propriétaire du test
 assessment#:#tst_finished#:#Terminé
 assessment#:#tst_form_dynamic_question_set_config#:#Sélection des Questions
@@ -1493,7 +1489,6 @@ assessment#:#tst_hide_info_tab#:#Hide Info Tab###31 10 2023 new variable
 assessment#:#tst_hide_info_tab_desc#:#Hides the tab ‘Info’ of the test.###31 10 2023 new variable
 assessment#:#tst_hide_pagecontents#:#Hide page content###31 10 2023 new variable
 assessment#:#tst_hide_pagecontents_desc#:#ILIAS content placed before and after the actual question text via the "Edit Page" button will not be displayed in the result views and print output.###31 10 2023 new variable
-assessment#:#tst_hide_side_list#:#Masquer liste de question
 assessment#:#tst_highscore_achieved_ts#:#Afficher la date du test
 assessment#:#tst_highscore_achieved_ts_description#:#Ajoute une colonne avec la date du test.
 assessment#:#tst_highscore_all_tables#:#All Rankings
@@ -1513,7 +1508,6 @@ assessment#:#tst_highscore_score#:#Afficher le score brut
 assessment#:#tst_highscore_score_description#:#Ajouter une colonne avec le score brut obtenu.
 assessment#:#tst_highscore_top_num#:#Nombre de lignes dans les meilleurs scores
 assessment#:#tst_highscore_top_num_description#:#Définit le nombre de meilleurs scores à afficher dans la page des meilleurs scores.
-assessment#:#tst_highscore_top_num_unit#:#lignes
 assessment#:#tst_highscore_top_table#:#Afficher la vue "Meilleurs scores"
 assessment#:#tst_highscore_top_table_description#:#Permet de contrôler l'affichage des meilleurs scores.
 assessment#:#tst_highscore_wtime#:#Afficher le temps passé
@@ -1909,10 +1903,6 @@ assessment#:#tst_show_results#:#Afficher les Résultats du Test
 assessment#:#tst_show_side_list#:#Afficher la liste de question sur le côté
 assessment#:#tst_show_solution_answers_only#:#Impression des Résultats (Réponses Seulement)
 assessment#:#tst_show_solution_answers_only_desc#:#If is selected, the ILIAS content you place around a question using the "Edit content" tab page will not be visible in a print-out. If you want to save some paper space, select this option.
-assessment#:#tst_show_solution_compare#:#Comparer la Réponse avec la Solution dans la Liste des Réponses
-assessment#:#tst_show_solution_compare_desc#:#Participants are presented with an overview comparing their own answers with the best solutions. Please note that this view will be displayed in the ‘Detailed Results’ that can be accessed via the ‘Show Test Results‘-button on the ‘Info’-tab. It will not be displayed in the printable ‘List of Answers’ even though the setting is made here.
-assessment#:#tst_show_solution_details#:#Afficher les Réponses Correctes dans les Résultats
-assessment#:#tst_show_solution_details_desc#:#If selected, the detailed question solution is available to participants in the test results presentation. This includes the exact scoring of every answer, otherwise only an overview with the question titles and the reached points is shown.
 assessment#:#tst_show_solution_details_singlepage#:#Scored Answers on single pages###31 10 2023 new variable
 assessment#:#tst_show_solution_details_singlepage_desc#:#Participants can access each question individually and see if their answers were correct and how many points they scored.###31 10 2023 new variable
 assessment#:#tst_show_solution_feedback#:#Afficher un Retour d'Information par Réponse dans les Résultats du Test
@@ -1935,7 +1925,6 @@ assessment#:#tst_skill_triggerings_num_req_answers_desc#:#Les Compétences ne so
 assessment#:#tst_skill_triggerings_num_req_answers_not_reached_warn#:#Au moins une des compétences abordées dans ce test n’est pas déclenchée par le nombre minimum de questions requises.<br />Nombre de questions requises: %s
 assessment#:#tst_skl_level_thresholds_link#:#Configure Competence-Thresholds
 assessment#:#tst_skl_level_thresholds_missing#:#Des seuils sont manquants pour les compétences pertinentes!
-assessment#:#tst_skl_res_interpretation_hint_msg#:#Veuillez tenir compte du fait que les résultats de compétence d’un seul test n’ont qu’une signification limitée. Plus il y a d’informations collectées par compétence, plus leur signification sera valide. Si une seule compétence n’a pas d’entrée, il n'y aura pas assez d’informations fournies.
 assessment#:#tst_skl_sub_tab_thresholds#:#Seuils de compétence
 assessment#:#tst_sol_comp_expressions#:#Expressions de comparaison
 assessment#:#tst_solution_compare_cfg#:#Configuration pour la comparaison des solutions
@@ -1997,7 +1986,6 @@ assessment#:#tst_unchanged_answer_is_correct#:#La réponse programmée est corre
 assessment#:#tst_unchanged_order_is_correct#:#L'ordre programmé est correct
 assessment#:#tst_use_previous_answers#:#Utiliser les Réponses des Essais Précédents
 assessment#:#tst_use_previous_answers_description#:#Si cochée, les réponses précédentes de chaque utilisateur sont affichées par défaut à  chaque question lorsque le test est repassé.
-assessment#:#tst_use_previous_answers_user#:#Utiliser mes réponses précédentes comme valeurs par défaut lorsque je referai le test
 assessment#:#tst_user_finished_test#:#Test terminé de l'utilisateur (%s)
 assessment#:#tst_view_competence_assign#:#Voir les propriétés de la tâche
 assessment#:#tst_virtual_pass_header_lo_initial#:#Initial Test Results for the Learning Objectives<br />%s

--- a/lang/ilias_hr.lang
+++ b/lang/ilias_hr.lang
@@ -693,12 +693,10 @@ assessment#:#examid_in_test_res#:#ID prolaza ILIAS testa
 assessment#:#examid_in_test_res_desc#:#ID prolaza ILIAS testa bit će uključen u rezultate testa.
 assessment#:#exp_all_test_runs#:#All test attempts###26 08 2024 new variable
 assessment#:#exp_eval_data#:#Izvezi evaluacijske podatke kao
-assessment#:#exp_file_created#:#Datoteka za izvoz je kreirana.
 assessment#:#exp_grammar_as#:#as###26 08 2024 new variable
 assessment#:#exp_scored_test_attempt#:#Scored Test Attempt###28 10 2024 new variable
 assessment#:#exp_type_certificate#:#Certifikat (PDF)
 assessment#:#exp_type_excel#:#Microsoft Excel
-assessment#:#exp_type_spss#:#Vrijednost odvojena zarezom (CSV)
 assessment#:#expected_result_type#:#Očekivana vrsta rezultata
 assessment#:#export_cert_failed_for_users_p#:#No certificate file could be generated and added for the following %s accounts: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
 assessment#:#export_cert_failed_for_users_s#:#No certificate file could be generated and added to the archive for the following account: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
@@ -1434,7 +1432,6 @@ assessment#:#tst_delete_missing_mark#:#Molimo odaberite najmanje jednu ocjenu za
 assessment#:#tst_derive_new_pool#:#Izvedi novi bazen pitanja
 assessment#:#tst_derive_new_pools#:#Izvedi nove bazene pitanja
 assessment#:#tst_dont_show_msg_again_in_current_session#:#Ne prikazuj više ovu poruku tijekom moje aktualne sesije.
-assessment#:#tst_dont_use_previous_answers#:#Vaši prethodni odgovori neće se koristiti kao zadane vrijednosti u budućim prolazima testa
 assessment#:#tst_edit_competence_assign#:#Obradi karakteristike dodjele
 assessment#:#tst_edit_scoring#:#Uredi ocjenjivanje
 assessment#:#tst_enable_questionlist#:#Show 'List of Questions’###26 08 2024 new variable
@@ -1494,7 +1491,6 @@ assessment#:#tst_finish_notification#:#Obavijest
 assessment#:#tst_finish_notification_advanced#:#Pošalji potpuni rezultat testa po korisniku
 assessment#:#tst_finish_notification_content_type#:#Sadržaj e-pošte
 assessment#:#tst_finish_notification_desc#:#Pošalje e-poštu vlasniku testa za svakog korisnika koji je završio test.
-assessment#:#tst_finish_notification_no#:#Nema e-pošte
 assessment#:#tst_finish_notification_simple#:#Pošalji korisničko ime i datum završetka
 assessment#:#tst_finished#:#Završeno
 assessment#:#tst_form_dynamic_question_set_config#:#Kontinuirani izbor pitanja
@@ -1508,7 +1504,6 @@ assessment#:#tst_hide_info_tab#:#Hide Info Tab###26 08 2024 new variable
 assessment#:#tst_hide_info_tab_desc#:#Hides the tab ‘Info’ of the test.###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents#:#Hide page content###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents_desc#:#ILIAS content placed before and after the actual question text via the "Edit Page" button will not be displayed in the result views and print output.###26 08 2024 new variable
-assessment#:#tst_hide_side_list#:#Sakrij popis pitanja
 assessment#:#tst_highscore_achieved_ts#:#Datum
 assessment#:#tst_highscore_achieved_ts_description#:#Prikazat će se dodatni stupac koji sadrži datum testa.
 assessment#:#tst_highscore_all_tables#:#Vlastiti rang sudionika i Popis najboljih (Top Ranking)
@@ -1528,7 +1523,6 @@ assessment#:#tst_highscore_score#:#Broj bodova
 assessment#:#tst_highscore_score_description#:#Prikazat će se dodatni stupac koji sadrži podatak o postignutom bodovima.
 assessment#:#tst_highscore_top_num#:#Duljina popisa najboljih (Top Ranking)
 assessment#:#tst_highscore_top_num_description#:#Odredite koliko mjesta se treba prikazati na popisu najboljih.
-assessment#:#tst_highscore_top_num_unit#:#Unosi
 assessment#:#tst_highscore_top_table#:#Popis najboljih
 assessment#:#tst_highscore_top_table_description#:#Sudionicima se prikazuje tablica s top ljestvicom.
 assessment#:#tst_highscore_wtime#:#Trajanje testa
@@ -1924,10 +1918,6 @@ assessment#:#tst_show_results#:#Rezultati testa
 assessment#:#tst_show_side_list#:#Pokaži popis pitanja
 assessment#:#tst_show_solution_answers_only#:#Prikaz ispisa rezultata (samo odgovori)
 assessment#:#tst_show_solution_answers_only_desc#:#Ako je odabrana ova opcija, sadržaj ILIAS-a koji s pomoću kartice ‘Uredi sadržaj’ možete postaviti ispred i iza samog teksta pitanja neće biti vidljiv na ispisu. Ako želite uštedjeti malo prostora na papiru, odaberite ovu opciju.
-assessment#:#tst_show_solution_compare#:#Prikaži najbolje rješenje u ‘Detaljnim rezultatima’
-assessment#:#tst_show_solution_compare_desc#:#Sudionicima se daje pregled u kojem se njihovi odgovori uspoređuju s najboljim mogućim rješenjima. Imajte na umu da će se ovaj prikaz prikazati u ‘Detaljnim rezultatima’ kojima se može pristupiti putem gumba ‘Prikaži rezultate testa’ na kartici ‘Informacije’. Taj pregled neće biti prikazan na ‘Popisu odgovora’ koji se može ispisati, iako je ovdje postavljen.
-assessment#:#tst_show_solution_details#:#Bodovani odgovori sudionika
-assessment#:#tst_show_solution_details_desc#:#Sudionik uz ‘Tablicu detaljnih rezultata testa’ dobiva za svako pitanje poveznicu na novu stranicu. Ova povezana stranica sadrži pitanje, odgovor sudionika, informaciju je li odgovor bio točan odgovor te koliko je bodova dobio za svoje odgovore.
 assessment#:#tst_show_solution_details_singlepage#:#Scored Answers on single pages###26 08 2024 new variable
 assessment#:#tst_show_solution_details_singlepage_desc#:#Participants can access each question individually and see if their answers were correct and how many points they scored.###26 08 2024 new variable
 assessment#:#tst_show_solution_feedback#:#Povratne informacije
@@ -1950,7 +1940,6 @@ assessment#:#tst_skill_triggerings_num_req_answers_desc#:#Kompetencije se procje
 assessment#:#tst_skill_triggerings_num_req_answers_not_reached_warn#:#Barem za jednu kompetenciju obrađenu u testu nije dodijeljen dovoljan broj pitanja. Za ove kompetencije ne evidentiraju se unosi kompetencija za sudionike. <br />Minimalni broj dodijeljenih pitanja: %s
 assessment#:#tst_skl_level_thresholds_link#:#Kofiguriraj pragove za kompetencije
 assessment#:#tst_skl_level_thresholds_missing#:#Nisu definirani pragovi za sve relevantne kompetencije!
-assessment#:#tst_skl_res_interpretation_hint_msg#:#Molimo uzmite u obzir da rezultati kompetencija iz jednog testa imaju ograničeno značenje. Što se više informacija prikupi o pojedinim kompetencijama, to će izjava biti valjanija. Ako postoje pojedinačne kompetencije bez ikakvog unosa, za te je komptenecije prikupljeno premalo podataka.
 assessment#:#tst_skl_sub_tab_thresholds#:#Pragovi za kompetencije
 assessment#:#tst_sol_comp_expressions#:#Komparativni izrazi
 assessment#:#tst_solution_compare_cfg#:#Konfiguracija za usporedbu odgovora
@@ -2012,7 +2001,6 @@ assessment#:#tst_unchanged_answer_is_correct#:#Unaprijed zadani odgovor je toča
 assessment#:#tst_unchanged_order_is_correct#:#Unaprijed zadani redoslijed je točan
 assessment#:#tst_use_previous_answers#:#Koristi prethodne odgovore
 assessment#:#tst_use_previous_answers_description#:#Sudionicima se prikazuju njihovi odgovori iz prijašnih prolaza testa. Ovu opciju mora aktivirati sudionik na kartici ‘Info’ prije početka prolaza testa.
-assessment#:#tst_use_previous_answers_user#:#Koristi moje prethodne odgovore kao zadane vrijednosti u budućim prolazima testa.
 assessment#:#tst_user_finished_test#:#Sudionik je završio test (%s)
 assessment#:#tst_view_competence_assign#:#Prikaži karakteristike dodjele
 assessment#:#tst_virtual_pass_header_lo_initial#:#Početni rezultati testa za cilj učenja<br />%s

--- a/lang/ilias_hu.lang
+++ b/lang/ilias_hu.lang
@@ -693,12 +693,10 @@ assessment#:#examid_in_test_res#:#ILIAS-vizsgaazonosító megjelenítése
 assessment#:#examid_in_test_res_desc#:#Az ILIAS-vizsgaazonosító a teszteredményeknél jelenik meg.
 assessment#:#exp_all_test_runs#:#Az összes tesztkitöltés
 assessment#:#exp_eval_data#:#Adatok exportálása
-assessment#:#exp_file_created#:#Elkészült az exportfájl.
 assessment#:#exp_grammar_as#:#mint
 assessment#:#exp_scored_test_attempt#:#Pontozott tesztkitöltés
 assessment#:#exp_type_certificate#:#Tanúsítvány (PDF)
 assessment#:#exp_type_excel#:#Microsoft Excel (XLS)
-assessment#:#exp_type_spss#:#Vesszővel tagolt szöveg (CSV)
 assessment#:#expected_result_type#:#Elvárt eredménytípus
 assessment#:#export_cert_failed_for_users_p#:#Nem sikerült tanúsítványfájlt létrehozni és hozzáadni a következő %s fiókhoz: %s. Kérem, keresse az üzemeltetőt, hogy tekintse meg a naplófájlt.
 assessment#:#export_cert_failed_for_users_s#:#Nem sikerült tanúsítványfájlt létrehozni és hozzáadni a következő fiókhoz: %s. Kérem, keresse az üzemeltetőt, hogy tekintse meg a naplófájlt.
@@ -1434,7 +1432,6 @@ assessment#:#tst_delete_missing_mark#:#Válasszon legalább egy érdemjegyet az 
 assessment#:#tst_derive_new_pool#:#Új kérdésgyűjtemény származtatása
 assessment#:#tst_derive_new_pools#:#Új kérdésgyűjtemények származtatása
 assessment#:#tst_dont_show_msg_again_in_current_session#:#Ez az üzenet többször ne jelenjen meg a munkamenet alatt.
-assessment#:#tst_dont_use_previous_answers#:#Korábbi válaszai nem lesznek alapértelmezett értékekként használva a jövőbeni tesztteljesítésekhez.
 assessment#:#tst_edit_competence_assign#:#Összerendelési tulajdonságok módosítása
 assessment#:#tst_edit_scoring#:#Pontozás módosítása
 assessment#:#tst_enable_questionlist#:#'Kérdések listája' megjelenítése
@@ -1494,7 +1491,6 @@ assessment#:#tst_finish_notification#:#Értesítés
 assessment#:#tst_finish_notification_advanced#:#Az összes teszteredmény küldése
 assessment#:#tst_finish_notification_content_type#:#A levél tartalma
 assessment#:#tst_finish_notification_desc#:#Minden alkalommal e-mail küldése a teszt tulajdonosának, amikor egy kitöltő befejezi a teszt kitöltését. A 'Jogosultság' lap 'Tulajdonos' lapján található a teszt tulajdonosa.
-assessment#:#tst_finish_notification_no#:#Nincs e-mail
 assessment#:#tst_finish_notification_simple#:#Felhasználónév és záró dátum
 assessment#:#tst_finished#:#Befejezve
 assessment#:#tst_form_dynamic_question_set_config#:#Folyamatos kérdéskiválasztás
@@ -1508,7 +1504,6 @@ assessment#:#tst_hide_info_tab#:#Az 'Információ' lap elrejtése
 assessment#:#tst_hide_info_tab_desc#:#A teszt 'Információ' lapja nem látható
 assessment#:#tst_hide_pagecontents#:#Oldaltartalom elrejtése
 assessment#:#tst_hide_pagecontents_desc#:#Az 'Oldal szerkesztése' gombbal a tényleges kérdésszöveg előtt és után elhelyezett LIAS-tartalom nem jelenik meg a eredménynézetekben és a nyomtatási kimenetben.
-assessment#:#tst_hide_side_list#:#Kérdéslista elrejtése
 assessment#:#tst_highscore_achieved_ts#:#Időpont
 assessment#:#tst_highscore_achieved_ts_description#:#A rangsorban a teszt időpontját tartalmazó oszlopot megjelenik.
 assessment#:#tst_highscore_all_tables#:#Kitöltő saját helyezése és legkiemelkedőbb helyezések
@@ -1528,7 +1523,6 @@ assessment#:#tst_highscore_score#:#Pontszám
 assessment#:#tst_highscore_score_description#:#A rangsorban a pontszámot tartalmazó oszlopot megjelenik.
 assessment#:#tst_highscore_top_num#:#Legkiemelkedőbb helyezések hossza
 assessment#:#tst_highscore_top_num_description#:#Hány helyezés legyen a legkiemelkedőbb helyezések felsorolásában.
-assessment#:#tst_highscore_top_num_unit#:#bejegyzések
 assessment#:#tst_highscore_top_table#:#Legkiemelkedőbb helyezések
 assessment#:#tst_highscore_top_table_description#:#A kitöltők láthatják a legkiemelkedőbb helyezéseket.
 assessment#:#tst_highscore_wtime#:#Tesztkitöltés ideje
@@ -1924,10 +1918,6 @@ assessment#:#tst_show_results#:#Teszteredmények
 assessment#:#tst_show_side_list#:#Kérdéslista megjelenítése
 assessment#:#tst_show_solution_answers_only#:#Eredmények nyomtatási előnézete (csak a válaszoké)
 assessment#:#tst_show_solution_answers_only_desc#:#A 'Tartalom módosítása' lapon a kérdéshez beállított tartalom nem jelenik meg nyomtatásban. Papír spórolása esetén válassza ezt az opciót.
-assessment#:#tst_show_solution_compare#:#Legjobb megoldás megjelenítése a 'Részletes teszteredmények'-ben
-assessment#:#tst_show_solution_compare_desc#:#A kitöltők összehasonlíthatják saját megoldásikat a legjobb megoldással. Ez az 'Információs' lapon lévő 'Teszteredmények megjelenítése' linkkel elérhető 'Részletes teszteredmények'-ben jelenik meg, a nyomtatható 'Válaszok felsorolása' részben viszont nem.
-assessment#:#tst_show_solution_details#:#A kitöltő pontozott válaszai
-assessment#:#tst_show_solution_details_desc#:#A teszkitöltések 'Részletes teszteredmények táblázata' kiegészül a válaszokkal.
 assessment#:#tst_show_solution_details_singlepage#:#Pontozott válaszok egyetlen oldalon
 assessment#:#tst_show_solution_details_singlepage_desc#:#A kitöltők minden kérdéshez külön-külön hozzáférhetnek, és megnézhetik, hogy helyesek voltak-e a válaszaik, illetve, hogy hány pontot szereztek.
 assessment#:#tst_show_solution_feedback#:#Válaszspecifikus visszajelzés megjelenítése a teszteredményekben
@@ -1950,7 +1940,6 @@ assessment#:#tst_skill_triggerings_num_req_answers_desc#:#Kompetenciára nem vá
 assessment#:#tst_skill_triggerings_num_req_answers_not_reached_warn#:#A teszt által legalább egy mérni kívánt kompetenciához nincs elegendő kérdés, így azokhoz egy kompetenciabejegyzést sem fogunk rögzíteni.<br />A szükséges minimális kérdésszám: %s
 assessment#:#tst_skl_level_thresholds_link#:#Kompetencia-küszöbértékek beállítása
 assessment#:#tst_skl_level_thresholds_missing#:#Az érintett kompetenciákhoz hiányoznak a küszöbértékek!
-assessment#:#tst_skl_res_interpretation_hint_msg#:#Kérjük, vegye figyelembe, hogy a csupán egy tesztből kapott kompetenciaeredmények korlátozott jelentőséggel bírnak. Minél több információt sikerül gyűjteni kompetenciánként, annál jobb lesz az eredmény. Amennyiben egyszerű kompetenciához nincs bejegyzés, a kompetencia megállapításához túl kevés információ áll rendelkezésre.
 assessment#:#tst_skl_sub_tab_thresholds#:#Kompetencia-küszöbértékek
 assessment#:#tst_sol_comp_expressions#:#Összehasonlító kifejezések
 assessment#:#tst_solution_compare_cfg#:#Megoldás összehasonlításához beállítások
@@ -2012,7 +2001,6 @@ assessment#:#tst_unchanged_answer_is_correct#:#A jelenlegi válasz helyes.
 assessment#:#tst_unchanged_order_is_correct#:#A jelenlegi sorrend helyes.
 assessment#:#tst_use_previous_answers#:#Korábbi válaszok használata
 assessment#:#tst_use_previous_answers_description#:#A kitöltők számára korábbi teszkitöltéseinek válaszai megjelennek. Ezt a lehetőséget a kitöltők saját maguknak tudják bekapcsolni egy felugró ablakban a teszkitöltés indítása előtt.
-assessment#:#tst_use_previous_answers_user#:#Használja korábbi válaszaimat alapértelmezett értékként a jövőbeni teszkitöltésekhez.
 assessment#:#tst_user_finished_test#:#'%s' tesztet egy felhasználó befejezte
 assessment#:#tst_view_competence_assign#:#Összerendelési tulajdonságok megtekintése
 assessment#:#tst_virtual_pass_header_lo_initial#:#A Tanulási célkitűzés Belépő tesztjének eredményei<br />%s

--- a/lang/ilias_it.lang
+++ b/lang/ilias_it.lang
@@ -693,12 +693,10 @@ assessment#:#examid_in_test_res#:#ILIAS Testpass ID
 assessment#:#examid_in_test_res_desc#:#The ILIAS Testpass ID will be included in the test results.
 assessment#:#exp_all_test_runs#:#All test attempts###26 08 2024 new variable
 assessment#:#exp_eval_data#:#Esporta i dati con le valutazioni in formato
-assessment#:#exp_file_created#:#Esporta file creato.
 assessment#:#exp_grammar_as#:#as###26 08 2024 new variable
 assessment#:#exp_scored_test_attempt#:#Scored Test Attempt###28 10 2024 new variable
 assessment#:#exp_type_certificate#:#Certificato (PDF)
 assessment#:#exp_type_excel#:#MS Excel
-assessment#:#exp_type_spss#:#Valori separati da una virgola (CSV)
 assessment#:#expected_result_type#:#Tipo di risultato previsto
 assessment#:#export_cert_failed_for_users_p#:#No certificate file could be generated and added for the following %s accounts: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
 assessment#:#export_cert_failed_for_users_s#:#No certificate file could be generated and added to the archive for the following account: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
@@ -1434,7 +1432,6 @@ assessment#:#tst_delete_missing_mark#:#Per favore, scegli almeno un voto se vuoi
 assessment#:#tst_derive_new_pool#:#Ricava nuovo gruppo di domande
 assessment#:#tst_derive_new_pools#:#Ricava nuovi gruppi di domande
 assessment#:#tst_dont_show_msg_again_in_current_session#:#Don't show this message again in my current session.
-assessment#:#tst_dont_use_previous_answers#:#La tua risposta precedente non verrà usata come risposta di default per test successivi
 assessment#:#tst_edit_competence_assign#:#Modifica delle proprietà di assegnazione
 assessment#:#tst_edit_scoring#:#Modifica il punteggio
 assessment#:#tst_enable_questionlist#:#Show 'List of Questions’###26 08 2024 new variable
@@ -1494,7 +1491,6 @@ assessment#:#tst_finish_notification#:#Segnalazione completata
 assessment#:#tst_finish_notification_advanced#:#Invia i risultati completi del test al responsabile
 assessment#:#tst_finish_notification_content_type#:#Contenuto dell’email
 assessment#:#tst_finish_notification_desc#:#Invia una mail al titolare del test per ogni utente che ha completato il test.
-assessment#:#tst_finish_notification_no#:#Nessun email
 assessment#:#tst_finish_notification_simple#:#Invia lo user name e la data di completamento al responsabile del test
 assessment#:#tst_finished#:#Finito
 assessment#:#tst_form_dynamic_question_set_config#:#Selezione continua di domande
@@ -1508,7 +1504,6 @@ assessment#:#tst_hide_info_tab#:#Hide Info Tab###26 08 2024 new variable
 assessment#:#tst_hide_info_tab_desc#:#Hides the tab ‘Info’ of the test.###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents#:#Hide page content###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents_desc#:#ILIAS content placed before and after the actual question text via the "Edit Page" button will not be displayed in the result views and print output.###26 08 2024 new variable
-assessment#:#tst_hide_side_list#:#Nascondi la lista di domande
 assessment#:#tst_highscore_achieved_ts#:#Mostra data del test
 assessment#:#tst_highscore_achieved_ts_description#:#Controlli, se una colonna con la data di prova deve essere visualizzata.
 assessment#:#tst_highscore_all_tables#:#All Rankings
@@ -1528,7 +1523,6 @@ assessment#:#tst_highscore_score#:#Mostra punteggio
 assessment#:#tst_highscore_score_description#:#Controlli, se una colonna con il punteggio dovrebbe essere mostrata.
 assessment#:#tst_highscore_top_num#:#Numero dei punteggi
 assessment#:#tst_highscore_top_num_description#:#Controlli, quanti punteggi dovrebbero essere inclusi nella tabella dei punteggi più alti.
-assessment#:#tst_highscore_top_num_unit#:#voci
 assessment#:#tst_highscore_top_table#:#Mostra tabella 'classifica'
 assessment#:#tst_highscore_top_table_description#:#Controlli, se la tabella 'classifica top' deve essere visualizzata.
 assessment#:#tst_highscore_wtime#:#Mostra il tempo di lavoro
@@ -1924,10 +1918,6 @@ assessment#:#tst_show_results#:#Mostra i risultati del test
 assessment#:#tst_show_side_list#:#Mostra la lista delle domande a lato
 assessment#:#tst_show_solution_answers_only#:#Stampa dei risultati (solo le risposte)
 assessment#:#tst_show_solution_answers_only_desc#:#If is selected, the ILIAS content you place around a question using the "Edit content" tab page will not be visible in a print-out. If you want to save some paper space, select this option.
-assessment#:#tst_show_solution_compare#:#Compare Answer with Solution in List of Answers
-assessment#:#tst_show_solution_compare_desc#:#Participants are presented with an overview comparing their own answers with the best solutions. Please note that this view will be displayed in the ‘Detailed Results’ that can be accessed via the ‘Show Test Results‘-button on the ‘Info’-tab. It will not be displayed in the printable ‘List of Answers’ even though the setting is made here.
-assessment#:#tst_show_solution_details#:#Mostra le soluzioni al momento dei risultati
-assessment#:#tst_show_solution_details_desc#:#If selected, the detailed question solution is available to participants in the test results presentation. This includes the exact scoring of every answer, otherwise only an overview with the question titles and the reached points is shown.
 assessment#:#tst_show_solution_details_singlepage#:#Scored Answers on single pages###26 08 2024 new variable
 assessment#:#tst_show_solution_details_singlepage_desc#:#Participants can access each question individually and see if their answers were correct and how many points they scored.###26 08 2024 new variable
 assessment#:#tst_show_solution_feedback#:#Mostra il feedback delle specifiche delle risposte nei risultati del test
@@ -1950,7 +1940,6 @@ assessment#:#tst_skill_triggerings_num_req_answers_desc#:#Le competenze non veng
 assessment#:#tst_skill_triggerings_num_req_answers_not_reached_warn#:#Almeno una delle competenze affrontate da questo test non è attivata dalla quantità minima richiesta di domande.<br />La quantità richiesta di domande: %s
 assessment#:#tst_skl_level_thresholds_link#:#Configure Competence-Thresholds
 assessment#:#tst_skl_level_thresholds_missing#:#Ci sono livelli mancanti per le competenze pertinenti!
-assessment#:#tst_skl_res_interpretation_hint_msg#:#Si prega di considerare che i risultati di competenza da un singolo test hanno rilevanza limitata. Più informazioni vengono raccolte per competenza, più sarà valido il significa. Nel caso in cui esistano singole competenze senza alcuna entrata, ci saranno meno informazioni raccolte.
 assessment#:#tst_skl_sub_tab_thresholds#:#Limiti di competenza
 assessment#:#tst_sol_comp_expressions#:#Espressioni di confronto
 assessment#:#tst_solution_compare_cfg#:#Configurazione per confronto soluzioni
@@ -2012,7 +2001,6 @@ assessment#:#tst_unchanged_answer_is_correct#:#La risposta predefinita è corret
 assessment#:#tst_unchanged_order_is_correct#:#L’ordine predefinito è corretto
 assessment#:#tst_use_previous_answers#:#Usa la risposta precedente
 assessment#:#tst_use_previous_answers_description#:#Se selezionato, la precedente risposta di un utente verrà utilizzata come valore di default per i test futuri, altrimenti le risposte date in precedenza, non verranno mostrate nelle future esecuzioni dei test.
-assessment#:#tst_use_previous_answers_user#:#Usa la mia risposta ad un test precedente come risposta di default
 assessment#:#tst_user_finished_test#:#L'utente ha finito il test (%s)
 assessment#:#tst_view_competence_assign#:#Visualizza proprietà di assegnazione
 assessment#:#tst_virtual_pass_header_lo_initial#:#Initial Test Results for the Learning Objectives<br />%s

--- a/lang/ilias_ja.lang
+++ b/lang/ilias_ja.lang
@@ -693,12 +693,10 @@ assessment#:#examid_in_test_res#:#ILIAS テスト実施 ID
 assessment#:#examid_in_test_res_desc#:#ILIASテスト実施ＩDはテスト結果内に含まれます。
 assessment#:#exp_all_test_runs#:#全テスト試み
 assessment#:#exp_eval_data#:#評価データ用にエクスポート
-assessment#:#exp_file_created#:#エクスポートファイルを作成しました。
 assessment#:#exp_grammar_as#:#as
 assessment#:#exp_scored_test_attempt#:#採点されたテスト試み
 assessment#:#exp_type_certificate#:#証明書 (PDF)
 assessment#:#exp_type_excel#:#Microsoft Excel
-assessment#:#exp_type_spss#:#カンマ区切り (CSV)
 assessment#:#expected_result_type#:#予想結果タイプ
 assessment#:#export_cert_failed_for_users_p#:#通知ファイルが生成されて次の %s アカウント: %s へ追加された可能性があります。ログファイルを確認するように管理者へコンタクトしてください。
 assessment#:#export_cert_failed_for_users_s#:#通知ファイルが生成されて次の %s アカウント: %s へアーカイブされた可能性があります。ログファイルを確認するように管理者へコンタクトしてください。
@@ -1434,7 +1432,6 @@ assessment#:#tst_delete_missing_mark#:#削除を進むには一つはマーク�
 assessment#:#tst_derive_new_pool#:#新規問題集を得る
 assessment#:#tst_derive_new_pools#:#新規問題集を得る
 assessment#:#tst_dont_show_msg_again_in_current_session#:#現在のセッションへこのメッセージを再表示しません。
-assessment#:#tst_dont_use_previous_answers#:#前回の解答が今後の試験の初期設定値として使用されることはありません
 assessment#:#tst_edit_competence_assign#:#割り当てのプロパティを編集
 assessment#:#tst_edit_scoring#:#点数を編集
 assessment#:#tst_enable_questionlist#:# '問題リスト’を表示
@@ -1494,7 +1491,6 @@ assessment#:#tst_finish_notification#:#通知
 assessment#:#tst_finish_notification_advanced#:#完了テスト結果を送信
 assessment#:#tst_finish_notification_content_type#:#e-mailのb内容
 assessment#:#tst_finish_notification_desc#:#テスト完了のユーザごとにテストオーナーへe-mailを送付する
-assessment#:#tst_finish_notification_no#:#e-mailしない
 assessment#:#tst_finish_notification_simple#:#ユーザ名と終了日を送る
 assessment#:#tst_finished#:#終了
 assessment#:#tst_form_dynamic_question_set_config#:#問題選択の継続
@@ -1508,7 +1504,6 @@ assessment#:#tst_hide_info_tab#:#Info タブを非表示
 assessment#:#tst_hide_info_tab_desc#:#テストの ‘Info’ タブを非表示
 assessment#:#tst_hide_pagecontents#:#ページコンテンツを非表示
 assessment#:#tst_hide_pagecontents_desc#:#ページ編集ボタン経由の実際のテキスト前後に位置するILIASコンテンツは結果ビューにも印刷にも出力されません。。
-assessment#:#tst_hide_side_list#:#問題一覧を表示しない
 assessment#:#tst_highscore_achieved_ts#:#日付
 assessment#:#tst_highscore_achieved_ts_description#:#テストデータの含まれる列は順位に含まれます。
 assessment#:#tst_highscore_all_tables#:#受験者の自身ランクとトップランキング
@@ -1528,7 +1523,6 @@ assessment#:#tst_highscore_score#:#点数
 assessment#:#tst_highscore_score_description#:#点数入りの列はランキングへ含まれます。
 assessment#:#tst_highscore_top_num#:#トップランキングの長さ
 assessment#:#tst_highscore_top_num_description#:#何位をトップ順位リスト内に含めるかを決める
-assessment#:#tst_highscore_top_num_unit#:#エントリー
 assessment#:#tst_highscore_top_table#:#トップ順位
 assessment#:#tst_highscore_top_table_description#:#受験者はトップランクに含まれるテーブルで表示されます。
 assessment#:#tst_highscore_wtime#:#テスト受験時間
@@ -1924,10 +1918,6 @@ assessment#:#tst_show_results#:#テスト結果を表示
 assessment#:#tst_show_side_list#:#脇に問題一覧を表示
 assessment#:#tst_show_solution_answers_only#:#結果印刷表示(解答のみ)
 assessment#:#tst_show_solution_answers_only_desc#:#選択すると"コンテンツ編集"タブを使って問題の周りに配置したILIASコンテンツのページは印刷には表示されません。少し紙面スペースを保存したい場合はこのオプションを選択します。
-assessment#:#tst_show_solution_compare#:#解答一覧の正解と解答を比較
-assessment#:#tst_show_solution_compare_desc#:#受験者は模範解答の回答と自身の全体回答を比較して表示されます。このビューは、''Info'タブの'テスト結果表示ボタン'を通してアクセス可能な'詳細結果'内へ表示されます。ここに設定しても印刷領域の'回答のリスト'には表示されません。
-assessment#:#tst_show_solution_details#:#受験者の得点回答
-assessment#:#tst_show_solution_details_desc#:#詳細テスト結果表'へadd-onとして追加し、受験者は各問題のページのリンクを得ます。このリンクページには問題、受験者の回答、この回答が正しいかどうかの情報、この問題による得点等が含まれます。
 assessment#:#tst_show_solution_details_singlepage#:#単一ページ上の採点済解答
 assessment#:#tst_show_solution_details_singlepage_desc#:#回答が正解で何点かを確認したければ、受験者は各問題個々にアクセスできます。
 assessment#:#tst_show_solution_feedback#:#フィードバック
@@ -1950,7 +1940,6 @@ assessment#:#tst_skill_triggerings_num_req_answers_desc#:#この前に能力は�
 assessment#:#tst_skill_triggerings_num_req_answers_not_reached_warn#:#これにより処理される能力の一つはこのテストは、必須問題最小数でトリガーされません。<br />必須問題数は: %sです。
 assessment#:#tst_skl_level_thresholds_link#:#能力-スレッショールドを構成
 assessment#:#tst_skl_level_thresholds_missing#:#関連する能力のスレッショールドがありません!
-assessment#:#tst_skl_res_interpretation_hint_msg#:#単一テストの能力結果は限定的な意味であることを考慮してください。詳細は能力別に収集されます。何もエントリーのない単一能力は価値のない情報収集になります。
 assessment#:#tst_skl_sub_tab_thresholds#:#能力しきい値
 assessment#:#tst_sol_comp_expressions#:#能力しきい値
 assessment#:#tst_solution_compare_cfg#:#正解比較用の構成
@@ -2012,7 +2001,6 @@ assessment#:#tst_unchanged_answer_is_correct#:#プリセット回答は正しい
 assessment#:#tst_unchanged_order_is_correct#:#プリセット順番は正しい
 assessment#:#tst_use_previous_answers#:#前回の回答を使用
 assessment#:#tst_use_previous_answers_description#:#参加者には前回使用の回答が表示されます。このオプションは登録開始前にInfoタブ上に参加者個々で有効する必要があります。
-assessment#:#tst_use_previous_answers_user#:#回答を続ける際の初期値に前の回答を使用
 assessment#:#tst_user_finished_test#:#終了したテスト(%s) を使用
 assessment#:#tst_view_competence_assign#:#割り当てプロパティを表示
 assessment#:#tst_virtual_pass_header_lo_initial#:#学習目標に対する最初のテスト結果<br />%s

--- a/lang/ilias_ka.lang
+++ b/lang/ilias_ka.lang
@@ -693,12 +693,10 @@ assessment#:#examid_in_test_res#:#ILIAS Testpass ID###27 01 2015 new variable
 assessment#:#examid_in_test_res_desc#:#The ILIAS Testpass ID will be included in the test results.###27 01 2015 new variable
 assessment#:#exp_all_test_runs#:#All test attempts###26 08 2024 new variable
 assessment#:#exp_eval_data#:#გადავაგზავნოთ შეფასების მონაცემები როგორც
-assessment#:#exp_file_created#:#Export file created.###24 10 2013 new variable
 assessment#:#exp_grammar_as#:#as###26 08 2024 new variable
 assessment#:#exp_scored_test_attempt#:#Scored Test Attempt###28 10 2024 new variable
 assessment#:#exp_type_certificate#:#სერთიფიკატი (PDF)
 assessment#:#exp_type_excel#:#Microsoft Excel
-assessment#:#exp_type_spss#:#მძიმეთი გამოყოფილი ღირებულება  (CSV)
 assessment#:#expected_result_type#:#Expected result type###24 10 2013 new variable
 assessment#:#export_cert_failed_for_users_p#:#No certificate file could be generated and added for the following %s accounts: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
 assessment#:#export_cert_failed_for_users_s#:#No certificate file could be generated and added to the archive for the following account: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
@@ -1434,7 +1432,6 @@ assessment#:#tst_delete_missing_mark#:#გთხოვთ აირჩიოთ 
 assessment#:#tst_derive_new_pool#:#Derive New Question Pool###25 10 2016 new variable
 assessment#:#tst_derive_new_pools#:#Derive New Question Pools###25 10 2016 new variable
 assessment#:#tst_dont_show_msg_again_in_current_session#:#Don't show this message again in my current session.###10 11 2018 new variable
-assessment#:#tst_dont_use_previous_answers#:#თქვენი წინა პასუხები არ გამოიყენება სტანდარტების ღირებულებად მომავალ ტესტის ჩაბარების დროს
 assessment#:#tst_edit_competence_assign#:#Edit Assignment Properties###30 08 2015 new variable
 assessment#:#tst_edit_scoring#:#Edit Scoring
 assessment#:#tst_enable_questionlist#:#Show 'List of Questions’###26 08 2024 new variable
@@ -1494,7 +1491,6 @@ assessment#:#tst_finish_notification#:#ემაილი დამთავრ�
 assessment#:#tst_finish_notification_advanced#:#გადავაგზავნოთ დასრულებული ტესტის შედეგი მფლობელთან
 assessment#:#tst_finish_notification_content_type#:#Content of e-mail###27 01 2015 new variable
 assessment#:#tst_finish_notification_desc#:#Sends an e-mail to the test owner for every user that has completed the test.###27 01 2015 new variable
-assessment#:#tst_finish_notification_no#:#No e-mail###06 02 2015 new variable
 assessment#:#tst_finish_notification_simple#:#გადავაგზავნოთ მომხმარებლის სახელი და დასრულების თარიღი ტესტის მფლობელთან
 assessment#:#tst_finished#:#დასრულებული
 assessment#:#tst_form_dynamic_question_set_config#:#Continues Question Selection###24 10 2013 new variable
@@ -1508,7 +1504,6 @@ assessment#:#tst_hide_info_tab#:#Hide Info Tab###26 08 2024 new variable
 assessment#:#tst_hide_info_tab_desc#:#Hides the tab ‘Info’ of the test.###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents#:#Hide page content###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents_desc#:#ILIAS content placed before and after the actual question text via the "Edit Page" button will not be displayed in the result views and print output.###26 08 2024 new variable
-assessment#:#tst_hide_side_list#:#დავმალოთ კითხვების სია
 assessment#:#tst_highscore_achieved_ts#:#Show date of test
 assessment#:#tst_highscore_achieved_ts_description#:#Controls, if a column with the test date should be shown.
 assessment#:#tst_highscore_all_tables#:#All Rankings###07 11 2014 new variable
@@ -1528,7 +1523,6 @@ assessment#:#tst_highscore_score#:#Show score
 assessment#:#tst_highscore_score_description#:#Controls, if a column with the score should be shown.
 assessment#:#tst_highscore_top_num#:#Number of ranks
 assessment#:#tst_highscore_top_num_description#:#Controls, how many ranks should be included in the top ranking table.
-assessment#:#tst_highscore_top_num_unit#:#entries
 assessment#:#tst_highscore_top_table#:#Show table 'top ranking'
 assessment#:#tst_highscore_top_table_description#:#Controls, if the table 'top ranking' should be shown.
 assessment#:#tst_highscore_wtime#:#Show working time
@@ -1924,10 +1918,6 @@ assessment#:#tst_show_results#:#აჩვენე ტესტის პას�
 assessment#:#tst_show_side_list#:#აჩვენე კითხვების სია ცალკე
 assessment#:#tst_show_solution_answers_only#:#შედეგების ამობეჭდვის წინ ჩვენება ( მხოლოდ პასუხები)
 assessment#:#tst_show_solution_answers_only_desc#:#If is selected, the ILIAS content you place around a question using the "Edit content" tab page will not be visible in a print-out. If you want to save some paper space, select this option.###07 11 2014 new variable
-assessment#:#tst_show_solution_compare#:#Compare Answer with Solution in List of Answers###24 10 2013 new variable
-assessment#:#tst_show_solution_compare_desc#:#Participants are presented with an overview comparing their own answers with the best solutions. Please note that this view will be displayed in the ‘Detailed Results’ that can be accessed via the ‘Show Test Results‘-button on the ‘Info’-tab. It will not be displayed in the printable ‘List of Answers’ even though the setting is made here.###06 02 2015 new variable
-assessment#:#tst_show_solution_details#:#აჩვენე ამოხსნები ტესტის შედეგებში
-assessment#:#tst_show_solution_details_desc#:#If selected, the detailed question solution is available to participants in the test results presentation. This includes the exact scoring of every answer, otherwise only an overview with the question titles and the reached points is shown.###07 11 2014 new variable
 assessment#:#tst_show_solution_details_singlepage#:#Scored Answers on single pages###26 08 2024 new variable
 assessment#:#tst_show_solution_details_singlepage_desc#:#Participants can access each question individually and see if their answers were correct and how many points they scored.###26 08 2024 new variable
 assessment#:#tst_show_solution_feedback#:#აჩვენე პასუხების უკუკავშირი ტესტის შედეგებში
@@ -1950,7 +1940,6 @@ assessment#:#tst_skill_triggerings_num_req_answers_desc#:#Competences aren't tri
 assessment#:#tst_skill_triggerings_num_req_answers_not_reached_warn#:#At least one of the competences addressed by this test is not triggered by the minimal required amount of questions.<br />The required amount of questions: %s###10 11 2018 new variable
 assessment#:#tst_skl_level_thresholds_link#:#Configure Competence-Thresholds###30 08 2015 new variable
 assessment#:#tst_skl_level_thresholds_missing#:#There are missing thresholds for the relevant competences!###30 08 2015 new variable
-assessment#:#tst_skl_res_interpretation_hint_msg#:#Please consider that competence results from a single test has a limited significance. The more information is collected per competence, the merrier valid the significance will be. Should there are single competences without any entry, there is to less information collected.###30 08 2015 new variable
 assessment#:#tst_skl_sub_tab_thresholds#:#Competence Thresholds###26 09 2014 new variable
 assessment#:#tst_sol_comp_expressions#:#Comparison Expressions###30 08 2015 new variable
 assessment#:#tst_solution_compare_cfg#:#Configuration for Solution Compare###30 08 2015 new variable
@@ -2012,7 +2001,6 @@ assessment#:#tst_unchanged_answer_is_correct#:#The preset answer is correct###fa
 assessment#:#tst_unchanged_order_is_correct#:#The preset order is correct###fau: testNav
 assessment#:#tst_use_previous_answers#:#გამოიყენე წინა პასუხები
 assessment#:#tst_use_previous_answers_description#:#თუ შემოწმებულია, მონაწილეს შეუძლია გამოიყენოს პასუხები მომავალ ტესტში როგორც სტანდარტული ღირებულება, სხვა შემთხვევაში წინა შედეგები არ გამოჩნდება მომავალი ტესტის ჩაბარების დროს
-assessment#:#tst_use_previous_answers_user#:#გამოიყენე ჩემი წინა შედეგი მომავალ ტესტში როგორ სტანდარტული ღირებულება
 assessment#:#tst_user_finished_test#:#მომხმარებელმა დაასრულა ტესტი
 assessment#:#tst_view_competence_assign#:#View Assignment Properties###30 08 2015 new variable
 assessment#:#tst_virtual_pass_header_lo_initial#:#Initial Test Results for the Learning Objectives<br />%s###30 08 2015 new variable

--- a/lang/ilias_lt.lang
+++ b/lang/ilias_lt.lang
@@ -693,12 +693,10 @@ assessment#:#examid_in_test_res#:#ILIAS Testpass ID###27 01 2015 new variable
 assessment#:#examid_in_test_res_desc#:#The ILIAS Testpass ID will be included in the test results.###27 01 2015 new variable
 assessment#:#exp_all_test_runs#:#All test attempts###26 08 2024 new variable
 assessment#:#exp_eval_data#:#Eksportuoti vertinimo rezultatus kaip
-assessment#:#exp_file_created#:#Export file created.###24 10 2013 new variable
 assessment#:#exp_grammar_as#:#as###26 08 2024 new variable
 assessment#:#exp_scored_test_attempt#:#Scored Test Attempt###28 10 2024 new variable
 assessment#:#exp_type_certificate#:#Sertifikatas (PDF)
 assessment#:#exp_type_excel#:#Microsoft Excel
-assessment#:#exp_type_spss#:#Kableliu atskirta reikšmė (CSV)
 assessment#:#expected_result_type#:#Expected result type###24 10 2013 new variable
 assessment#:#export_cert_failed_for_users_p#:#No certificate file could be generated and added for the following %s accounts: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
 assessment#:#export_cert_failed_for_users_s#:#No certificate file could be generated and added to the archive for the following account: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
@@ -1434,7 +1432,6 @@ assessment#:#tst_delete_missing_mark#:#Prašome pasirinkti bent vertinimą (mark
 assessment#:#tst_derive_new_pool#:#Derive New Question Pool###25 10 2016 new variable
 assessment#:#tst_derive_new_pools#:#Derive New Question Pools###25 10 2016 new variable
 assessment#:#tst_dont_show_msg_again_in_current_session#:#Don't show this message again in my current session.###10 11 2018 new variable
-assessment#:#tst_dont_use_previous_answers#:#Jūsų ankstesni atsakymai nebus naudojami kaip numatytosio vertės būsimuose testo laikymuose
 assessment#:#tst_edit_competence_assign#:#Edit Assignment Properties###30 08 2015 new variable
 assessment#:#tst_edit_scoring#:#Edit Scoring###28 08 2012 new variable
 assessment#:#tst_enable_questionlist#:#Show 'List of Questions’###26 08 2024 new variable
@@ -1494,7 +1491,6 @@ assessment#:#tst_finish_notification#:#Mail on completion###24 07 2009 new varia
 assessment#:#tst_finish_notification_advanced#:#Send complete test result to test owner###24 07 2009 new variable
 assessment#:#tst_finish_notification_content_type#:#Content of e-mail###27 01 2015 new variable
 assessment#:#tst_finish_notification_desc#:#Sends an e-mail to the test owner for every user that has completed the test.###27 01 2015 new variable
-assessment#:#tst_finish_notification_no#:#No e-mail###06 02 2015 new variable
 assessment#:#tst_finish_notification_simple#:#Send user name and finish date to test owner###24 07 2009 new variable
 assessment#:#tst_finished#:#Baigtas
 assessment#:#tst_form_dynamic_question_set_config#:#Continues Question Selection###24 10 2013 new variable
@@ -1508,7 +1504,6 @@ assessment#:#tst_hide_info_tab#:#Hide Info Tab###26 08 2024 new variable
 assessment#:#tst_hide_info_tab_desc#:#Hides the tab ‘Info’ of the test.###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents#:#Hide page content###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents_desc#:#ILIAS content placed before and after the actual question text via the "Edit Page" button will not be displayed in the result views and print output.###26 08 2024 new variable
-assessment#:#tst_hide_side_list#:#Hide question list###24 07 2009 new variable
 assessment#:#tst_highscore_achieved_ts#:#Show date of test###28 08 2012 new variable
 assessment#:#tst_highscore_achieved_ts_description#:#Controls, if a column with the test date should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_all_tables#:#All Rankings###07 11 2014 new variable
@@ -1528,7 +1523,6 @@ assessment#:#tst_highscore_score#:#Show score###28 08 2012 new variable
 assessment#:#tst_highscore_score_description#:#Controls, if a column with the score should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_top_num#:#Number of ranks###28 08 2012 new variable
 assessment#:#tst_highscore_top_num_description#:#Controls, how many ranks should be included in the top ranking table.###28 08 2012 new variable
-assessment#:#tst_highscore_top_num_unit#:#entries###28 08 2012 new variable
 assessment#:#tst_highscore_top_table#:#Show table 'top ranking'###28 08 2012 new variable
 assessment#:#tst_highscore_top_table_description#:#Controls, if the table 'top ranking' should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_wtime#:#Show working time###28 08 2012 new variable
@@ -1924,10 +1918,6 @@ assessment#:#tst_show_results#:#Rodyti testo rezultatus
 assessment#:#tst_show_side_list#:#Show question list aside###24 07 2009 new variable
 assessment#:#tst_show_solution_answers_only#:#Rezultatai spausdinimo formatu (tik atsakymai)
 assessment#:#tst_show_solution_answers_only_desc#:#If is selected, the ILIAS content you place around a question using the "Edit content" tab page will not be visible in a print-out. If you want to save some paper space, select this option.###07 11 2014 new variable
-assessment#:#tst_show_solution_compare#:#Compare Answer with Solution in List of Answers###24 10 2013 new variable
-assessment#:#tst_show_solution_compare_desc#:#Participants are presented with an overview comparing their own answers with the best solutions. Please note that this view will be displayed in the ‘Detailed Results’ that can be accessed via the ‘Show Test Results‘-button on the ‘Info’-tab. It will not be displayed in the printable ‘List of Answers’ even though the setting is made here.###06 02 2015 new variable
-assessment#:#tst_show_solution_details#:#Įvertinimas detaliau
-assessment#:#tst_show_solution_details_desc#:#If selected, the detailed question solution is available to participants in the test results presentation. This includes the exact scoring of every answer, otherwise only an overview with the question titles and the reached points is shown.###07 11 2014 new variable
 assessment#:#tst_show_solution_details_singlepage#:#Scored Answers on single pages###26 08 2024 new variable
 assessment#:#tst_show_solution_details_singlepage_desc#:#Participants can access each question individually and see if their answers were correct and how many points they scored.###26 08 2024 new variable
 assessment#:#tst_show_solution_feedback#:#Show Answer-Specific Feedback in Test Results###10 05 2007 new variable
@@ -1950,7 +1940,6 @@ assessment#:#tst_skill_triggerings_num_req_answers_desc#:#Competences aren't tri
 assessment#:#tst_skill_triggerings_num_req_answers_not_reached_warn#:#At least one of the competences addressed by this test is not triggered by the minimal required amount of questions.<br />The required amount of questions: %s###10 11 2018 new variable
 assessment#:#tst_skl_level_thresholds_link#:#Configure Competence-Thresholds###30 08 2015 new variable
 assessment#:#tst_skl_level_thresholds_missing#:#There are missing thresholds for the relevant competences!###30 08 2015 new variable
-assessment#:#tst_skl_res_interpretation_hint_msg#:#Please consider that competence results from a single test has a limited significance. The more information is collected per competence, the merrier valid the significance will be. Should there are single competences without any entry, there is to less information collected.###30 08 2015 new variable
 assessment#:#tst_skl_sub_tab_thresholds#:#Competence Thresholds###26 09 2014 new variable
 assessment#:#tst_sol_comp_expressions#:#Comparison Expressions###30 08 2015 new variable
 assessment#:#tst_solution_compare_cfg#:#Configuration for Solution Compare###30 08 2015 new variable
@@ -2012,7 +2001,6 @@ assessment#:#tst_unchanged_answer_is_correct#:#The preset answer is correct###fa
 assessment#:#tst_unchanged_order_is_correct#:#The preset order is correct###fau: testNav
 assessment#:#tst_use_previous_answers#:#Naudoti Ankstesnius Atsakymus
 assessment#:#tst_use_previous_answers_description#:#Jei pažymėta, ankstesni dalyvio atsakymai bus naudojami kaip numatytosios reikšmės būsimuose testo laikymuose
-assessment#:#tst_use_previous_answers_user#:#Naudoti mano ankstesnius atsakymus kaip numatytasias reikšmes būsimuose testo laikymuose
 assessment#:#tst_user_finished_test#:#User finished test (%s)###24 07 2009 new variable
 assessment#:#tst_view_competence_assign#:#View Assignment Properties###30 08 2015 new variable
 assessment#:#tst_virtual_pass_header_lo_initial#:#Initial Test Results for the Learning Objectives<br />%s###30 08 2015 new variable

--- a/lang/ilias_nl.lang
+++ b/lang/ilias_nl.lang
@@ -693,12 +693,10 @@ assessment#:#examid_in_test_res#:#Tonen Examennummer
 assessment#:#examid_in_test_res_desc#:#Tonen Examennummer
 assessment#:#exp_all_test_runs#:#All test attempts###26 08 2024 new variable
 assessment#:#exp_eval_data#:#Evaluatiegegevens exporteren als
-assessment#:#exp_file_created#:#Export bestand aangemaakt.
 assessment#:#exp_grammar_as#:#as###26 08 2024 new variable
 assessment#:#exp_scored_test_attempt#:#Scored Test Attempt###28 10 2024 new variable
 assessment#:#exp_type_certificate#:#Certificaat (PDF)
 assessment#:#exp_type_excel#:#Microsoft Excel
-assessment#:#exp_type_spss#:#Door komma's gescheiden waarde(CVS)
 assessment#:#expected_result_type#:#Verwacht resultaat-type
 assessment#:#export_cert_failed_for_users_p#:#No certificate file could be generated and added for the following %s accounts: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
 assessment#:#export_cert_failed_for_users_s#:#No certificate file could be generated and added to the archive for the following account: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
@@ -1434,7 +1432,6 @@ assessment#:#tst_delete_missing_mark#:#Selecteer op zijn minst één markerings-
 assessment#:#tst_derive_new_pool#:#Derive New Question Pool###25 10 2016 new variable
 assessment#:#tst_derive_new_pools#:#Derive New Question Pools###25 10 2016 new variable
 assessment#:#tst_dont_show_msg_again_in_current_session#:#Don't show this message again in my current session.###10 11 2018 new variable
-assessment#:#tst_dont_use_previous_answers#:#Je vorige antwoorden zullen niet gebruikt worden als standaardwaarden in toekomstige toetspogingen
 assessment#:#tst_edit_competence_assign#:#Edit Assignment Properties###30 08 2015 new variable
 assessment#:#tst_edit_scoring#:#Wijzig Scores
 assessment#:#tst_enable_questionlist#:#Show 'List of Questions’###26 08 2024 new variable
@@ -1494,7 +1491,6 @@ assessment#:#tst_finish_notification#:#Mail bij beëindiging
 assessment#:#tst_finish_notification_advanced#:#Stuur volledige toets resultaten naar de toets eigenaar
 assessment#:#tst_finish_notification_content_type#:#Content of e-mail###06 02 2015 new variable
 assessment#:#tst_finish_notification_desc#:#Sends an e-mail to the test owner for every user that has completed the test.###06 02 2015 new variable
-assessment#:#tst_finish_notification_no#:#Verzend geen mailbericht als een gebruiker een toets afmaakt
 assessment#:#tst_finish_notification_simple#:#Stuur gebruikersnaam en einddatum naar de toets eigenaar
 assessment#:#tst_finished#:#Klaar
 assessment#:#tst_form_dynamic_question_set_config#:#Doorgaan met vragenselectie
@@ -1508,7 +1504,6 @@ assessment#:#tst_hide_info_tab#:#Hide Info Tab###26 08 2024 new variable
 assessment#:#tst_hide_info_tab_desc#:#Hides the tab ‘Info’ of the test.###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents#:#Hide page content###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents_desc#:#ILIAS content placed before and after the actual question text via the "Edit Page" button will not be displayed in the result views and print output.###26 08 2024 new variable
-assessment#:#tst_hide_side_list#:#Verberg vragen bestand
 assessment#:#tst_highscore_achieved_ts#:#Toon toetsdatum
 assessment#:#tst_highscore_achieved_ts_description#:#Bepaalt of een kolom met de datum van de toets wordt getoond.
 assessment#:#tst_highscore_all_tables#:#Alle beoordelingen
@@ -1528,7 +1523,6 @@ assessment#:#tst_highscore_score#:#Toon score
 assessment#:#tst_highscore_score_description#:#Bepaalt of een kolom met de score wordt getoond.
 assessment#:#tst_highscore_top_num#:#Aantal scores
 assessment#:#tst_highscore_top_num_description#:#Bepaalt hoeveel items worden getoond in de top-score lijst.
-assessment#:#tst_highscore_top_num_unit#:#bezoeken aan objecten
 assessment#:#tst_highscore_top_table#:#Toon tabel met top scores
 assessment#:#tst_highscore_top_table_description#:#Bepaalt of de tabel "top scores" wordt getoond.
 assessment#:#tst_highscore_wtime#:#Toon werktijd
@@ -1924,10 +1918,6 @@ assessment#:#tst_show_results#:#Laat toetsresultaten zien
 assessment#:#tst_show_side_list#:#Tonen vragenlijst aan zijkant
 assessment#:#tst_show_solution_answers_only#:#Resultaten overzicht (alleen de antwoorden)
 assessment#:#tst_show_solution_answers_only_desc#:#Als geselecteerd zal de ILIAS inhoud die je rond een vraag hebt aangemaakt met behulp van de pagina editor niet worden getoond bij het afdrukken. Als je bezuinigt op papier, selecteer dan deze optie.
-assessment#:#tst_show_solution_compare#:#Vergelijk antwoord met oplossing in antwoordenlijst
-assessment#:#tst_show_solution_compare_desc#:#Participants are presented with an overview comparing their own answers with the best solutions. Please note that this view will be displayed in the ‘Detailed Results’ that can be accessed via the ‘Show Test Results‘-button on the ‘Info’-tab. It will not be displayed in the printable ‘List of Answers’ even though the setting is made here.###06 02 2015 new variable
-assessment#:#tst_show_solution_details#:#Score details
-assessment#:#tst_show_solution_details_desc#:#Als geselecteerd is de gedetailleerde oplossing beschikbaar voor deelnemers in de toetsresultaten. Dit is inclusief de exacte score voor ieder antwoord. Anders wordt alleen een overzicht met de vragentitles en de behaalde punten getoond.
 assessment#:#tst_show_solution_details_singlepage#:#Scored Answers on single pages###26 08 2024 new variable
 assessment#:#tst_show_solution_details_singlepage_desc#:#Participants can access each question individually and see if their answers were correct and how many points they scored.###26 08 2024 new variable
 assessment#:#tst_show_solution_feedback#:#Toon antwoord feedback in toetsresultaten.
@@ -1950,7 +1940,6 @@ assessment#:#tst_skill_triggerings_num_req_answers_desc#:#Competences aren't tri
 assessment#:#tst_skill_triggerings_num_req_answers_not_reached_warn#:#At least one of the competences addressed by this test is not triggered by the minimal required amount of questions.<br />The required amount of questions: %s###10 11 2018 new variable
 assessment#:#tst_skl_level_thresholds_link#:#Configure Competence-Thresholds###30 08 2015 new variable
 assessment#:#tst_skl_level_thresholds_missing#:#There are missing thresholds for the relevant competences!###30 08 2015 new variable
-assessment#:#tst_skl_res_interpretation_hint_msg#:#Please consider that competence results from a single test has a limited significance. The more information is collected per competence, the merrier valid the significance will be. Should there are single competences without any entry, there is to less information collected.###30 08 2015 new variable
 assessment#:#tst_skl_sub_tab_thresholds#:#Competentiedrempel
 assessment#:#tst_sol_comp_expressions#:#Comparison Expressions###30 08 2015 new variable
 assessment#:#tst_solution_compare_cfg#:#Configuration for Solution Compare###30 08 2015 new variable
@@ -2012,7 +2001,6 @@ assessment#:#tst_unchanged_answer_is_correct#:#The preset answer is correct###fa
 assessment#:#tst_unchanged_order_is_correct#:#The preset order is correct###fau: testNav
 assessment#:#tst_use_previous_answers#:#Gebruik vorige antwoorden
 assessment#:#tst_use_previous_answers_description#:#Indien aangevinkt, kan een deelnemer verkiezen om de vorige antwoorden te gebruiken aangezien de standaardwaarden passen toetsen, anders worden de vorige antwoorden voortaan getoond toets geen passen
-assessment#:#tst_use_previous_answers_user#:#Vul bij toekomstige toetspogingen mijn eerder gegeven antwoorden alvast in.
 assessment#:#tst_user_finished_test#:#Gebruiker beëindigde toets (%s)
 assessment#:#tst_view_competence_assign#:#View Assignment Properties###30 08 2015 new variable
 assessment#:#tst_virtual_pass_header_lo_initial#:#Initial Test Results for the Learning Objectives<br />%s###30 08 2015 new variable

--- a/lang/ilias_pl.lang
+++ b/lang/ilias_pl.lang
@@ -693,12 +693,10 @@ assessment#:#examid_in_test_res#:#Pokaż numer egzaminacyjny ILIAS
 assessment#:#examid_in_test_res_desc#:#Numer egzaminacyjny ILIAS widoczny jest w wynikach testu.
 assessment#:#exp_all_test_runs#:#All test attempts###26 08 2024 new variable
 assessment#:#exp_eval_data#:#Eksport danej szacunkowej
-assessment#:#exp_file_created#:#Utworzono plik eksportowy ILIAS 2.
 assessment#:#exp_grammar_as#:#as###26 08 2024 new variable
 assessment#:#exp_scored_test_attempt#:#Scored Test Attempt###28 10 2024 new variable
 assessment#:#exp_type_certificate#:#Certyfikat (PDF)
 assessment#:#exp_type_excel#:#Excel
-assessment#:#exp_type_spss#:#SPSS
 assessment#:#expected_result_type#:#Oczekiwany typ wyniku
 assessment#:#export_cert_failed_for_users_p#:#No certificate file could be generated and added for the following %s accounts: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
 assessment#:#export_cert_failed_for_users_s#:#No certificate file could be generated and added to the archive for the following account: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
@@ -1434,7 +1432,6 @@ assessment#:#tst_delete_missing_mark#:#Wybierz co najmniej jedną pozycję, aby 
 assessment#:#tst_derive_new_pool#:#Utwórz nową pulę pytań
 assessment#:#tst_derive_new_pools#:#Utwórz nowe pule pytań
 assessment#:#tst_dont_show_msg_again_in_current_session#:#Don't show this message again in my current session.
-assessment#:#tst_dont_use_previous_answers#:#Twoje poprzednie odpowiedzi nie będą użyte jako domyślne wartości w następnych wykonaniach testu
 assessment#:#tst_edit_competence_assign#:#Przetwarzaj właściwości przydziału
 assessment#:#tst_edit_scoring#:#Edytuj punktację
 assessment#:#tst_enable_questionlist#:#Show 'List of Questions’###26 08 2024 new variable
@@ -1494,7 +1491,6 @@ assessment#:#tst_finish_notification#:#Mail po zakończeniu
 assessment#:#tst_finish_notification_advanced#:#Wyślij wynik testu do uczestnika testu
 assessment#:#tst_finish_notification_content_type#:#Treść wiadomości
 assessment#:#tst_finish_notification_desc#:#Właściciel testu otrzyma dla każdego uczestnika, który ukończył test, wiadomość mailową zawierającą następujące informacje.
-assessment#:#tst_finish_notification_no#:#Brak wiadomości
 assessment#:#tst_finish_notification_simple#:#Tylko nazwa użytkownika oraz data ukończenia
 assessment#:#tst_finished#:#Ukończone
 assessment#:#tst_form_dynamic_question_set_config#:#Bieżący wybór pytań
@@ -1508,7 +1504,6 @@ assessment#:#tst_hide_info_tab#:#Hide Info Tab###26 08 2024 new variable
 assessment#:#tst_hide_info_tab_desc#:#Hides the tab ‘Info’ of the test.###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents#:#Hide page content###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents_desc#:#ILIAS content placed before and after the actual question text via the "Edit Page" button will not be displayed in the result views and print output.###26 08 2024 new variable
-assessment#:#tst_hide_side_list#:#Ukryj listy pytań.
 assessment#:#tst_highscore_achieved_ts#:#Data
 assessment#:#tst_highscore_achieved_ts_description#:#Wyświetlana jest dodatkowa kolumna z czasem, w którym test został przeprowadzony.
 assessment#:#tst_highscore_all_tables#:#Własne miejsce na liście rankingowej i lista najlepszych
@@ -1528,7 +1523,6 @@ assessment#:#tst_highscore_score#:#Punkty
 assessment#:#tst_highscore_score_description#:#Wyświetlana jest dodatkowa kolumna z liczbą uzyskanych punktów.
 assessment#:#tst_highscore_top_num#:#Długość listy najlepszych
 assessment#:#tst_highscore_top_num_description#:#Określa, ile wpisów wyświetlanych jest w liście najlepszych.
-assessment#:#tst_highscore_top_num_unit#:#Listy rankingowe
 assessment#:#tst_highscore_top_table#:#Lista najlepszych
 assessment#:#tst_highscore_top_table_description#:#Uczestnikom wyświetla się tabela z najlepszymi wynikami.
 assessment#:#tst_highscore_wtime#:#Czas pracy
@@ -1924,10 +1918,6 @@ assessment#:#tst_show_results#:#Pokaż wyniki testu
 assessment#:#tst_show_side_list#:#Lista pytań do
 assessment#:#tst_show_solution_answers_only#:#Wydruk wyników (tylko odpowiedzi)
 assessment#:#tst_show_solution_answers_only_desc#:#Jeśli aktywna jest opcja „Drukowanie wyników (tylko odpowiedzi)", treści ILIAS, które w zakładce "Przetwarzanie treści" można umieszczać przed i za właściwym tekstem pytania, nie będą drukowane.
-assessment#:#tst_show_solution_compare#:#Pokaż najlepsze możliwe rozwiązanie w 'Tabeli ze szczegółowymi wynikami'
-assessment#:#tst_show_solution_compare_desc#:#Uczestnikom prezentowany jest widok ogólny jako część 'Tabeli ze szczegółowymi wynikami', gdzie porównywane są odpowiedzi uczestników i najlepsze możliwe odpowiedzi.<br> Ten widok nie jest prezentowany za pomocą przycisku 'Lista odpowiedzi', nawet wówczas, gdy to ustawienie zostało tutaj aktywowane.
-assessment#:#tst_show_solution_details#:#Szczegóły punktacji
-assessment#:#tst_show_solution_details_desc#:#Uczestnicy oprócz 'Tabeli ze szczegółowymi danymi dotyczącymi wyników testu' otrzymają na osobnej stronie dla każdego pytania informacje o tym, jakich odpowiedzi udzielili, czy te odpowiedzi były prawidłowe oraz ile punktów za nie otrzymali.
 assessment#:#tst_show_solution_details_singlepage#:#Scored Answers on single pages###26 08 2024 new variable
 assessment#:#tst_show_solution_details_singlepage_desc#:#Participants can access each question individually and see if their answers were correct and how many points they scored.###26 08 2024 new variable
 assessment#:#tst_show_solution_feedback#:#Pokaż specyficzną dla odpowiedzi reakcję w wynikach testu
@@ -1950,7 +1940,6 @@ assessment#:#tst_skill_triggerings_num_req_answers_desc#:#Kompetencje podnoszone
 assessment#:#tst_skill_triggerings_num_req_answers_not_reached_warn#:#Przynajmniej jedna zawarta w teście kompetencja nie została przyporządkowana do wystarczającej liczby pytań.<br />Minimalna liczba dla przyporządkowanych pytań: %s
 assessment#:#tst_skl_level_thresholds_link#:#Skonfiguruj wartości progowe kompetencji
 assessment#:#tst_skl_level_thresholds_missing#:#Nie zdefiniowano jeszcze wartości progowych dla wszystkich istotnych kompetencji.
-assessment#:#tst_skl_res_interpretation_hint_msg#:#Pamiętaj, że wyniki kompetencyjne jednego testu są miarodajne jedynie w ograniczonym zakresie. Im więcej informacji dotyczących poszczególnych kompetencji zebrano, tym bardziej miarodajne jest stwierdzenie. Jeśli niektóre kompetencje nie otrzymały żadnej wartości, oznacza to, że dla tej kompetencji brakowało informacji.
 assessment#:#tst_skl_sub_tab_thresholds#:#Wartości progowe kompetencji
 assessment#:#tst_sol_comp_expressions#:#Stwierdzenia porównawcze
 assessment#:#tst_solution_compare_cfg#:#Konfiguracja na potrzeby porównania odpowiedzi
@@ -2012,7 +2001,6 @@ assessment#:#tst_unchanged_answer_is_correct#:#Poprzednia odpowiedź jest prawid
 assessment#:#tst_unchanged_order_is_correct#:#Poprzedni układ jest poprawny.
 assessment#:#tst_use_previous_answers#:#Użyj poprzednich odpowiedzi
 assessment#:#tst_use_previous_answers_description#:#Jeśli zaznaczone, uczestnik może wybrać poprzednie odpowiedzi jako wartości domyślne w przyszłych wykonaniach testu, w przeciwnym razie poprzednie odpowiedzi nie są wyświetlane w kolejnych wykonaniach testu.
-assessment#:#tst_use_previous_answers_user#:#Użyj moich poprzednich odpowiedzi jako domyślnych wartości w przyszłych wykonaniach testu
 assessment#:#tst_user_finished_test#:#Jeden uczestnik zakończył test (%s)
 assessment#:#tst_view_competence_assign#:#Pokaż właściwości przydziału
 assessment#:#tst_virtual_pass_header_lo_initial#:#Wyniki początkowe dla celu dydaktycznego<br />%s

--- a/lang/ilias_pt.lang
+++ b/lang/ilias_pt.lang
@@ -693,12 +693,10 @@ assessment#:#examid_in_test_res#:#ID de tentativa de teste ILIAS
 assessment#:#examid_in_test_res_desc#:#O ID de tentativa de teste ILIAS será incluído nos resultados do teste.
 assessment#:#exp_all_test_runs#:#All test attempts###26 08 2024 new variable
 assessment#:#exp_eval_data#:#Exportar dados de avaliação como
-assessment#:#exp_file_created#:#Exportar ficheiro criado.
 assessment#:#exp_grammar_as#:#as###26 08 2024 new variable
 assessment#:#exp_scored_test_attempt#:#Scored Test Attempt###28 10 2024 new variable
 assessment#:#exp_type_certificate#:#Certificado (PDF)
 assessment#:#exp_type_excel#:#Microsoft Excel
-assessment#:#exp_type_spss#:#Comma Separated Value (CSV)
 assessment#:#expected_result_type#:#Tipo de resultado esperado
 assessment#:#export_cert_failed_for_users_p#:#No certificate file could be generated and added for the following %s accounts: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
 assessment#:#export_cert_failed_for_users_s#:#No certificate file could be generated and added to the archive for the following account: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
@@ -1434,7 +1432,6 @@ assessment#:#tst_delete_missing_mark#:#Selecione pelo menos um avanço de nota p
 assessment#:#tst_derive_new_pool#:#Derivar novo banco de perguntas
 assessment#:#tst_derive_new_pools#:#Derivar novo banco de perguntas
 assessment#:#tst_dont_show_msg_again_in_current_session#:#Não mostrar esta mensagem novamente durante a minha sessão atual.
-assessment#:#tst_dont_use_previous_answers#:#As suas respostas anteriores não serão usadas como valores predefinidos em futuras tentativas de teste
 assessment#:#tst_edit_competence_assign#:#Editar propriedades de atribuição
 assessment#:#tst_edit_scoring#:#Editar pontuação
 assessment#:#tst_enable_questionlist#:#Show 'List of Questions’###26 08 2024 new variable
@@ -1494,7 +1491,6 @@ assessment#:#tst_finish_notification#:#Enviar resultado de teste completo
 assessment#:#tst_finish_notification_advanced#:#Enviar nome de utilizador e data de fim
 assessment#:#tst_finish_notification_content_type#:#Conteúdo do e-mail
 assessment#:#tst_finish_notification_desc#:#Envia um e-mail para o proprietário do teste relativamente a cada utilizador que completou o teste.
-assessment#:#tst_finish_notification_no#:#Nenhum e-mail
 assessment#:#tst_finish_notification_simple#:#Definições gerais
 assessment#:#tst_finished#:#Terminado
 assessment#:#tst_form_dynamic_question_set_config#:#Continuar seleção de perguntas
@@ -1508,7 +1504,6 @@ assessment#:#tst_hide_info_tab#:#Hide Info Tab###26 08 2024 new variable
 assessment#:#tst_hide_info_tab_desc#:#Hides the tab ‘Info’ of the test.###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents#:#Hide page content###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents_desc#:#ILIAS content placed before and after the actual question text via the "Edit Page" button will not be displayed in the result views and print output.###26 08 2024 new variable
-assessment#:#tst_hide_side_list#:#Data
 assessment#:#tst_highscore_achieved_ts#:#Será incluída na classificação uma coluna que contém a data do teste.
 assessment#:#tst_highscore_achieved_ts_description#:#Classificação própria do participante e Top da classificação
 assessment#:#tst_highscore_all_tables#:#Os participantes recebem informação sobre o Top da classificação e a respetiva posição própria na classificação.
@@ -1528,7 +1523,6 @@ assessment#:#tst_highscore_score#:#Será incluída na classificação uma coluna
 assessment#:#tst_highscore_score_description#:#Comprimento do Top de classificação
 assessment#:#tst_highscore_top_num#:#Especifica quantas classificações devem ser incluídas na lista de classificação.
 assessment#:#tst_highscore_top_num_description#:#Top de classificação
-assessment#:#tst_highscore_top_num_unit#:#entradas
 assessment#:#tst_highscore_top_table#:#Aos participantes é apresentada uma tabela com o top das classificações.
 assessment#:#tst_highscore_top_table_description#:#Duração do teste
 assessment#:#tst_highscore_wtime#:#Será incluída na classificação uma coluna que contém a duração do teste.
@@ -1924,10 +1918,6 @@ assessment#:#tst_show_results#:#Tempo médio para analisar
 assessment#:#tst_show_side_list#:#Primeira visita
 assessment#:#tst_show_solution_answers_only#:#Última visita
 assessment#:#tst_show_solution_answers_only_desc#:#Percentagem do trabalho total já feito
-assessment#:#tst_show_solution_compare#:#Perguntas já processadas
-assessment#:#tst_show_solution_compare_desc#:#Resultados de testes em anotações
-assessment#:#tst_show_solution_details#:#Resultados de testes em pontos
-assessment#:#tst_show_solution_details_desc#:#Tempo para trabalhar
 assessment#:#tst_show_solution_details_singlepage#:#Scored Answers on single pages###26 08 2024 new variable
 assessment#:#tst_show_solution_details_singlepage_desc#:#Participants can access each question individually and see if their answers were correct and how many points they scored.###26 08 2024 new variable
 assessment#:#tst_show_solution_feedback#:#Para terminar este teste, tem de responder a todas as perguntas obrigatórias (*).
@@ -1950,7 +1940,6 @@ assessment#:#tst_skill_triggerings_num_req_answers_desc#:#As competências não 
 assessment#:#tst_skill_triggerings_num_req_answers_not_reached_warn#:#Pelo menos uma das competências abordadas por este teste não é ativada pela quantidade mínima exigida de perguntas.<br />A quantidade de perguntas exigida: %s
 assessment#:#tst_skl_level_thresholds_link#:#Resultados de teste iniciais para o objetivo de aprendizagem<br />%s
 assessment#:#tst_skl_level_thresholds_missing#:#Faltam limites para as competências relevantes!
-assessment#:#tst_skl_res_interpretation_hint_msg#:#Note que os resultados de competência a partir de um único teste tem uma importância limitada. Quanto mais informação é recolhida por competência, mais importância terá. Se houver competências únicas sem qualquer entrada, foi recolhida informação a menos.
 assessment#:#tst_skl_sub_tab_thresholds#:#Limites de competência
 assessment#:#tst_sol_comp_expressions#:#Expressões de comparação
 assessment#:#tst_solution_compare_cfg#:#Configuração para comparação de soluções
@@ -2012,7 +2001,6 @@ assessment#:#tst_unchanged_answer_is_correct#:#A resposta predefinida está corr
 assessment#:#tst_unchanged_order_is_correct#:#A ordem predefinida está correta
 assessment#:#tst_use_previous_answers#:#Cria automaticamente contas de utilizador ILIAS, para utilizadores autenticados com sucesso contra CAS, sem ter ainda uma conta ILIAS.
 assessment#:#tst_use_previous_answers_description#:#Ativar editor para idiomas selecionados
-assessment#:#tst_use_previous_answers_user#:#O editor de páginas ativo foi modificado
 assessment#:#tst_user_finished_test#:#Utilizador terminou o teste (%s)
 assessment#:#tst_view_competence_assign#:#Ver propriedades de atribuição
 assessment#:#tst_virtual_pass_header_lo_initial#:#Usar o editor de páginas ILIAS

--- a/lang/ilias_ro.lang
+++ b/lang/ilias_ro.lang
@@ -693,12 +693,10 @@ assessment#:#examid_in_test_res#:#ILIAS Testpass ID###27 01 2015 new variable
 assessment#:#examid_in_test_res_desc#:#The ILIAS Testpass ID will be included in the test results.###27 01 2015 new variable
 assessment#:#exp_all_test_runs#:#All test attempts###26 08 2024 new variable
 assessment#:#exp_eval_data#:#Exportati datele evaluarii ca
-assessment#:#exp_file_created#:#Export file created.###24 10 2013 new variable
 assessment#:#exp_grammar_as#:#as###26 08 2024 new variable
 assessment#:#exp_scored_test_attempt#:#Scored Test Attempt###28 10 2024 new variable
 assessment#:#exp_type_certificate#:#Certificate (PDF)###10 10 2006 new variable
 assessment#:#exp_type_excel#:#Microsoft Excel###10 Jul 2006 content changed
-assessment#:#exp_type_spss#:#Valori separate de virgula (CSV)
 assessment#:#expected_result_type#:#Expected result type###24 10 2013 new variable
 assessment#:#export_cert_failed_for_users_p#:#No certificate file could be generated and added for the following %s accounts: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
 assessment#:#export_cert_failed_for_users_s#:#No certificate file could be generated and added to the archive for the following account: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
@@ -1434,7 +1432,6 @@ assessment#:#tst_delete_missing_mark#:#Va rugam sa selectati cel putin o nota in
 assessment#:#tst_derive_new_pool#:#Derive New Question Pool###25 10 2016 new variable
 assessment#:#tst_derive_new_pools#:#Derive New Question Pools###25 10 2016 new variable
 assessment#:#tst_dont_show_msg_again_in_current_session#:#Don't show this message again in my current session.###10 11 2018 new variable
-assessment#:#tst_dont_use_previous_answers#:#Your previous answers will not be used as default values in future test passes###12 11 2006 new variable
 assessment#:#tst_edit_competence_assign#:#Edit Assignment Properties###30 08 2015 new variable
 assessment#:#tst_edit_scoring#:#Edit Scoring###28 08 2012 new variable
 assessment#:#tst_enable_questionlist#:#Show 'List of Questions’###26 08 2024 new variable
@@ -1494,7 +1491,6 @@ assessment#:#tst_finish_notification#:#Mail on completion###24 07 2009 new varia
 assessment#:#tst_finish_notification_advanced#:#Send complete test result to test owner###24 07 2009 new variable
 assessment#:#tst_finish_notification_content_type#:#Content of e-mail###27 01 2015 new variable
 assessment#:#tst_finish_notification_desc#:#Sends an e-mail to the test owner for every user that has completed the test.###27 01 2015 new variable
-assessment#:#tst_finish_notification_no#:#No e-mail###06 02 2015 new variable
 assessment#:#tst_finish_notification_simple#:#Send user name and finish date to test owner###24 07 2009 new variable
 assessment#:#tst_finished#:#Terminat
 assessment#:#tst_form_dynamic_question_set_config#:#Continues Question Selection###24 10 2013 new variable
@@ -1508,7 +1504,6 @@ assessment#:#tst_hide_info_tab#:#Hide Info Tab###26 08 2024 new variable
 assessment#:#tst_hide_info_tab_desc#:#Hides the tab ‘Info’ of the test.###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents#:#Hide page content###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents_desc#:#ILIAS content placed before and after the actual question text via the "Edit Page" button will not be displayed in the result views and print output.###26 08 2024 new variable
-assessment#:#tst_hide_side_list#:#Hide question list###24 07 2009 new variable
 assessment#:#tst_highscore_achieved_ts#:#Show date of test###28 08 2012 new variable
 assessment#:#tst_highscore_achieved_ts_description#:#Controls, if a column with the test date should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_all_tables#:#All Rankings###07 11 2014 new variable
@@ -1528,7 +1523,6 @@ assessment#:#tst_highscore_score#:#Show score###28 08 2012 new variable
 assessment#:#tst_highscore_score_description#:#Controls, if a column with the score should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_top_num#:#Number of ranks###28 08 2012 new variable
 assessment#:#tst_highscore_top_num_description#:#Controls, how many ranks should be included in the top ranking table.###28 08 2012 new variable
-assessment#:#tst_highscore_top_num_unit#:#entries###28 08 2012 new variable
 assessment#:#tst_highscore_top_table#:#Show table 'top ranking'###28 08 2012 new variable
 assessment#:#tst_highscore_top_table_description#:#Controls, if the table 'top ranking' should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_wtime#:#Show working time###28 08 2012 new variable
@@ -1924,10 +1918,6 @@ assessment#:#tst_show_results#:#Aratati rezultatele testului
 assessment#:#tst_show_side_list#:#Show question list aside###24 07 2009 new variable
 assessment#:#tst_show_solution_answers_only#:#Results print view (answers only)###14 11 2007 new variable
 assessment#:#tst_show_solution_answers_only_desc#:#If is selected, the ILIAS content you place around a question using the "Edit content" tab page will not be visible in a print-out. If you want to save some paper space, select this option.###07 11 2014 new variable
-assessment#:#tst_show_solution_compare#:#Compare Answer with Solution in List of Answers###24 10 2013 new variable
-assessment#:#tst_show_solution_compare_desc#:#Participants are presented with an overview comparing their own answers with the best solutions. Please note that this view will be displayed in the ‘Detailed Results’ that can be accessed via the ‘Show Test Results‘-button on the ‘Info’-tab. It will not be displayed in the printable ‘List of Answers’ even though the setting is made here.###06 02 2015 new variable
-assessment#:#tst_show_solution_details#:#Score details###10 Jul 2006 new variable
-assessment#:#tst_show_solution_details_desc#:#If selected, the detailed question solution is available to participants in the test results presentation. This includes the exact scoring of every answer, otherwise only an overview with the question titles and the reached points is shown.###07 11 2014 new variable
 assessment#:#tst_show_solution_details_singlepage#:#Scored Answers on single pages###26 08 2024 new variable
 assessment#:#tst_show_solution_details_singlepage_desc#:#Participants can access each question individually and see if their answers were correct and how many points they scored.###26 08 2024 new variable
 assessment#:#tst_show_solution_feedback#:#Show Answer-Specific Feedback in Test Results###10 05 2007 new variable
@@ -1950,7 +1940,6 @@ assessment#:#tst_skill_triggerings_num_req_answers_desc#:#Competences aren't tri
 assessment#:#tst_skill_triggerings_num_req_answers_not_reached_warn#:#At least one of the competences addressed by this test is not triggered by the minimal required amount of questions.<br />The required amount of questions: %s###10 11 2018 new variable
 assessment#:#tst_skl_level_thresholds_link#:#Configure Competence-Thresholds###30 08 2015 new variable
 assessment#:#tst_skl_level_thresholds_missing#:#There are missing thresholds for the relevant competences!###30 08 2015 new variable
-assessment#:#tst_skl_res_interpretation_hint_msg#:#Please consider that competence results from a single test has a limited significance. The more information is collected per competence, the merrier valid the significance will be. Should there are single competences without any entry, there is to less information collected.###30 08 2015 new variable
 assessment#:#tst_skl_sub_tab_thresholds#:#Competence Thresholds###26 09 2014 new variable
 assessment#:#tst_sol_comp_expressions#:#Comparison Expressions###30 08 2015 new variable
 assessment#:#tst_solution_compare_cfg#:#Configuration for Solution Compare###30 08 2015 new variable
@@ -2012,7 +2001,6 @@ assessment#:#tst_unchanged_answer_is_correct#:#The preset answer is correct###fa
 assessment#:#tst_unchanged_order_is_correct#:#The preset order is correct###fau: testNav
 assessment#:#tst_use_previous_answers#:#Use Previous Answers###26 10 2006 new variable
 assessment#:#tst_use_previous_answers_description#:#If checked, the previous answers of a participant will be used as default values in future test passes###26 10 2006 new variable
-assessment#:#tst_use_previous_answers_user#:#Use my previous answers as default values in future test passes###26 10 2006 new variable
 assessment#:#tst_user_finished_test#:#User finished test (%s)###24 07 2009 new variable
 assessment#:#tst_view_competence_assign#:#View Assignment Properties###30 08 2015 new variable
 assessment#:#tst_virtual_pass_header_lo_initial#:#Initial Test Results for the Learning Objectives<br />%s###30 08 2015 new variable

--- a/lang/ilias_ru.lang
+++ b/lang/ilias_ru.lang
@@ -693,12 +693,10 @@ assessment#:#examid_in_test_res#:#ILIAS Testpass ID###27 01 2015 new variable
 assessment#:#examid_in_test_res_desc#:#The ILIAS Testpass ID will be included in the test results.###27 01 2015 new variable
 assessment#:#exp_all_test_runs#:#All test attempts###26 08 2024 new variable
 assessment#:#exp_eval_data#:#Экспортировать данные оценивания как
-assessment#:#exp_file_created#:#Export file created.
 assessment#:#exp_grammar_as#:#as###26 08 2024 new variable
 assessment#:#exp_scored_test_attempt#:#Scored Test Attempt###28 10 2024 new variable
 assessment#:#exp_type_certificate#:#Сертификат (PDF)
 assessment#:#exp_type_excel#:#Microsoft Excel
-assessment#:#exp_type_spss#:#Текст разделенный запятыми (CSV)
 assessment#:#expected_result_type#:#Expected result type
 assessment#:#export_cert_failed_for_users_p#:#No certificate file could be generated and added for the following %s accounts: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
 assessment#:#export_cert_failed_for_users_s#:#No certificate file could be generated and added to the archive for the following account: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
@@ -1434,7 +1432,6 @@ assessment#:#tst_delete_missing_mark#:#Пожалуйста, выберите х
 assessment#:#tst_derive_new_pool#:#Derive New Question Pool###25 10 2016 new variable
 assessment#:#tst_derive_new_pools#:#Derive New Question Pools###25 10 2016 new variable
 assessment#:#tst_dont_show_msg_again_in_current_session#:#Don't show this message again in my current session.###10 11 2018 new variable
-assessment#:#tst_dont_use_previous_answers#:#Ваши предыдущие ответы не будут использоваться, как значения по умолчанию при следующих прохождениях теста
 assessment#:#tst_edit_competence_assign#:#Edit Assignment Properties###30 08 2015 new variable
 assessment#:#tst_edit_scoring#:#Оценить
 assessment#:#tst_enable_questionlist#:#Show 'List of Questions’###26 08 2024 new variable
@@ -1494,7 +1491,6 @@ assessment#:#tst_finish_notification#:#Уведомление о прохожд�
 assessment#:#tst_finish_notification_advanced#:#Отослать подробные результаты теста владельцу
 assessment#:#tst_finish_notification_content_type#:#Content of e-mail###27 01 2015 new variable
 assessment#:#tst_finish_notification_desc#:#Sends an e-mail to the test owner for every user that has completed the test.###27 01 2015 new variable
-assessment#:#tst_finish_notification_no#:#No e-mail###06 02 2015 new variable
 assessment#:#tst_finish_notification_simple#:#Отсылать имя пользователя и дату завершения владельцу теста
 assessment#:#tst_finished#:#Окончен
 assessment#:#tst_form_dynamic_question_set_config#:#Продолжить выбор вопросов
@@ -1508,7 +1504,6 @@ assessment#:#tst_hide_info_tab#:#Hide Info Tab###26 08 2024 new variable
 assessment#:#tst_hide_info_tab_desc#:#Hides the tab ‘Info’ of the test.###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents#:#Hide page content###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents_desc#:#ILIAS content placed before and after the actual question text via the "Edit Page" button will not be displayed in the result views and print output.###26 08 2024 new variable
-assessment#:#tst_hide_side_list#:#Скрыть список вопросов
 assessment#:#tst_highscore_achieved_ts#:#Показать дату прохождения теста
 assessment#:#tst_highscore_achieved_ts_description#:#Controls, if a column with the test date should be shown.
 assessment#:#tst_highscore_all_tables#:#All Rankings###07 11 2014 new variable
@@ -1528,7 +1523,6 @@ assessment#:#tst_highscore_score#:#Показать баллы
 assessment#:#tst_highscore_score_description#:#Controls, if a column with the score should be shown.
 assessment#:#tst_highscore_top_num#:#Число рангов
 assessment#:#tst_highscore_top_num_description#:#Controls, how many ranks should be included in the top ranking table.
-assessment#:#tst_highscore_top_num_unit#:#записи
 assessment#:#tst_highscore_top_table#:#Показать таблицу 'лучший ранг'
 assessment#:#tst_highscore_top_table_description#:#Controls, if the table 'top ranking' should be shown.
 assessment#:#tst_highscore_wtime#:#Показать время работы
@@ -1924,10 +1918,6 @@ assessment#:#tst_show_results#:#Просмотреть результаты те
 assessment#:#tst_show_side_list#:#Показать список вопросов сбоку
 assessment#:#tst_show_solution_answers_only#:#Печатный вид результатов (только ответы)
 assessment#:#tst_show_solution_answers_only_desc#:#If is selected, the ILIAS content you place around a question using the "Edit content" tab page will not be visible in a print-out. If you want to save some paper space, select this option.###07 11 2014 new variable
-assessment#:#tst_show_solution_compare#:#Compare Answer with Solution in List of Answers
-assessment#:#tst_show_solution_compare_desc#:#Participants are presented with an overview comparing their own answers with the best solutions. Please note that this view will be displayed in the ‘Detailed Results’ that can be accessed via the ‘Show Test Results‘-button on the ‘Info’-tab. It will not be displayed in the printable ‘List of Answers’ even though the setting is made here.###06 02 2015 new variable
-assessment#:#tst_show_solution_details#:#Показать решения в результатах теста
-assessment#:#tst_show_solution_details_desc#:#If selected, the detailed question solution is available to participants in the test results presentation. This includes the exact scoring of every answer, otherwise only an overview with the question titles and the reached points is shown.###07 11 2014 new variable
 assessment#:#tst_show_solution_details_singlepage#:#Scored Answers on single pages###26 08 2024 new variable
 assessment#:#tst_show_solution_details_singlepage_desc#:#Participants can access each question individually and see if their answers were correct and how many points they scored.###26 08 2024 new variable
 assessment#:#tst_show_solution_feedback#:#Показать отзывы на отдельные вопросы в результатах теста
@@ -1950,7 +1940,6 @@ assessment#:#tst_skill_triggerings_num_req_answers_desc#:#Competences aren't tri
 assessment#:#tst_skill_triggerings_num_req_answers_not_reached_warn#:#At least one of the competences addressed by this test is not triggered by the minimal required amount of questions.<br />The required amount of questions: %s###10 11 2018 new variable
 assessment#:#tst_skl_level_thresholds_link#:#Configure Competence-Thresholds###30 08 2015 new variable
 assessment#:#tst_skl_level_thresholds_missing#:#There are missing thresholds for the relevant competences!###30 08 2015 new variable
-assessment#:#tst_skl_res_interpretation_hint_msg#:#Please consider that competence results from a single test has a limited significance. The more information is collected per competence, the merrier valid the significance will be. Should there are single competences without any entry, there is to less information collected.###30 08 2015 new variable
 assessment#:#tst_skl_sub_tab_thresholds#:#Competence Thresholds###26 09 2014 new variable
 assessment#:#tst_sol_comp_expressions#:#Comparison Expressions###30 08 2015 new variable
 assessment#:#tst_solution_compare_cfg#:#Configuration for Solution Compare###30 08 2015 new variable
@@ -2012,7 +2001,6 @@ assessment#:#tst_unchanged_answer_is_correct#:#The preset answer is correct###fa
 assessment#:#tst_unchanged_order_is_correct#:#The preset order is correct###fau: testNav
 assessment#:#tst_use_previous_answers#:#Использовать предыдущие ответы
 assessment#:#tst_use_previous_answers_description#:#Если включено, то участник тестирования может использовать ранее выбранные ответы как значения по умолчанию для будущих попыток прохождения теста, иначе ранее выбранные ответы не отображаются в последующих попытках.
-assessment#:#tst_use_previous_answers_user#:#Использовать мои предыдущие ответы, как значения по умолчанию для будущих прохождений
 assessment#:#tst_user_finished_test#:#Пользователь завершил тест (%s)
 assessment#:#tst_view_competence_assign#:#View Assignment Properties###30 08 2015 new variable
 assessment#:#tst_virtual_pass_header_lo_initial#:#Initial Test Results for the Learning Objectives<br />%s###30 08 2015 new variable

--- a/lang/ilias_sk.lang
+++ b/lang/ilias_sk.lang
@@ -693,12 +693,10 @@ assessment#:#examid_in_test_res#:#ILIAS Testpass ID###27 01 2015 new variable
 assessment#:#examid_in_test_res_desc#:#The ILIAS Testpass ID will be included in the test results.###27 01 2015 new variable
 assessment#:#exp_all_test_runs#:#All test attempts###26 08 2024 new variable
 assessment#:#exp_eval_data#:#Exportovat data hodnocení jako
-assessment#:#exp_file_created#:#Export file created.###24 10 2013 new variable
 assessment#:#exp_grammar_as#:#as###26 08 2024 new variable
 assessment#:#exp_scored_test_attempt#:#Scored Test Attempt###28 10 2024 new variable
 assessment#:#exp_type_certificate#:#Certifikát (PDF)
 assessment#:#exp_type_excel#:#Microsoft Excel
-assessment#:#exp_type_spss#:#Desetinnou čárkou oddělená hodnota (CSV)
 assessment#:#expected_result_type#:#Expected result type###24 10 2013 new variable
 assessment#:#export_cert_failed_for_users_p#:#No certificate file could be generated and added for the following %s accounts: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
 assessment#:#export_cert_failed_for_users_s#:#No certificate file could be generated and added to the archive for the following account: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
@@ -1434,7 +1432,6 @@ assessment#:#tst_delete_missing_mark#:#Vyberte alespoň jednu známku kroku ke s
 assessment#:#tst_derive_new_pool#:#Derive New Question Pool###25 10 2016 new variable
 assessment#:#tst_derive_new_pools#:#Derive New Question Pools###25 10 2016 new variable
 assessment#:#tst_dont_show_msg_again_in_current_session#:#Don't show this message again in my current session.###10 11 2018 new variable
-assessment#:#tst_dont_use_previous_answers#:#Vaše předchozí odpovědi nebudou použity jako výchozí hodnoty v budoucích průchodech testem
 assessment#:#tst_edit_competence_assign#:#Edit Assignment Properties###30 08 2015 new variable
 assessment#:#tst_edit_scoring#:#Edit Scoring###28 08 2012 new variable
 assessment#:#tst_enable_questionlist#:#Show 'List of Questions’###26 08 2024 new variable
@@ -1494,7 +1491,6 @@ assessment#:#tst_finish_notification#:#E-mail při dokončení
 assessment#:#tst_finish_notification_advanced#:#Poslat kompletní výsledky testu jeho vlastníkovi
 assessment#:#tst_finish_notification_content_type#:#Content of e-mail###27 01 2015 new variable
 assessment#:#tst_finish_notification_desc#:#Sends an e-mail to the test owner for every user that has completed the test.###27 01 2015 new variable
-assessment#:#tst_finish_notification_no#:#No e-mail###06 02 2015 new variable
 assessment#:#tst_finish_notification_simple#:#Poslat uživatelské jméno a finální datum vlastníkovi testu
 assessment#:#tst_finished#:#Ukončeno
 assessment#:#tst_form_dynamic_question_set_config#:#Continues Question Selection###24 10 2013 new variable
@@ -1508,7 +1504,6 @@ assessment#:#tst_hide_info_tab#:#Hide Info Tab###26 08 2024 new variable
 assessment#:#tst_hide_info_tab_desc#:#Hides the tab ‘Info’ of the test.###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents#:#Hide page content###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents_desc#:#ILIAS content placed before and after the actual question text via the "Edit Page" button will not be displayed in the result views and print output.###26 08 2024 new variable
-assessment#:#tst_hide_side_list#:#Skrýt seznam otázek
 assessment#:#tst_highscore_achieved_ts#:#Show date of test###28 08 2012 new variable
 assessment#:#tst_highscore_achieved_ts_description#:#Controls, if a column with the test date should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_all_tables#:#All Rankings###07 11 2014 new variable
@@ -1528,7 +1523,6 @@ assessment#:#tst_highscore_score#:#Show score###28 08 2012 new variable
 assessment#:#tst_highscore_score_description#:#Controls, if a column with the score should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_top_num#:#Number of ranks###28 08 2012 new variable
 assessment#:#tst_highscore_top_num_description#:#Controls, how many ranks should be included in the top ranking table.###28 08 2012 new variable
-assessment#:#tst_highscore_top_num_unit#:#entries###28 08 2012 new variable
 assessment#:#tst_highscore_top_table#:#Show table 'top ranking'###28 08 2012 new variable
 assessment#:#tst_highscore_top_table_description#:#Controls, if the table 'top ranking' should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_wtime#:#Show working time###28 08 2012 new variable
@@ -1924,10 +1918,6 @@ assessment#:#tst_show_results#:#Zobrazit výsledky testu
 assessment#:#tst_show_side_list#:#Zobrazit boční seznam otázek
 assessment#:#tst_show_solution_answers_only#:#Přehled výsledků (jen odpovědi)
 assessment#:#tst_show_solution_answers_only_desc#:#If is selected, the ILIAS content you place around a question using the "Edit content" tab page will not be visible in a print-out. If you want to save some paper space, select this option.###07 11 2014 new variable
-assessment#:#tst_show_solution_compare#:#Compare Answer with Solution in List of Answers###24 10 2013 new variable
-assessment#:#tst_show_solution_compare_desc#:#Participants are presented with an overview comparing their own answers with the best solutions. Please note that this view will be displayed in the ‘Detailed Results’ that can be accessed via the ‘Show Test Results‘-button on the ‘Info’-tab. It will not be displayed in the printable ‘List of Answers’ even though the setting is made here.###06 02 2015 new variable
-assessment#:#tst_show_solution_details#:#Zobrazit řešení ve výsledcích testu
-assessment#:#tst_show_solution_details_desc#:#If selected, the detailed question solution is available to participants in the test results presentation. This includes the exact scoring of every answer, otherwise only an overview with the question titles and the reached points is shown.###07 11 2014 new variable
 assessment#:#tst_show_solution_details_singlepage#:#Scored Answers on single pages###26 08 2024 new variable
 assessment#:#tst_show_solution_details_singlepage_desc#:#Participants can access each question individually and see if their answers were correct and how many points they scored.###26 08 2024 new variable
 assessment#:#tst_show_solution_feedback#:#Zobrazit odpovědi-specifikovaný ohlas ve výsledcích testu
@@ -1950,7 +1940,6 @@ assessment#:#tst_skill_triggerings_num_req_answers_desc#:#Competences aren't tri
 assessment#:#tst_skill_triggerings_num_req_answers_not_reached_warn#:#At least one of the competences addressed by this test is not triggered by the minimal required amount of questions.<br />The required amount of questions: %s###10 11 2018 new variable
 assessment#:#tst_skl_level_thresholds_link#:#Configure Competence-Thresholds###30 08 2015 new variable
 assessment#:#tst_skl_level_thresholds_missing#:#There are missing thresholds for the relevant competences!###30 08 2015 new variable
-assessment#:#tst_skl_res_interpretation_hint_msg#:#Please consider that competence results from a single test has a limited significance. The more information is collected per competence, the merrier valid the significance will be. Should there are single competences without any entry, there is to less information collected.###30 08 2015 new variable
 assessment#:#tst_skl_sub_tab_thresholds#:#Competence Thresholds###26 09 2014 new variable
 assessment#:#tst_sol_comp_expressions#:#Comparison Expressions###30 08 2015 new variable
 assessment#:#tst_solution_compare_cfg#:#Configuration for Solution Compare###30 08 2015 new variable
@@ -2012,7 +2001,6 @@ assessment#:#tst_unchanged_answer_is_correct#:#The preset answer is correct###fa
 assessment#:#tst_unchanged_order_is_correct#:#The preset order is correct###fau: testNav
 assessment#:#tst_use_previous_answers#:#Použít předchozí odpovědi
 assessment#:#tst_use_previous_answers_description#:#Pokud je vybráno, účastník může zvolit použití předchozích odpovědí jako výchozích hodnot v dalších průchodech testem, jinak předchozí odpovědi nebudou v dalších průchodech testem zobrazeny.
-assessment#:#tst_use_previous_answers_user#:#Použít mé předchozí odpovědi jako výchozí hodnoty v budoucích průchodech testem
 assessment#:#tst_user_finished_test#:#Uživatel ukončil test (%s)
 assessment#:#tst_view_competence_assign#:#View Assignment Properties###30 08 2015 new variable
 assessment#:#tst_virtual_pass_header_lo_initial#:#Initial Test Results for the Learning Objectives<br />%s###30 08 2015 new variable

--- a/lang/ilias_sl.lang
+++ b/lang/ilias_sl.lang
@@ -693,12 +693,10 @@ assessment#:#examid_in_test_res#:#Prikaži ILIAS številko preizkusa:
 assessment#:#examid_in_test_res_desc#:#V rezultatih testa je prikazana ILIAS številka preizkusa:
 assessment#:#exp_all_test_runs#:#All test attempts###26 08 2024 new variable
 assessment#:#exp_eval_data#:#Izvozi ocenjevalne podatke kot
-assessment#:#exp_file_created#:#Datoteka za izvoz je ustvarjena.
 assessment#:#exp_grammar_as#:#as###26 08 2024 new variable
 assessment#:#exp_scored_test_attempt#:#Scored Test Attempt###28 10 2024 new variable
 assessment#:#exp_type_certificate#:#Certifikat (PDF)
 assessment#:#exp_type_excel#:#Microsoft Excel
-assessment#:#exp_type_spss#:#Z vejico ločene vrednosti (CSV)
 assessment#:#expected_result_type#:#Pričakovani tip rezultata
 assessment#:#export_cert_failed_for_users_p#:#No certificate file could be generated and added for the following %s accounts: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
 assessment#:#export_cert_failed_for_users_s#:#No certificate file could be generated and added to the archive for the following account: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
@@ -1434,7 +1432,6 @@ assessment#:#tst_delete_missing_mark#:#Izberite vsaj eno oceno, ki jo želite od
 assessment#:#tst_derive_new_pool#:#Izpelji novo skupino vprašanj
 assessment#:#tst_derive_new_pools#:#Ustvarite nove skupine vprašanj
 assessment#:#tst_dont_show_msg_again_in_current_session#:#Ne prikaži več tega sporočila med mojo trenutno sejo.
-assessment#:#tst_dont_use_previous_answers#:#Vaši prejšnji odgovori ne bodo uporabljeni kot privzete vrednosti pri prihodnjih opravljanjih testa
 assessment#:#tst_edit_competence_assign#:#Obdelaj značilnosti dodelitve
 assessment#:#tst_edit_scoring#:#Drugo ocenjevanje
 assessment#:#tst_enable_questionlist#:#Show 'List of Questions’###26 08 2024 new variable
@@ -1494,7 +1491,6 @@ assessment#:#tst_finish_notification#:#Obveščanje
 assessment#:#tst_finish_notification_advanced#:#Celoten rezultat testa na uporabnika
 assessment#:#tst_finish_notification_content_type#:#Vsebina obvestila
 assessment#:#tst_finish_notification_desc#:#Za vsakega udeleženca, ki zaključi test, prejme imetnik testa e-pošto z naslednjimi informacijami.
-assessment#:#tst_finish_notification_no#:#Ni obvestila
 assessment#:#tst_finish_notification_simple#:#Le uporabniško ime in datum zaključka
 assessment#:#tst_finished#:#Zaključeno
 assessment#:#tst_form_dynamic_question_set_config#:#Zaporedni izbor vprašanj
@@ -1508,7 +1504,6 @@ assessment#:#tst_hide_info_tab#:#Hide Info Tab###26 08 2024 new variable
 assessment#:#tst_hide_info_tab_desc#:#Hides the tab ‘Info’ of the test.###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents#:#Hide page content###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents_desc#:#ILIAS content placed before and after the actual question text via the "Edit Page" button will not be displayed in the result views and print output.###26 08 2024 new variable
-assessment#:#tst_hide_side_list#:#Seznam vprašanj iz
 assessment#:#tst_highscore_achieved_ts#:#Date
 assessment#:#tst_highscore_achieved_ts_description#:#Prikaže se dodaten stolpec z datumom testiranja.
 assessment#:#tst_highscore_all_tables#:#Lastna razvrstitev in seznam najboljših
@@ -1528,7 +1523,6 @@ assessment#:#tst_highscore_score#:#Točke
 assessment#:#tst_highscore_score_description#:#Prikaže se dodaten stolpec z informacijo o doseženih točkah.
 assessment#:#tst_highscore_top_num#:#Dolžina seznama najboljših
 assessment#:#tst_highscore_top_num_description#:#Določi število prikazanih vnosov s seznama najboljših
-assessment#:#tst_highscore_top_num_unit#:#Razvrstitev
 assessment#:#tst_highscore_top_table#:#Seznam najboljših
 assessment#:#tst_highscore_top_table_description#:#Udeležencem se prikaže tabela z najboljšimi razvrstitvami.
 assessment#:#tst_highscore_wtime#:#Trajanje obdelave
@@ -1924,10 +1918,6 @@ assessment#:#tst_show_results#:#Rezultati testa
 assessment#:#tst_show_side_list#:#Seznam vprašanj za
 assessment#:#tst_show_solution_answers_only#:#Tiskana različica rezultatov (samo odgovori)
 assessment#:#tst_show_solution_answers_only_desc#:#Če je izbrana "Tiskana različica rezultatov (samo odgovori)", vsebine v ILIAS, ki jih prek zavihka "Uredi vsebino" lahko uvrstite pred in za besedilom vprašanja z zavihkom 'Uredi vsebino', ne bodo vidne na izpisu.
-assessment#:#tst_show_solution_compare#:#Pokaži najboljšo rešitev v ‚Tabela s podrobnimi rezultati testa'
-assessment#:#tst_show_solution_compare_desc#:#Udeležencem se kot del ‚Tabele s podrobnimi rezultati testa' prikaže pregled z vzporednim prikazom njihovih odgovorov in najboljših možnih rešitev. <br> Ta pregled ni prikazan v podzavihku  ‚Oceni odgovore' zavihka ‚Rezultati‘, čeprav je tukaj izbrana ta rešitev.
-assessment#:#tst_show_solution_details#:#Ocenjeni odgovori udeležencev
-assessment#:#tst_show_solution_details_desc#:#Poleg ‚Tabele s podrobnimi rezultati testa' udeleženci za vsako vprašanje na posebni strani prejmejo prikaz lastnega odgovora, informacijo o tem, ali je bil odgovor pravilen in koliko točk so prejeli zanj.
 assessment#:#tst_show_solution_details_singlepage#:#Scored Answers on single pages###26 08 2024 new variable
 assessment#:#tst_show_solution_details_singlepage_desc#:#Participants can access each question individually and see if their answers were correct and how many points they scored.###26 08 2024 new variable
 assessment#:#tst_show_solution_feedback#:#Povratne informacije
@@ -1950,7 +1940,6 @@ assessment#:#tst_skill_triggerings_num_req_answers_desc#:#Kompetence se ugotavlj
 assessment#:#tst_skill_triggerings_num_req_answers_not_reached_warn#:#Najmanj ena od kompetenc, ki jih vključuje test, ni bila dodeljena zadostnemu številu vprašanj. Za te kompetence niso zabeleženi nobeni vnosi kompetenc za udeležence.<br />Minimalno število za dodeljena vprašanja: %s
 assessment#:#tst_skl_level_thresholds_link#:#Konfiguriraj mejne vrednosti kompetenc
 assessment#:#tst_skl_level_thresholds_missing#:#Za vse relevantne kompetence še ni opredeljenih mejnih vrednosti!
-assessment#:#tst_skl_res_interpretation_hint_msg#:#Upoštevajte, da je pomen rezultatov kompetenc iz enega testa omejen. Čim več je zbranih informacij o posameznih kompetencah, bolj verodostojno je sporočilo. Če za posamezne kompetence ni nobenega vnosa, je bilo zanje na voljo premalo podatkov.
 assessment#:#tst_skl_sub_tab_thresholds#:#Mejne vrednosti kompetenc
 assessment#:#tst_sol_comp_expressions#:#Primerjalni izrazi
 assessment#:#tst_solution_compare_cfg#:#Konfiguracija za primerjavo odgovorov
@@ -2012,7 +2001,6 @@ assessment#:#tst_unchanged_answer_is_correct#:#Privzeti odgovor je pravilen.
 assessment#:#tst_unchanged_order_is_correct#:#Privzeti vrstni red je pravilen.
 assessment#:#tst_use_previous_answers#:#Uporaba prejšnjih rešitev
 assessment#:#tst_use_previous_answers_description#:#Udeležencem prikaže odgovore iz prejšnjega opravljanja testa. To možnost mora udeleženec aktivirati v zavihku 'Informacije' pred začetkom testa.
-assessment#:#tst_use_previous_answers_user#:#Uporabi moje rešitve iz prejšnjega opravljanja testa kot privzete vrednosti
 assessment#:#tst_user_finished_test#:#Udeleženec je zaključil test (%s)
 assessment#:#tst_view_competence_assign#:#Pokaži lastnosti dodeljevanja
 assessment#:#tst_virtual_pass_header_lo_initial#:#Vstopni rezultati za učni cilj <br/>%s

--- a/lang/ilias_sq.lang
+++ b/lang/ilias_sq.lang
@@ -693,12 +693,10 @@ assessment#:#examid_in_test_res#:#ILIAS Testpass ID###27 01 2015 new variable
 assessment#:#examid_in_test_res_desc#:#The ILIAS Testpass ID will be included in the test results.###27 01 2015 new variable
 assessment#:#exp_all_test_runs#:#All test attempts###26 08 2024 new variable
 assessment#:#exp_eval_data#:#Eksporto të dhënat e vlerësimit si
-assessment#:#exp_file_created#:#Export file created.###24 10 2013 new variable
 assessment#:#exp_grammar_as#:#as###26 08 2024 new variable
 assessment#:#exp_scored_test_attempt#:#Scored Test Attempt###28 10 2024 new variable
 assessment#:#exp_type_certificate#:#Certificate (PDF)###10 10 2006 new variable
 assessment#:#exp_type_excel#:#Microsoft Excel###17 May 2005 content changed
-assessment#:#exp_type_spss#:#Vlera të ndara me presje (CSV)
 assessment#:#expected_result_type#:#Expected result type###24 10 2013 new variable
 assessment#:#export_cert_failed_for_users_p#:#No certificate file could be generated and added for the following %s accounts: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
 assessment#:#export_cert_failed_for_users_s#:#No certificate file could be generated and added to the archive for the following account: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
@@ -1434,7 +1432,6 @@ assessment#:#tst_delete_missing_mark#:#Ju lutem zgjedhni së paku një rresht t�
 assessment#:#tst_derive_new_pool#:#Derive New Question Pool###25 10 2016 new variable
 assessment#:#tst_derive_new_pools#:#Derive New Question Pools###25 10 2016 new variable
 assessment#:#tst_dont_show_msg_again_in_current_session#:#Don't show this message again in my current session.###10 11 2018 new variable
-assessment#:#tst_dont_use_previous_answers#:#Your previous answers will not be used as default values in future test passes###12 11 2006 new variable
 assessment#:#tst_edit_competence_assign#:#Edit Assignment Properties###30 08 2015 new variable
 assessment#:#tst_edit_scoring#:#Edit Scoring###28 08 2012 new variable
 assessment#:#tst_enable_questionlist#:#Show 'List of Questions’###26 08 2024 new variable
@@ -1494,7 +1491,6 @@ assessment#:#tst_finish_notification#:#Mail on completion###24 07 2009 new varia
 assessment#:#tst_finish_notification_advanced#:#Send complete test result to test owner###24 07 2009 new variable
 assessment#:#tst_finish_notification_content_type#:#Content of e-mail###27 01 2015 new variable
 assessment#:#tst_finish_notification_desc#:#Sends an e-mail to the test owner for every user that has completed the test.###27 01 2015 new variable
-assessment#:#tst_finish_notification_no#:#No e-mail###06 02 2015 new variable
 assessment#:#tst_finish_notification_simple#:#Send user name and finish date to test owner###24 07 2009 new variable
 assessment#:#tst_finished#:#Finished ### 2006-8-11 --- Add new translation here.
 assessment#:#tst_form_dynamic_question_set_config#:#Continues Question Selection###24 10 2013 new variable
@@ -1508,7 +1504,6 @@ assessment#:#tst_hide_info_tab#:#Hide Info Tab###26 08 2024 new variable
 assessment#:#tst_hide_info_tab_desc#:#Hides the tab ‘Info’ of the test.###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents#:#Hide page content###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents_desc#:#ILIAS content placed before and after the actual question text via the "Edit Page" button will not be displayed in the result views and print output.###26 08 2024 new variable
-assessment#:#tst_hide_side_list#:#Hide question list###24 07 2009 new variable
 assessment#:#tst_highscore_achieved_ts#:#Show date of test###28 08 2012 new variable
 assessment#:#tst_highscore_achieved_ts_description#:#Controls, if a column with the test date should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_all_tables#:#All Rankings###07 11 2014 new variable
@@ -1528,7 +1523,6 @@ assessment#:#tst_highscore_score#:#Show score###28 08 2012 new variable
 assessment#:#tst_highscore_score_description#:#Controls, if a column with the score should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_top_num#:#Number of ranks###28 08 2012 new variable
 assessment#:#tst_highscore_top_num_description#:#Controls, how many ranks should be included in the top ranking table.###28 08 2012 new variable
-assessment#:#tst_highscore_top_num_unit#:#entries###28 08 2012 new variable
 assessment#:#tst_highscore_top_table#:#Show table 'top ranking'###28 08 2012 new variable
 assessment#:#tst_highscore_top_table_description#:#Controls, if the table 'top ranking' should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_wtime#:#Show working time###28 08 2012 new variable
@@ -1924,10 +1918,6 @@ assessment#:#tst_show_results#:#Shih rezultatet e testit
 assessment#:#tst_show_side_list#:#Show question list aside###24 07 2009 new variable
 assessment#:#tst_show_solution_answers_only#:#Results print view (answers only)###14 11 2007 new variable
 assessment#:#tst_show_solution_answers_only_desc#:#If is selected, the ILIAS content you place around a question using the "Edit content" tab page will not be visible in a print-out. If you want to save some paper space, select this option.###07 11 2014 new variable
-assessment#:#tst_show_solution_compare#:#Compare Answer with Solution in List of Answers###24 10 2013 new variable
-assessment#:#tst_show_solution_compare_desc#:#Participants are presented with an overview comparing their own answers with the best solutions. Please note that this view will be displayed in the ‘Detailed Results’ that can be accessed via the ‘Show Test Results‘-button on the ‘Info’-tab. It will not be displayed in the printable ‘List of Answers’ even though the setting is made here.###06 02 2015 new variable
-assessment#:#tst_show_solution_details#:#Score details###10 Jul 2006 new variable
-assessment#:#tst_show_solution_details_desc#:#If selected, the detailed question solution is available to participants in the test results presentation. This includes the exact scoring of every answer, otherwise only an overview with the question titles and the reached points is shown.###07 11 2014 new variable
 assessment#:#tst_show_solution_details_singlepage#:#Scored Answers on single pages###26 08 2024 new variable
 assessment#:#tst_show_solution_details_singlepage_desc#:#Participants can access each question individually and see if their answers were correct and how many points they scored.###26 08 2024 new variable
 assessment#:#tst_show_solution_feedback#:#Show Answer-Specific Feedback in Test Results###10 05 2007 new variable
@@ -1950,7 +1940,6 @@ assessment#:#tst_skill_triggerings_num_req_answers_desc#:#Competences aren't tri
 assessment#:#tst_skill_triggerings_num_req_answers_not_reached_warn#:#At least one of the competences addressed by this test is not triggered by the minimal required amount of questions.<br />The required amount of questions: %s###10 11 2018 new variable
 assessment#:#tst_skl_level_thresholds_link#:#Configure Competence-Thresholds###30 08 2015 new variable
 assessment#:#tst_skl_level_thresholds_missing#:#There are missing thresholds for the relevant competences!###30 08 2015 new variable
-assessment#:#tst_skl_res_interpretation_hint_msg#:#Please consider that competence results from a single test has a limited significance. The more information is collected per competence, the merrier valid the significance will be. Should there are single competences without any entry, there is to less information collected.###30 08 2015 new variable
 assessment#:#tst_skl_sub_tab_thresholds#:#Competence Thresholds###26 09 2014 new variable
 assessment#:#tst_sol_comp_expressions#:#Comparison Expressions###30 08 2015 new variable
 assessment#:#tst_solution_compare_cfg#:#Configuration for Solution Compare###30 08 2015 new variable
@@ -2012,7 +2001,6 @@ assessment#:#tst_unchanged_answer_is_correct#:#The preset answer is correct###fa
 assessment#:#tst_unchanged_order_is_correct#:#The preset order is correct###fau: testNav
 assessment#:#tst_use_previous_answers#:#Use Previous Answers###26 10 2006 new variable
 assessment#:#tst_use_previous_answers_description#:#If checked, the previous answers of a participant will be used as default values in future test passes###26 10 2006 new variable
-assessment#:#tst_use_previous_answers_user#:#Use my previous answers as default values in future test passes###26 10 2006 new variable
 assessment#:#tst_user_finished_test#:#User finished test (%s)###24 07 2009 new variable
 assessment#:#tst_view_competence_assign#:#View Assignment Properties###30 08 2015 new variable
 assessment#:#tst_virtual_pass_header_lo_initial#:#Initial Test Results for the Learning Objectives<br />%s###30 08 2015 new variable

--- a/lang/ilias_sr.lang
+++ b/lang/ilias_sr.lang
@@ -693,12 +693,10 @@ assessment#:#examid_in_test_res#:#ILIAS Testpass ID###27 01 2015 new variable
 assessment#:#examid_in_test_res_desc#:#The ILIAS Testpass ID will be included in the test results.###27 01 2015 new variable
 assessment#:#exp_all_test_runs#:#All test attempts###26 08 2024 new variable
 assessment#:#exp_eval_data#:#Ispišite podatke o ocenjivanju kao
-assessment#:#exp_file_created#:#Export file created.###24 10 2013 new variable
 assessment#:#exp_grammar_as#:#as###26 08 2024 new variable
 assessment#:#exp_scored_test_attempt#:#Scored Test Attempt###28 10 2024 new variable
 assessment#:#exp_type_certificate#:#Certificate (PDF)###10 10 2006 new variable
 assessment#:#exp_type_excel#:#Microsoft Excel###17 May 2005 content changed
-assessment#:#exp_type_spss#:#Zarezom odvojene vrednosti (CSV)
 assessment#:#expected_result_type#:#Expected result type###24 10 2013 new variable
 assessment#:#export_cert_failed_for_users_p#:#No certificate file could be generated and added for the following %s accounts: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
 assessment#:#export_cert_failed_for_users_s#:#No certificate file could be generated and added to the archive for the following account: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
@@ -1434,7 +1432,6 @@ assessment#:#tst_delete_missing_mark#:#Molimo odaberite bar jedan postupak ocenj
 assessment#:#tst_derive_new_pool#:#Derive New Question Pool###25 10 2016 new variable
 assessment#:#tst_derive_new_pools#:#Derive New Question Pools###25 10 2016 new variable
 assessment#:#tst_dont_show_msg_again_in_current_session#:#Don't show this message again in my current session.###10 11 2018 new variable
-assessment#:#tst_dont_use_previous_answers#:#Your previous answers will not be used as default values in future test passes###12 11 2006 new variable
 assessment#:#tst_edit_competence_assign#:#Edit Assignment Properties###30 08 2015 new variable
 assessment#:#tst_edit_scoring#:#Edit Scoring###28 08 2012 new variable
 assessment#:#tst_enable_questionlist#:#Show 'List of Questions’###26 08 2024 new variable
@@ -1494,7 +1491,6 @@ assessment#:#tst_finish_notification#:#Mail on completion###24 07 2009 new varia
 assessment#:#tst_finish_notification_advanced#:#Send complete test result to test owner###24 07 2009 new variable
 assessment#:#tst_finish_notification_content_type#:#Content of e-mail###27 01 2015 new variable
 assessment#:#tst_finish_notification_desc#:#Sends an e-mail to the test owner for every user that has completed the test.###27 01 2015 new variable
-assessment#:#tst_finish_notification_no#:#No e-mail###06 02 2015 new variable
 assessment#:#tst_finish_notification_simple#:#Send user name and finish date to test owner###24 07 2009 new variable
 assessment#:#tst_finished#:#Finished ### 2006-8-11 --- Add new translation here.
 assessment#:#tst_form_dynamic_question_set_config#:#Continues Question Selection###24 10 2013 new variable
@@ -1508,7 +1504,6 @@ assessment#:#tst_hide_info_tab#:#Hide Info Tab###26 08 2024 new variable
 assessment#:#tst_hide_info_tab_desc#:#Hides the tab ‘Info’ of the test.###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents#:#Hide page content###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents_desc#:#ILIAS content placed before and after the actual question text via the "Edit Page" button will not be displayed in the result views and print output.###26 08 2024 new variable
-assessment#:#tst_hide_side_list#:#Hide question list###24 07 2009 new variable
 assessment#:#tst_highscore_achieved_ts#:#Show date of test###28 08 2012 new variable
 assessment#:#tst_highscore_achieved_ts_description#:#Controls, if a column with the test date should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_all_tables#:#All Rankings###07 11 2014 new variable
@@ -1528,7 +1523,6 @@ assessment#:#tst_highscore_score#:#Show score###28 08 2012 new variable
 assessment#:#tst_highscore_score_description#:#Controls, if a column with the score should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_top_num#:#Number of ranks###28 08 2012 new variable
 assessment#:#tst_highscore_top_num_description#:#Controls, how many ranks should be included in the top ranking table.###28 08 2012 new variable
-assessment#:#tst_highscore_top_num_unit#:#entries###28 08 2012 new variable
 assessment#:#tst_highscore_top_table#:#Show table 'top ranking'###28 08 2012 new variable
 assessment#:#tst_highscore_top_table_description#:#Controls, if the table 'top ranking' should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_wtime#:#Show working time###28 08 2012 new variable
@@ -1924,10 +1918,6 @@ assessment#:#tst_show_results#:#Prikaži rezultate testa
 assessment#:#tst_show_side_list#:#Show question list aside###24 07 2009 new variable
 assessment#:#tst_show_solution_answers_only#:#Results print view (answers only)###14 11 2007 new variable
 assessment#:#tst_show_solution_answers_only_desc#:#If is selected, the ILIAS content you place around a question using the "Edit content" tab page will not be visible in a print-out. If you want to save some paper space, select this option.###07 11 2014 new variable
-assessment#:#tst_show_solution_compare#:#Compare Answer with Solution in List of Answers###24 10 2013 new variable
-assessment#:#tst_show_solution_compare_desc#:#Participants are presented with an overview comparing their own answers with the best solutions. Please note that this view will be displayed in the ‘Detailed Results’ that can be accessed via the ‘Show Test Results‘-button on the ‘Info’-tab. It will not be displayed in the printable ‘List of Answers’ even though the setting is made here.###06 02 2015 new variable
-assessment#:#tst_show_solution_details#:#Score details###10 Jul 2006 new variable
-assessment#:#tst_show_solution_details_desc#:#If selected, the detailed question solution is available to participants in the test results presentation. This includes the exact scoring of every answer, otherwise only an overview with the question titles and the reached points is shown.###07 11 2014 new variable
 assessment#:#tst_show_solution_details_singlepage#:#Scored Answers on single pages###26 08 2024 new variable
 assessment#:#tst_show_solution_details_singlepage_desc#:#Participants can access each question individually and see if their answers were correct and how many points they scored.###26 08 2024 new variable
 assessment#:#tst_show_solution_feedback#:#Show Answer-Specific Feedback in Test Results###10 05 2007 new variable
@@ -1950,7 +1940,6 @@ assessment#:#tst_skill_triggerings_num_req_answers_desc#:#Competences aren't tri
 assessment#:#tst_skill_triggerings_num_req_answers_not_reached_warn#:#At least one of the competences addressed by this test is not triggered by the minimal required amount of questions.<br />The required amount of questions: %s###10 11 2018 new variable
 assessment#:#tst_skl_level_thresholds_link#:#Configure Competence-Thresholds###30 08 2015 new variable
 assessment#:#tst_skl_level_thresholds_missing#:#There are missing thresholds for the relevant competences!###30 08 2015 new variable
-assessment#:#tst_skl_res_interpretation_hint_msg#:#Please consider that competence results from a single test has a limited significance. The more information is collected per competence, the merrier valid the significance will be. Should there are single competences without any entry, there is to less information collected.###30 08 2015 new variable
 assessment#:#tst_skl_sub_tab_thresholds#:#Competence Thresholds###26 09 2014 new variable
 assessment#:#tst_sol_comp_expressions#:#Comparison Expressions###30 08 2015 new variable
 assessment#:#tst_solution_compare_cfg#:#Configuration for Solution Compare###30 08 2015 new variable
@@ -2012,7 +2001,6 @@ assessment#:#tst_unchanged_answer_is_correct#:#The preset answer is correct###fa
 assessment#:#tst_unchanged_order_is_correct#:#The preset order is correct###fau: testNav
 assessment#:#tst_use_previous_answers#:#Use Previous Answers###26 10 2006 new variable
 assessment#:#tst_use_previous_answers_description#:#If checked, the previous answers of a participant will be used as default values in future test passes###26 10 2006 new variable
-assessment#:#tst_use_previous_answers_user#:#Use my previous answers as default values in future test passes###26 10 2006 new variable
 assessment#:#tst_user_finished_test#:#User finished test (%s)###24 07 2009 new variable
 assessment#:#tst_view_competence_assign#:#View Assignment Properties###30 08 2015 new variable
 assessment#:#tst_virtual_pass_header_lo_initial#:#Initial Test Results for the Learning Objectives<br />%s###30 08 2015 new variable

--- a/lang/ilias_sv.lang
+++ b/lang/ilias_sv.lang
@@ -693,12 +693,10 @@ assessment#:#examid_in_test_res#:#Visa ILIAS provnummer
 assessment#:#examid_in_test_res_desc#:#I testresultaten, statistiken och Excel-exporten visas ILIAS-examensnumret.
 assessment#:#exp_all_test_runs#:#All test runs###21 11 2023 new variable
 assessment#:#exp_eval_data#:#Exportera utvärderingsdata som
-assessment#:#exp_file_created#:#Exportfil genererad.
 assessment#:#exp_grammar_as#:#as###26 08 2024 new variable
 assessment#:#exp_scored_test_attempt#:#Scored Test Attempt
 assessment#:#exp_type_certificate#:#Certifikat (PDF)
 assessment#:#exp_type_excel#:#Microsoft Excel
-assessment#:#exp_type_spss#:#Kommaseparerade värden (CSV)
 assessment#:#expected_result_type#:#Typ av förväntat resultat
 assessment#:#export_cert_failed_for_users_p#:#No certificate file could be generated and added for the following %s accounts: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
 assessment#:#export_cert_failed_for_users_s#:#No certificate file could be generated and added to the archive for the following account: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
@@ -1434,7 +1432,6 @@ assessment#:#tst_delete_missing_mark#:#Välj minst en årskurs för att ta bort!
 assessment#:#tst_derive_new_pool#:#Skapa ny frågepool
 assessment#:#tst_derive_new_pools#:#Skapa nya frågepooler
 assessment#:#tst_dont_show_msg_again_in_current_session#:#Visa inte detta meddelande igen i min nuvarande session.
-assessment#:#tst_dont_use_previous_answers#:#Dina tidigare svar kommer inte att användas som standardvärden i framtida testkörningar
 assessment#:#tst_edit_competence_assign#:#Redigera egenskaper för tilldelning
 assessment#:#tst_edit_scoring#:#Ändra betyg
 assessment#:#tst_enable_questionlist#:#Show 'List of Questions’###21 11 2023 new variable
@@ -1494,7 +1491,6 @@ assessment#:#tst_finish_notification#:#Notifiering
 assessment#:#tst_finish_notification_advanced#:#Fullständigt testresultat per användare
 assessment#:#tst_finish_notification_content_type#:#Content of e-mail###21 11 2023 new variable
 assessment#:#tst_finish_notification_desc#:#Ett mail skickas för varje person som genomför ett test. Mailet skickas till den användare som är angiven på fliken "Rättigheter" under "Ägs av". Mailet innehåller följande information
-assessment#:#tst_finish_notification_no#:#Ingen anmälan
 assessment#:#tst_finish_notification_simple#:#Endast inloggningsnamn och datum för uppsägning
 assessment#:#tst_finished#:#Färdig
 assessment#:#tst_form_dynamic_question_set_config#:#Kontinuerligt urval av frågor
@@ -1508,7 +1504,6 @@ assessment#:#tst_hide_info_tab#:#Hide Info Tab###21 11 2023 new variable
 assessment#:#tst_hide_info_tab_desc#:#Hides the tab ‘Info’ of the test.###21 11 2023 new variable
 assessment#:#tst_hide_pagecontents#:# Dölj sidans innehåll
 assessment#:#tst_hide_pagecontents_desc#:#ILIAS-innehåll som placeras före och efter den faktiska frågetexten via knappen "Redigera sida" visas inte i resultatvyerna och utskriften.
-assessment#:#tst_hide_side_list#:#Frågelista från
 assessment#:#tst_highscore_achieved_ts#:#Datum
 assessment#:#tst_highscore_achieved_ts_description#:#En extra kolumn med tiden för testet visas.
 assessment#:#tst_highscore_all_tables#:#Egen rankning och leaderboard
@@ -1528,7 +1523,6 @@ assessment#:#tst_highscore_score#:#Poäng
 assessment#:#tst_highscore_score_description#:#Ytterligare en kolumn visas med antalet uppnådda poäng.
 assessment#:#tst_highscore_top_num#:#Bästa listlängd
 assessment#:#tst_highscore_top_num_description#:#Bestämmer hur många poster som visas i topplistan.
-assessment#:#tst_highscore_top_num_unit#:#Placeringar
 assessment#:#tst_highscore_top_table#:#Bästalista
 assessment#:#tst_highscore_top_table_description#:#Deltagarna kommer att få se en tabell med de bästa placeringarna.
 assessment#:#tst_highscore_wtime#:#Bearbetningstid
@@ -1924,10 +1918,6 @@ assessment#:#tst_show_results#:#Testresultat
 assessment#:#tst_show_side_list#:#Frågelista till
 assessment#:#tst_show_solution_answers_only#:#Skriv ut resultaten (endast svar)
 assessment#:#tst_show_solution_answers_only_desc#:#Om "Skriv ut resultat (endast svar)" är markerat, kommer ILIAS-innehåll som du kan placera före och efter den faktiska frågetexten via fliken "Redigera innehåll" i frågorna inte att visas i en utskrift.
-assessment#:#tst_show_solution_compare#:#Visa bästa möjliga lösning i 'Tabell med detaljerade testresultat'.
-assessment#:#tst_show_solution_compare_desc#:#Deltagarna presenteras med en översikt som en del av 'Tabell med detaljerade testresultat', som jämför deras egna svar och den bästa möjliga lösningen. <br> Denna översikt visas inte i underfliken "Poängbedömda svar" på fliken "Resultat", även om denna i
-assessment#:#tst_show_solution_details#:#Rated svar som en lista
-assessment#:#tst_show_solution_details_desc#:#En lista med dina egna svar läggs till i tabellen "Detaljerade testresultat".
 assessment#:#tst_show_solution_details_singlepage#:#Relaterade svar på enskilda sidor
 assessment#:#tst_show_solution_details_singlepage_desc#:#Deltagarna kan ringa upp varje fråga individuellt och se om deras svar var korrekta och hur många poäng de fick.
 assessment#:#tst_show_solution_feedback#:#Tillbaka
@@ -1950,7 +1940,6 @@ assessment#:#tst_skill_triggerings_num_req_answers_desc#:#Kompetens samlas endas
 assessment#:#tst_skill_triggerings_num_req_answers_not_reached_warn#:#Minst en kompetens som tas upp i testet har inte tilldelats ett tillräckligt antal frågor. För dessa kompetenser registreras inga kompetensposter för deltagarna.<br />Minsta antal tilldelade frågor
 assessment#:#tst_skl_level_thresholds_link#:#Konfigurera tröskelvärden för kompetens
 assessment#:#tst_skl_level_thresholds_missing#:#Tröskelvärden har ännu inte definierats för alla relevanta kompetenser!
-assessment#:#tst_skl_res_interpretation_hint_msg#:#Tänk på att kompetensresultaten från ett enskilt test endast är villkorligt meningsfulla. Ju mer information som samlas in om de enskilda kompetenserna, desto mer giltigt blir påståendet. Om enskilda kompetenser inte har angetts, har för lite information
 assessment#:#tst_skl_sub_tab_thresholds#:#Tröskelvärden för kompetens
 assessment#:#tst_sol_comp_expressions#:#Jämförelse av uttryck
 assessment#:#tst_solution_compare_cfg#:#Konfiguration för jämförelse av svar
@@ -2012,7 +2001,6 @@ assessment#:#tst_unchanged_answer_is_correct#:#Det angivna svaret är korrekt.
 assessment#:#tst_unchanged_order_is_correct#:#Det givna arrangemanget är korrekt.
 assessment#:#tst_use_previous_answers#:#Använda tidigare lösningar
 assessment#:#tst_use_previous_answers_description#:#Visar deltagarna svaren från föregående testkörning. Alternativet måste aktiveras av deltagaren via en kryssruta på fliken "Info" innan testet påbörjas.
-assessment#:#tst_use_previous_answers_user#:#Använd mina lösningar från en tidigare testkörning som standardvärden
 assessment#:#tst_user_finished_test#:#En deltagare har avslutat testet (%s)
 assessment#:#tst_view_competence_assign#:#Visa egenskaper för tilldelning
 assessment#:#tst_virtual_pass_header_lo_initial#:#Establishment-resultat för lärandemålet<br />%s

--- a/lang/ilias_tr.lang
+++ b/lang/ilias_tr.lang
@@ -693,12 +693,10 @@ assessment#:#examid_in_test_res#:#ILIAS Testpass ID###27 01 2015 new variable
 assessment#:#examid_in_test_res_desc#:#The ILIAS Testpass ID will be included in the test results.###27 01 2015 new variable
 assessment#:#exp_all_test_runs#:#All test attempts###26 08 2024 new variable
 assessment#:#exp_eval_data#:#Değerlendirme verilerini dışa aktar
-assessment#:#exp_file_created#:#Export file created.###24 10 2013 new variable
 assessment#:#exp_grammar_as#:#as###26 08 2024 new variable
 assessment#:#exp_scored_test_attempt#:#Scored Test Attempt###28 10 2024 new variable
 assessment#:#exp_type_certificate#:#Sertifika (PDF)
 assessment#:#exp_type_excel#:#Microsoft Excel
-assessment#:#exp_type_spss#:#Virgülle Ayrılmış Değer (CSV)
 assessment#:#expected_result_type#:#Expected result type###24 10 2013 new variable
 assessment#:#export_cert_failed_for_users_p#:#No certificate file could be generated and added for the following %s accounts: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
 assessment#:#export_cert_failed_for_users_s#:#No certificate file could be generated and added to the archive for the following account: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
@@ -1434,7 +1432,6 @@ assessment#:#tst_delete_missing_mark#:#Silmek için en az bir adım seçiniz.
 assessment#:#tst_derive_new_pool#:#Derive New Question Pool###25 10 2016 new variable
 assessment#:#tst_derive_new_pools#:#Derive New Question Pools###25 10 2016 new variable
 assessment#:#tst_dont_show_msg_again_in_current_session#:#Don't show this message again in my current session.###10 11 2018 new variable
-assessment#:#tst_dont_use_previous_answers#:#Sonraki testleriniz için önceki cevaplarınız varsayılan olarak kullanılmayacaktır.
 assessment#:#tst_edit_competence_assign#:#Edit Assignment Properties###30 08 2015 new variable
 assessment#:#tst_edit_scoring#:#Puanlama Düzenle
 assessment#:#tst_enable_questionlist#:#Show 'List of Questions’###26 08 2024 new variable
@@ -1494,7 +1491,6 @@ assessment#:#tst_finish_notification#:#Tamamlandığında E-Posta
 assessment#:#tst_finish_notification_advanced#:#Test sahibine test sonucunu gönder
 assessment#:#tst_finish_notification_content_type#:#Content of e-mail###27 01 2015 new variable
 assessment#:#tst_finish_notification_desc#:#Sends an e-mail to the test owner for every user that has completed the test.###27 01 2015 new variable
-assessment#:#tst_finish_notification_no#:#No e-mail###06 02 2015 new variable
 assessment#:#tst_finish_notification_simple#:#Test sahibine kullanıcı adını ve bitirme tarihini gönder
 assessment#:#tst_finished#:#Bitti
 assessment#:#tst_form_dynamic_question_set_config#:#Continues Question Selection###24 10 2013 new variable
@@ -1508,7 +1504,6 @@ assessment#:#tst_hide_info_tab#:#Hide Info Tab###26 08 2024 new variable
 assessment#:#tst_hide_info_tab_desc#:#Hides the tab ‘Info’ of the test.###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents#:#Hide page content###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents_desc#:#ILIAS content placed before and after the actual question text via the "Edit Page" button will not be displayed in the result views and print output.###26 08 2024 new variable
-assessment#:#tst_hide_side_list#:#Soru listesini Gizle
 assessment#:#tst_highscore_achieved_ts#:#Test tarihini göster
 assessment#:#tst_highscore_achieved_ts_description#:#Kontroller, test tarihi sütunda gösterilecekse
 assessment#:#tst_highscore_all_tables#:#All Rankings###07 11 2014 new variable
@@ -1528,7 +1523,6 @@ assessment#:#tst_highscore_score#:#Skoru Göster
 assessment#:#tst_highscore_score_description#:#Skor sütununu göstermek için kontroller
 assessment#:#tst_highscore_top_num#:#Başarı Sırası Eleman Sayısı
 assessment#:#tst_highscore_top_num_description#:#En iyi derece tablosuna kaç adet kayıt eklenmeli
-assessment#:#tst_highscore_top_num_unit#:#eleman
 assessment#:#tst_highscore_top_table#:#'En iyi derece' Tablosunu Göster
 assessment#:#tst_highscore_top_table_description#:#Kontroller, tablo 'üst düzey' gösterildiği gibi olmalıdır eğer.
 assessment#:#tst_highscore_wtime#:#Çalışma süresini göster
@@ -1924,10 +1918,6 @@ assessment#:#tst_show_results#:#Test Sonuçlarını Göster
 assessment#:#tst_show_side_list#:#Soru listesini göster
 assessment#:#tst_show_solution_answers_only#:#Sonuçları Yazdır (Sadece Yanıtlar)
 assessment#:#tst_show_solution_answers_only_desc#:#If is selected, the ILIAS content you place around a question using the "Edit content" tab page will not be visible in a print-out. If you want to save some paper space, select this option.###07 11 2014 new variable
-assessment#:#tst_show_solution_compare#:#Compare Answer with Solution in List of Answers###24 10 2013 new variable
-assessment#:#tst_show_solution_compare_desc#:#Participants are presented with an overview comparing their own answers with the best solutions. Please note that this view will be displayed in the ‘Detailed Results’ that can be accessed via the ‘Show Test Results‘-button on the ‘Info’-tab. It will not be displayed in the printable ‘List of Answers’ even though the setting is made here.###06 02 2015 new variable
-assessment#:#tst_show_solution_details#:#Test Sonuçlarında Çözümleri Göster
-assessment#:#tst_show_solution_details_desc#:#If selected, the detailed question solution is available to participants in the test results presentation. This includes the exact scoring of every answer, otherwise only an overview with the question titles and the reached points is shown.###07 11 2014 new variable
 assessment#:#tst_show_solution_details_singlepage#:#Scored Answers on single pages###26 08 2024 new variable
 assessment#:#tst_show_solution_details_singlepage_desc#:#Participants can access each question individually and see if their answers were correct and how many points they scored.###26 08 2024 new variable
 assessment#:#tst_show_solution_feedback#:#Soruya Özgü Geri Bildirimleri Test Sonuçlarında Göster
@@ -1950,7 +1940,6 @@ assessment#:#tst_skill_triggerings_num_req_answers_desc#:#Competences aren't tri
 assessment#:#tst_skill_triggerings_num_req_answers_not_reached_warn#:#At least one of the competences addressed by this test is not triggered by the minimal required amount of questions.<br />The required amount of questions: %s###10 11 2018 new variable
 assessment#:#tst_skl_level_thresholds_link#:#Configure Competence-Thresholds###30 08 2015 new variable
 assessment#:#tst_skl_level_thresholds_missing#:#There are missing thresholds for the relevant competences!###30 08 2015 new variable
-assessment#:#tst_skl_res_interpretation_hint_msg#:#Please consider that competence results from a single test has a limited significance. The more information is collected per competence, the merrier valid the significance will be. Should there are single competences without any entry, there is to less information collected.###30 08 2015 new variable
 assessment#:#tst_skl_sub_tab_thresholds#:#Competence Thresholds###26 09 2014 new variable
 assessment#:#tst_sol_comp_expressions#:#Comparison Expressions###30 08 2015 new variable
 assessment#:#tst_solution_compare_cfg#:#Configuration for Solution Compare###30 08 2015 new variable
@@ -2012,7 +2001,6 @@ assessment#:#tst_unchanged_answer_is_correct#:#The preset answer is correct###fa
 assessment#:#tst_unchanged_order_is_correct#:#The preset order is correct###fau: testNav
 assessment#:#tst_use_previous_answers#:#Önceki Cevapları Kullan
 assessment#:#tst_use_previous_answers_description#:#Etkinse, katılımcı önceki cevaplarını geçtiği her testte varsayılan cevaplar olarak seçebilir. Etkin değilse, önceki cevaplar geçilen testlerde gösterilmez.
-assessment#:#tst_use_previous_answers_user#:#Geçilen testlerde önceki cevaplarımı varsayılan değer olarak kullan
 assessment#:#tst_user_finished_test#:#Kullanıcı testi bitirdi (% s)
 assessment#:#tst_view_competence_assign#:#View Assignment Properties###30 08 2015 new variable
 assessment#:#tst_virtual_pass_header_lo_initial#:#Initial Test Results for the Learning Objectives<br />%s###30 08 2015 new variable

--- a/lang/ilias_uk.lang
+++ b/lang/ilias_uk.lang
@@ -693,12 +693,10 @@ assessment#:#examid_in_test_res#:#ILIAS Testpass ID###27 01 2015 new variable
 assessment#:#examid_in_test_res_desc#:#The ILIAS Testpass ID will be included in the test results.###27 01 2015 new variable
 assessment#:#exp_all_test_runs#:#All test attempts###26 08 2024 new variable
 assessment#:#exp_eval_data#:#Експортувати Оціночну Дату
-assessment#:#exp_file_created#:#Export file created.###24 10 2013 new variable
 assessment#:#exp_grammar_as#:#as###26 08 2024 new variable
 assessment#:#exp_scored_test_attempt#:#Scored Test Attempt###28 10 2024 new variable
 assessment#:#exp_type_certificate#:#Certificate (PDF)###25 02 2007 new variable
 assessment#:#exp_type_excel#:#  Excel  ###17 May 2005 content changed
-assessment#:#exp_type_spss#:#  SPSS
 assessment#:#expected_result_type#:#Expected result type###24 10 2013 new variable
 assessment#:#export_cert_failed_for_users_p#:#No certificate file could be generated and added for the following %s accounts: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
 assessment#:#export_cert_failed_for_users_s#:#No certificate file could be generated and added to the archive for the following account: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
@@ -1434,7 +1432,6 @@ assessment#:#tst_delete_missing_mark#:#Будь ласка виберіть пр
 assessment#:#tst_derive_new_pool#:#Derive New Question Pool###25 10 2016 new variable
 assessment#:#tst_derive_new_pools#:#Derive New Question Pools###25 10 2016 new variable
 assessment#:#tst_dont_show_msg_again_in_current_session#:#Don't show this message again in my current session.###10 11 2018 new variable
-assessment#:#tst_dont_use_previous_answers#:#Your previous answers will not be used as default values in future test passes###25 02 2007 new variable
 assessment#:#tst_edit_competence_assign#:#Edit Assignment Properties###30 08 2015 new variable
 assessment#:#tst_edit_scoring#:#Edit Scoring###28 08 2012 new variable
 assessment#:#tst_enable_questionlist#:#Show 'List of Questions’###26 08 2024 new variable
@@ -1494,7 +1491,6 @@ assessment#:#tst_finish_notification#:#Mail on completion###24 07 2009 new varia
 assessment#:#tst_finish_notification_advanced#:#Send complete test result to test owner###24 07 2009 new variable
 assessment#:#tst_finish_notification_content_type#:#Content of e-mail###27 01 2015 new variable
 assessment#:#tst_finish_notification_desc#:#Sends an e-mail to the test owner for every user that has completed the test.###27 01 2015 new variable
-assessment#:#tst_finish_notification_no#:#No e-mail###06 02 2015 new variable
 assessment#:#tst_finish_notification_simple#:#Send user name and finish date to test owner###24 07 2009 new variable
 assessment#:#tst_finished#:#Закінчений
 assessment#:#tst_form_dynamic_question_set_config#:#Continues Question Selection###24 10 2013 new variable
@@ -1508,7 +1504,6 @@ assessment#:#tst_hide_info_tab#:#Hide Info Tab###26 08 2024 new variable
 assessment#:#tst_hide_info_tab_desc#:#Hides the tab ‘Info’ of the test.###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents#:#Hide page content###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents_desc#:#ILIAS content placed before and after the actual question text via the "Edit Page" button will not be displayed in the result views and print output.###26 08 2024 new variable
-assessment#:#tst_hide_side_list#:#Hide question list###24 07 2009 new variable
 assessment#:#tst_highscore_achieved_ts#:#Show date of test###28 08 2012 new variable
 assessment#:#tst_highscore_achieved_ts_description#:#Controls, if a column with the test date should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_all_tables#:#All Rankings###07 11 2014 new variable
@@ -1528,7 +1523,6 @@ assessment#:#tst_highscore_score#:#Show score###28 08 2012 new variable
 assessment#:#tst_highscore_score_description#:#Controls, if a column with the score should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_top_num#:#Number of ranks###28 08 2012 new variable
 assessment#:#tst_highscore_top_num_description#:#Controls, how many ranks should be included in the top ranking table.###28 08 2012 new variable
-assessment#:#tst_highscore_top_num_unit#:#entries###28 08 2012 new variable
 assessment#:#tst_highscore_top_table#:#Show table 'top ranking'###28 08 2012 new variable
 assessment#:#tst_highscore_top_table_description#:#Controls, if the table 'top ranking' should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_wtime#:#Show working time###28 08 2012 new variable
@@ -1924,10 +1918,6 @@ assessment#:#tst_show_results#:#Показати результати тесту
 assessment#:#tst_show_side_list#:#Show question list aside###24 07 2009 new variable
 assessment#:#tst_show_solution_answers_only#:#Results print view (answers only)###14 11 2007 new variable
 assessment#:#tst_show_solution_answers_only_desc#:#If is selected, the ILIAS content you place around a question using the "Edit content" tab page will not be visible in a print-out. If you want to save some paper space, select this option.###07 11 2014 new variable
-assessment#:#tst_show_solution_compare#:#Compare Answer with Solution in List of Answers###24 10 2013 new variable
-assessment#:#tst_show_solution_compare_desc#:#Participants are presented with an overview comparing their own answers with the best solutions. Please note that this view will be displayed in the ‘Detailed Results’ that can be accessed via the ‘Show Test Results‘-button on the ‘Info’-tab. It will not be displayed in the printable ‘List of Answers’ even though the setting is made here.###06 02 2015 new variable
-assessment#:#tst_show_solution_details#:#Show Solutions in Test Results###25 02 2007 new variable
-assessment#:#tst_show_solution_details_desc#:#If selected, the detailed question solution is available to participants in the test results presentation. This includes the exact scoring of every answer, otherwise only an overview with the question titles and the reached points is shown.###07 11 2014 new variable
 assessment#:#tst_show_solution_details_singlepage#:#Scored Answers on single pages###26 08 2024 new variable
 assessment#:#tst_show_solution_details_singlepage_desc#:#Participants can access each question individually and see if their answers were correct and how many points they scored.###26 08 2024 new variable
 assessment#:#tst_show_solution_feedback#:#Show Answer-Specific Feedback in Test Results###10 05 2007 new variable
@@ -1950,7 +1940,6 @@ assessment#:#tst_skill_triggerings_num_req_answers_desc#:#Competences aren't tri
 assessment#:#tst_skill_triggerings_num_req_answers_not_reached_warn#:#At least one of the competences addressed by this test is not triggered by the minimal required amount of questions.<br />The required amount of questions: %s###10 11 2018 new variable
 assessment#:#tst_skl_level_thresholds_link#:#Configure Competence-Thresholds###30 08 2015 new variable
 assessment#:#tst_skl_level_thresholds_missing#:#There are missing thresholds for the relevant competences!###30 08 2015 new variable
-assessment#:#tst_skl_res_interpretation_hint_msg#:#Please consider that competence results from a single test has a limited significance. The more information is collected per competence, the merrier valid the significance will be. Should there are single competences without any entry, there is to less information collected.###30 08 2015 new variable
 assessment#:#tst_skl_sub_tab_thresholds#:#Competence Thresholds###26 09 2014 new variable
 assessment#:#tst_sol_comp_expressions#:#Comparison Expressions###30 08 2015 new variable
 assessment#:#tst_solution_compare_cfg#:#Configuration for Solution Compare###30 08 2015 new variable
@@ -2012,7 +2001,6 @@ assessment#:#tst_unchanged_answer_is_correct#:#The preset answer is correct###fa
 assessment#:#tst_unchanged_order_is_correct#:#The preset order is correct###fau: testNav
 assessment#:#tst_use_previous_answers#:#Use Previous Answers###25 02 2007 new variable
 assessment#:#tst_use_previous_answers_description#:#If checked, a participant may choose to use the previous answers as default values in future test passes, otherwise the previous answers are not shown in future test passes###25 02 2007 new variable
-assessment#:#tst_use_previous_answers_user#:#Use my previous answers as default values in future test passes###25 02 2007 new variable
 assessment#:#tst_user_finished_test#:#User finished test (%s)###24 07 2009 new variable
 assessment#:#tst_view_competence_assign#:#View Assignment Properties###30 08 2015 new variable
 assessment#:#tst_virtual_pass_header_lo_initial#:#Initial Test Results for the Learning Objectives<br />%s###30 08 2015 new variable

--- a/lang/ilias_vi.lang
+++ b/lang/ilias_vi.lang
@@ -695,12 +695,10 @@ assessment#:#examid_in_test_res#:#ILIAS Testpass ID###27 01 2015 new variable
 assessment#:#examid_in_test_res_desc#:#The ILIAS Testpass ID will be included in the test results.###27 01 2015 new variable
 assessment#:#exp_all_test_runs#:#All test attempts###26 08 2024 new variable
 assessment#:#exp_eval_data#:#Xuất kết quả đánh giá như là
-assessment#:#exp_file_created#:#Export file created.###24 10 2013 new variable
 assessment#:#exp_grammar_as#:#as###26 08 2024 new variable
 assessment#:#exp_scored_test_attempt#:#Scored Test Attempt###28 10 2024 new variable
 assessment#:#exp_type_certificate#:#Certificate (PDF)###25 02 2007 new variable
 assessment#:#exp_type_excel#:#Microsoft Excel###23 Mar 2006 content changed
-assessment#:#exp_type_spss#:#Giá trị phân tách bằng dấu phẩy (CSV)
 assessment#:#expected_result_type#:#Expected result type###24 10 2013 new variable
 assessment#:#export_cert_failed_for_users_p#:#No certificate file could be generated and added for the following %s accounts: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
 assessment#:#export_cert_failed_for_users_s#:#No certificate file could be generated and added to the archive for the following account: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
@@ -1436,7 +1434,6 @@ assessment#:#tst_delete_missing_mark#:#Hãy chọn ít nhất một thang điể
 assessment#:#tst_derive_new_pool#:#Derive New Question Pool###25 10 2016 new variable
 assessment#:#tst_derive_new_pools#:#Derive New Question Pools###25 10 2016 new variable
 assessment#:#tst_dont_show_msg_again_in_current_session#:#Don't show this message again in my current session.###10 11 2018 new variable
-assessment#:#tst_dont_use_previous_answers#:#Your previous answers will not be used as default values in future test passes###25 02 2007 new variable
 assessment#:#tst_edit_competence_assign#:#Edit Assignment Properties###30 08 2015 new variable
 assessment#:#tst_edit_scoring#:#Edit Scoring###28 08 2012 new variable
 assessment#:#tst_enable_questionlist#:#Show 'List of Questions’###26 08 2024 new variable
@@ -1496,7 +1493,6 @@ assessment#:#tst_finish_notification#:#Mail on completion###24 07 2009 new varia
 assessment#:#tst_finish_notification_advanced#:#Send complete test result to test owner###24 07 2009 new variable
 assessment#:#tst_finish_notification_content_type#:#Content of e-mail###27 01 2015 new variable
 assessment#:#tst_finish_notification_desc#:#Sends an e-mail to the test owner for every user that has completed the test.###27 01 2015 new variable
-assessment#:#tst_finish_notification_no#:#No e-mail###06 02 2015 new variable
 assessment#:#tst_finish_notification_simple#:#Send user name and finish date to test owner###24 07 2009 new variable
 assessment#:#tst_finished#:#Kết thúc
 assessment#:#tst_form_dynamic_question_set_config#:#Continues Question Selection###24 10 2013 new variable
@@ -1510,7 +1506,6 @@ assessment#:#tst_hide_info_tab#:#Hide Info Tab###26 08 2024 new variable
 assessment#:#tst_hide_info_tab_desc#:#Hides the tab ‘Info’ of the test.###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents#:#Hide page content###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents_desc#:#ILIAS content placed before and after the actual question text via the "Edit Page" button will not be displayed in the result views and print output.###26 08 2024 new variable
-assessment#:#tst_hide_side_list#:#Hide question list###24 07 2009 new variable
 assessment#:#tst_highscore_achieved_ts#:#Show date of test###28 08 2012 new variable
 assessment#:#tst_highscore_achieved_ts_description#:#Controls, if a column with the test date should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_all_tables#:#All Rankings###07 11 2014 new variable
@@ -1530,7 +1525,6 @@ assessment#:#tst_highscore_score#:#Show score###28 08 2012 new variable
 assessment#:#tst_highscore_score_description#:#Controls, if a column with the score should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_top_num#:#Number of ranks###28 08 2012 new variable
 assessment#:#tst_highscore_top_num_description#:#Controls, how many ranks should be included in the top ranking table.###28 08 2012 new variable
-assessment#:#tst_highscore_top_num_unit#:#entries###28 08 2012 new variable
 assessment#:#tst_highscore_top_table#:#Show table 'top ranking'###28 08 2012 new variable
 assessment#:#tst_highscore_top_table_description#:#Controls, if the table 'top ranking' should be shown.###28 08 2012 new variable
 assessment#:#tst_highscore_wtime#:#Show working time###28 08 2012 new variable
@@ -1926,10 +1920,6 @@ assessment#:#tst_show_results#:#Hiện kết quả bài kiểm tra
 assessment#:#tst_show_side_list#:#Show question list aside###24 07 2009 new variable
 assessment#:#tst_show_solution_answers_only#:#Results print view (answers only)###14 11 2007 new variable
 assessment#:#tst_show_solution_answers_only_desc#:#If is selected, the ILIAS content you place around a question using the "Edit content" tab page will not be visible in a print-out. If you want to save some paper space, select this option.###07 11 2014 new variable
-assessment#:#tst_show_solution_compare#:#Compare Answer with Solution in List of Answers###24 10 2013 new variable
-assessment#:#tst_show_solution_compare_desc#:#Participants are presented with an overview comparing their own answers with the best solutions. Please note that this view will be displayed in the ‘Detailed Results’ that can be accessed via the ‘Show Test Results‘-button on the ‘Info’-tab. It will not be displayed in the printable ‘List of Answers’ even though the setting is made here.###06 02 2015 new variable
-assessment#:#tst_show_solution_details#:#Show Solutions in Test Results###25 02 2007 new variable
-assessment#:#tst_show_solution_details_desc#:#If selected, the detailed question solution is available to participants in the test results presentation. This includes the exact scoring of every answer, otherwise only an overview with the question titles and the reached points is shown.###07 11 2014 new variable
 assessment#:#tst_show_solution_details_singlepage#:#Scored Answers on single pages###26 08 2024 new variable
 assessment#:#tst_show_solution_details_singlepage_desc#:#Participants can access each question individually and see if their answers were correct and how many points they scored.###26 08 2024 new variable
 assessment#:#tst_show_solution_feedback#:#Show Answer-Specific Feedback in Test Results###10 05 2007 new variable
@@ -1952,7 +1942,6 @@ assessment#:#tst_skill_triggerings_num_req_answers_desc#:#Competences aren't tri
 assessment#:#tst_skill_triggerings_num_req_answers_not_reached_warn#:#At least one of the competences addressed by this test is not triggered by the minimal required amount of questions.<br />The required amount of questions: %s###10 11 2018 new variable
 assessment#:#tst_skl_level_thresholds_link#:#Configure Competence-Thresholds###30 08 2015 new variable
 assessment#:#tst_skl_level_thresholds_missing#:#There are missing thresholds for the relevant competences!###30 08 2015 new variable
-assessment#:#tst_skl_res_interpretation_hint_msg#:#Please consider that competence results from a single test has a limited significance. The more information is collected per competence, the merrier valid the significance will be. Should there are single competences without any entry, there is to less information collected.###30 08 2015 new variable
 assessment#:#tst_skl_sub_tab_thresholds#:#Competence Thresholds###26 09 2014 new variable
 assessment#:#tst_sol_comp_expressions#:#Comparison Expressions###30 08 2015 new variable
 assessment#:#tst_solution_compare_cfg#:#Configuration for Solution Compare###30 08 2015 new variable
@@ -2014,7 +2003,6 @@ assessment#:#tst_unchanged_answer_is_correct#:#The preset answer is correct###fa
 assessment#:#tst_unchanged_order_is_correct#:#The preset order is correct###fau: testNav
 assessment#:#tst_use_previous_answers#:#Use Previous Answers###25 02 2007 new variable
 assessment#:#tst_use_previous_answers_description#:#If checked, a participant may choose to use the previous answers as default values in future test passes, otherwise the previous answers are not shown in future test passes###25 02 2007 new variable
-assessment#:#tst_use_previous_answers_user#:#Use my previous answers as default values in future test passes###25 02 2007 new variable
 assessment#:#tst_user_finished_test#:#User finished test (%s)###24 07 2009 new variable
 assessment#:#tst_view_competence_assign#:#View Assignment Properties###30 08 2015 new variable
 assessment#:#tst_virtual_pass_header_lo_initial#:#Initial Test Results for the Learning Objectives<br />%s###30 08 2015 new variable

--- a/lang/ilias_zh.lang
+++ b/lang/ilias_zh.lang
@@ -692,12 +692,10 @@ assessment#:#examid_in_test_res#:#ILIAS Testpass ID###27 01 2015 new variable
 assessment#:#examid_in_test_res_desc#:#The ILIAS Testpass ID will be included in the test results.###27 01 2015 new variable
 assessment#:#exp_all_test_runs#:#All test attempts###26 08 2024 new variable
 assessment#:#exp_eval_data#:#导出评价数据
-assessment#:#exp_file_created#:#Export file created.###24 10 2013 new variable
 assessment#:#exp_grammar_as#:#as###26 08 2024 new variable
 assessment#:#exp_scored_test_attempt#:#Scored Test Attempt###28 10 2024 new variable
 assessment#:#exp_type_certificate#:#Certificate (PDF) xy
 assessment#:#exp_type_excel#:#  Excel
-assessment#:#exp_type_spss#:#  SPSS
 assessment#:#expected_result_type#:#Expected result type###24 10 2013 new variable
 assessment#:#export_cert_failed_for_users_p#:#No certificate file could be generated and added for the following %s accounts: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
 assessment#:#export_cert_failed_for_users_s#:#No certificate file could be generated and added to the archive for the following account: %s. Please contact an administrator to check the log file.###26 08 2024 new variable
@@ -1433,7 +1431,6 @@ assessment#:#tst_delete_missing_mark#:#请至少选择一个标记步骤去删�
 assessment#:#tst_derive_new_pool#:#Derive New Question Pool###25 10 2016 new variable
 assessment#:#tst_derive_new_pools#:#Derive New Question Pools###25 10 2016 new variable
 assessment#:#tst_dont_show_msg_again_in_current_session#:#Don't show this message again in my current session.###10 11 2018 new variable
-assessment#:#tst_dont_use_previous_answers#:#您之前的答案将不会在未来的测试中作为默认值使用
 assessment#:#tst_edit_competence_assign#:#Edit Assignment Properties###30 08 2015 new variable
 assessment#:#tst_edit_scoring#:#编辑评分
 assessment#:#tst_enable_questionlist#:#Show 'List of Questions’###26 08 2024 new variable
@@ -1493,7 +1490,6 @@ assessment#:#tst_finish_notification#:#邮报完成
 assessment#:#tst_finish_notification_advanced#:#发送完成的测试结果给测试者
 assessment#:#tst_finish_notification_content_type#:#Content of e-mail###27 01 2015 new variable
 assessment#:#tst_finish_notification_desc#:#Sends an e-mail to the test owner for every user that has completed the test.###27 01 2015 new variable
-assessment#:#tst_finish_notification_no#:#No e-mail###06 02 2015 new variable
 assessment#:#tst_finish_notification_simple#:#发送用户名和完成日期给测试者
 assessment#:#tst_finished#:#已完成
 assessment#:#tst_form_dynamic_question_set_config#:#Continues Question Selection###24 10 2013 new variable
@@ -1507,7 +1503,6 @@ assessment#:#tst_hide_info_tab#:#Hide Info Tab###26 08 2024 new variable
 assessment#:#tst_hide_info_tab_desc#:#Hides the tab ‘Info’ of the test.###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents#:#Hide page content###26 08 2024 new variable
 assessment#:#tst_hide_pagecontents_desc#:#ILIAS content placed before and after the actual question text via the "Edit Page" button will not be displayed in the result views and print output.###26 08 2024 new variable
-assessment#:#tst_hide_side_list#:#隐藏题目列表
 assessment#:#tst_highscore_achieved_ts#:#显示测试的日期
 assessment#:#tst_highscore_achieved_ts_description#:#控制，如果测试日期应被显示的一列。
 assessment#:#tst_highscore_all_tables#:#All Rankings###07 11 2014 new variable
@@ -1527,7 +1522,6 @@ assessment#:#tst_highscore_score#:#显示得分
 assessment#:#tst_highscore_score_description#:#控制，如果得分应被显示的一列。
 assessment#:#tst_highscore_top_num#:#行列数
 assessment#:#tst_highscore_top_num_description#:#控制，多少行列应包含在顶部行列表中。
-assessment#:#tst_highscore_top_num_unit#:#条目
 assessment#:#tst_highscore_top_table#:#显示表“顶部排名”
 assessment#:#tst_highscore_top_table_description#:#控制，如果表“顶部行列”应显示。
 assessment#:#tst_highscore_wtime#:#显示工作时间
@@ -1923,10 +1917,6 @@ assessment#:#tst_show_results#:#显示测试成绩
 assessment#:#tst_show_side_list#:#在旁边显示题目列表
 assessment#:#tst_show_solution_answers_only#:#成绩打印视图(仅答案)
 assessment#:#tst_show_solution_answers_only_desc#:#If is selected, the ILIAS content you place around a question using the "Edit content" tab page will not be visible in a print-out. If you want to save some paper space, select this option.###07 11 2014 new variable
-assessment#:#tst_show_solution_compare#:#Compare Answer with Solution in List of Answers###24 10 2013 new variable
-assessment#:#tst_show_solution_compare_desc#:#Participants are presented with an overview comparing their own answers with the best solutions. Please note that this view will be displayed in the ‘Detailed Results’ that can be accessed via the ‘Show Test Results‘-button on the ‘Info’-tab. It will not be displayed in the printable ‘List of Answers’ even though the setting is made here.###06 02 2015 new variable
-assessment#:#tst_show_solution_details#:#显示测试成绩的方案
-assessment#:#tst_show_solution_details_desc#:#If selected, the detailed question solution is available to participants in the test results presentation. This includes the exact scoring of every answer, otherwise only an overview with the question titles and the reached points is shown.###07 11 2014 new variable
 assessment#:#tst_show_solution_details_singlepage#:#Scored Answers on single pages###26 08 2024 new variable
 assessment#:#tst_show_solution_details_singlepage_desc#:#Participants can access each question individually and see if their answers were correct and how many points they scored.###26 08 2024 new variable
 assessment#:#tst_show_solution_feedback#:#在测试成绩中显示特定的答案反馈
@@ -1949,7 +1939,6 @@ assessment#:#tst_skill_triggerings_num_req_answers_desc#:#Competences aren't tri
 assessment#:#tst_skill_triggerings_num_req_answers_not_reached_warn#:#At least one of the competences addressed by this test is not triggered by the minimal required amount of questions.<br />The required amount of questions: %s###10 11 2018 new variable
 assessment#:#tst_skl_level_thresholds_link#:#Configure Competence-Thresholds###30 08 2015 new variable
 assessment#:#tst_skl_level_thresholds_missing#:#There are missing thresholds for the relevant competences!###30 08 2015 new variable
-assessment#:#tst_skl_res_interpretation_hint_msg#:#Please consider that competence results from a single test has a limited significance. The more information is collected per competence, the merrier valid the significance will be. Should there are single competences without any entry, there is to less information collected.###30 08 2015 new variable
 assessment#:#tst_skl_sub_tab_thresholds#:#Competence Thresholds###26 09 2014 new variable
 assessment#:#tst_sol_comp_expressions#:#Comparison Expressions###30 08 2015 new variable
 assessment#:#tst_solution_compare_cfg#:#Configuration for Solution Compare###30 08 2015 new variable
@@ -2011,7 +2000,6 @@ assessment#:#tst_unchanged_answer_is_correct#:#The preset answer is correct###fa
 assessment#:#tst_unchanged_order_is_correct#:#The preset order is correct###fau: testNav
 assessment#:#tst_use_previous_answers#:#使用之前的答案
 assessment#:#tst_use_previous_answers_description#:#如果勾选，在未来的测试过程中，参与者可以选择使用以前的答案做为默认值，否则以前的答案不显示在未来的测试过程中
-assessment#:#tst_use_previous_answers_user#:#在未来的测试过程中使用我以前的答案做为默认值
 assessment#:#tst_user_finished_test#:#用户已完成的测试(%s)
 assessment#:#tst_view_competence_assign#:#View Assignment Properties###30 08 2015 new variable
 assessment#:#tst_virtual_pass_header_lo_initial#:#Initial Test Results for the Learning Objectives<br />%s###30 08 2015 new variable


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45954

Aims to remove many orphaned assessment language variables.

Already reviewed by @thojou.