### PR TITLE
LegalDocuments: Move modals out of UI tables (11)

### DIFF
--- a/components/ILIAS/LegalDocuments/classes/Table/DocumentModal.php
+++ b/components/ILIAS/LegalDocuments/classes/Table/DocumentModal.php
@@ -65,8 +65,10 @@ class DocumentModal
     /**
      * @return Component[]
      */
-    public function components(): array
+    public function popComponents(): array
     {
-        return $this->components;
+        $c = $this->components;
+        $this->components = [];
+        return $c;
     }
 }

--- a/components/ILIAS/LegalDocuments/classes/Table/DocumentTable.php
+++ b/components/ILIAS/LegalDocuments/classes/Table/DocumentTable.php
@@ -57,8 +57,11 @@ class DocumentTable implements OrderingRetrieval
     private readonly ilCtrlInterface $ctrl;
     private readonly Ordering $table;
     private readonly Renderer $ui_renderer;
-    private ilObjUser $user;
-    private \DateTimeZone $usr_timezone;
+    private readonly ilObjUser $user;
+    private readonly \DateTimeZone $usr_timezone;
+
+    /** @var Component[] */
+    private array $modals = [];
 
     public function __construct(
         private readonly Closure $criterion_as_component,
@@ -149,7 +152,7 @@ class DocumentTable implements OrderingRetrieval
                     )->withOnClick($delete_modal->getShowSignal())
                 ]);
 
-                $criterion_components[] = $delete_modal;
+                $this->modals[] = $delete_modal;
                 $criterion_components[] = $dropdown;
             }
 
@@ -185,7 +188,7 @@ class DocumentTable implements OrderingRetrieval
         // because the components are filled within the rendering process.
         $html = $this->ui_renderer->render($this->table);
 
-        return $html . $this->ui_renderer->render($this->modal->components());
+        return $html . $this->ui_renderer->render([...$this->modal->popComponents(), ...$this->modals]);
     }
 
     /**

--- a/components/ILIAS/LegalDocuments/classes/Table/HistoryTable.php
+++ b/components/ILIAS/LegalDocuments/classes/Table/HistoryTable.php
@@ -43,7 +43,8 @@ class HistoryTable implements Table
     private readonly Closure $format_date;
 
     /**
-     * @param Closure(class-string, ... $constructor_args): object<class-string> $create
+     * @template C
+     * @param Closure(class-string<C>, mixed...): C $create
      * @param null|Closure(DateTimeImmutable): string $format_date
      */
     public function __construct(
@@ -114,7 +115,7 @@ class HistoryTable implements Table
             'login' => $user?->getLogin() ?? $this->ui->txt('deleted'),
             'firstname' => $user?->getFirstname() ?? '-',
             'lastname' => $user?->getLastname() ?? '-',
-            'document' => $this->modal->create($record->documentContent()),
+            'document' => [...$this->modal->create($record->documentContent()), ...$this->modal->popComponents()],
             'criteria' => $this->showCriteria($record),
         ];
     }

--- a/components/ILIAS/LegalDocuments/tests/Table/DocumentModalTest.php
+++ b/components/ILIAS/LegalDocuments/tests/Table/DocumentModalTest.php
@@ -72,6 +72,7 @@ class DocumentModalTest extends TestCase
         });
 
         $this->assertSame([$button_component], $instance->create($content));
-        $this->assertSame([$modal_component], $instance->components($content));
+        $this->assertSame([$modal_component], $instance->popComponents());
+        $this->assertSame([], $instance->popComponents());
     }
 }


### PR DESCRIPTION
This PR fixes Mantis Bugs:
https://mantis.ilias.de/view.php?id=46279
https://mantis.ilias.de/view.php?id=46281

UI Tables and Modals are wrapped in a HTML form element. As per HTML standard form elements cannot be nested. This PR moves the modal rendering so they are not nested anymore.