### PR TITLE
AuthApache: Refactor mechanism to provide a "Username"

### DIFF
--- a/components/ILIAS/AuthApache/AuthApache.php
+++ b/components/ILIAS/AuthApache/AuthApache.php
@@ -20,6 +20,10 @@ declare(strict_types=1);
 
 namespace ILIAS;
 
+use ILIAS\Setup\Agent as SetupAgent;
+use ILIAS\ApacheAuth\Setup\ApacheAuthAgent;
+use ILIAS\ApacheAuth\UsernameProvider\UsernameProvider;
+
 class AuthApache implements Component\Component
 {
     public function init(
@@ -32,6 +36,7 @@ class AuthApache implements Component\Component
         array | \ArrayAccess &$pull,
         array | \ArrayAccess &$internal,
     ): void {
-        // ...
+        $contribute[SetupAgent::class] =
+            static fn() => new ApacheAuthAgent($seek[UsernameProvider::class]);
     }
 }

--- a/components/ILIAS/AuthApache/README.md
+++ b/components/ILIAS/AuthApache/README.md
@@ -1,0 +1,143 @@
+# Apache-based Authentication (AuthApache)
+
+This document gives a technical, in-depth introduction to the AuthApache component
+and how to extend it with custom `UsernameProvider`s.
+
+The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”,
+“SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be
+interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+**Table of Contents**
+
+## Overview
+
+`AuthApache` is responsible for handling authentication data that is provided by Apache
+(or other upstream web server components) and for producing an ILIAS username that can be used
+to map or create an ILIAS account.
+
+The username resolution is configurable (in the ILIAS "Apache Authentication" administration) with
+two alternatives:
+
+- Direct Mapping: Use a single server parameter directly as the username.
+- Username Provider: Delegate resolution to the `UsernameResolver`, which evaluates registered `UsernameProvider`s in
+ priority order to determine the first valid username.
+
+### Direct Mapping
+
+When the configuration is set to `AuthProviderApache::APACHE_AUTH_TYPE_DIRECT_MAPPING`, the username is taken
+directly from a single HTTP server parameter without transformation. The parameter key is configured via the setting
+`apache_auth_username_direct_mapping_fieldname`. If the configured key exists in
+`ServerRequestInterface->getServerParams()` and its value is non-empty, that value is used as the
+ILIAS username.
+
+### Username Provider
+
+The component exposes a small extension point: implementers can provide classes that
+implement `ILIAS\ApacheAuth\UsernameProvider\UsernameProvider` to extract a username from the incoming
+HTTP `ServerRequestInterface` in case `AuthProviderApache::APACHE_AUTH_TYPE_BY_FUNCTION` is set as mode.
+
+The following sections document the contract, expectations, and patterns for implementing such providers 
+and integrating them into ILIAS.
+
+#### Terminology and Contract
+
+- Request: A `Psr\Http\Message\ServerRequestInterface` instance representing the incoming HTTP request.
+- UsernameProvider: A class that implements `ILIAS\ApacheAuth\UsernameProvider\UsernameProvider` and returns
+ a `UsernameInterface` when invoked with a request.
+- Resolved username: A `UsernameInterface` that returns a non-empty string via `asString()` and where `isEmpty()`
+ returns `false`.
+- Null / no-result: A `UsernameInterface` that represents the absence of a username; use `NullUsername` or
+ a `UsernameInterface` implementation whose `isEmpty()` returns `true`.
+
+Contract:
+- Input: `ServerRequestInterface`.
+- Output: `ILIAS\ApacheAuth\UsernameProvider\UsernameInterface`.
+- Providers MUST NOT throw uncaught exceptions during normal resolution. They MUST catch errors and return
+  a `NullUsername` instance to preserve system stability.
+
+####  Architecture and Key Classes
+
+This section describes the responsibilities of the main classes in `UsernameProvider`.
+
+`UsernameProvider` interface
+
+Responsibilities:
+- Define two methods:
+  - `getPriority(): int`: Higher values are evaluated earlier by `UsernameResolver`.
+  - `getUsername(ServerRequestInterface $request): UsernameInterface`: Return a resolved `Username` or
+   an empty representation.
+
+Implementation notes:
+- Classes that implement `UsernameProvider` should be stateless or at least safely
+  instantiable without external dependencies if they are to be used
+  with `UsernameProviderFactory::fromClassNames()`.
+
+`UsernameInterface`, `Username`, `NullUsername`
+
+- `UsernameInterface` is an interface and defines `asString(): string` and `isEmpty(): bool`.
+- `Username` is an immutable value object that contains a non-empty username and throws on construction
+  if the supplied string is empty.
+- `NullUsername` is the marker object for "no username resolved" and returns an empty string
+ and `isEmpty() === true`.
+
+`UsernameProviderFactory`
+
+Behavior:
+- Accepts a list of fully-qualified class names.
+- It attempts to instantiate each class with and only returns objects
+ that implement `UsernameProvider`.
+
+Implications:
+- The factory intentionally keeps instantiation simple. Providers MUST be instantiable without
+  constructor arguments to be used here.
+
+`UsernameResolver`
+
+Behavior:
+- Sorts providers by `getPriority()` in descending order.
+- Invokes `getUsername()` for each provider in order and returns the first non-empty `UsernameInterface`.
+- If none returns a non-empty username it returns `NullUsername`.
+
+#### Example
+
+This example is the minimal, idiomatic approach.
+
+```php
+<?php
+
+use ILIAS\ApacheAuth\UsernameProvider\UsernameProvider;
+use ILIAS\ApacheAuth\UsernameProvider\Username;
+use ILIAS\ApacheAuth\UsernameProvider\NullUsername;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class HeaderUsernameProvider implements UsernameProvider
+{
+    public function getPriority(): int
+    {
+        return 100;
+    }
+
+    public function getUsername(ServerRequestInterface $request): \ILIAS\ApacheAuth\UsernameProvider\UsernameInterface
+    {
+        try {
+            $values = $request->getHeader('REMOTE_USER');
+            if (empty($values)) {
+                return new NullUsername();
+            }
+
+            $candidate = trim($values[0]);
+            if ($candidate === '') {
+                return new NullUsername();
+            }
+
+            if (preg_match('/\s/', $candidate)) {
+                return new NullUsername();
+            }
+
+            return new Username($candidate);
+        } catch (\Throwable $e) {
+            return new NullUsername();
+        }
+    }
+}
+```

--- a/components/ILIAS/AuthApache/phpunit.xml
+++ b/components/ILIAS/AuthApache/phpunit.xml
@@ -27,7 +27,7 @@
     </logging>
     <source>
         <include>
-            <directory suffix=".php">classes</directory>
+            <directory suffix=".php">src</directory>
         </include>
     </source>
 </phpunit>

--- a/components/ILIAS/AuthApache/src/AuthFrontendCredentialsApache.php
+++ b/components/ILIAS/AuthApache/src/AuthFrontendCredentialsApache.php
@@ -18,17 +18,28 @@
 
 declare(strict_types=1);
 
-use Psr\Http\Message\ServerRequestInterface;
+namespace ILIAS\AuthApache;
 
-class ilAuthFrontendCredentialsApache extends ilAuthFrontendCredentials
+use Psr\Http\Message\ServerRequestInterface;
+use ilAuthFrontendCredentials;
+use ilUtil;
+use ilSetting;
+use ilContext;
+use ilLogLevel;
+use ilCtrlInterface;
+use ILIAS\ApacheAuth\UsernameProvider\CollectUsernameProvidersObjective;
+use ILIAS\ApacheAuth\UsernameProvider\UsernameProviderFactory;
+use ILIAS\ApacheAuth\UsernameProvider\UsernameResolver;
+
+class AuthFrontendCredentialsApache extends ilAuthFrontendCredentials
 {
-    private ServerRequestInterface $httpRequest;
+    private ServerRequestInterface $http_request;
     private ilCtrlInterface $ctrl;
     private ilSetting $settings;
 
-    public function __construct(ServerRequestInterface $httpRequest, ilCtrlInterface $ctrl)
+    public function __construct(ServerRequestInterface $http_request, ilCtrlInterface $ctrl)
     {
-        $this->httpRequest = $httpRequest;
+        $this->http_request = $http_request;
         $this->ctrl = $ctrl;
         $this->settings = new ilSetting('apache_auth');
         parent::__construct();
@@ -40,9 +51,9 @@ class ilAuthFrontendCredentialsApache extends ilAuthFrontendCredentials
      */
     public function tryAuthenticationOnLoginPage(): void
     {
-        $cmd = (string) ($this->httpRequest->getQueryParams()['cmd'] ?? '');
+        $cmd = (string) ($this->http_request->getQueryParams()['cmd'] ?? '');
         if ($cmd === '') {
-            $cmd = (string) ($this->httpRequest->getParsedBody()['cmd'] ?? '');
+            $cmd = (string) ($this->http_request->getParsedBody()['cmd'] ?? '');
         }
 
         if ($cmd === 'force_login') {
@@ -57,15 +68,13 @@ class ilAuthFrontendCredentialsApache extends ilAuthFrontendCredentials
             return;
         }
 
-        if (
-            (defined('IL_CERT_SSO') && (int) IL_CERT_SSO === 1) ||
+        if ((\defined('IL_CERT_SSO') && \IL_CERT_SSO === true) ||
             !ilContext::supportsRedirects() ||
-            isset($this->httpRequest->getQueryParams()['passed_sso'])
-        ) {
+            isset($this->http_request->getQueryParams()['passed_sso'])) {
             return;
         }
 
-        $path = (string) ($this->httpRequest->getServerParams()['REQUEST_URI'] ?? '');
+        $path = (string) ($this->http_request->getServerParams()['REQUEST_URI'] ?? '');
         if (str_starts_with($path, '/')) {
             $path = substr($path, 1);
         }
@@ -94,46 +103,51 @@ class ilAuthFrontendCredentialsApache extends ilAuthFrontendCredentials
 
     public function initFromRequest(): void
     {
-        $mappingFieldName = $this->getSettings()->get('apache_auth_username_direct_mapping_fieldname', '');
+        $mapping_field_name = $this->getSettings()->get('apache_auth_username_direct_mapping_fieldname', '');
 
-        $this->logger->dump($this->httpRequest->getServerParams(), ilLogLevel::DEBUG);
-        $this->logger->debug($mappingFieldName);
+        $this->logger->dump($this->http_request->getServerParams(), ilLogLevel::DEBUG);
+        $this->logger->debug($mapping_field_name);
 
         switch ($this->getSettings()->get('apache_auth_username_config_type')) {
-            case ilAuthProviderApache::APACHE_AUTH_TYPE_DIRECT_MAPPING:
-                if (isset($this->httpRequest->getServerParams()[$mappingFieldName])) {
-                    $this->setUsername($this->httpRequest->getServerParams()[$mappingFieldName]);
+            case AuthProviderApache::APACHE_AUTH_TYPE_DIRECT_MAPPING:
+                if (isset($this->http_request->getServerParams()[$mapping_field_name])) {
+                    $this->setUsername($this->http_request->getServerParams()[$mapping_field_name]);
                 }
                 break;
 
-            case ilAuthProviderApache::APACHE_AUTH_TYPE_BY_FUNCTION:
-                $this->setUsername(ApacheCustom::getUsername());
+            case AuthProviderApache::APACHE_AUTH_TYPE_BY_FUNCTION:
+                $factory = new UsernameProviderFactory();
+                $resolver = new UsernameResolver($factory->fromClassNames(
+                    require CollectUsernameProvidersObjective::PATH()
+                ), $this->logger);
+
+                $this->setUsername($resolver->resolve($this->http_request)->asString());
                 break;
         }
     }
 
     public function hasValidTargetUrl(): bool
     {
-        $targetUrl = trim((string) ($this->httpRequest->getQueryParams()['r'] ?? ''));
-        if ($targetUrl === '') {
+        $target_url = trim((string) ($this->http_request->getQueryParams()['r'] ?? ''));
+        if ($target_url === '') {
             return false;
         }
 
-        $validDomains = [];
+        $valid_hosts = [];
         $path = ILIAS_DATA_DIR . '/' . CLIENT_ID . '/apache_auth_allowed_domains.txt';
         if (file_exists($path) && is_readable($path)) {
             foreach (file($path) as $line) {
                 if (trim($line)) {
-                    $validDomains[] = trim($line);
+                    $valid_hosts[] = trim($line);
                 }
             }
         }
 
-        return (new ilWhiteListUrlValidator($targetUrl, $validDomains))->isValid();
+        return (new WhiteListUrlValidator($target_url, $valid_hosts))->isValid();
     }
 
     public function getTargetUrl(): string
     {
-        return ilUtil::appendUrlParameterString(trim($this->httpRequest->getQueryParams()['r']), 'passed_sso=1');
+        return ilUtil::appendUrlParameterString(trim($this->http_request->getQueryParams()['r']), 'passed_sso=1');
     }
 }

--- a/components/ILIAS/AuthApache/src/AuthProviderApache.php
+++ b/components/ILIAS/AuthApache/src/AuthProviderApache.php
@@ -18,13 +18,30 @@
 
 declare(strict_types=1);
 
-final class ilAuthProviderApache extends ilAuthProvider implements ilAuthProviderAccountMigrationInterface
+namespace ILIAS\AuthApache;
+
+use ilUtil;
+use ilAuthCredentials;
+use ilLDAPSynchronisationFailedException;
+use ilSetting;
+use ilAuthUtils;
+use ilObjUser;
+use ilAuthProvider;
+use ilLDAPServer;
+use ilLDAPSynchronisationForbiddenException;
+use ilAuthStatus;
+use ilAuthProviderAccountMigrationInterface;
+use ilLDAPAccountMigrationRequiredException;
+use ilLDAPUserSynchronisation;
+
+final class AuthProviderApache extends ilAuthProvider implements ilAuthProviderAccountMigrationInterface
 {
     public const int APACHE_AUTH_TYPE_DIRECT_MAPPING = 1;
     public const int APACHE_AUTH_TYPE_EXTENDED_MAPPING = 2;
     public const int APACHE_AUTH_TYPE_BY_FUNCTION = 3;
 
     private const string ENV_APACHE_AUTH_INDICATOR_NAME = 'apache_auth_indicator_name';
+    private const string ENV_APACHE_AUTH_INDICATOR_VALUE = 'apache_auth_indicator_value';
 
     private const string ERR_WRONG_LOGIN = 'err_wrong_login';
 
@@ -49,24 +66,27 @@ final class ilAuthProviderApache extends ilAuthProvider implements ilAuthProvide
             return false;
         }
 
-        if (
-            !$this->settings->get(self::ENV_APACHE_AUTH_INDICATOR_NAME, '') ||
-            !$this->settings->get('apache_auth_indicator_value', '')
-        ) {
+        if (!$this->settings->get(self::ENV_APACHE_AUTH_INDICATOR_NAME, '') ||
+            !$this->settings->get(self::ENV_APACHE_AUTH_INDICATOR_VALUE, '')) {
             $this->getLogger()->warning('Apache auth indicator match failure.');
             $this->handleAuthenticationFail($status, 'apache_auth_err_indicator_match_failure');
             return false;
         }
 
-        $validIndicatorValues = array_filter(array_map(
-            'trim',
-            str_getcsv($this->settings->get('apache_auth_indicator_value', ''), ',', '"', '\\')
-        ));
+        $validIndicatorValues = array_filter(
+            array_map(
+                'trim',
+                str_getcsv($this->settings->get(self::ENV_APACHE_AUTH_INDICATOR_VALUE, ''), ',', '"', '\\')
+            )
+        );
+
         //TODO PHP8-REVIEW: $DIC->http()->request()->getServerParams()['apache_auth_indicator_name']
-        if (
-            !isset($_SERVER[$this->settings->get(self::ENV_APACHE_AUTH_INDICATOR_NAME, '')]) ||
-            !in_array($_SERVER[$this->settings->get(self::ENV_APACHE_AUTH_INDICATOR_NAME, '')], $validIndicatorValues, true)
-        ) {
+        if (!isset($_SERVER[$this->settings->get(self::ENV_APACHE_AUTH_INDICATOR_NAME, '')]) ||
+            !\in_array(
+                $_SERVER[$this->settings->get(self::ENV_APACHE_AUTH_INDICATOR_NAME, '')],
+                $validIndicatorValues,
+                true
+            )) {
             $this->getLogger()->warning('Apache authentication failed (indicator name <-> value');
             $this->handleAuthenticationFail($status, self::ERR_WRONG_LOGIN);
             return false;
@@ -92,7 +112,9 @@ final class ilAuthProviderApache extends ilAuthProvider implements ilAuthProvide
         $login = ilObjUser::_checkExternalAuthAccount('apache', $this->getCredentials()->getUsername());
         $usr_id = ilObjUser::_lookupId($login);
         if (!$usr_id) {
-            $this->getLogger()->info('Cannot find user id for external account: ' . $this->getCredentials()->getUsername());
+            $this->getLogger()->info(
+                'Cannot find user id for external account: ' . $this->getCredentials()->getUsername()
+            );
             $this->handleAuthenticationFail($status, self::ERR_WRONG_LOGIN);
             return false;
         }
@@ -159,7 +181,7 @@ final class ilAuthProviderApache extends ilAuthProvider implements ilAuthProvide
         try {
             $internal_account = $sync->sync();
             $this->getLogger()->debug('Internal account: ' . $internal_account);
-        } catch (UnexpectedValueException $e) {
+        } catch (\UnexpectedValueException $e) {
             $this->getLogger()->info('Login failed with message: ' . $e->getMessage());
             $this->handleAuthenticationFail($status, self::ERR_WRONG_LOGIN);
             return false;
@@ -172,7 +194,10 @@ final class ilAuthProviderApache extends ilAuthProvider implements ilAuthProvide
             return false;
         } catch (ilLDAPAccountMigrationRequiredException) {
             $this->setExternalAccountName($this->getCredentials()->getUsername());
-            $this->getLogger()->info('Authentication failed: account migration required for external account: ' . $this->getCredentials()->getUsername());
+            $this->getLogger()->info(\sprintf(
+                'Authentication failed: account migration required for external account: %s',
+                $this->getCredentials()->getUsername()
+            ));
             $status->setStatus(ilAuthStatus::STATUS_ACCOUNT_MIGRATION_REQUIRED);
             return false;
         }

--- a/components/ILIAS/AuthApache/src/Setup/ApacheAuthAgent.php
+++ b/components/ILIAS/AuthApache/src/Setup/ApacheAuthAgent.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\ApacheAuth\Setup;
+
+use ILIAS\Setup;
+use ILIAS\ApacheAuth\UsernameProvider;
+
+class ApacheAuthAgent implements Setup\Agent
+{
+    use Setup\Agent\HasNoNamedObjective;
+
+    /**
+     * @param list<UsernameProvider\UsernameProvider> $username_provider_contributions
+     */
+    public function __construct(
+        private readonly array $username_provider_contributions
+    ) {
+    }
+
+    public function hasConfig(): bool
+    {
+        return false;
+    }
+
+    public function getArrayToConfigTransformation(): \ILIAS\Refinery\Transformation
+    {
+        throw new \LogicException(self::class . ' has no Config.');
+    }
+
+    public function getInstallObjective(?Setup\Config $config = null): Setup\Objective
+    {
+        return new Setup\ObjectiveCollection(
+            'Installing ApacheAuthentication',
+            false,
+            new UsernameProvider\CollectUsernameProvidersObjective($this->username_provider_contributions)
+        );
+    }
+
+    public function getBuildObjective(): Setup\Objective
+    {
+        return new Setup\ObjectiveCollection(
+            'Building ApacheAuthentication',
+            false,
+            new UsernameProvider\CollectUsernameProvidersObjective($this->username_provider_contributions)
+        );
+    }
+
+    public function getUpdateObjective(?Setup\Config $config = null): Setup\Objective
+    {
+        return new Setup\ObjectiveCollection(
+            'Updating ApacheAuthentication',
+            false,
+            new UsernameProvider\CollectUsernameProvidersObjective($this->username_provider_contributions)
+        );
+    }
+
+    public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
+
+    public function getMigrations(): array
+    {
+        return [];
+    }
+}

--- a/components/ILIAS/AuthApache/src/UsernameProvider/CollectUsernameProvidersObjective.php
+++ b/components/ILIAS/AuthApache/src/UsernameProvider/CollectUsernameProvidersObjective.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\ApacheAuth\UsernameProvider;
+
+use ILIAS\Setup\Artifact;
+
+class CollectUsernameProvidersObjective extends Artifact\BuildArtifactObjective
+{
+    /**
+     * @param list<UsernameProvider> $contributions
+     */
+    public function __construct(
+        private readonly array $contributions
+    ) {
+    }
+
+    public function getArtifactName(): string
+    {
+        return 'apache_auth_username_providers';
+    }
+
+    public function build(): Artifact
+    {
+        return new Artifact\ArrayArtifact(
+            array_map(
+                static fn(UsernameProvider $p): string => $p::class,
+                $this->contributions
+            )
+        );
+    }
+}

--- a/components/ILIAS/AuthApache/src/UsernameProvider/NullUsername.php
+++ b/components/ILIAS/AuthApache/src/UsernameProvider/NullUsername.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ * *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\ApacheAuth\UsernameProvider;
+
+final class NullUsername implements UsernameInterface
+{
+    public function asString(): string
+    {
+        return '';
+    }
+
+    public function isEmpty(): bool
+    {
+        return true;
+    }
+
+    public function __toString(): string
+    {
+        return '';
+    }
+}

--- a/components/ILIAS/AuthApache/src/UsernameProvider/Username.php
+++ b/components/ILIAS/AuthApache/src/UsernameProvider/Username.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\ApacheAuth\UsernameProvider;
+
+final readonly class Username implements UsernameInterface
+{
+    public function __construct(private string $username)
+    {
+        if (trim($username) === '') {
+            throw new \InvalidArgumentException('Username cannot be empty');
+        }
+    }
+
+    public function asString(): string
+    {
+        return $this->__toString();
+    }
+
+    public function isEmpty(): bool
+    {
+        return false;
+    }
+
+    public function __toString(): string
+    {
+        return $this->username;
+    }
+}

--- a/components/ILIAS/AuthApache/src/UsernameProvider/UsernameInterface.php
+++ b/components/ILIAS/AuthApache/src/UsernameProvider/UsernameInterface.php
@@ -14,20 +14,24 @@
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- *********************************************************************/
+ * *********************************************************************/
 
 declare(strict_types=1);
 
-final class ApacheCustom
+namespace ILIAS\ApacheAuth\UsernameProvider;
+
+/**
+ * Implementations may represent a resolved, concrete username or a null/empty value.
+ */
+interface UsernameInterface
 {
-    public static function getUsername(): string
-    {
-        /*
-         * enter your custom login-name resolve function here
-         *
-         * if you are using the "auto create account" feature
-         * be sure to return a valid username IN ANY CASE
-         */
-        return '';
-    }
+    /**
+     * Returns the username as string
+     */
+    public function asString(): string;
+
+    /**
+     * True if this represents an empty (non-real) username.
+     */
+    public function isEmpty(): bool;
 }

--- a/components/ILIAS/AuthApache/src/UsernameProvider/UsernameProvider.php
+++ b/components/ILIAS/AuthApache/src/UsernameProvider/UsernameProvider.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\ApacheAuth\UsernameProvider;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+interface UsernameProvider
+{
+    /**
+     * Priority semantics: higher values are processed earlier
+     */
+    public function getPriority(): int;
+
+    public function getUsername(ServerRequestInterface $request): UsernameInterface;
+}

--- a/components/ILIAS/AuthApache/src/UsernameProvider/UsernameProviderFactory.php
+++ b/components/ILIAS/AuthApache/src/UsernameProvider/UsernameProviderFactory.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\ApacheAuth\UsernameProvider;
+
+final class UsernameProviderFactory
+{
+    /**
+     * @param list<class-string<UsernameProvider>> $class_names
+     * @return list<UsernameProvider>
+     */
+    public function fromClassNames(array $class_names): array
+    {
+        $instances = [];
+        foreach ($class_names as $class) {
+            if (!\is_string($class) || !class_exists($class)) {
+                continue;
+            }
+
+            try {
+                $obj = new $class();
+            } catch (\Throwable) {
+                continue;
+            }
+
+            if ($obj instanceof UsernameProvider) {
+                $instances[] = $obj;
+            }
+        }
+
+        return $instances;
+    }
+}

--- a/components/ILIAS/AuthApache/src/UsernameProvider/UsernameResolver.php
+++ b/components/ILIAS/AuthApache/src/UsernameProvider/UsernameResolver.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\ApacheAuth\UsernameProvider;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Resolves a username by selecting the first provider (by descending priority)
+ * that returns a non-empty/non-null value for getUsername().
+ */
+final class UsernameResolver
+{
+    /** @var list<UsernameProvider> */
+    private array $providers;
+
+    /**
+     * @param list<UsernameProvider> $providers
+     */
+    public function __construct(array $providers, private readonly \ilLogger $logger)
+    {
+        if (!array_is_list($providers)) {
+            throw new \InvalidArgumentException('Providers must be passed as list');
+        }
+
+        $this->providers = $providers;
+
+        // Sort by descending priority, this also ensures the expected type of the elements
+        usort(
+            $this->providers,
+            static fn(UsernameProvider $a, UsernameProvider $b): int => $b->getPriority() <=> $a->getPriority()
+        );
+    }
+
+    public function resolve(ServerRequestInterface $request): UsernameInterface
+    {
+        foreach ($this->providers as $provider) {
+            $this->logger->debug('Trying to resolve username using provider {provider} with prio {priority}', [
+                'provider' => $provider::class,
+                'priority' => $provider->getPriority(),
+            ]);
+
+            $username = $provider->getUsername($request);
+
+            if (!$username->isEmpty()) {
+                $this->logger->debug('Username resolved to {username} by provider {provider}', [
+                    'username' => $username->asString(),
+                    'provider' => $provider::class,
+                ]);
+
+                return $username;
+            }
+
+            $this->logger->debug('Provider {provider} could not resolve a username', [
+                'provider' => $provider::class,
+            ]);
+        }
+
+        $this->logger->debug('No username could be resolved by any provider, returning NullUsername');
+
+        return new NullUsername();
+    }
+}

--- a/components/ILIAS/AuthApache/src/WhiteListUrlValidator.php
+++ b/components/ILIAS/AuthApache/src/WhiteListUrlValidator.php
@@ -18,7 +18,9 @@
 
 declare(strict_types=1);
 
-final readonly class ilWhiteListUrlValidator
+namespace ILIAS\AuthApache;
+
+final readonly class WhiteListUrlValidator
 {
     /** @var list<string> */
     private array $whitelist;
@@ -29,26 +31,25 @@ final readonly class ilWhiteListUrlValidator
     public function __construct(private string $url, array $whitelist)
     {
         $this->whitelist = array_filter(array_map(static function (string $domain): string {
-            return trim($domain); // Used for trimming and type validation (strict primitive type hint)
+            return trim($domain);
         }, $whitelist));
     }
 
-    private function isValidDomain(string $domain): bool
+    private function isValidHost(string $host): bool
     {
-        foreach ($this->whitelist as $validDomain) {
-            if ($domain === $validDomain) {
+        foreach ($this->whitelist as $valid_host) {
+            if ($host === $valid_host) {
                 return true;
             }
 
-            $firstChar = $validDomain[0];
-            if ('.' !== $firstChar) {
-                $validDomain = '.' . $validDomain;
+            if (!str_starts_with($valid_host, '.')) {
+                $valid_host = '.' . $valid_host;
             }
 
-            if ((strlen($domain) > strlen($validDomain)) && substr(
-                $domain,
-                (0 - strlen($validDomain))
-            ) === $validDomain) {
+            if ((\strlen($host) > \strlen($valid_host)) && substr(
+                $host,
+                (0 - \strlen($valid_host))
+            ) === $valid_host) {
                 return true;
             }
         }
@@ -58,11 +59,11 @@ final readonly class ilWhiteListUrlValidator
 
     public function isValid(): bool
     {
-        $redirectDomain = parse_url($this->url, PHP_URL_HOST);
-        if (null === $redirectDomain) {
+        $host = parse_url($this->url, PHP_URL_HOST);
+        if ($host === null) {
             return false;
         }
 
-        return $this->isValidDomain($redirectDomain);
+        return $this->isValidHost($host);
     }
 }

--- a/components/ILIAS/AuthApache/tests/ilWhiteListUrlValidatorTest.php
+++ b/components/ILIAS/AuthApache/tests/ilWhiteListUrlValidatorTest.php
@@ -19,6 +19,7 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
+use ILIAS\AuthApache\WhiteListUrlValidator;
 
 final class ilWhiteListUrlValidatorTest extends TestCase
 {
@@ -63,6 +64,6 @@ final class ilWhiteListUrlValidatorTest extends TestCase
     #[\PHPUnit\Framework\Attributes\DataProvider('domainProvider')]
     public function testValidator(string $domain, array $whitelist, bool $result): void
     {
-        $this->assertSame((new ilWhiteListUrlValidator($domain, $whitelist))->isValid(), $result);
+        $this->assertSame((new WhiteListUrlValidator($domain, $whitelist))->isValid(), $result);
     }
 }

--- a/components/ILIAS/Authentication/classes/Provider/class.ilAuthProviderFactory.php
+++ b/components/ILIAS/Authentication/classes/Provider/class.ilAuthProviderFactory.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\AuthApache\AuthProviderApache;
+
 class ilAuthProviderFactory
 {
     private ilLogger $logger;
@@ -76,7 +78,7 @@ class ilAuthProviderFactory
 
             case ilAuthUtils::AUTH_APACHE:
                 $this->logger->debug('Using apache authentication.');
-                return new ilAuthProviderApache($credentials);
+                return new AuthProviderApache($credentials);
 
             case ilAuthUtils::AUTH_SHIBBOLETH:
                 $this->logger->debug('Using shibboleth authentication.');

--- a/components/ILIAS/Init/classes/class.ilStartUpGUI.php
+++ b/components/ILIAS/Init/classes/class.ilStartUpGUI.php
@@ -31,6 +31,7 @@ use ILIAS\DataProtection\Consumer as DataProtection;
 use ILIAS\components\Authentication\Logout\ConfigurableLogoutTarget;
 use ILIAS\LegalDocuments\Conductor;
 use ILIAS\components\Authentication\Pages\AuthPageEditorContext;
+use ILIAS\AuthApache\AuthFrontendCredentialsApache;
 
 /**
  * @ilCtrl_Calls ilStartUpGUI: ilAccountRegistrationGUI, ilPasswordAssistanceGUI, ilLoginPageGUI, ilDashboardGUI
@@ -308,7 +309,7 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
         $credentials->setPassword($soapPw);
         $credentials->tryAuthenticationOnLoginPage();
 
-        $frontend = new ilAuthFrontendCredentialsApache($this->httpRequest, $this->ctrl);
+        $frontend = new AuthFrontendCredentialsApache($this->httpRequest, $this->ctrl);
         $frontend->tryAuthenticationOnLoginPage();
 
         $tpl = self::initStartUpTemplate('tpl.login.html');
@@ -663,7 +664,7 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
     {
         $this->getLogger()->debug('Trying apache authentication');
 
-        $credentials = new ilAuthFrontendCredentialsApache($this->httpRequest, $this->ctrl);
+        $credentials = new AuthFrontendCredentialsApache($this->httpRequest, $this->ctrl);
         $credentials->initFromRequest();
 
         $provider_factory = new ilAuthProviderFactory();


### PR DESCRIPTION
This PR proposes an improvement to how components can provide the "Username" for "Apache Authentication".

Until now, developers have been required to override the `custom_username_func.php` file.
However, this file is version-controlled in Git, meaning any modification results in a local change. In addition, the file defines a PHP class, which violates PSR-4 conventions.

The new approach leverages the "Component Revision" (where applicable), avoids the use of static methods, and introduces a clean interface and clear semantics for components to:

1. Contribute a "Username Provider"
2. Let the "Username Provider" indicate whether it is relevant for the current server request
3. Define a priority, which determines the order of evaluation (this concept is, of course, not set in stone and may evolve)