### PR TITLE
T&A 44715: Implements sync back to QPL for IPE Feedback questions

### DIFF
--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionFeedbackEditingGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionFeedbackEditingGUI.php
@@ -300,10 +300,6 @@ class ilAssQuestionFeedbackEditingGUI
             return false;
         }
 
-        if ($this->questionOBJ->isAdditionalContentEditingModePageObject()) {
-            return false;
-        }
-
         if (!$this->questioninfo->questionExistsInPool((int) $this->questionOBJ->getOriginalId())) {
             return false;
         }

--- a/Modules/TestQuestionPool/classes/feedback/class.ilAssMultiOptionQuestionFeedback.php
+++ b/Modules/TestQuestionPool/classes/feedback/class.ilAssMultiOptionQuestionFeedback.php
@@ -266,17 +266,31 @@ abstract class ilAssMultiOptionQuestionFeedback extends ilAssQuestionFeedback
 
     protected function syncSpecificFeedback(int $original_question_id, int $duplicate_question_id): void
     {
+        if ($this->questionOBJ->isAdditionalContentEditingModePageObject()) {
+            $original_result = $this->db->queryF(
+                "SELECT feedback_id FROM {$this->getSpecificFeedbackTableName()} WHERE question_fi = %s",
+                [ilDBConstants::T_INTEGER],
+                [$original_question_id]
+            );
+            while ($original_row = $this->db->fetchAssoc($original_result)) {
+                $this->ensurePageObjectDeleted(
+                    $this->getSpecificAnswerFeedbackPageObjectType(),
+                    $original_row['feedback_id']
+                );
+            }
+        }
+
         // delete specific feedback of the original
         $this->db->manipulateF(
             "DELETE FROM {$this->getSpecificFeedbackTableName()} WHERE question_fi = %s",
-            ['integer'],
+            [ilDBConstants::T_INTEGER],
             [$original_question_id]
         );
 
         // get specific feedback of the actual question
         $res = $this->db->queryF(
             "SELECT * FROM {$this->getSpecificFeedbackTableName()} WHERE question_fi = %s",
-            ['integer'],
+            [ilDBConstants::T_INTEGER],
             [$duplicate_question_id]
         );
 
@@ -285,13 +299,18 @@ abstract class ilAssMultiOptionQuestionFeedback extends ilAssQuestionFeedback
             $next_id = $this->db->nextId($this->getSpecificFeedbackTableName());
 
             $this->db->insert($this->getSpecificFeedbackTableName(), [
-                'feedback_id' => ['integer', $next_id],
-                'question_fi' => ['integer', $original_question_id],
-                'question' => ['integer', $row['question']],
-                'answer' => ['integer', $row['answer']],
-                'feedback' => ['text', $row['feedback']],
-                'tstamp' => ['integer', time()]
+                'feedback_id' => [ilDBConstants::T_INTEGER, $next_id],
+                'question_fi' => [ilDBConstants::T_INTEGER, $original_question_id],
+                'question' => [ilDBConstants::T_INTEGER, $row['question']],
+                'answer' => [ilDBConstants::T_INTEGER, $row['answer']],
+                'feedback' => [ilDBConstants::T_TEXT, $row['feedback']],
+                'tstamp' => [ilDBConstants::T_INTEGER, time()]
             ]);
+
+            if ($this->questionOBJ->isAdditionalContentEditingModePageObject()) {
+                $page_object_type = $this->getSpecificAnswerFeedbackPageObjectType();
+                $this->syncPageObject($page_object_type, $row['feedback_id'], $next_id, $original_question_id);
+            }
         }
     }
 

--- a/Modules/TestQuestionPool/classes/feedback/class.ilAssMultiOptionQuestionFeedback.php
+++ b/Modules/TestQuestionPool/classes/feedback/class.ilAssMultiOptionQuestionFeedback.php
@@ -309,7 +309,7 @@ abstract class ilAssMultiOptionQuestionFeedback extends ilAssQuestionFeedback
 
             if ($this->questionOBJ->isAdditionalContentEditingModePageObject()) {
                 $page_object_type = $this->getSpecificAnswerFeedbackPageObjectType();
-                $this->syncPageObject($page_object_type, $row['feedback_id'], $next_id, $original_question_id);
+                $this->copyPageObject($page_object_type, $row['feedback_id'], $next_id, $original_question_id);
             }
         }
     }

--- a/Modules/TestQuestionPool/classes/feedback/class.ilAssQuestionFeedback.php
+++ b/Modules/TestQuestionPool/classes/feedback/class.ilAssQuestionFeedback.php
@@ -447,33 +447,52 @@ abstract class ilAssQuestionFeedback
     /**
      * syncs the GENERIC feedback from a duplicated question back to the original question
      */
-    private function syncGenericFeedback(int $originalQuestionId, int $duplicateQuestionId): void
+    private function syncGenericFeedback(int $original_question_id, int $duplicate_question_id): void
     {
+        if ($this->questionOBJ->isAdditionalContentEditingModePageObject()) {
+            $original_result = $this->db->queryF(
+                "SELECT feedback_id FROM {$this->getGenericFeedbackTableName()} WHERE question_fi = %s",
+                [ilDBConstants::T_INTEGER],
+                [$original_question_id]
+            );
+            while ($original_row = $this->db->fetchAssoc($original_result)) {
+                $this->ensurePageObjectDeleted(
+                    $this->getGenericFeedbackPageObjectType(),
+                    $original_row['feedback_id']
+                );
+            }
+        }
+
         // delete generic feedback of the original question
         $this->db->manipulateF(
             "DELETE FROM {$this->getGenericFeedbackTableName()} WHERE question_fi = %s",
-            ['integer'],
-            [$originalQuestionId]
+            [ilDBConstants::T_INTEGER],
+            [$original_question_id]
         );
 
         // get generic feedback of the actual (duplicated) question
         $result = $this->db->queryF(
             "SELECT * FROM {$this->getGenericFeedbackTableName()} WHERE question_fi = %s",
-            ['integer'],
-            [$duplicateQuestionId]
+            [ilDBConstants::T_INTEGER],
+            [$duplicate_question_id]
         );
 
         // save generic feedback to the original question
         while ($row = $this->db->fetchAssoc($result)) {
-            $nextId = $this->db->nextId($this->getGenericFeedbackTableName());
+            $next_id = $this->db->nextId($this->getGenericFeedbackTableName());
 
             $this->db->insert($this->getGenericFeedbackTableName(), [
-                'feedback_id' => ['integer', $nextId],
-                'question_fi' => ['integer', $originalQuestionId],
-                'correctness' => ['text', $row['correctness']],
-                'feedback' => ['clob', $row['feedback']],
-                'tstamp' => ['integer', time()]
+                'feedback_id' => [ilDBConstants::T_INTEGER, $next_id],
+                'question_fi' => [ilDBConstants::T_INTEGER, $original_question_id],
+                'correctness' => [ilDBConstants::T_TEXT, $row['correctness']],
+                'feedback' => [ilDBConstants::T_CLOB, $row['feedback']],
+                'tstamp' => [ilDBConstants::T_INTEGER, time()]
             ]);
+
+            if ($this->questionOBJ->isAdditionalContentEditingModePageObject()) {
+                $page_object_type = $this->getGenericFeedbackPageObjectType();
+                $this->syncPageObject($page_object_type, $row['feedback_id'], $next_id, $original_question_id);
+            }
         }
     }
 
@@ -644,6 +663,28 @@ abstract class ilAssQuestionFeedback
         $pageObject->setParentId($duplicate_page_object_parent_id);
         $pageObject->setId($duplicate_page_object_id);
         $pageObject->createFromXML();
+    }
+
+    /**
+     * Syncs a page object from a duplicated question back to the original question
+     */
+    final protected function syncPageObject(
+        string $page_object_type,
+        int $duplicate_page_object_id,
+        int $original_page_object_id,
+        int $original_question_id
+    ): void {
+        $this->ensurePageObjectExists($page_object_type, $duplicate_page_object_id);
+
+        $cl = $this->getClassNameByType($page_object_type);
+
+        $this->ensurePageObjectDeleted($page_object_type, $original_page_object_id);
+
+        $original_page_object = new $cl();
+        $original_page_object->setParentId($original_question_id);
+        $original_page_object->setId($original_page_object_id);
+        $original_page_object->setXMLContent((new $cl($duplicate_page_object_id))->getXMLContent());
+        $original_page_object->createFromXML();
     }
 
     final protected function ensurePageObjectDeleted(string $page_object_type, int $page_object_id): void

--- a/Modules/TestQuestionPool/classes/feedback/class.ilAssQuestionFeedback.php
+++ b/Modules/TestQuestionPool/classes/feedback/class.ilAssQuestionFeedback.php
@@ -491,7 +491,7 @@ abstract class ilAssQuestionFeedback
 
             if ($this->questionOBJ->isAdditionalContentEditingModePageObject()) {
                 $page_object_type = $this->getGenericFeedbackPageObjectType();
-                $this->syncPageObject($page_object_type, $row['feedback_id'], $next_id, $original_question_id);
+                $this->copyPageObject($page_object_type, $row['feedback_id'], $next_id, $original_question_id);
             }
         }
     }
@@ -666,25 +666,25 @@ abstract class ilAssQuestionFeedback
     }
 
     /**
-     * Syncs a page object from a duplicated question back to the original question
+     * Copies a page object from source to target
      */
-    final protected function syncPageObject(
+    final protected function copyPageObject(
         string $page_object_type,
-        int $duplicate_page_object_id,
-        int $original_page_object_id,
-        int $original_question_id
+        int $source_page_object_id,
+        int $target_page_object_id,
+        int $target_question_id
     ): void {
-        $this->ensurePageObjectExists($page_object_type, $duplicate_page_object_id);
+        $this->ensurePageObjectExists($page_object_type, $source_page_object_id);
 
         $cl = $this->getClassNameByType($page_object_type);
 
-        $this->ensurePageObjectDeleted($page_object_type, $original_page_object_id);
+        $this->ensurePageObjectDeleted($page_object_type, $target_page_object_id);
 
-        $original_page_object = new $cl();
-        $original_page_object->setParentId($original_question_id);
-        $original_page_object->setId($original_page_object_id);
-        $original_page_object->setXMLContent((new $cl($duplicate_page_object_id))->getXMLContent());
-        $original_page_object->createFromXML();
+        $target_page_object = new $cl();
+        $target_page_object->setParentId($target_question_id);
+        $target_page_object->setId($target_page_object_id);
+        $target_page_object->setXMLContent((new $cl($source_page_object_id))->getXMLContent());
+        $target_page_object->createFromXML();
     }
 
     final protected function ensurePageObjectDeleted(string $page_object_type, int $page_object_id): void


### PR DESCRIPTION
This PR attempts to solve https://mantis.ilias.de/view.php?id=44715.

Since the ticket has been created, the error of saving Tiny Feedback back to QPL has been fixed. The behavior described in the ticket can't be replicated anymore. Furthermore, questions that have IPE feedback never had an option to be saved back into QPL, which was also something mentioned in the ticket. I have implemented the sync back to QPL.

Kind regards,
@bidzanaaron 