### PR TITLE
[LTI] fix: icons in object releases tables

### DIFF
--- a/components/ILIAS/LTIProvider/templates/default/tpl.lti_object_table_row.html
+++ b/components/ILIAS/LTIProvider/templates/default/tpl.lti_object_table_row.html
@@ -7,7 +7,7 @@
 	</td>
 	<!-- END row_selection -->
 	<td class="std">
-		<img src="{TYPE_IMG}" alt="{TYPE_STR}" />
+		{TYPE_IMG}
 	</td>
 	<td class="std">
 		<!-- BEGIN title -->


### PR DESCRIPTION
In ILIAS 9 Fabian Kruse found an error in this table inside the configuration about LTI. It was reported in [Mantis](https://mantis.ilias.de/view.php?id=40731). After some testing the same error was found in ILIAS 10. This change fix the icon in that table.

New version:
<img width="3090" height="603" alt="image" src="https://github.com/user-attachments/assets/e44031d8-5896-4592-925c-772922ad95a3" />

Previous version:
<img width="3592" height="640" alt="image" src="https://github.com/user-attachments/assets/b2f7e985-dfa1-4820-94c7-c47636f103be" />
