### PR TITLE
Mantis #42939: Fix soap webservice getTestResults

### DIFF
--- a/webservice/soap/classes/class.ilSoapTestAdministration.php
+++ b/webservice/soap/classes/class.ilSoapTestAdministration.php
@@ -663,8 +663,10 @@ class ilSoapTestAdministration extends ilSoapAdministration
 
         require_once 'Modules/Test/classes/class.ilTestParticipantAccessFilter.php';
         require_once 'Modules/Test/classes/class.ilTestParticipantList.php';
-        $accessFilter = ilTestParticipantAccessFilter::getAccessResultsUserFilter($test_ref_id);
-        $participantList = new ilTestParticipantList($test_obj);
+        $accessFilterFactory = new ilTestParticipantAccessFilterFactory($DIC['ilAccess']);
+        $accessFilter = $accessFilterFactory->getAccessResultsUserFilter($test_ref_id);
+
+        $participantList = new ilTestParticipantList($test_obj, $DIC['ilUser'], $DIC['lng'], $DIC['ilDB']);
         $participantList->initializeFromDbRows($participants);
         $participantList = $participantList->getAccessFilteredList($accessFilter);
         $participantList = $participantList->getScoredParticipantList();


### PR DESCRIPTION
This fixes the "getTestResults returns SoapFault: Class "ilTestParticipantAccessFilter" not found" error as described here: https://mantis.ilias.de/view.php?id=42939