### PR TITLE
Fix multiple type issues

### DIFF
--- a/components/ILIAS/LearningModule/Presentation/class.ilLMNavigationStatus.php
+++ b/components/ILIAS/LearningModule/Presentation/class.ilLMNavigationStatus.php
@@ -108,7 +108,7 @@ class ilLMNavigationStatus
             $active = ilLMPage::_lookupActive(
                 $obj_id,
                 $this->lm->getType(),
-                $this->lm_set->get("time_scheduled_page_activation")
+                (bool) $this->lm_set->get("time_scheduled_page_activation")
             );
 
             if (!$active &&
@@ -149,7 +149,7 @@ class ilLMNavigationStatus
                     $active = ilLMPage::_lookupActive(
                         $page_id,
                         $this->lm->getType(),
-                        $this->lm_set->get("time_scheduled_page_activation")
+                        (bool) $this->lm_set->get("time_scheduled_page_activation")
                     );
                     if (!$active) {
                         // look, whether activation data should be shown
@@ -227,7 +227,7 @@ class ilLMNavigationStatus
                 $active = ilLMPage::_lookupActive(
                     $c_id,
                     $this->lm->getType(),
-                    $this->lm_set->get("time_scheduled_page_activation")
+                    (bool) $this->lm_set->get("time_scheduled_page_activation")
                 );
             }
             if (is_array($succ_node) && $succ_node["obj_id"] > 0 && !$active) {

--- a/components/ILIAS/LearningModule/classes/class.ilLearningModuleNotification.php
+++ b/components/ILIAS/LearningModule/classes/class.ilLearningModuleNotification.php
@@ -132,7 +132,7 @@ class ilLearningModuleNotification
             $this->page_id,
             $this->learning_module->getPageHeader(),
             $this->learning_module->isActiveNumbering(),
-            $this->lm_set->get("time_scheduled_page_activation"),
+            (bool) $this->lm_set->get("time_scheduled_page_activation"),
             false,
             0,
             $this->lng->getLangKey()

--- a/components/ILIAS/Test/classes/class.ilObjTest.php
+++ b/components/ILIAS/Test/classes/class.ilObjTest.php
@@ -6555,7 +6555,7 @@ class ilObjTest extends ilObject
             $results['overview']['tst_eval_total_passed_average_points'] = sprintf('%2.2f', $average_passed_reached)
                 . ' ' . strtolower('of') . ' ' . sprintf('%2.2f', $average_passed_max);
             $results['overview']['tst_eval_total_passed_average_time'] =
-                $this->secondsToHoursMinutesSecondsString($average_passed_time);
+                $this->secondsToHoursMinutesSecondsString((int)$average_passed_time);
         }
 
         foreach ($data->getQuestionTitles() as $question_id => $question_title) {

--- a/components/ILIAS/Test/classes/class.ilTestRandomQuestionSetNonAvailablePool.php
+++ b/components/ILIAS/Test/classes/class.ilTestRandomQuestionSetNonAvailablePool.php
@@ -93,9 +93,9 @@ class ilTestRandomQuestionSetNonAvailablePool
                     break;
                 case 'pool_ref_id': $this->setRefId($value ? (int) $value : null);
                     break;
-                case 'pool_title': $this->setTitle($value);
+                case 'pool_title': $this->setTitle($value ? (string) $value : "");
                     break;
-                case 'pool_path': $this->setPath($value);
+                case 'pool_path': $this->setPath($value ? (string) $value : "");
                     break;
             }
         }


### PR DESCRIPTION
- LearningModule: cast time_scheduled_page_activation as boolean: `TypeError thrown with message ilPageObject::_lookupActive(): Argument #3 ($a_check_scheduled_activation) must be of type bool, null given`

- class.ilObjTest: Cast float to int: `TypeError thrown with message "ilObjTest::secondsToHoursMinutesSecondsString(): Argument #1 ($seconds) must be of type int, float given`

-  class.ilTestRandomQuestionSetNonAvailablePool: Use valid string instead of null: `TypeError thrown with message ilTestRandomQuestionSetNonAvailablePool::setPath(): Argument #1 ($path) must be of type string, null given`