### PR TITLE
Mantis #46258: Fix SOAP Service Argument Type Error – Fetch User Data for Roles

### DIFF
--- a/webservice/soap/classes/class.ilSoapUserAdministration.php
+++ b/webservice/soap/classes/class.ilSoapUserAdministration.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  +-----------------------------------------------------------------------------+
  | ILIAS open source                                                           |
@@ -477,7 +478,9 @@ class ilSoapUserAdministration extends ilSoapAdministration
                     $roles = $object->__getLocalRoles();
 
                     foreach ($roles as $role_id) {
-                        $data = array_merge($rbacreview->assignedUsers($role_id), $data);
+                        $user_ids = $rbacreview->assignedUsers($role_id);
+                        $role_users = ilObjUser::_getUsersForIds($user_ids, $active);
+                        $data = array_merge($data, $role_users);
                     }
 
                     break;


### PR DESCRIPTION
This PR addresses the issue outlined in Mantis ticket [#46258](https://mantis.ilias.de/view.php?id=46258), where a SOAP request to the `getUsersForContainer` endpoint was returning a `SOAP-ENV:Server` error due to an incorrect argument type.
The code has been updated to fetch user data instead of just user IDs for each role, resolving the type mismatch.

---

⚠️ **PR is for release_9 but should be cherry-picked in `release_10`, `release_11` and `trunk`.**

---


CURL example _Replace placeholder values to your values_:
```bash

curl --location 'http://<ILIAS_URL>/webservice/soap/server.php' \
--header 'SOAPAction;' \
--header 'Content-Type: text/xml; charset=utf-8' \
--data '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:ilUserAdministration">
   <soapenv:Header/>
   <soapenv:Body>
      <urn:getUsersForContainer soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
         <sid xsi:type="xsd:string"><REPLACE_WITH_SID>::<REPLACE_WITH_CLIENT_NAME></sid>
         <ref_id xsi:type="xsd:int"><REPLACE_WITH_EXISTING_REF_ID></ref_id>
         <attach_roles xsi:type="xsd:int">1</attach_roles>
         <active xsi:type="xsd:int">1</active>
      </urn:getUsersForContainer>
   </soapenv:Body>
</soapenv:Envelope>
'
```
---

### Test Steps:

- Enable SOAP on the ILIAS server.
- Make a SOAP request with the following body:

```
<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:ilUserAdministration">
   <soapenv:Header/>
   <soapenv:Body>
      <urn:getUsersForContainer soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
         <sid xsi:type="xsd:string">REPLACE_WITH_SID::REPLACE_WITH_CLIENT_NAME</sid>
         <ref_id xsi:type="xsd:int">REPLACE_WITH_EXISTING_REF_ID</ref_id>
         <attach_roles xsi:type="xsd:int">1</attach_roles>
         <active xsi:type="xsd:int">1</active>
      </urn:getUsersForContainer>
   </soapenv:Body>
</soapenv:Envelope>
```

### Expected Result:

A 200 OK response with the following XML:

```
<ns1:getUsersForContainerResponse><user_xml xsi:type="xsd:string">ENCODED_XML</user_xml></ns1:getUsersForContainerResponse>
```

### Actual Result Before Fix:

The request results in the following error:

```
<SOAP-ENV:Fault>
    <faultcode>SOAP-ENV:Server</faultcode>
    <faultstring>ilUserXMLWriter::__handleUser(): Argument #1 ($row) must be of type array, int given, called in /var/www/html/ilias9/Services/User/classes/class.ilUserXMLWriter.php on line 82</faultstring>
</SOAP-ENV:Fault>
```





