### PR TITLE
UI: relative header nesting

### DIFF
--- a/components/ILIAS/DataCollection/classes/Table/class.ilDclTableListGUI.php
+++ b/components/ILIAS/DataCollection/classes/Table/class.ilDclTableListGUI.php
@@ -135,7 +135,7 @@ class ilDclTableListGUI
         $this->toolbar->addStickyItem($add_new);
 
         $this->tpl->setContent(
-            $this->renderer->render(
+            $this->renderer->withHeaderNesting(1)->render(
                 $this->ui_factory->panel()->listing()->standard(
                     $this->lng->txt('dcl_tables'),
                     [$this->ui_factory->item()->group('', $this->getItems())]

--- a/components/ILIAS/LearningSequence/classes/Player/class.ilKioskPageRenderer.php
+++ b/components/ILIAS/LearningSequence/classes/Player/class.ilKioskPageRenderer.php
@@ -63,7 +63,7 @@ class ilKioskPageRenderer
         return $this->ui_factory->maincontrols()->slate()->legacy(
             $this->lng->txt('lso_mainbar_button_label_curriculum'),
             $f->symbol()->icon()->standard("lso", "Learning Sequence"),
-            $this->ui_factory->legacy(
+            $this->ui_factory->legacy()->content(
                 $this->ui_renderer->render($curriculum)
             )
         );

--- a/components/ILIAS/Test/templates/default/tpl.il_as_tst_manual_scoring_consecutive_question.html
+++ b/components/ILIAS/Test/templates/default/tpl.il_as_tst_manual_scoring_consecutive_question.html
@@ -2,7 +2,7 @@
     <!-- BEGIN expandable_title -->
     <details>
         <summary>
-            <h2 class="c-consecutive-scoring__question__title">{TITLE}</h2>
+            <h3 class="c-consecutive-scoring__question__title">{TITLE}</h3>
         </summary>
         <div class="c-consecutive-scoring__question__text">
             {QUESTION}

--- a/components/ILIAS/UI/src/Implementation/Component/Divider/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Divider/Renderer.php
@@ -32,7 +32,7 @@ class Renderer extends AbstractComponentRenderer
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
         if ($component instanceof Component\Divider\Horizontal) {
-            return $this->renderDividerHorizontal($component);
+            return $this->renderDividerHorizontal($component, $default_renderer);
         }
         if ($component instanceof Component\Divider\Vertical) {
             return $this->renderDividerVertical();
@@ -40,8 +40,10 @@ class Renderer extends AbstractComponentRenderer
         $this->cannotHandleComponent($component);
     }
 
-    protected function renderDividerHorizontal(Component\Divider\Horizontal $component): string
-    {
+    protected function renderDividerHorizontal(
+        Component\Divider\Horizontal $component,
+        RendererInterface $default_renderer
+    ): string {
         $tpl = $this->getTemplate("tpl.horizontal.html", true, true);
 
         $label = $component->getLabel();
@@ -49,6 +51,7 @@ class Renderer extends AbstractComponentRenderer
         if ($label !== null) {
             $tpl->setCurrentBlock("label");
             $tpl->setVariable("LABEL", $label);
+            $tpl->setVariable("HEADLINE_NESTING_LEVEL", $default_renderer->getHeaderNesting(1));
             $tpl->parseCurrentBlock();
             $tpl->touchBlock("with_label");
         } else {

--- a/components/ILIAS/UI/src/Implementation/Component/Item/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Item/Renderer.php
@@ -39,6 +39,8 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component $component, RendererInterface $default_renderer): string
     {
+        $default_renderer = $default_renderer->withHeaderNesting($default_renderer->getHeaderNesting(1));
+
         if ($component instanceof Notification) {
             return $this->renderNotification($component, $default_renderer);
         } elseif ($component instanceof Group) {
@@ -57,16 +59,19 @@ class Renderer extends AbstractComponentRenderer
         $title = $component->getTitle();
         $items = $component->getItems();
 
+        if ($title != "") {
+            $tpl->setCurrentBlock("title");
+            $tpl->setVariable("TITLE", $title);
+            $tpl->setVariable("HEADLINE_NESTING_LEVEL", $default_renderer->getHeaderNesting());
+            $tpl->parseCurrentBlock();
+        } else {
+            $default_renderer = $default_renderer->withHeaderNesting($default_renderer->getHeaderNesting()-1);
+        }
+
         // items
         foreach ($items as $item) {
             $tpl->setCurrentBlock("item");
             $tpl->setVariable("ITEM", $default_renderer->render($item));
-            $tpl->parseCurrentBlock();
-        }
-
-        if ($title != "") {
-            $tpl->setCurrentBlock("title");
-            $tpl->setVariable("TITLE", $title);
             $tpl->parseCurrentBlock();
         }
 
@@ -295,6 +300,7 @@ class Renderer extends AbstractComponentRenderer
             $title = htmlentities($title);
         }
         $tpl->setVariable("TITLE", $title);
+        $tpl->setVariable("HEADLINE_NESTING_LEVEL", $default_renderer->getHeaderNesting());
     }
 
     protected function renderDescription(Item $component, Template $tpl): void

--- a/components/ILIAS/UI/src/Implementation/Component/Item/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Item/Renderer.php
@@ -65,7 +65,7 @@ class Renderer extends AbstractComponentRenderer
             $tpl->setVariable("HEADLINE_NESTING_LEVEL", $default_renderer->getHeaderNesting());
             $tpl->parseCurrentBlock();
         } else {
-            $default_renderer = $default_renderer->withHeaderNesting($default_renderer->getHeaderNesting()-1);
+            $default_renderer = $default_renderer->withHeaderNesting($default_renderer->getHeaderNesting() - 1);
         }
 
         // items

--- a/components/ILIAS/UI/src/Implementation/Component/Listing/Workflow/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Listing/Workflow/Renderer.php
@@ -43,6 +43,7 @@ class Renderer extends AbstractComponentRenderer
     {
         $tpl = $this->getTemplate("tpl.linear.html", true, true);
         $tpl->setVariable("TITLE", $component->getTitle());
+        $tpl->setVariable("HEADLINE_NESTING_LEVEL", $default_renderer->getHeaderNesting(1));
 
         foreach ($component->getSteps() as $index => $step) {
             $tpl->setCurrentBlock("step");

--- a/components/ILIAS/UI/src/Implementation/Component/Navigation/Sequence/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Navigation/Sequence/Renderer.php
@@ -117,6 +117,7 @@ class Renderer extends AbstractComponentRenderer
         $title = $component->getTitle();
         if ($title !== null) {
             $tpl->setVariable('TITLE', $title);
+            $tpl->setVariable("HEADLINE_NESTING_LEVEL", $default_renderer->getHeaderNesting(1));
         }
 
         return $tpl->get();

--- a/components/ILIAS/UI/src/Implementation/Component/Panel/Listing/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Panel/Listing/Renderer.php
@@ -33,6 +33,8 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(C\Component $component, RendererInterface $default_renderer): string
     {
+        $default_renderer = $default_renderer->withHeaderNesting($default_renderer->getHeaderNesting(1));
+
         if ($component instanceof C\Panel\Listing\Standard) {
             return $this->renderStandard($component, $default_renderer);
         }
@@ -67,6 +69,7 @@ class Renderer extends AbstractComponentRenderer
 
         if ($title !== "" || $actions || $view_controls) {
             $tpl->setVariable("TITLE", $title);
+            $tpl->setVariable("HEADLINE_NESTING_LEVEL", $default_renderer->getHeaderNesting());
             if ($actions) {
                 $tpl->setVariable("ACTIONS", $default_renderer->render($actions));
             }

--- a/components/ILIAS/UI/src/Implementation/Component/Panel/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Panel/Renderer.php
@@ -36,6 +36,8 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
+        $default_renderer = $default_renderer->withHeaderNesting($default_renderer->getHeaderNesting(1));
+
         if ($component instanceof Component\Panel\Standard) {
             return $this->renderStandard($component, $default_renderer);
         } elseif ($component instanceof Component\Panel\Sub) {
@@ -71,7 +73,6 @@ class Renderer extends AbstractComponentRenderer
 
         if ($component->getTitle() != "" || $actions !== null) {
             $tpl->setCurrentBlock("title");
-
             // actions
             if ($actions !== null) {
                 $tpl->setVariable("ACTIONS", $default_renderer->render($actions));
@@ -79,6 +80,7 @@ class Renderer extends AbstractComponentRenderer
 
             // title
             $tpl->setVariable("TITLE", $component->getTitle());
+            $tpl->setVariable("HEADLINE_NESTING_LEVEL", $default_renderer->getHeaderNesting());
             $tpl->parseCurrentBlock();
         }
 
@@ -124,6 +126,7 @@ class Renderer extends AbstractComponentRenderer
         }
 
         $tpl->setVariable("TITLE", $component->getTitle());
+        $tpl->setVariable("HEADLINE_NESTING_LEVEL", $default_renderer->getHeaderNesting());
 
         return $tpl;
     }

--- a/components/ILIAS/UI/src/Implementation/Component/Panel/Secondary/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Panel/Secondary/Renderer.php
@@ -45,7 +45,7 @@ class Renderer extends AbstractComponentRenderer
     {
         $tpl = $this->getTemplate("tpl.secondary.html", true, true);
 
-        $tpl = $this->parseHeader($component, $default_renderer, $tpl);
+        [$tpl, $default_renderer] = $this->parseHeader($component, $default_renderer, $tpl);
 
         foreach ($component->getItemGroups() as $group) {
             if ($group instanceof C\Item\Group) {
@@ -64,8 +64,7 @@ class Renderer extends AbstractComponentRenderer
     {
         $tpl = $this->getTemplate("tpl.secondary.html", true, true);
 
-        $tpl = $this->parseHeader($component, $default_renderer, $tpl);
-
+        [$tpl, $default_renderer] = $this->parseHeader($component, $default_renderer, $tpl);
         $tpl->setCurrentBlock("legacy");
         $tpl->setVariable("BODY_LEGACY", $default_renderer->render($component->getLegacyComponent()));
         $tpl->parseCurrentBlock();
@@ -79,13 +78,16 @@ class Renderer extends AbstractComponentRenderer
         C\Panel\Secondary\Secondary $component,
         RendererInterface $default_renderer,
         Template $tpl
-    ): Template {
+    ): array {
         $title = $component->getTitle();
         $actions = $component->getActions();
         $view_controls = $component->getViewControls();
 
         if ($title != "" || $actions || $view_controls) {
+            $default_renderer = $default_renderer->withHeaderNesting($default_renderer->getHeaderNesting(1));
             $tpl->setVariable("TITLE", $title);
+            $tpl->setVariable("HEADLINE_NESTING_LEVEL", $default_renderer->getHeaderNesting());
+
             if ($actions) {
                 $tpl->setVariable("ACTIONS", $default_renderer->render($actions));
             }
@@ -99,7 +101,7 @@ class Renderer extends AbstractComponentRenderer
             $tpl->setCurrentBlock("heading");
             $tpl->parseCurrentBlock();
         }
-        return $tpl;
+        return [$tpl, $default_renderer];
     }
 
     protected function parseFooter(

--- a/components/ILIAS/UI/src/Implementation/Component/Popover/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Popover/Renderer.php
@@ -42,8 +42,12 @@ class Renderer extends AbstractComponentRenderer
             $this->cannotHandleComponent($component);
         }
 
+
         $tpl = $this->getTemplate('tpl.popover.html', true, true);
         $tpl->setVariable('FORCE_RENDERING', '');
+        $default_renderer = $default_renderer->withHeaderNesting(1);
+        $tpl->setVariable("HEADLINE_NESTING_LEVEL", $default_renderer->getHeaderNesting());
+
 
         $replacement = array(
             '"' => '\"',

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Renderer.php
@@ -65,7 +65,13 @@ class Renderer extends AbstractComponentRenderer
         Component\Table\Presentation $component,
         RendererInterface $default_renderer
     ): string {
+
+        $default_renderer = $default_renderer->withHeaderNesting(
+            $default_renderer->getHeaderNesting(1)
+        );
+
         $tpl = $this->getTemplate("tpl.presentationtable.html", true, true);
+        $tpl->setVariable("HEADLINE_NESTING_LEVEL", $default_renderer->getHeaderNesting());
         $tpl->setVariable("TITLE", $component->getTitle());
         $expcollapsebtns = [];
         if ($sig_ta = $component->getExpandCollapseAllSignal()) {
@@ -106,6 +112,9 @@ class Renderer extends AbstractComponentRenderer
             return $tpl->get();
         }
 
+        $default_renderer = $default_renderer->withHeaderNesting(
+            $default_renderer->getHeaderNesting(1)
+        );
         foreach ($data as $record) {
             $row = $row_mapping(
                 new PresentationRow($component->getSignalGenerator(), $component_id),
@@ -118,7 +127,6 @@ class Renderer extends AbstractComponentRenderer
             $tpl->setVariable("ROW", $default_renderer->render($row));
             $tpl->parseCurrentBlock();
         }
-
         return $tpl->get();
     }
 
@@ -147,6 +155,8 @@ class Renderer extends AbstractComponentRenderer
         $tpl->setVariable("COLLAPSER", $default_renderer->render($collapser));
         $tpl->setVariable("SHY_EXPANDER", $default_renderer->render($shy_expander));
 
+
+        $tpl->setVariable("HEADLINE_NESTING_LEVEL", $default_renderer->getHeaderNesting());
         if ($symbol = $component->getLeadingSymbol()) {
             $tpl->setVariable("SYMBOL", $default_renderer->render($symbol));
         }
@@ -175,6 +185,7 @@ class Renderer extends AbstractComponentRenderer
             $tpl->touchBlock("has_further_fields");
 
             if ($further_fields_headline) {
+                $tpl->setVariable("HEADLINE_NESTING_LEVEL_FURTHER", $default_renderer->getHeaderNesting(1));
                 $tpl->setVariable("FURTHER_FIELDS_HEADLINE", $further_fields_headline);
             }
 
@@ -234,6 +245,7 @@ class Renderer extends AbstractComponentRenderer
 
         $id = $this->bindJavaScript($component);
         $tpl->setVariable('ID', $id);
+        $tpl->setVariable("HEADLINE_NESTING_LEVEL", $default_renderer->getHeaderNesting(1));
         $tpl->setVariable('TITLE', $component->getTitle());
         $tpl->setVariable('COL_COUNT', (string) $component->getColumnCount() + $compensate_col_count);
         $tpl->setVariable('VIEW_CONTROLS', $default_renderer->render($view_controls));
@@ -702,6 +714,7 @@ class Renderer extends AbstractComponentRenderer
         $tpl->setVariable('ID', $tableid);
         $tpl->setVariable('TARGET_URL', $component->getTargetURL() ? $component->getTargetURL()->__toString() : '#');
         $tpl->setVariable('TITLE', $component->getTitle());
+        $tpl->setVariable("HEADLINE_NESTING_LEVEL", $default_renderer->getHeaderNesting(1));
         $tpl->setVariable('COL_COUNT', (string) $component->getColumnCount() + $compensate_col_count);
         $tpl->setVariable('VIEW_CONTROLS', $default_renderer->render($view_controls));
 

--- a/components/ILIAS/UI/src/Implementation/DefaultRenderer.php
+++ b/components/ILIAS/UI/src/Implementation/DefaultRenderer.php
@@ -36,6 +36,7 @@ class DefaultRenderer implements Renderer
      * @var Component[]
      */
     private array $contexts = [];
+    private int $header_nesting = 1;
 
     public function __construct(
         private Render\Loader $component_renderer_loader,
@@ -130,4 +131,24 @@ class DefaultRenderer implements Renderer
     {
         array_pop($this->contexts);
     }
+
+    public function withHeaderNesting(int $nesting_level): static
+    {
+        if ($nesting_level < 1) {
+            throw new \LogicException('Headings with values smaller 1 are not allowed');
+        }
+        $clone = clone $this;
+        $clone->header_nesting = $nesting_level;
+        return $clone;
+    }
+
+    public function getHeaderNesting(?int $offset = 0): int
+    {
+        $new_nesting = $this->header_nesting + $offset;
+        if ($new_nesting < 1) {
+            throw new \LogicException('Headings with values smaller 1 are not allowed');
+        }
+        return $new_nesting;
+    }
+
 }

--- a/components/ILIAS/UI/src/examples/Dropdown/Standard/with_divider_with_label.php
+++ b/components/ILIAS/UI/src/examples/Dropdown/Standard/with_divider_with_label.php
@@ -44,5 +44,7 @@ function with_divider_with_label()
         $f->button()->shy("Features", "https://feature.ilias.de"),
         $f->button()->shy("Bugs", "https://mantis.ilias.de"),
     );
-    return $renderer->render($f->dropdown()->standard($items)->withLabel("Actions"));
+    return $renderer
+        ->withHeaderNesting(3)
+        ->render($f->dropdown()->standard($items)->withLabel("Actions"));
 }

--- a/components/ILIAS/UI/src/templates/default/Divider/tpl.horizontal.html
+++ b/components/ILIAS/UI/src/templates/default/Divider/tpl.horizontal.html
@@ -1,4 +1,4 @@
 <!-- BEGIN divider -->
 <hr <!-- BEGIN with_label -->class="il-divider-with-label"<!-- END with_label --> />
-<!-- BEGIN label --><h4 class="il-divider">{LABEL}</h4><!-- END label -->
+<!-- BEGIN label --><h{HEADLINE_NESTING_LEVEL} class="il-divider">{LABEL}</h{HEADLINE_NESTING_LEVEL}><!-- END label -->
 <!-- END divider -->

--- a/components/ILIAS/UI/src/templates/default/Item/tpl.group.html
+++ b/components/ILIAS/UI/src/templates/default/Item/tpl.group.html
@@ -1,5 +1,5 @@
 <div class="il-item-group">
-<!-- BEGIN title --><h3>{TITLE}</h3><!-- END title -->{ACTIONS}
+<!-- BEGIN title --><h{HEADLINE_NESTING_LEVEL}>{TITLE}</h{HEADLINE_NESTING_LEVEL}><!-- END title -->{ACTIONS}
 <div class="il-item-group-items">
 	<ul>
 	<!-- BEGIN item --><li class="il-std-item-container">{ITEM}</li><!-- END item -->

--- a/components/ILIAS/UI/src/templates/default/Item/tpl.item_notification.html
+++ b/components/ILIAS/UI/src/templates/default/Item/tpl.item_notification.html
@@ -5,7 +5,7 @@
 				<!-- BEGIN lead_icon -->{LEAD_ICON}<!-- END lead_icon -->
 			</div>
 			<div class="media-body">
-				<h4 class="il-item-notification-title">{TITLE}</h4>
+				<h{HEADLINE_NESTING_LEVEL} class="il-item-notification-title">{TITLE}</h{HEADLINE_NESTING_LEVEL}>
 				{CLOSE_ACTION}
 
 				<!-- BEGIN desc -->

--- a/components/ILIAS/UI/src/templates/default/Item/tpl.item_standard.html
+++ b/components/ILIAS/UI/src/templates/default/Item/tpl.item_standard.html
@@ -35,7 +35,7 @@
 		</div>
 		<div class="media-body">
 			<!-- END lead_start_icon -->
-			<h4 class="il-item-title">{TITLE}</h4>
+			<h{HEADLINE_NESTING_LEVEL} class="il-item-title">{TITLE}</h{HEADLINE_NESTING_LEVEL}>
 			<!-- BEGIN action_bar -->
 			<div class="il-item-actions l-bar__space-keeper">
 				<!-- BEGIN main_action --><div class="l-bar__element">{MAIN_ACTION}</div><!-- END main_action -->

--- a/components/ILIAS/UI/src/templates/default/Listing/tpl.linear.html
+++ b/components/ILIAS/UI/src/templates/default/Listing/tpl.linear.html
@@ -1,6 +1,6 @@
 <div class="il-workflow linear"<!-- BEGIN id --> id="{ID}"<!-- END id -->>
 	<div class="il-workflow-header">
-		<h3 class="il-workflow-title">{TITLE}</h3>
+		<h{HEADLINE_NESTING_LEVEL} class="il-workflow-title">{TITLE}</h{HEADLINE_NESTING_LEVEL}>
 	</div>
 	<ul class="il-workflow-container">
 	<!-- BEGIN step -->

--- a/components/ILIAS/UI/src/templates/default/Navigation/tpl.sequence.html
+++ b/components/ILIAS/UI/src/templates/default/Navigation/tpl.sequence.html
@@ -1,6 +1,6 @@
 <div class="c-sequence c-sequence--linear"<!-- BEGIN id --> id="{ID}"<!-- END id -->>
     <!-- BEGIN title -->
-    <h2 class="ilHeader">{TITLE}</h2>
+    <h{HEADLINE_NESTING_LEVEL} class="ilHeader">{TITLE}</h{HEADLINE_NESTING_LEVEL}>
     <!-- END title -->
     <div class="c-sequence__header">
         <div  id="{NAVIGATION_ID}" class="c-sequence__navigation">

--- a/components/ILIAS/UI/src/templates/default/Panel/tpl.listing_standard.html
+++ b/components/ILIAS/UI/src/templates/default/Panel/tpl.listing_standard.html
@@ -1,7 +1,7 @@
 <div class="panel panel-flex il-panel-listing-std-container clearfix">
     <!-- BEGIN heading -->
     <div class="panel-heading ilHeader">
-        <div class="panel-title"><h2>{TITLE}</h2></div>
+        <div class="panel-title"><h{HEADLINE_NESTING_LEVEL}>{TITLE}</h{HEADLINE_NESTING_LEVEL}></div>
         <!-- BEGIN vc_container -->
         <div class="panel-viewcontrols l-bar__space-keeper"><!-- BEGIN view_controls -->{VIEW_CONTROL}<!-- END view_controls --></div>
         <!-- END vc_container -->

--- a/components/ILIAS/UI/src/templates/default/Panel/tpl.report.html
+++ b/components/ILIAS/UI/src/templates/default/Panel/tpl.report.html
@@ -1,6 +1,6 @@
 <div class="panel panel-primary il-panel-report panel-flex">
 	<div class="panel-heading ilHeader">
-        <div class="panel-title"><h2>{TITLE}</h2></div>
+        <div class="panel-title"><h{HEADLINE_NESTING_LEVEL}>{TITLE}</h{HEADLINE_NESTING_LEVEL}></div>
         <!-- BEGIN vc_container -->
 		<div class="panel-viewcontrols l-bar__space-keeper"><!-- BEGIN view_controls -->{VIEW_CONTROL}<!-- END view_controls --></div>
 		<!-- END vc_container -->

--- a/components/ILIAS/UI/src/templates/default/Panel/tpl.secondary.html
+++ b/components/ILIAS/UI/src/templates/default/Panel/tpl.secondary.html
@@ -1,7 +1,7 @@
 <div class="panel panel-secondary panel-flex">
 	<!-- BEGIN heading -->
 	<div class="panel-heading ilHeader">
-		<div class="panel-title"><h2>{TITLE}</h2></div>
+		<div class="panel-title"><h{HEADLINE_NESTING_LEVEL}>{TITLE}</h{HEADLINE_NESTING_LEVEL}></div>
 		<!-- BEGIN vc_container -->
 		<div class="panel-viewcontrols l-bar__space-keeper"><!-- BEGIN view_controls -->{VIEW_CONTROL}<!-- END view_controls --></div>
 		<!-- END vc_container -->

--- a/components/ILIAS/UI/src/templates/default/Panel/tpl.standard.html
+++ b/components/ILIAS/UI/src/templates/default/Panel/tpl.standard.html
@@ -1,6 +1,6 @@
 <div class="panel panel-primary panel-flex">
 	<div class="panel-heading ilHeader">
-		<div class="panel-title"><h2>{TITLE}</h2></div>
+		<div class="panel-title"><h{HEADLINE_NESTING_LEVEL}>{TITLE}</h{HEADLINE_NESTING_LEVEL}></div>
 		<!-- BEGIN vc_container -->
 		<div class="panel-viewcontrols l-bar__space-keeper"><!-- BEGIN view_controls -->{VIEW_CONTROL}<!-- END view_controls --></div>
 		<!-- END vc_container -->

--- a/components/ILIAS/UI/src/templates/default/Panel/tpl.sub.html
+++ b/components/ILIAS/UI/src/templates/default/Panel/tpl.sub.html
@@ -1,7 +1,7 @@
 <div class="panel panel-sub panel-flex">
 	<!-- BEGIN title -->
 	<div class="panel-heading ilBlockHeader">
-		<h3>{TITLE}</h3>
+		<h{HEADLINE_NESTING_LEVEL}>{TITLE}</h{HEADLINE_NESTING_LEVEL}>
 		<div class="panel-controls">
 			{ACTIONS}
 		</div>

--- a/components/ILIAS/UI/src/templates/default/Popover/tpl.popover.html
+++ b/components/ILIAS/UI/src/templates/default/Popover/tpl.popover.html
@@ -1,7 +1,7 @@
 <div class="webui-popover il-popover" role="tooltip">
 	<div class="webui-arrow il-popover-arrow"></div>
 	<div class="webui-popover-inner webui-no-padding il-popover-inner"><a href="#" class="close"></a>
-		<div class="il-popover-title-container"><h4 class="webui-popover-title il-popover-title"></h4></div>
+		<div class="il-popover-title-container"><h{HEADLINE_NESTING_LEVEL} class="webui-popover-title il-popover-title"></h{HEADLINE_NESTING_LEVEL}></div>
 		<div class="il-popover-content webui-popover-content" data-replace-marker="content"><p><i class="icon-refresh"></i><br>&nbsp;</p></div>
 	</div>
 </div>{FORCE_RENDERING}

--- a/components/ILIAS/UI/src/templates/default/Table/tpl.datatable.html
+++ b/components/ILIAS/UI/src/templates/default/Table/tpl.datatable.html
@@ -1,7 +1,7 @@
 <div class="c-table-data" id="{ID}">
 
 	<!-- BEGIN header_title -->
-	<h2 class="ilHeader" id="{ID}_label">{TITLE}</h2>
+	<h{HEADLINE_NESTING_LEVEL} class="ilHeader" id="{ID}_label">{TITLE}</h{HEADLINE_NESTING_LEVEL}>
 	<!-- END header_title -->
 
 	<div class="viewcontrols">{VIEW_CONTROLS}</div>

--- a/components/ILIAS/UI/src/templates/default/Table/tpl.orderingtable.html
+++ b/components/ILIAS/UI/src/templates/default/Table/tpl.orderingtable.html
@@ -2,7 +2,7 @@
 
 
 	<!-- BEGIN header_title -->
-	<h2 class="ilHeader" id="{ID}_label">{TITLE}</h2>
+	<h{HEADLINE_NESTING_LEVEL} class="ilHeader" id="{ID}_label">{TITLE}</h{HEADLINE_NESTING_LEVEL}>
 	<!-- END header_title -->
 
 	<div class="viewcontrols">{VIEW_CONTROLS}</div>

--- a/components/ILIAS/UI/src/templates/default/Table/tpl.presentationrow.html
+++ b/components/ILIAS/UI/src/templates/default/Table/tpl.presentationrow.html
@@ -13,7 +13,7 @@
 		<div class="row">
 			<div class="il-table-presentation-row-header col-lg col-sm-12">
 
-				<h4 class="il-table-presentation-row-header-headline" onClick="$(document).trigger('{TOGGLE_SIGNAL}');">
+				<h{HEADLINE_NESTING_LEVEL} class="il-table-presentation-row-header-headline" onClick="$(document).trigger('{TOGGLE_SIGNAL}');">
 					{SYMBOL}
 					{HEADLINE}
 					<!-- BEGIN subheadline -->
@@ -22,7 +22,7 @@
 						{SUBHEADLINE}
 					</small>
 					<!-- END subheadline -->
-				</h4>
+				</h{HEADLINE_NESTING_LEVEL}>
 
 				<div class="il-table-presentation-row-header-fields">
 					<!-- BEGIN important_field -->
@@ -54,7 +54,7 @@
 
 						<div class="il-table-presentation-fields">
 							<!-- BEGIN further_fields_headline -->
-							<h5>{FURTHER_FIELDS_HEADLINE}</h5>
+							<h{HEADLINE_NESTING_LEVEL_FURTHER}>{FURTHER_FIELDS_HEADLINE}</h{HEADLINE_NESTING_LEVEL_FURTHER}>
 							<!-- END further_fields_headline -->
 
 							<!-- BEGIN further_field -->

--- a/components/ILIAS/UI/src/templates/default/Table/tpl.presentationtable.html
+++ b/components/ILIAS/UI/src/templates/default/Table/tpl.presentationtable.html
@@ -1,6 +1,6 @@
 <div class="il-table-presentation"<!-- BEGIN id --> id="{ID}"<!-- END id -->>
 
-	<h3 class="ilHeader">{TITLE}</h3>
+	<h{HEADLINE_NESTING_LEVEL} class="ilHeader">{TITLE}</h{HEADLINE_NESTING_LEVEL}>
 
 	<div class="il-table-presentation-viewcontrols">
 		<div class="l-bar__space-keeper l-bar__space-keeper--space-between">

--- a/components/ILIAS/UI/tests/Client/Item/Notification/NotificationItemTest.html
+++ b/components/ILIAS/UI/tests/Client/Item/Notification/NotificationItemTest.html
@@ -23,7 +23,7 @@
                                             <img class="icon name small" src="./assets/images/standard/icon_default.svg" alt="aria_label"/>
                                         </div>
                                         <div class="media-body">
-                                            <h4 class="il-item-notification-title">item title</h4>
+                                            <h2 class="il-item-notification-title">item title</h2>
                                             <button type="button" class="close" aria-label="close" id="id_3">
                                                 <span aria-hidden="true">&times;</span>
                                             </button>
@@ -51,7 +51,7 @@
                                             <img class="icon name small" src="./assets/images/standard/icon_default.svg" alt="aria_label"/>
                                         </div>
                                         <div class="media-body">
-                                            <h4 class="il-item-notification-title">item title</h4>
+                                            <h2 class="il-item-notification-title">item title</h2>
                                             <button type="button" class="close" aria-label="close" id="id_7">
                                                 <span aria-hidden="true">&times;</span>
                                             </button>
@@ -85,7 +85,7 @@
                                                                         <img class="icon name small" src="./assets/images/standard/icon_default.svg" alt="aria_label"/>
                                                                     </div>
                                                                     <div class="media-body">
-                                                                        <h4 class="il-item-notification-title">item title</h4>
+                                                                        <h3 class="il-item-notification-title">item title</h3>
                                                                         <button type="button" class="close" aria-label="close" id="id_5">
                                                                             <span aria-hidden="true">&times;</span>
                                                                         </button>

--- a/components/ILIAS/UI/tests/Component/Divider/DividerTest.php
+++ b/components/ILIAS/UI/tests/Component/Divider/DividerTest.php
@@ -71,7 +71,7 @@ class DividerTest extends ILIAS_UI_TestBase
         $c = $f->horizontal()->withLabel("label");
 
         $html = trim($r->render($c));
-        $expected_html = '<hr class="il-divider-with-label" /><h4 class="il-divider">label</h4>';
+        $expected_html = '<hr class="il-divider-with-label" /><h2 class="il-divider">label</h2>';
 
         $this->assertHTMLEquals("<div>" . $expected_html . "</div>", "<div>" . $html . "</div>");
     }

--- a/components/ILIAS/UI/tests/Component/Item/ItemGroupTest.php
+++ b/components/ILIAS/UI/tests/Component/Item/ItemGroupTest.php
@@ -105,18 +105,18 @@ class ItemGroupTest extends ILIAS_UI_TestBase
 
         $expected = <<<EOT
 <div class="il-item-group">
-  <h3>group</h3>
+  <h2>group</h2>
     <div class="il-item-group-items">
 
   <ul>
     <li class="il-std-item-container">
       <div class="il-item il-std-item ">
-        <h4 class="il-item-title">title1</h4>
+        <h3 class="il-item-title">title1</h3>
       </div>
     </li>
     <li class="il-std-item-container">
       <div class="il-item il-std-item ">
-        <h4 class="il-item-title">title2</h4>
+        <h3 class="il-item-title">title2</h3>
       </div>
     </li>
   </ul>
@@ -149,7 +149,7 @@ EOT;
 
         $expected = <<<EOT
 <div class="il-item-group">
-  <h3>group</h3>
+  <h2>group</h2>
   <div class="dropdown" id="id_3">
     <button class="btn btn-default dropdown-toggle" type="button" aria-label="actions" aria-haspopup="true" aria-expanded="false" aria-controls="id_3_menu">
      <span class="caret"></span>
@@ -167,12 +167,12 @@ EOT;
     <ul>
         <li class="il-std-item-container">
           <div class="il-item il-std-item ">
-            <h4 class="il-item-title">title1</h4>
+            <h3 class="il-item-title">title1</h3>
           </div>
         </li>
         <li class="il-std-item-container">
           <div class="il-item il-std-item ">
-            <h4 class="il-item-title">title2</h4>
+            <h3 class="il-item-title">title2</h3>
           </div>
         </li>
     </ul>

--- a/components/ILIAS/UI/tests/Component/Item/ItemNotificationTest.php
+++ b/components/ILIAS/UI/tests/Component/Item/ItemNotificationTest.php
@@ -233,9 +233,9 @@ class ItemNotificationTest extends ILIAS_UI_TestBase
 				<img class="icon name small" src="./assets/images/standard/icon_default.svg" alt="aria_label"/>
 			</div>
 			<div class="media-body">
-				<h4 class="il-item-notification-title">
+				<h2 class="il-item-notification-title">
 					<a href="">TestLink</a>
-				</h4>
+				</h2>
 				<button type="button" class="close" aria-label="close" id="id">
 					<span aria-hidden="true">&times;</span>
 				</button>
@@ -281,7 +281,7 @@ class ItemNotificationTest extends ILIAS_UI_TestBase
                                                 <img class="icon name small" src="./assets/images/standard/icon_default.svg" alt="aria_label"/>
 											</div>
 											<div class="media-body">
-												<h4 class="il-item-notification-title">title_aggregate</h4>
+												<h3 class="il-item-notification-title">title_aggregate</h3>
 												<div class="il-aggregate-notifications" data-aggregatedby="id">
 													<div class="il-maincontrols-slate il-maincontrols-slate-notification">
 														<div class="il-maincontrols-slate-notification-title">

--- a/components/ILIAS/UI/tests/Component/Item/ItemTest.php
+++ b/components/ILIAS/UI/tests/Component/Item/ItemTest.php
@@ -219,7 +219,7 @@ class ItemTest extends ILIAS_UI_TestBase
 
         $expected = <<<EOT
         <div class="il-item il-std-item ">
-            <h4 class="il-item-title">Item Title</h4>
+            <h2 class="il-item-title">Item Title</h2>
 			<div class="il-item-actions l-bar__space-keeper"><div class="l-bar__element"><div class="dropdown" id="id_3"><button class="btn btn-default dropdown-toggle" type="button" aria-label="actions" aria-haspopup="true" aria-expanded="false" aria-controls="id_3_menu"><span class="caret"></span></button>
                 <ul id="id_3_menu" class="dropdown-menu">
 	                <li><button class="btn btn-link" data-action="https://www.ilias.de" id="id_1"  >ILIAS</button>
@@ -272,7 +272,7 @@ EOT;
 			<img src="src" class="img-standard" alt="str" />
 		</div>
 		<div class="col-xs-10 col-sm-9">
-            <h4 class="il-item-title">title</h4>
+            <h2 class="il-item-title">title</h2>
 		</div>
 	</div>
 </div>
@@ -301,7 +301,7 @@ EOT;
 			<img class="icon name small" src="./assets/images/standard/icon_default.svg" alt="aria_label" />
         </div>
 		<div class="media-body">
-            <h4 class="il-item-title">title</h4>
+            <h2 class="il-item-title">title</h2>
 		</div>
 	</div>
 </div>
@@ -333,7 +333,7 @@ EOT;
             </span>
         </div>
         <div class="media-body">
-            <h4 class="il-item-title">title</h4>
+            <h2 class="il-item-title">title</h2>
         </div>
     </div>
 </div>
@@ -364,7 +364,7 @@ EOT;
             </span>
         </div>
         <div class="media-body">
-            <h4 class="il-item-title">title</h4>
+            <h2 class="il-item-title">title</h2>
         </div>
     </div>
 </div>
@@ -390,7 +390,7 @@ EOT;
 <div class="il-item il-std-item ">
 	<div class="row">
 	    <div class="col-sm-9">
-            <h4 class="il-item-title">title</h4>
+            <h2 class="il-item-title">title</h2>
 		</div>
 		<div class="col-xs-3 col-sm-2 col-lg-2">
 		    <div class="il-chart-progressmeter-box ">
@@ -442,7 +442,7 @@ EOT;
 			<img src="src" class="img-standard" alt="str" />
 		</div>
 	    <div class="col-xs-6 col-sm-7 col-lg-8">
-            <h4 class="il-item-title">title</h4>
+            <h2 class="il-item-title">title</h2>
 		</div>
 		<div class="col-xs-3 col-sm-2 col-lg-2">
 		    <div class="il-chart-progressmeter-box ">
@@ -494,7 +494,7 @@ EOT;
 			<img class="icon name small" src="./assets/images/standard/icon_default.svg" alt="aria_label" />
         </div>
 		<div class="media-body">
-            <h4 class="il-item-title">title</h4>
+            <h2 class="il-item-title">title</h2>
 		</div>
 		<div class="media-right">
 			<div class="il-chart-progressmeter-box ">
@@ -547,7 +547,7 @@ EOT;
 			lead
 		</div>
 		<div class="col-sm-9">
-            <h4 class="il-item-title">title</h4>
+            <h2 class="il-item-title">title</h2>
 		</div>
 	</div>
 </div>
@@ -578,9 +578,9 @@ EOT;
         $html = $this->brutallyTrimHTML($r->render($c));
         $expected = $this->brutallyTrimHTML(<<<EOT
 <div class="il-item il-std-item ">
-    <h4 class="il-item-title">
+    <h2 class="il-item-title">
         <button class="btn btn-link" data-action="https://www.ilias.de" id="id_1">ILIAS</button>
-    </h4>
+    </h2>
     <hr class="il-item-divider" />
     <div class="row">
         <div class="col-md-6 il-multi-line-cap-3">
@@ -623,7 +623,7 @@ EOT);
         $html = $r->render($c);
 
         $expected = <<<EOT
-<div class="il-item il-std-item "><h4 class="il-item-title"><a href="https://www.ilias.de">ILIAS</a></h4></div>
+<div class="il-item il-std-item "><h2 class="il-item-title"><a href="https://www.ilias.de">ILIAS</a></h2></div>
 EOT;
 
         $this->assertHTMLEquals($expected, $html);
@@ -640,7 +640,7 @@ EOT;
         $html = $r->render($c);
         $expected = <<<EOT
 <div class="il-item il-std-item ">
-    <h4 class="il-item-title">title</h4>
+    <h2 class="il-item-title">title</h2>
     <div class="il-item-audio"><div class="il-audio-container">
     <audio class="il-audio-player" id="id_1" src="src" preload="metadata"></audio>
 </div></div>
@@ -668,7 +668,7 @@ EOT;
 
         $expected = <<<EOT
         <div class="il-item il-std-item ">
-            <h4 class="il-item-title">Title</h4>
+            <h2 class="il-item-title">Title</h2>
             <div class="il-item-actions l-bar__space-keeper">
                 <div class="l-bar__element">$expected_button_html
             </div>
@@ -697,7 +697,7 @@ EOT;
 
         $expected = <<<EOT
         <div class="il-item il-std-item ">
-            <h4 class="il-item-title">Title</h4>
+            <h2 class="il-item-title">Title</h2>
             <div class="il-item-actions l-bar__space-keeper">
                 <div class="l-bar__element">$expected_link_html</div>
             </div>

--- a/components/ILIAS/UI/tests/Component/Listing/Workflow/LinearWorkflowTest.php
+++ b/components/ILIAS/UI/tests/Component/Listing/Workflow/LinearWorkflowTest.php
@@ -101,7 +101,7 @@ class LinearWorkflowTest extends ILIAS_UI_TestBase
         $expected = <<<EOT
             <div class="il-workflow linear" id="id_1">
                 <div class="il-workflow-header">
-                    <h3 class="il-workflow-title">title</h3>
+                    <h2 class="il-workflow-title">title</h2>
                 </div>
                 <ul class="il-workflow-container">
                     <li class="il-workflow-step first available not-started">

--- a/components/ILIAS/UI/tests/Component/MainControls/Slate/CombinedSlateTest.php
+++ b/components/ILIAS/UI/tests/Component/MainControls/Slate/CombinedSlateTest.php
@@ -109,19 +109,26 @@ class CombinedSlateTest extends ILIAS_UI_TestBase
             ->withAdditionalEntry($subdivider_with_text)
             ->withAdditionalEntry($subdivider);
 
-        $r = $this->getDefaultRenderer();
-        $html = $r->render($slate);
-
-        $expected = <<<EOT
+        $out = <<<EOT
         <div class="il-maincontrols-slate disengaged" id="id_1">
             <div class="il-maincontrols-slate-content" data-replace-marker="content">
                 <ul>
-                    <li><hr class="il-divider-with-label" /><h4 class="il-divider">Title</h4></li>
+                    <li><hr class="il-divider-with-label" /><h[LEVEL] class="il-divider">Title</h[LEVEL]></li>
                     <li><hr /></li>
                 </ul>
             </div>
         </div>
 EOT;
+
+        $html = $this->getDefaultRenderer()->render($slate);
+        $expected = str_replace('[LEVEL]', '2', $out);
+        $this->assertEquals(
+            $this->brutallyTrimHTML($expected),
+            $this->brutallyTrimHTML($html)
+        );
+
+        $html = $this->getDefaultRenderer()->withHeaderNesting(3)->render($slate);
+        $expected = str_replace('[LEVEL]', '4', $out);
         $this->assertEquals(
             $this->brutallyTrimHTML($expected),
             $this->brutallyTrimHTML($html)

--- a/components/ILIAS/UI/tests/Component/MainControls/Slate/NotificationSlateTest.php
+++ b/components/ILIAS/UI/tests/Component/MainControls/Slate/NotificationSlateTest.php
@@ -133,7 +133,7 @@ class NotificationSlateTest extends ILIAS_UI_TestBase
 						<img class="icon name small" src="./assets/images/standard/icon_default.svg" alt="aria_label"/>
 					</div>
 					<div class="media-body">
-						<h4 class="il-item-notification-title">item title</h4>
+						<h2 class="il-item-notification-title">item title</h2>
 						<div class="il-aggregate-notifications" data-aggregatedby="id_1">
 							<div class="il-maincontrols-slate il-maincontrols-slate-notification">
 								<div class="il-maincontrols-slate-notification-title">

--- a/components/ILIAS/UI/tests/Component/Panel/PanelSecondaryListingTest.php
+++ b/components/ILIAS/UI/tests/Component/Panel/PanelSecondaryListingTest.php
@@ -330,7 +330,7 @@ EOT;
 <div class="panel panel-secondary panel-flex">
   <div class="panel-body">
     <div class="il-item-group">
-      <h3>Subtitle 1</h3>
+      <h2>Subtitle 1</h2>
       <div class="il-item-group-items">
         <ul>
             <li class="il-std-item-container">
@@ -340,7 +340,7 @@ EOT;
             </li>
             <li class="il-std-item-container">
               <div class="il-item il-std-item ">
-                <h4 class="il-item-title">title2</h4>
+                <h3 class="il-item-title">title2</h3>
               </div>
             </li>
         </ul>

--- a/components/ILIAS/UI/tests/Component/Panel/PanelSecondaryListingTest.php
+++ b/components/ILIAS/UI/tests/Component/Panel/PanelSecondaryListingTest.php
@@ -335,7 +335,7 @@ EOT;
         <ul>
             <li class="il-std-item-container">
               <div class="il-item il-std-item ">
-                <h4 class="il-item-title">title1</h4>
+                <h3 class="il-item-title">title1</h3>
               </div>
             </li>
             <li class="il-std-item-container">

--- a/components/ILIAS/UI/tests/Component/Panel/PanelTest.php
+++ b/components/ILIAS/UI/tests/Component/Panel/PanelTest.php
@@ -265,7 +265,7 @@ EOT;
         $expected_html = <<<EOT
 <div class="panel panel-sub panel-flex">
     <div class="panel-heading ilBlockHeader">
-        <h3>Title</h3>
+        <h2>Title</h2>
         <div class="panel-controls">
             <div class="dropdown" id="id_3"><button class="btn btn-default dropdown-toggle" type="button" aria-label="actions" aria-haspopup="true" aria-expanded="false" aria-controls="id_3_menu"><span class="caret"></span></button>
                 <ul id="id_3_menu" class="dropdown-menu">
@@ -306,7 +306,7 @@ EOT;
         $expected_html = <<<EOT
 <div class="panel panel-sub panel-flex">
     <div class="panel-heading ilBlockHeader">
-        <h3>Title</h3>
+        <h2>Title</h2>
         <div class="panel-controls"></div>
     </div>
     <div class="panel-body">
@@ -315,7 +315,7 @@ EOT;
             <div class="col-sm-4">
                 <div class="panel panel-secondary panel-flex">
                     <div class="panel-heading ilHeader">
-                        <div class="panel-title"><h2>Legacy panel title</h2></div>
+                        <div class="panel-title"><h3>Legacy panel title</h3></div>
                         <div class="panel-controls"></div>
                     </div>
                     <div class="panel-body">Legacy content</div>

--- a/components/ILIAS/UI/tests/Component/Table/PresentationTest.php
+++ b/components/ILIAS/UI/tests/Component/Table/PresentationTest.php
@@ -146,7 +146,7 @@ class PresentationTest extends TableTestBase
 
         $expected = <<<EXP
 <div class="il-table-presentation" id="id_3">
-    <h3 class="ilHeader">title</h3>
+    <h2 class="ilHeader">title</h2>
     <div class="il-table-presentation-viewcontrols">
         <div class="l-bar__space-keeper l-bar__space-keeper--space-between">
             <div class="l-bar__group">
@@ -177,8 +177,8 @@ class PresentationTest extends TableTestBase
             <div class="il-table-presentation-row-contents col-lg col-sm-12">
                 <div class="row">
                    <div class="il-table-presentation-row-header col-lg col-sm-12">
-                       <h4 class="il-table-presentation-row-header-headline" onClick="$(document).trigger('il_signal...');">some title<br /><small>some type</small>
-                       </h4>
+                       <h3 class="il-table-presentation-row-header-headline" onClick="$(document).trigger('il_signal...');">some title<br /><small>some type</small>
+                       </h3>
                        <div class="il-table-presentation-row-header-fields">
                           <div class="l-bar__space-keeper">
                               <div class="l-bar__group">
@@ -208,7 +208,7 @@ class PresentationTest extends TableTestBase
                             </div>
                             <div class="il-table-presentation-details col-lg-5 col-sm-12">
                                 <div class="il-table-presentation-fields">
-                                    <h5>further fields</h5>
+                                    <h4>further fields</h4>
                                     <span class="il-item-property-name">f-1</span>
                                     <span class="il-item-property-value">further</span>
                                     <br />
@@ -247,7 +247,7 @@ EXP;
 
         $expected = <<<EXP
 <div class="il-table-presentation" id="id_3">
-    <h3 class="ilHeader">title</h3>
+    <h2 class="ilHeader">title</h2>
     <div class="il-table-presentation-viewcontrols">
 
         <div class="l-bar__space-keeper l-bar__space-keeper--space-between">
@@ -280,7 +280,7 @@ EXP;
             <div class="il-table-presentation-row-contents col-lg col-sm-12">
                 <div class="row">
                     <div class="il-table-presentation-row-header col-lg col-sm-12">
-                        <h4 class="il-table-presentation-row-header-headline" onClick="$(document).trigger('il_signal...');">some title</h4>
+                        <h3 class="il-table-presentation-row-header-headline" onClick="$(document).trigger('il_signal...');">some title</h3>
                         <div class="il-table-presentation-row-header-fields">                  
                             <button class="btn btn-link" id="id_7">presentation_table_more</button>
                         </div>

--- a/components/ILIAS/UI/tests/Renderer/DefaultRendererTest.php
+++ b/components/ILIAS/UI/tests/Renderer/DefaultRendererTest.php
@@ -269,4 +269,27 @@ class DefaultRendererTest extends ILIAS_UI_TestBase
         $res = $renderer->render([$component, $component], $root);
         $this->assertEquals("..", $res);
     }
+
+    public function testHeaderNestingLevels(): void
+    {
+        $renderer = $this->getDefaultRenderer();
+        $this->assertEquals(1, $renderer->getHeaderNesting());
+        $this->assertEquals(2, $renderer->getHeaderNesting(1));
+        $this->assertEquals(5, $renderer->getHeaderNesting(4));
+        $this->assertEquals(3, $renderer->withHeaderNesting(5)->getHeaderNesting(-2));
+    }
+
+    public function testGetHeaderNestingLevelsError(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->getDefaultRenderer()->getHeaderNesting(-10);
+    }
+
+    public function testSetHeaderNestingLevelsError(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->getDefaultRenderer()->withHeaderNesting(-10);
+    }
+
+
 }


### PR DESCRIPTION
This removes static `<h1>, <h2>`,... from templates and uses a counter on the DefaultRenderer to adjust the nesting level dynamically.