### PR TITLE
T&A 45379: Removes byline for maximum duration of test in minutes

### DIFF
--- a/components/ILIAS/Test/src/Settings/MainSettings/SettingsTestBehaviour.php
+++ b/components/ILIAS/Test/src/Settings/MainSettings/SettingsTestBehaviour.php
@@ -249,8 +249,7 @@ class SettingsTestBehaviour extends TestSettings
 
         $sub_inputs_time_limit_for_completion['time_limit_for_completion_value'] = $f
             ->numeric(
-                $lng->txt('tst_processing_time_duration'),
-                $lng->txt('tst_processing_time_desc')
+                $lng->txt('tst_processing_time_duration')
             )
             ->withRequired(true)
             ->withAdditionalTransformation($refinery->int()->isGreaterThan(0))


### PR DESCRIPTION
This PR attempts to solve https://mantis.ilias.de/view.php?id=45379.

Removes duplicate byline `tst_processing_time_desc`.

Kind regards,
@bidzanaaron 