### PR TITLE
Auth/Apache: Remove wrong path element (`public/`) from redirect URL

### DIFF
--- a/components/ILIAS/Authentication/classes/Frontend/class.ilAuthFrontendCredentialsApache.php
+++ b/components/ILIAS/Authentication/classes/Frontend/class.ilAuthFrontendCredentialsApache.php
@@ -77,10 +77,12 @@ class ilAuthFrontendCredentialsApache extends ilAuthFrontendCredentials
 
         $this->ctrl->redirectToURL(
             ilUtil::getHtmlPath(
-                './public/sso/index.php?force_mode_apache=1&' .
-                'r=' . urlencode($path) .
-                '&cookie_path=' . urlencode(IL_COOKIE_PATH) .
-                '&ilias_path=' . urlencode(ILIAS_HTTP_PATH)
+                './sso/index.php?' . http_build_query([
+                    'force_mode_apache' => 1,
+                    'r' => $path,
+                    'cookie_path' => IL_COOKIE_PATH,
+                    'ilias_path' => ILIAS_HTTP_PATH,
+                ])
             )
         );
     }


### PR DESCRIPTION
This PR removes `public` from the apache auth. redirection URL.

If approved, please pick this to `trunk` as well.