### PR TITLE
Dependencies: Add empty files as preparation for "Dependency Jour Fixe"

### DIFF
--- a/components/ILIAS/Chatroom/chat/package_new.json
+++ b/components/ILIAS/Chatroom/chat/package_new.json
@@ -1,0 +1,9 @@
+{
+  "name": "ILIAS-Chat",
+  "description": "ILIAS CHAT",
+  "version": "12.0.0",
+  "dependencies": {
+  },
+  "extra": {
+  }
+}

--- a/composer_new.json
+++ b/composer_new.json
@@ -1,0 +1,68 @@
+{
+	"name": "ilias/ilias",
+	"description": "ILIAS",
+	"license": "GPL v3",
+	"authors": [],
+	"config": {
+		"optimize-autoloader": true,
+		"vendor-dir": "./vendor/composer/vendor",
+		"allow-plugins": {
+			"cweagans/composer-patches": true,
+			"captainhook/plugin-composer": true,
+			"simplesamlphp/composer-module-installer": false,
+			"simplesamlphp/composer-xmlprovider-installer": false
+		}
+	},
+	"scripts": {
+		"post-autoload-dump": [
+			"@php cli/build_bootstrap.php components/ILIAS/Setup/resources/dependency_resolution.php setup components/ILIAS/Init/resources/dependency_resolution.php default",
+			"@php cli/setup.php build --yes"
+		],
+		"pre-install-cmd": [
+			"mkdir -p public/Customizing/global/plugins",
+			"mkdir -p public/Customizing/skin"
+		],
+		"post-install-cmd": [
+			"@php vendor/composer/rmdirs.php"
+		],
+		"post-update-cmd": [
+			"@php vendor/composer/rmdirs.php"
+		],
+		"test-php-all": [
+			"./vendor/composer/vendor/bin/phpunit -c ./components/ILIAS/PHPUnit/config/PhpUnitConfig.xml --colors=always --disallow-todo-tests"
+		],
+		"test-php": [
+			"./scripts/PHPUnit/run_tests.sh"
+		],
+		"rector": [
+			"./vendor/composer/vendor/bin/rector process --config ./scripts/Rector/basic_rector.php --no-diffs"
+		]
+	},
+	"require": {
+	},
+	"require-dev": {
+	},
+	"autoload": {
+		"psr-4" : {
+			"ILIAS\\Scripts\\" : "./scripts"
+		},
+		"classmap": [
+			"./public/Customizing/global/plugins",
+			"./components",
+			"./vendor/ilias",
+			"./components/ILIAS/soap",
+			"./components/ILIAS/setup_/classes"
+		],
+		"exclude-from-classmap": [
+			"./components/ILIAS/Migration",
+			"./*/*/lib",
+			"./public/Customizing/**/vendor",
+			"./components/ILIAS/setup_/sql",
+			"./cli/setup.php",
+			"./components/ILIAS/setup_/client.master.ini.php",
+			"./components/ILIAS/setup_/ilias.master.ini.php"
+		]
+	},
+	"extra": {
+	}
+}

--- a/package_new.json
+++ b/package_new.json
@@ -1,0 +1,33 @@
+{
+  "name": "ilias",
+  "version": "12.0.0",
+  "description": "ILIAS open source e-Learning",
+  "type": "module",
+  "directories": {
+    "doc": "docs"
+  },
+  "engines": {
+    "node": "^22.18 || ^24.0",
+    "npm": "^10.9.3 || ^11.3"
+  },
+  "dependencies": {
+  },
+  "devDependencies": {
+  },
+  "scripts": {
+    "test": "node --test \"./components/ILIAS/**/tests/**/*.js\""
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ILIAS-eLearning/ILIAS.git"
+  },
+  "keywords": [],
+  "author": "ILIAS open source developer group",
+  "license": "GPL-3.0-or-later",
+  "bugs": {
+    "url": "https://github.com/ILIAS-eLearning/ILIAS/issues"
+  },
+  "homepage": "https://github.com/ILIAS-eLearning/ILIAS#readme",
+  "extra": {
+  }
+}


### PR DESCRIPTION
This PR adds "empty" `composer_new.json` and `package_new.json` files to enable code authorities to create pull requests for 3rd-party libraries their code depends on.