### PR TITLE
LearningSequence/KioskMode/UI: Fix legacy element usage

### DIFF
--- a/components/ILIAS/LearningSequence/classes/Player/class.ilKioskPageRenderer.php
+++ b/components/ILIAS/LearningSequence/classes/Player/class.ilKioskPageRenderer.php
@@ -63,7 +63,7 @@ class ilKioskPageRenderer
         return $this->ui_factory->maincontrols()->slate()->legacy(
             $this->lng->txt('lso_mainbar_button_label_curriculum'),
             $f->symbol()->icon()->standard("lso", "Learning Sequence"),
-            $this->ui_factory->legacy(
+            $this->ui_factory->legacy()->content(
                 $this->ui_renderer->render($curriculum)
             )
         );


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=46297

If approved, this must be picked to `trunk` as well.