### PR TITLE
Fix(Accessibility): Add aria-modal and aria-labelledby to UI Modals.

### DIFF
--- a/components/ILIAS/UI/src/templates/default/Modal/tpl.interruptive.html
+++ b/components/ILIAS/UI/src/templates/default/Modal/tpl.interruptive.html
@@ -1,10 +1,10 @@
-<dialog class="c-modal c-modal--interruptive" tabindex="-1" id="{ID}">
+<dialog class="c-modal c-modal--interruptive" tabindex="-1" id="{ID}" aria-modal="true" aria-labelledby="{ID}_title">
 	<div class="modal-dialog" role="document">
 		<form action="{FORM_ACTION}" method="POST">
 			<div class="modal-content">
 				<div class="modal-header">
 					<button formmethod="dialog" class="close" aria-label="{CLOSE_LABEL}"><span aria-hidden="true">&times;</span></button>
-					<h1 class="modal-title">{TITLE}</h1>
+					<h1 id="{ID}_title" class="modal-title">{TITLE}</h1>
 				</div>
 				<div class="modal-body">
 					<div class="alert alert-warning c-modal--interruptive__message" role="alert">

--- a/components/ILIAS/UI/src/templates/default/Modal/tpl.lightbox.html
+++ b/components/ILIAS/UI/src/templates/default/Modal/tpl.lightbox.html
@@ -1,9 +1,9 @@
-<dialog class="c-modal c-modal--lightbox il-modal-lightbox il-modal-lightbox-{COLOR_SCHEME}" tabindex="-1" id="{ID}">
+<dialog class="c-modal c-modal--lightbox il-modal-lightbox il-modal-lightbox-{COLOR_SCHEME}" tabindex="-1" id="{ID}" aria-modal="true" aria-labelledby="{ID}_title">
 	<div class="modal-dialog modal-lg" role="document">
 		<div class="modal-content il-modal-lightbox-page">
 			<div class="modal-header">
 				<form><button formmethod="dialog" class="close" aria-label="{CLOSE_LABEL}"><span aria-hidden="true">&times;</span></button></form>
-				<h1 class="modal-title">{TITLE}</h1>
+				<h1 id="{ID}_title" class="modal-title">{TITLE}</h1>
 			</div>
 			<div class="modal-body">
 				<div id="{ID_CAROUSEL}" class="carousel slide" data-ride="carousel" data-interval="false">

--- a/components/ILIAS/UI/src/templates/default/Modal/tpl.roundtrip.html
+++ b/components/ILIAS/UI/src/templates/default/Modal/tpl.roundtrip.html
@@ -1,9 +1,9 @@
-<dialog class="c-modal il-modal-roundtrip" tabindex="-1" id="{ID}">
+<dialog class="c-modal il-modal-roundtrip" tabindex="-1" id="{ID}" aria-modal="true" aria-labelledby="{ID}_title">
 	<div class="modal-dialog" role="document" data-replace-marker="component">
 		<div class="modal-content">
 			<div class="modal-header">
 				<form><button formmethod="dialog" class="close" aria-label="{CLOSE_LABEL}"><span aria-hidden="true">&times;</span></button></form>
-				<h1 class="modal-title">{TITLE}</h1>
+				<h1 id="{ID}_title" class="modal-title">{TITLE}</h1>
 			</div>
 			<div class="modal-body">
 				<!-- BEGIN with_content -->

--- a/components/ILIAS/UI/tests/Component/Dropzone/File/StandardTest.php
+++ b/components/ILIAS/UI/tests/Component/Dropzone/File/StandardTest.php
@@ -42,10 +42,10 @@ class StandardTest extends FileTestBase
 
         $expected_html = $this->brutallyTrimHTML('
 <div id="id_4" class="ui-dropzone ">
-    <dialog class="c-modal il-modal-roundtrip" tabindex="-1" id="id_1">
+    <dialog class="c-modal il-modal-roundtrip" tabindex="-1" id="id_1" aria-modal="true" aria-labelledby="id_1_title">
 		<div class="modal-dialog" role="document" data-replace-marker="component">
 			<div class="modal-content">
-				<div class="modal-header"><form><button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button></form><h1 class="modal-title">' . $expected_title . ' </h1></div>
+				<div class="modal-header"><form><button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button></form><h1 id="id_1_title" class="modal-title">' . $expected_title . ' </h1></div>
 				<div class="modal-body">
 					<form id="id_2" class="c-form c-form--horizontal" enctype="multipart/form-data" action="' . $expected_url . '" method="post">' . $this->input->getCanonicalName() . '</form>
 				</div>
@@ -111,10 +111,10 @@ class StandardTest extends FileTestBase
 
         $expected_html = $this->brutallyTrimHTML('
 <div id="id_4" class="ui-dropzone ui-dropzone-bulky">
-	<dialog class="c-modal il-modal-roundtrip" tabindex="-1" id="id_1">
+	<dialog class="c-modal il-modal-roundtrip" tabindex="-1" id="id_1" aria-modal="true" aria-labelledby="id_1_title">
 		<div class="modal-dialog" role="document" data-replace-marker="component">
 			<div class="modal-content">
-				<div class="modal-header"><form><button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button></form><h1 class="modal-title">' . $expected_title . ' </h1></div>
+				<div class="modal-header"><form><button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button></form><h1 id="id_1_title" class="modal-title">' . $expected_title . ' </h1></div>
 				<div class="modal-body">
 					<form id="id_2" class="c-form c-form--horizontal" enctype="multipart/form-data" action="' . $expected_url . '" method="post">' . $this->input->getCanonicalName() . '</form>
 				</div>

--- a/components/ILIAS/UI/tests/Component/Dropzone/File/WrapperTest.php
+++ b/components/ILIAS/UI/tests/Component/Dropzone/File/WrapperTest.php
@@ -38,10 +38,10 @@ class WrapperTest extends FileTestBase
         $expected_html = $this->brutallyTrimHTML(
             '
 <div id="id_4" class="ui-dropzone ui-dropzone-wrapper">
-    <dialog class="c-modal il-modal-roundtrip" tabindex="-1" id="id_1">
+    <dialog class="c-modal il-modal-roundtrip" tabindex="-1" id="id_1" aria-modal="true" aria-labelledby="id_1_title">
         <div class="modal-dialog" role="document" data-replace-marker="component">
             <div class="modal-content">
-                <div class="modal-header"><form><button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button></form><h1 class="modal-title">' . $expected_title . ' </h1></div>
+                <div class="modal-header"><form><button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button></form><h1 id="id_1_title" class="modal-title">' . $expected_title . ' </h1></div>
                 <div class="modal-body">
                     <form id="id_2" class="c-form c-form--horizontal" enctype="multipart/form-data" action="' . $expected_url . '" method="post">File Field Input</form>
                 </div>

--- a/components/ILIAS/UI/tests/Component/Launcher/LauncherInlineTest.php
+++ b/components/ILIAS/UI/tests/Component/Launcher/LauncherInlineTest.php
@@ -221,12 +221,12 @@ class LauncherInlineTest extends ILIAS_UI_TestBase
     </div>
     <button class="btn btn-bulky" id="id_5" disabled="disabled"><span class="glyph" role="img"><span class="glyphicon glyphicon-launch" aria-hidden="true"></span></span><span class="bulky-label">different label</span></button>
     <div class="c-launcher__form">
-        <dialog class="c-modal il-modal-roundtrip" tabindex="-1" id="id_1">
+        <dialog class="c-modal il-modal-roundtrip" tabindex="-1" id="id_1" aria-modal="true" aria-labelledby="id_1_title">
             <div class="modal-dialog" role="document" data-replace-marker="component">
                 <div class="modal-content">
                     <div class="modal-header">
                         <form><button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button></form>
-                        <h1 class="modal-title">different label</h1>
+                        <h1 id="id_1_title" class="modal-title">different label</h1>
                     </div>
                     <div class="modal-body">$msg_html
                         <form id="id_3" class="c-form c-form--horizontal" enctype="multipart/form-data" action="http://localhost/ilias.php" method="post">

--- a/components/ILIAS/UI/tests/Component/Modal/InterruptiveTest.php
+++ b/components/ILIAS/UI/tests/Component/Modal/InterruptiveTest.php
@@ -113,13 +113,13 @@ class InterruptiveTest extends ModalBase
     protected function getExpectedHTML(bool $with_items = false): string
     {
         $expected_start = <<<EOT
-<dialog class="c-modal c-modal--interruptive" tabindex="-1" id="id_1">
+<dialog class="c-modal c-modal--interruptive" tabindex="-1" id="id_1" aria-modal="true" aria-labelledby="id_1_title">
 	<div class="modal-dialog" role="document">
 		<form action="myAction.php" method="POST">
 			<div class="modal-content">
 				<div class="modal-header">
 					<button formmethod="dialog" class="close" aria-label="cancel"><span aria-hidden="true">&times;</span></button>
-					<h1 class="modal-title">Title</h1>
+					<h1 id="id_1_title" class="modal-title">Title</h1>
 				</div>
 				<div class="modal-body">
 					<div class="alert alert-warning c-modal--interruptive__message" role="alert">Message</div>

--- a/components/ILIAS/UI/tests/Component/Modal/LightboxTest.php
+++ b/components/ILIAS/UI/tests/Component/Modal/LightboxTest.php
@@ -90,12 +90,12 @@ class LightboxTest extends ModalBase
     protected static function getExpectedTextPageHTML(): string
     {
         return <<<EOT
-<dialog class="c-modal c-modal--lightbox il-modal-lightbox il-modal-lightbox-bright" tabindex="-1" id="id_1">
+<dialog class="c-modal c-modal--lightbox il-modal-lightbox il-modal-lightbox-bright" tabindex="-1" id="id_1" aria-modal="true" aria-labelledby="id_1_title">
 	<div class="modal-dialog modal-lg" role="document">
 		<div class="modal-content il-modal-lightbox-page">
 			<div class="modal-header">
 				<form><button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true"></span></button></form>
-				<h1 class="modal-title">title</h1>
+				<h1 id="id_1_title" class="modal-title">title</h1>
 			</div>
 			<div class="modal-body">
 				<div id="id_1_carousel" class="carousel slide" data-ride="carousel" data-interval="false">
@@ -119,12 +119,12 @@ EOT;
     protected static function getExpectedImagePageHTML(): string
     {
         return <<<EOT
-<dialog class="c-modal c-modal--lightbox il-modal-lightbox il-modal-lightbox-dark" tabindex="-1" id="id_1">
+<dialog class="c-modal c-modal--lightbox il-modal-lightbox il-modal-lightbox-dark" tabindex="-1" id="id_1" aria-modal="true" aria-labelledby="id_1_title">
 	<div class="modal-dialog modal-lg" role="document">
 		<div class="modal-content il-modal-lightbox-page">
 			<div class="modal-header">
 				<form><button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true"></span></button></form>
-				<h1 class="modal-title">title</h1>
+				<h1 id="id_1_title" class="modal-title">title</h1>
 			</div>
 			<div class="modal-body">
 				<div id="id_1_carousel" class="carousel slide" data-ride="carousel" data-interval="false">
@@ -153,12 +153,12 @@ EOT;
     protected static function getExpectedMixedPagesHTML(): string
     {
         return <<<EOT
-<dialog class="c-modal c-modal--lightbox il-modal-lightbox il-modal-lightbox-dark" tabindex="-1" id="id_1">
+<dialog class="c-modal c-modal--lightbox il-modal-lightbox il-modal-lightbox-dark" tabindex="-1" id="id_1" aria-modal="true" aria-labelledby="id_1_title">
 	<div class="modal-dialog modal-lg" role="document">
 		<div class="modal-content il-modal-lightbox-page">
 			<div class="modal-header">
 				<form><button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true"></span></button></form>
-				<h1 class="modal-title">title</h1>
+				<h1 id="id_1_title" class="modal-title">title</h1>
 			</div>
 			<div class="modal-body">
 				<div id="id_1_carousel" class="carousel slide" data-ride="carousel" data-interval="false">
@@ -205,12 +205,12 @@ EOT;
     private static function getExpectedCardPageHTML(): string
     {
         return <<<EOT
-<dialog class="c-modal c-modal--lightbox il-modal-lightbox il-modal-lightbox-bright" tabindex="-1" id="id_1">
+<dialog class="c-modal c-modal--lightbox il-modal-lightbox il-modal-lightbox-bright" tabindex="-1" id="id_1" aria-modal="true" aria-labelledby="id_1_title">
 	<div class="modal-dialog modal-lg" role="document">
 		<div class="modal-content il-modal-lightbox-page">
 			<div class="modal-header">
 				<form><button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true"></span></button></form>
-				<h1 class="modal-title">foo</h1>
+				<h1 id="id_1_title" class="modal-title">foo</h1>
 			</div>
 			<div class="modal-body">
 				<div id="id_1_carousel" class="carousel slide" data-ride="carousel" data-interval="false">

--- a/components/ILIAS/UI/tests/Component/Modal/RoundTripTest.php
+++ b/components/ILIAS/UI/tests/Component/Modal/RoundTripTest.php
@@ -82,12 +82,12 @@ class RoundTripTest extends ModalBase
     protected function getExpectedHTML(): string
     {
         return <<<EOT
-<dialog class="c-modal il-modal-roundtrip" tabindex="-1" id="id_1">
+<dialog class="c-modal il-modal-roundtrip" tabindex="-1" id="id_1" aria-modal="true" aria-labelledby="id_1_title">
    <div class="modal-dialog" role="document" data-replace-marker="component">
       <div class="modal-content">
          <div class="modal-header">
             <form><button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button></form>
-            <h1 class="modal-title">Title</h1>
+            <h1 id="id_1_title" class="modal-title">Title</h1>
          </div>
          <div class="modal-body">Content</div>
          <div class="modal-footer">


### PR DESCRIPTION
Fixes a WCAG violation by adding `aria-modal="true"` and `aria-labelledby="{ID}_title"` to the `<dialog>` element in all core modal templates. The corresponding `id="{ID}_title"` is also added to the modal's `<h1>` title.

This ensures screen readers properly announce the modal's purpose and correctly treat it as a priority overlay.

⚠️ This change currently does not pass the PHP Unit Tests, because they modify the HTML generated in these tests.
To optimise time, we want to be sure that the implementation is correct, since if any additional changes are required, the tests will have to be updated again, with the corresponding time expenditure on this task.
Therefore, we would appreciate feedback on these changes, and when we can confirm that they are adequate, we will update the tests in this same PR before performing the merge.

[Ticket 43962](https://mantis.ilias.de/view.php?id=43962)