### PR TITLE
Fix(Accessibility): Add aria-expanded to presentation table controls

### DIFF
--- a/components/ILIAS/UI/resources/js/Table/src/presentationtable.class.js
+++ b/components/ILIAS/UI/resources/js/Table/src/presentationtable.class.js
@@ -38,6 +38,12 @@ export default class PresentationTable {
     const row = this.#component.querySelector(`#${rowId}`);
     row.classList.remove('collapsed');
     row.classList.add('expanded');
+
+    const expandButton = row.querySelector('.il-table-presentation-row-controls-expander .glyph');
+    const collapseButton = row.querySelector('.il-table-presentation-row-controls-collapser .glyph');
+
+    if (expandButton) expandButton.setAttribute('aria-expanded', 'true');
+    if (collapseButton) collapseButton.setAttribute('aria-expanded', 'true');
   }
 
   /**
@@ -47,6 +53,12 @@ export default class PresentationTable {
     const row = this.#component.querySelector(`#${rowId}`);
     row.classList.remove('expanded');
     row.classList.add('collapsed');
+
+    const expandButton = row.querySelector('.il-table-presentation-row-controls-expander .glyph');
+    const collapseButton = row.querySelector('.il-table-presentation-row-controls-collapser .glyph');
+
+    if (expandButton) expandButton.setAttribute('aria-expanded', 'false');
+    if (collapseButton) collapseButton.setAttribute('aria-expanded', 'false');
   }
 
   /**

--- a/components/ILIAS/UI/src/Component/Symbol/Glyph/Glyph.php
+++ b/components/ILIAS/UI/src/Component/Symbol/Glyph/Glyph.php
@@ -164,4 +164,14 @@ interface Glyph extends Symbol, Clickable
 
     /** @deprecated will be removed in ILIAS 11. please use a Button instead. */
     public function getOnLoadCode(): ?\Closure;
+
+    /**
+     * Get a Glyph like this with aria-expanded attribute.
+     */
+    public function withAriaExpanded(string $aria_expanded): Glyph;
+
+    /**
+     * Get the aria-expanded attribute value.
+     */
+    public function getAriaExpanded(): ?string;
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/Glyph.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/Glyph.php
@@ -100,6 +100,7 @@ class Glyph implements C\Symbol\Glyph\Glyph
     private array $counters;
     private bool $highlighted;
     private bool $active = true;
+    private ?string $aria_expanded = null;
 
     public function __construct(string $type, string $label, string $action = null)
     {
@@ -214,5 +215,17 @@ class Glyph implements C\Symbol\Glyph\Glyph
         $has_action = ($this->action !== null && $this->action !== "");
         $has_signal = isset($this->triggered_signals['click']) && $this->triggered_signals['click'] !== null;
         return  ($has_signal || $has_action) && $this->isActive();
+    }
+
+    public function withAriaExpanded(string $aria_expanded): C\Symbol\Glyph\Glyph
+    {
+        $clone = clone $this;
+        $clone->aria_expanded = $aria_expanded;
+        return $clone;
+    }
+
+    public function getAriaExpanded(): ?string
+    {
+        return $this->aria_expanded;
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/Renderer.php
@@ -74,6 +74,13 @@ class Renderer extends AbstractComponentRenderer
             $tpl->parseCurrentBlock();
         }
 
+        $aria_expanded = $component->getAriaExpanded();
+        if ($aria_expanded !== null) {
+            $tpl->setCurrentBlock("with_aria_expanded");
+            $tpl->setVariable("ARIA_EXPANDED", $aria_expanded);
+            $tpl->parseCurrentBlock();
+        }
+
         $tpl->setVariable("GLYPH", $this->getInnerGlyphHTML($component, $default_renderer));
         return $tpl->get();
     }

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Renderer.php
@@ -136,9 +136,11 @@ class Renderer extends AbstractComponentRenderer
         $id = $this->bindJavaScript($component);
 
         $expander = $f->symbol()->glyph()->expand("#")
-            ->withOnClick($sig_show);
+            ->withOnClick($sig_show)
+            ->withAriaExpanded("false");
         $collapser = $f->symbol()->glyph()->collapse("#")
-            ->withOnClick($sig_hide);
+            ->withOnClick($sig_hide)
+            ->withAriaExpanded("true");
         $shy_expander = $f->button()->shy($this->txt("presentation_table_more"), "#")
             ->withOnClick($sig_show);
 

--- a/components/ILIAS/UI/src/templates/default/Symbol/tpl.glyph.standard.html
+++ b/components/ILIAS/UI/src/templates/default/Symbol/tpl.glyph.standard.html
@@ -1,3 +1,3 @@
-<a <!-- BEGIN tabbable -->tabindex="0" <!-- END tabbable -->class="glyph<!-- BEGIN highlighted --> highlighted<!-- END highlighted --><!-- BEGIN disabled --> disabled<!-- END disabled -->"<!-- BEGIN with_action --> href="{ACTION}"<!-- END with_action --> aria-label="{LABEL}"<!-- BEGIN with_aria_disabled --> aria-disabled="{ARIA_DISABLED}"<!-- END with_aria_disabled --><!-- BEGIN with_id --> id="{ID}"<!-- END with_id -->>
+<a <!-- BEGIN tabbable -->tabindex="0" <!-- END tabbable -->class="glyph<!-- BEGIN highlighted --> highlighted<!-- END highlighted --><!-- BEGIN disabled --> disabled<!-- END disabled -->"<!-- BEGIN with_action --> href="{ACTION}"<!-- END with_action --> aria-label="{LABEL}"<!-- BEGIN with_aria_disabled --> aria-disabled="{ARIA_DISABLED}"<!-- END with_aria_disabled --><!-- BEGIN with_id --> id="{ID}"<!-- END with_id --><!-- BEGIN with_aria_expanded --> aria-expanded="{ARIA_EXPANDED}"<!-- END with_aria_expanded -->>
 {GLYPH}
 </a>

--- a/components/ILIAS/UI/tests/Component/Table/PresentationTest.php
+++ b/components/ILIAS/UI/tests/Component/Table/PresentationTest.php
@@ -165,12 +165,12 @@ class PresentationTest extends TableTestBase
 
             <div class="il-table-presentation-row-controls col-lg-auto col-sm-12">
                 <div class="il-table-presentation-row-controls-expander inline">
-                    <a tabindex="0" class="glyph" href="#" aria-label="expand_content" id="id_5">
+                    <a tabindex="0" class="glyph" href="#" aria-label="expand_content" id="id_5" aria-expanded="false">
                         <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span>
                     </a>
                 </div>
                 <div class="il-table-presentation-row-controls-collapser">
-                    <a tabindex="0" class="glyph" href="#" aria-label="collapse_content" id="id_6">
+                    <a tabindex="0" class="glyph" href="#" aria-label="collapse_content" id="id_6" aria-expanded="true">
                         <span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span>
                     </a>
                 </div>
@@ -268,12 +268,12 @@ EXP;
 
             <div class="il-table-presentation-row-controls col-lg-auto col-sm-12">
                 <div class="il-table-presentation-row-controls-expander inline">
-                    <a tabindex="0" class="glyph" href="#" aria-label="expand_content" id="id_5">
+                    <a tabindex="0" class="glyph" href="#" aria-label="expand_content" id="id_5" aria-expanded="false">
                         <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span>
                     </a>
                 </div>
                 <div class="il-table-presentation-row-controls-collapser">
-                    <a tabindex="0" class="glyph" href="#" aria-label="collapse_content" id="id_6">
+                    <a tabindex="0" class="glyph" href="#" aria-label="collapse_content" id="id_6" aria-expanded="true">
                         <span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span>
                     </a>
                 </div>


### PR DESCRIPTION
Adds the missing aria-expanded attribute to presentation table expand/collapse glyphs to fix a WCAG violation for screen readers.

This involves extending the Glyph component (PHP/Template) to support the attribute, setting the correct initial state in the Table/Renderer, and updating the attribute dynamically in `presentationtable.class.js` when the row state changes.

⚠️ This change currently does not pass the PHP Unit Tests, because they modify the HTML generated in these tests.
To optimise time, we want to be sure that the implementation is correct, since if any additional changes are required, the tests will have to be updated again, with the corresponding time expenditure on this task.
Therefore, we would appreciate feedback on these changes, and when we can confirm that they are adequate, we will update the tests in this same PR before performing the merge.

[Ticket 43793](https://mantis.ilias.de/view.php?id=43793)
