### PR TITLE
Fix: Improve accessibility of expand/collapse controls in Test Results view

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Table/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Renderer.php
@@ -139,13 +139,10 @@ class Renderer extends AbstractComponentRenderer
             ->withOnClick($sig_show);
         $collapser = $f->symbol()->glyph()->collapse("#")
             ->withOnClick($sig_hide);
-        $shy_expander = $f->button()->shy($this->txt("presentation_table_more"), "#")
-            ->withOnClick($sig_show);
 
         $tpl->setVariable("ID", $id);
         $tpl->setVariable("EXPANDER", $default_renderer->render($expander));
         $tpl->setVariable("COLLAPSER", $default_renderer->render($collapser));
-        $tpl->setVariable("SHY_EXPANDER", $default_renderer->render($shy_expander));
 
         if ($symbol = $component->getLeadingSymbol()) {
             $tpl->setVariable("SYMBOL", $default_renderer->render($symbol));

--- a/components/ILIAS/UI/src/templates/default/Table/tpl.presentationrow.html
+++ b/components/ILIAS/UI/src/templates/default/Table/tpl.presentationrow.html
@@ -39,7 +39,6 @@
 						</div>
 						<!-- END important_field -->
 					</dl>
-					{SHY_EXPANDER}
 				</div>
 			</div>
 

--- a/components/ILIAS/UI/tests/Client/Table/Presentation/PresentationTest.html
+++ b/components/ILIAS/UI/tests/Client/Table/Presentation/PresentationTest.html
@@ -37,7 +37,6 @@
 
             <div class="il-table-presentation-row-header-fields" style="display: none;">
               30.09.2017
-              <button class="btn btn-link" id="il_ui_fw_64d08e54d5db79_97396919">Show More</button>
             </div>
           </div>
 

--- a/components/ILIAS/UI/tests/Component/Table/PresentationTest.php
+++ b/components/ILIAS/UI/tests/Component/Table/PresentationTest.php
@@ -201,11 +201,10 @@ class PresentationTest extends TableTestBase
                                   </div>
                               </div>
                           </dl>
-                          <button class="btn btn-link" id="id_7">presentation_table_more</button>
                        </div>
                    </div>
                    <div class="il-table-presentation-actions col-lg-auto col-sm-12">
-                        <button class="btn btn-default" data-action="#" id="id_8">do</button><br />
+                        <button class="btn btn-default" data-action="#" id="id_7">do</button><br />
                    </div>
                    <div class="il-table-presentation-row-expanded col-lg-12 col-sm-12">
                         <div class="row">
@@ -294,7 +293,6 @@ EXP;
                         <h4 class="il-table-presentation-row-header-headline" onClick="$(document).trigger('il_signal...');">some title</h4>
                         <div class="il-table-presentation-row-header-fields">
                             <dl></dl>
-                            <button class="btn btn-link" id="id_7">presentation_table_more</button>
                         </div>
                     </div>
                     <div class="il-table-presentation-actions col-lg-auto col-sm-12"></div>

--- a/lang/ilias_ar.lang
+++ b/lang/ilias_ar.lang
@@ -5379,7 +5379,6 @@ common#:#preconditions_obligatory_hint#:#Please edit the following preconditions
 common#:#preconditions_optional_hint#:#Please edit one of the following preconditions
 common#:#predefined_template#:#Predefined role template
 common#:#preferences#:#مفضلات
-common#:#presentation_table_more#:#more###10 11 2018 new variable
 common#:#preview#:#Preview###24 10 2013 new variable
 common#:#preview_create#:#Create Preview###24 10 2013 new variable
 common#:#preview_delete#:#Delete Preview###24 10 2013 new variable

--- a/lang/ilias_bg.lang
+++ b/lang/ilias_bg.lang
@@ -5379,7 +5379,6 @@ common#:#preconditions_obligatory_hint#:#Please edit the following preconditions
 common#:#preconditions_optional_hint#:#Please edit one of the following preconditions###22 03 2011 new variable
 common#:#predefined_template#:#Predefined role template###06 09 2006 new variable
 common#:#preferences#:#User-defined Preferences###26 06 2009 new variable
-common#:#presentation_table_more#:#more###10 11 2018 new variable
 common#:#preview#:#Preview###24 10 2013 new variable
 common#:#preview_create#:#Create Preview###24 10 2013 new variable
 common#:#preview_delete#:#Delete Preview###24 10 2013 new variable

--- a/lang/ilias_cs.lang
+++ b/lang/ilias_cs.lang
@@ -5379,7 +5379,6 @@ common#:#preconditions_obligatory_hint#:#Musíte splnit všechny následující 
 common#:#preconditions_optional_hint#:#Musíte splnít <b>%s</b> následujících podmínek
 common#:#predefined_template#:#Předdefinovaná šablona role
 common#:#preferences#:#Uživatelsky definované preference
-common#:#presentation_table_more#:#více
 common#:#preview#:#Náhled
 common#:#preview_create#:#Vytvořit náhled
 common#:#preview_delete#:#Smazat náhled

--- a/lang/ilias_da.lang
+++ b/lang/ilias_da.lang
@@ -5379,7 +5379,6 @@ common#:#preconditions_obligatory_hint#:#Please edit the following preconditions
 common#:#preconditions_optional_hint#:#Please edit one of the following preconditions###22 03 2011 new variable
 common#:#predefined_template#:#Fordefineret rolleskabelon
 common#:#preferences#:#Brugerdefinerede ønsker
-common#:#presentation_table_more#:#more###10 11 2018 new variable
 common#:#preview#:#Preview###16 09 2013 new variable
 common#:#preview_create#:#Create Preview###16 09 2013 new variable
 common#:#preview_delete#:#Delete Preview###16 09 2013 new variable

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -5379,7 +5379,6 @@ common#:#preconditions_obligatory_hint#:#Bitte erfüllen Sie die folgenden Vorbe
 common#:#preconditions_optional_hint#:#Bitte erfüllen Sie mindestens <b>%s</b> der folgenden Vorbedingungen
 common#:#predefined_template#:#Vordefinierte Rollenvorlage
 common#:#preferences#:#Benutzerdefinierte Einstellungen
-common#:#presentation_table_more#:#Mehr anzeigen
 common#:#preview#:#Vorschau
 common#:#preview_create#:#Vorschau erstellen
 common#:#preview_delete#:#Vorschau löschen

--- a/lang/ilias_el.lang
+++ b/lang/ilias_el.lang
@@ -5380,7 +5380,6 @@ common#:#preconditions_obligatory_hint#:#Please edit the following preconditions
 common#:#preconditions_optional_hint#:#Please edit one of the following preconditions###22 03 2011 new variable
 common#:#predefined_template#:#Προκαθορισμένο πρότυπο ρόλου
 common#:#preferences#:#User-defined Preferences###26 06 2009 new variable
-common#:#presentation_table_more#:#more###10 11 2018 new variable
 common#:#preview#:#Preview###24 10 2013 new variable
 common#:#preview_create#:#Create Preview###24 10 2013 new variable
 common#:#preview_delete#:#Delete Preview###24 10 2013 new variable

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -5380,7 +5380,6 @@ common#:#preconditions_obligatory_hint#:#You have to fulfill all of the followin
 common#:#preconditions_optional_hint#:#You have to fulfill <b>%s</b> of the following preconditions
 common#:#predefined_template#:#Predefined role template
 common#:#preferences#:#Preferences
-common#:#presentation_table_more#:#Show More
 common#:#preview#:#Preview
 common#:#preview_create#:#Create Preview
 common#:#preview_delete#:#Delete Preview

--- a/lang/ilias_es.lang
+++ b/lang/ilias_es.lang
@@ -5383,7 +5383,6 @@ common#:#preconditions_obligatory_hint#:#Debe cumplir todas las siguientes condi
 common#:#preconditions_optional_hint#:#Debe cumplir <b>%s</b> de las siguientes condiciones previas
 common#:#predefined_template#:#Plantilla de rol predefinida
 common#:#preferences#:#Preferencias
-common#:#presentation_table_more#:#Mostrar más
 common#:#preview#:#Vista previa
 common#:#preview_create#:#Crear vista previa
 common#:#preview_delete#:#Eliminar vista previa

--- a/lang/ilias_et.lang
+++ b/lang/ilias_et.lang
@@ -5379,7 +5379,6 @@ common#:#preconditions_obligatory_hint#:#Palun muuda järgmisi eeltingimusi
 common#:#preconditions_optional_hint#:#Please edit one of the following preconditions
 common#:#predefined_template#:#Predefined role template
 common#:#preferences#:#Kasutaja eelistused
-common#:#presentation_table_more#:#more###10 11 2018 new variable
 common#:#preview#:#Preview
 common#:#preview_create#:#Create Preview
 common#:#preview_delete#:#Delete Preview

--- a/lang/ilias_fa.lang
+++ b/lang/ilias_fa.lang
@@ -5379,7 +5379,6 @@ common#:#preconditions_obligatory_hint#:#لطفا این پیش شرط ها را
 common#:#preconditions_optional_hint#:#Please edit one of the following preconditions
 common#:#predefined_template#:#Predefined role template
 common#:#preferences#:#ترجیحات
-common#:#presentation_table_more#:#more###10 11 2018 new variable
 common#:#preview#:#Preview###24 10 2013 new variable
 common#:#preview_create#:#Create Preview###24 10 2013 new variable
 common#:#preview_delete#:#Delete Preview###24 10 2013 new variable

--- a/lang/ilias_fr.lang
+++ b/lang/ilias_fr.lang
@@ -5364,7 +5364,6 @@ common#:#preconditions_obligatory_hint#:#Vous devez remplir toutes les précondi
 common#:#preconditions_optional_hint#:#Vous devez remplir <b>%s</b> des préconditions suivantes
 common#:#predefined_template#:#Modèle de rôle prédéfini
 common#:#preferences#:#Préférences Utilisateur-défini
-common#:#presentation_table_more#:#more
 common#:#preview#:#Aperçu
 common#:#preview_create#:#Créer Aperçu
 common#:#preview_delete#:#Supprimer Aperçu

--- a/lang/ilias_hr.lang
+++ b/lang/ilias_hr.lang
@@ -5379,7 +5379,6 @@ common#:#preconditions_obligatory_hint#:#Morate ispuniti sve sljedeće preduvjet
 common#:#preconditions_optional_hint#:#Morate ispuniti <b>%s</b> sljedećih preduvjeta
 common#:#predefined_template#:#Preddefinirani predložak uloge
 common#:#preferences#:#Korisničke postavke
-common#:#presentation_table_more#:#Prikaži više
 common#:#preview#:#Pregled
 common#:#preview_create#:#Kreiraj pregled
 common#:#preview_delete#:#Izbriši pregled

--- a/lang/ilias_hu.lang
+++ b/lang/ilias_hu.lang
@@ -5379,7 +5379,6 @@ common#:#preconditions_obligatory_hint#:#Teljesítenie kell az alábbi előfelt�
 common#:#preconditions_optional_hint#:#Az alábbi előfeltételekből <b>%s</b> darabot kell teljesítenie
 common#:#predefined_template#:#Előre definiált szerepsablon
 common#:#preferences#:#Beállítások
-common#:#presentation_table_more#:#Több megjelenítése
 common#:#preview#:#Előnézet
 common#:#preview_create#:#Előnézet létrehozása
 common#:#preview_delete#:#Előnézet törlése

--- a/lang/ilias_it.lang
+++ b/lang/ilias_it.lang
@@ -5378,7 +5378,6 @@ common#:#preconditions_obligatory_hint#:#Modifica i seguenti presupposti
 common#:#preconditions_optional_hint#:#Modifica una delle seguenti condizioni preliminari
 common#:#predefined_template#:#Template di ruolo predefiniti
 common#:#preferences#:#Preferenze definite dall'utente
-common#:#presentation_table_more#:#Di Più
 common#:#preview#:#Anteprima
 common#:#preview_create#:#Crea anteprima
 common#:#preview_delete#:#Elimina anteprima

--- a/lang/ilias_ja.lang
+++ b/lang/ilias_ja.lang
@@ -5379,7 +5379,6 @@ common#:#preconditions_obligatory_hint#:#次の前提条件を遂行してくだ
 common#:#preconditions_optional_hint#:#次の前提条件<b>%s</b>の中から遂行してください
 common#:#predefined_template#:#事前定義の役割テンプレート
 common#:#preferences#:#プレファレンス
-common#:#presentation_table_more#:#詳しく見る
 common#:#preview#:#プレビュー
 common#:#preview_create#:#プレビューを作成
 common#:#preview_delete#:#プレビューを削除

--- a/lang/ilias_ka.lang
+++ b/lang/ilias_ka.lang
@@ -5379,7 +5379,6 @@ common#:#preconditions_obligatory_hint#:#თქვენ უნდა შას�
 common#:#preconditions_optional_hint#:#გთხოვთ შეასრულოთ მინიმუმ შემდეგი წინაპირობების <b>%s</b>
 common#:#predefined_template#:#განსაზღვრული პასუხისმგებლობის ნიმუში
 common#:#preferences#:#წყაროები
-common#:#presentation_table_more#:#more###10 11 2018 new variable
 common#:#preview#:#Preview###24 10 2013 new variable
 common#:#preview_create#:#Create Preview###24 10 2013 new variable
 common#:#preview_delete#:#Delete Preview###24 10 2013 new variable

--- a/lang/ilias_lt.lang
+++ b/lang/ilias_lt.lang
@@ -5379,7 +5379,6 @@ common#:#preconditions_obligatory_hint#:#Please edit the following preconditions
 common#:#preconditions_optional_hint#:#Please edit one of the following preconditions###22 03 2011 new variable
 common#:#predefined_template#:#Iš anksto apibrėžtos rolės šablonas
 common#:#preferences#:#User-defined Preferences###26 06 2009 new variable
-common#:#presentation_table_more#:#more###10 11 2018 new variable
 common#:#preview#:#Preview###24 10 2013 new variable
 common#:#preview_create#:#Create Preview###24 10 2013 new variable
 common#:#preview_delete#:#Delete Preview###24 10 2013 new variable

--- a/lang/ilias_nl.lang
+++ b/lang/ilias_nl.lang
@@ -5379,7 +5379,6 @@ common#:#preconditions_obligatory_hint#:#Je moet voldoen aan alle volgende voorw
 common#:#preconditions_optional_hint#:#Je moet nog voldoen aan  <b>%s</b> van de volgende voorwaarden.
 common#:#predefined_template#:#Vooraf ingestelde sjabloon rol
 common#:#preferences#:#Gebruiker's voorkeuren
-common#:#presentation_table_more#:#more###10 11 2018 new variable
 common#:#preview#:#voorbeeldweergave
 common#:#preview_create#:#Aanmaken voorbeeldweergave
 common#:#preview_delete#:#Verwijderen voorbeeldweergave

--- a/lang/ilias_pl.lang
+++ b/lang/ilias_pl.lang
@@ -5379,7 +5379,6 @@ common#:#preconditions_obligatory_hint#:#Musisz spełnić wszystkie poniższe wa
 common#:#preconditions_optional_hint#:#Musisz spełnić min. <b>%s</b> poniższych warunków.
 common#:#predefined_template#:#Predefiniowany szablon roli
 common#:#preferences#:#Preferencje
-common#:#presentation_table_more#:#more
 common#:#preview#:#Podgląd
 common#:#preview_create#:#Utwórz podgląd
 common#:#preview_delete#:#Usuń podgląd

--- a/lang/ilias_pt.lang
+++ b/lang/ilias_pt.lang
@@ -5379,7 +5379,6 @@ common#:#preconditions_obligatory_hint#:#Verificação do Sistema
 common#:#preconditions_optional_hint#:#Idioma do sistema
 common#:#predefined_template#:#Modelo de função predefinido
 common#:#preferences#:#Importar mail
-common#:#presentation_table_more#:#Os meus Tags
 common#:#preview#:#Pré-visualização
 common#:#preview_create#:#Criar pré-visualização
 common#:#preview_delete#:#Apagar pré-visualização

--- a/lang/ilias_ro.lang
+++ b/lang/ilias_ro.lang
@@ -5379,7 +5379,6 @@ common#:#preconditions_obligatory_hint#:#Please edit the following preconditions
 common#:#preconditions_optional_hint#:#Please edit one of the following preconditions###22 03 2011 new variable
 common#:#predefined_template#:#Predefined role template ### 2006-8-11 --- Add new translation here.
 common#:#preferences#:#User-defined Preferences###26 06 2009 new variable
-common#:#presentation_table_more#:#more###10 11 2018 new variable
 common#:#preview#:#Preview###24 10 2013 new variable
 common#:#preview_create#:#Create Preview###24 10 2013 new variable
 common#:#preview_delete#:#Delete Preview###24 10 2013 new variable

--- a/lang/ilias_ru.lang
+++ b/lang/ilias_ru.lang
@@ -5379,7 +5379,6 @@ common#:#preconditions_obligatory_hint#:#Please edit the following preconditions
 common#:#preconditions_optional_hint#:#Please edit one of the following preconditions
 common#:#predefined_template#:#Predefined role template
 common#:#preferences#:#User-defined Preferences
-common#:#presentation_table_more#:#more###10 11 2018 new variable
 common#:#preview#:#Preview
 common#:#preview_create#:#Create Preview
 common#:#preview_delete#:#Delete Preview

--- a/lang/ilias_sk.lang
+++ b/lang/ilias_sk.lang
@@ -5379,7 +5379,6 @@ common#:#preconditions_obligatory_hint#:#Please edit the following preconditions
 common#:#preconditions_optional_hint#:#Please edit one of the following preconditions###22 03 2011 new variable
 common#:#predefined_template#:#Předdefinovaná šablona role
 common#:#preferences#:#User-defined Preferences
-common#:#presentation_table_more#:#more###10 11 2018 new variable
 common#:#preview#:#Preview###24 10 2013 new variable
 common#:#preview_create#:#Create Preview###24 10 2013 new variable
 common#:#preview_delete#:#Delete Preview###24 10 2013 new variable

--- a/lang/ilias_sl.lang
+++ b/lang/ilias_sl.lang
@@ -5379,7 +5379,6 @@ common#:#preconditions_obligatory_hint#:#Izpolnite naslednje predpogoje
 common#:#preconditions_optional_hint#:#Izpolnite vsaj <b>%s</b> od naslednjih predpogojev
 common#:#predefined_template#:#Vnaprej določena predloga vlog
 common#:#preferences#:#Uporabniške nastavitve
-common#:#presentation_table_more#:#Prikaži več
 common#:#preview#:#Predogled
 common#:#preview_create#:#Ustvari predogled
 common#:#preview_delete#:#Izbriši predogled

--- a/lang/ilias_sq.lang
+++ b/lang/ilias_sq.lang
@@ -5379,7 +5379,6 @@ common#:#preconditions_obligatory_hint#:#Please edit the following preconditions
 common#:#preconditions_optional_hint#:#Please edit one of the following preconditions###22 03 2011 new variable
 common#:#predefined_template#:#Predefined role template###14 Jul 2005 new variable
 common#:#preferences#:#User-defined Preferences###26 06 2009 new variable
-common#:#presentation_table_more#:#more###10 11 2018 new variable
 common#:#preview#:#Preview###24 10 2013 new variable
 common#:#preview_create#:#Create Preview###24 10 2013 new variable
 common#:#preview_delete#:#Delete Preview###24 10 2013 new variable

--- a/lang/ilias_sr.lang
+++ b/lang/ilias_sr.lang
@@ -5379,7 +5379,6 @@ common#:#preconditions_obligatory_hint#:#Please edit the following preconditions
 common#:#preconditions_optional_hint#:#Please edit one of the following preconditions###22 03 2011 new variable
 common#:#predefined_template#:#Predefined role template###14 Jul 2005 new variable
 common#:#preferences#:#User-defined Preferences###26 06 2009 new variable
-common#:#presentation_table_more#:#more###10 11 2018 new variable
 common#:#preview#:#Preview###24 10 2013 new variable
 common#:#preview_create#:#Create Preview###24 10 2013 new variable
 common#:#preview_delete#:#Delete Preview###24 10 2013 new variable

--- a/lang/ilias_sv.lang
+++ b/lang/ilias_sv.lang
@@ -5379,7 +5379,6 @@ common#:#preconditions_obligatory_hint#:#Välkomna att uppfylla följande villko
 common#:#preconditions_optional_hint#:#Var vänlig uppfyll minst <b>%s av</b> följande förhandsvillkor
 common#:#predefined_template#:#Fördefinierad rollmall
 common#:#preferences#:#Användardefinierade inställningar
-common#:#presentation_table_more#:#Visa mer
 common#:#preview#:#Förhandsgranskning
 common#:#preview_create#:#Skapa förhandsvisning
 common#:#preview_delete#:#Ta bort förhandsgranskning

--- a/lang/ilias_tr.lang
+++ b/lang/ilias_tr.lang
@@ -5379,7 +5379,6 @@ common#:#preconditions_obligatory_hint#:#Aşağıdaki koşulların tümünü yer
 common#:#preconditions_optional_hint#:#<b>% s </ b>, aşağıdaki önkoşulları yerine getirmek zorundasınız
 common#:#predefined_template#:#Öntanımlı rol şablonu
 common#:#preferences#:#Tercihler
-common#:#presentation_table_more#:#more###10 11 2018 new variable
 common#:#preview#:#Preview###24 10 2013 new variable
 common#:#preview_create#:#Create Preview###24 10 2013 new variable
 common#:#preview_delete#:#Delete Preview###24 10 2013 new variable

--- a/lang/ilias_uk.lang
+++ b/lang/ilias_uk.lang
@@ -5379,7 +5379,6 @@ common#:#preconditions_obligatory_hint#:#Please edit the following preconditions
 common#:#preconditions_optional_hint#:#Please edit one of the following preconditions###22 03 2011 new variable
 common#:#predefined_template#:#Predefined role template###14 Jul 2005 new variable
 common#:#preferences#:#User-defined Preferences###26 06 2009 new variable
-common#:#presentation_table_more#:#more###10 11 2018 new variable
 common#:#preview#:#Preview###24 10 2013 new variable
 common#:#preview_create#:#Create Preview###24 10 2013 new variable
 common#:#preview_delete#:#Delete Preview###24 10 2013 new variable

--- a/lang/ilias_vi.lang
+++ b/lang/ilias_vi.lang
@@ -5381,7 +5381,6 @@ common#:#preconditions_obligatory_hint#:#Please edit the following preconditions
 common#:#preconditions_optional_hint#:#Please edit one of the following preconditions###22 03 2011 new variable
 common#:#predefined_template#:#Vai trò mẫu định nghĩa trước
 common#:#preferences#:#User-defined Preferences###26 06 2009 new variable
-common#:#presentation_table_more#:#more###10 11 2018 new variable
 common#:#preview#:#Preview###24 10 2013 new variable
 common#:#preview_create#:#Create Preview###24 10 2013 new variable
 common#:#preview_delete#:#Delete Preview###24 10 2013 new variable

--- a/lang/ilias_zh.lang
+++ b/lang/ilias_zh.lang
@@ -5378,7 +5378,6 @@ common#:#preconditions_obligatory_hint#:#请编辑以下先决条件
 common#:#preconditions_optional_hint#:#请编辑以下先决条件之一
 common#:#predefined_template#:#预定义的角色模板
 common#:#preferences#:#用户定义偏好
-common#:#presentation_table_more#:#more###10 11 2018 new variable
 common#:#preview#:#Preview###24 10 2013 new variable
 common#:#preview_create#:#Create Preview###24 10 2013 new variable
 common#:#preview_delete#:#Delete Preview###24 10 2013 new variable


### PR DESCRIPTION
Adjusted the language variable used for expand/collapse controls in the `Test → Results → Detailed Results` view to enhance accessibility and provide clearer, more consistent labeling.
This update ensures that assistive technologies can better interpret the purpose of the buttons.
Reference: [Ticket #43953.](https://mantis.ilias.de/view.php?id=43953)

Additionally, we have included the modification in all languages and it has been specifically translated for:
- German
- French
- Japanese
- Swedish