### PR TITLE
LegalDocuments: Fix wrong history count with deleted documents (11)

### DIFF
--- a/components/ILIAS/LegalDocuments/classes/Repository/DatabaseHistoryRepository.php
+++ b/components/ILIAS/LegalDocuments/classes/Repository/DatabaseHistoryRepository.php
@@ -145,8 +145,8 @@ class DatabaseHistoryRepository implements HistoryRepository
         [$filter, $join] = $this->filterAndJoin($filter);
 
         return (int) $this->database->fetchAssoc($this->database->query(
-            "SELECT COUNT(1) as count FROM $tracking INNER JOIN $version ON $tracking.tosv_id = $version.id INNER JOIN $documents ON $version.doc_id = $documents.id AND $version.provider = $provider " .
-            "$join WHERE $filter"
+            "SELECT COUNT(1) as count FROM $tracking INNER JOIN $version ON $tracking.tosv_id = $version.id LEFT JOIN $documents ON $version.doc_id = $documents.id " .
+            "$join WHERE $version.provider = $provider AND $filter"
         ))['count'];
     }
 


### PR DESCRIPTION
This PR fixes Mantis Bug: https://mantis.ilias.de/view.php?id=46278

History Table count is incorrectly calculated if referenced documents are deleted.