### PR TITLE
ErrorHandling: Ignore `E_USER_DEPRECATED` errors (even in `DEVMODE`)

### DIFF
--- a/components/ILIAS/Init/classes/class.ilErrorHandling.php
+++ b/components/ILIAS/Init/classes/class.ilErrorHandling.php
@@ -150,7 +150,7 @@ class ilErrorHandling
         global $log;
 
         $session_failure = ilSession::get('failure');
-        if ($session_failure && strpos($message, 'Cannot find this block') !== 0) {
+        if ($session_failure && !str_starts_with($message, 'Cannot find this block')) {
             $m = 'Fatal Error: Called raise error two times.<br>' .
                 'First error: ' . $session_failure . '<br>' .
                 'Last Error:' . $message;
@@ -159,8 +159,8 @@ class ilErrorHandling
             die($m);
         }
 
-        if (strpos($message, 'Cannot find this block') === 0) {
-            if (defined('DEVMODE') && DEVMODE) {
+        if (str_starts_with($message, 'Cannot find this block')) {
+            if ($this->isDevmodeActive()) {
                 echo '<b>DEVMODE</b><br><br>';
                 echo '<b>Template Block not found.</b><br>';
                 echo 'You used a template block in your code that is not available.<br>';
@@ -439,8 +439,18 @@ class ilErrorHandling
                         $severity = Whoops\Util\Misc::translateErrorCode($level);
                         $ilLog->write("\n\n" . $severity . ' - ' . $message . "\n" . $file . ' - line ' . $line . "\n");
                     }
+
                     return true;
                 }
+            }
+
+            if ($level === E_USER_DEPRECATED) {
+                if ($ilLog) {
+                    $severity = Whoops\Util\Misc::translateErrorCode($level);
+                    $ilLog->write("\n\n" . $severity . ' - ' . $message . "\n" . $file . ' - line ' . $line . "\n");
+                }
+
+                return true;
             }
 
             if ($this->whoops instanceof RunInterface) {


### PR DESCRIPTION
This PR suggests ignoring errors of type `E_USER_DEPRECATED`, even if the `DEVMODE` is enabled.

Why? Without this change, developers are not able to make use of the native PHP `\Deprecated` attribute without affecting the official ILIAS testing installation, which runs with enabled `DEVMODE` and PHP 8.4.
ILIAS currently just responds with a PHP error message.

See: https://mantis.ilias.de/view.php?id=46271