### PR TITLE
Session: preload registration for access checks (45807)

### DIFF
--- a/Modules/Session/classes/class.ilObjSessionAccess.php
+++ b/Modules/Session/classes/class.ilObjSessionAccess.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -16,8 +14,9 @@ declare(strict_types=1);
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- ********************************************************************
- */
+ *********************************************************************/
+
+declare(strict_types=1);
 
 /**
 *

--- a/Modules/Session/classes/class.ilObjSessionAccess.php
+++ b/Modules/Session/classes/class.ilObjSessionAccess.php
@@ -134,16 +134,36 @@ class ilObjSessionAccess extends ilObjectAccess
 
         $ilDB = $DIC->database();
 
-        if (!is_null(self::$registrations)) {
+        if (isset(self::$registrations[$a_obj_id])) {
             return (bool) self::$registrations[$a_obj_id];
         }
 
-        $query = "SELECT registration,obj_id FROM event ";
+        $query = "SELECT registration,obj_id FROM event WHERE obj_id = " .
+            $ilDB->quote($a_obj_id, ilDBConstants::T_INTEGER);
         $res = $ilDB->query($query);
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
             self::$registrations[$row->obj_id] = (bool) $row->registration;
         }
         return (bool) self::$registrations[$a_obj_id];
+    }
+
+    /**
+     * @param int[] $a_obj_ids
+     */
+    public static function preloadRegistrations(array $a_obj_ids): void
+    {
+        global $DIC;
+
+        $ilDB = $DIC->database();
+
+        self::$registrations = [];
+
+        $query = "SELECT registration,obj_id FROM event WHERE " .
+            $ilDB->in('obj_id', $a_obj_ids, false, ilDBConstants::T_INTEGER);
+        $res = $ilDB->query($query);
+        while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
+            self::$registrations[$row->obj_id] = (bool) $row->registration;
+        }
     }
 
     public static function _lookupRegistered(int $a_usr_id, int $a_obj_id): bool
@@ -170,13 +190,14 @@ class ilObjSessionAccess extends ilObjectAccess
     {
         global $DIC;
 
+        self::preloadRegistrations($a_obj_ids);
         self::$booking_repo = $DIC->bookingManager()
             ->internal()
             ->repo()
             ->reservationWithContextObjCache($a_obj_ids);
     }
 
-    public static function getBookingInfoRepo() : ?\ILIAS\BookingManager\Reservations\ReservationDBRepository
+    public static function getBookingInfoRepo(): ?\ILIAS\BookingManager\Reservations\ReservationDBRepository
     {
         if (self::$booking_repo instanceof \ILIAS\BookingManager\Reservations\ReservationDBRepository) {
             return self::$booking_repo;


### PR DESCRIPTION
This PR fixes [45807](https://mantis.ilias.de/view.php?id=45807). I wanted to have a second pair of eyes on this, because I'm not quite sure whether I fully understand the impact of this change.

Preloading the registration status should massively improve the situation for object lists, but only works there. Are there any other cases besides object lists where access checks are done for multiple sessions? If so, it might be better to keep the full table scan in ` _lookupRegistration` as a fallback (instead of my current fallback loading the registration session by session).