### PR TITLE
Mantis #45742: Accordions containing Content-Snippets crash ILIAS when clicked in the page editor

### DIFF
--- a/Services/COPage/classes/class.ilPageEditorGUI.php
+++ b/Services/COPage/classes/class.ilPageEditorGUI.php
@@ -33,7 +33,7 @@ use Psr\Http\Message\ServerRequestInterface;
  * @ilCtrl_Calls ilPageEditorGUI: ilPCInteractiveImageGUI, ilPCProfileGUI, ilPCVerificationGUI
  * @ilCtrl_Calls ilPageEditorGUI: ilPCBlogGUI, ilPCQuestionOverviewGUI, ilPCSkillsGUI
  * @ilCtrl_Calls ilPageEditorGUI: ilPCConsultationHoursGUI, ilPCMyCoursesGUI, ilPCAMDPageListGUI
- * @ilCtrl_Calls ilPageEditorGUI: ilPCGridGUI, ilPCGridCellGUI, ilPageEditorServerAdapterGUI
+ * @ilCtrl_Calls ilPageEditorGUI: ilPCGridGUI, ilPCGridCellGUI, ilPageEditorServerAdapterGUI, ilMediaPoolPageGUI
  */
 class ilPageEditorGUI
 {


### PR DESCRIPTION
Fixes https://mantis.ilias.de/view.php?id=45742

If accepted should be picked into **release_10**, **release_11** & **trunk**