### PR TITLE
Object/InfoScreen: fix presentation of precondition operator (46224)

### DIFF
--- a/components/ILIAS/ILIASObject/classes/class.ilObjectListGUI.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObjectListGUI.php
@@ -1464,8 +1464,7 @@ class ilObjectListGUI
                 continue;
             }
 
-            $operator = ilConditionHandlerGUI::translateOperator($condition['trigger_obj_id'], $condition['operator'], $condition['value']);
-            $cond_txt = $operator . ' ' . $condition['value'];
+            $cond_txt = ilConditionHandlerGUI::translateOperator($condition['trigger_obj_id'], $condition['operator'], $condition['value']);
 
             // display trigger item
             $class = $this->obj_definition->getClassName($condition['trigger_type']);

--- a/components/ILIAS/InfoScreen/classes/class.ilInfoScreenGUI.php
+++ b/components/ILIAS/InfoScreen/classes/class.ilInfoScreenGUI.php
@@ -1186,8 +1186,9 @@ class ilInfoScreenGUI
             $properties[] = [
                 "condition" => ilConditionHandlerGUI::translateOperator(
                     $condition['trigger_obj_id'],
-                    $condition['operator']
-                ) . ' ' . $condition['value'],
+                    $condition['operator'],
+                    $condition['value']
+                ),
                 "title" => ilObject::_lookupTitle($condition['trigger_obj_id']),
                 "link" => ilLink::_getLink($condition['trigger_ref_id'])
             ];


### PR DESCRIPTION
This PR fixes [46224](https://mantis.ilias.de/view.php?id=46224), the unparsed `value` of a precondition should not be shown in the GUI.