### PR TITLE
[LTI] fix: icons in object releases tables

### DIFF
--- a/Services/LTI/templates/default/tpl.lti_object_table_row.html
+++ b/Services/LTI/templates/default/tpl.lti_object_table_row.html
@@ -7,7 +7,7 @@
 	</td>
 	<!-- END row_selection -->
 	<td class="std">
-		<img src="{TYPE_IMG}" alt="{TYPE_STR}" />
+		{TYPE_IMG}
 	</td>
 	<td class="std">
 		<!-- BEGIN title -->


### PR DESCRIPTION
Fabian Kruse found an error in the table which show the list of object releases using LTI inside the configuration. It was reported in [Mantis](https://mantis.ilias.de/view.php?id=40731). This change fix the icon in that table.

Current version:
<img width="3082" height="554" alt="image" src="https://github.com/user-attachments/assets/74d8d77f-00fc-49cc-8276-5d991dbdac93" />

Previous version:
<img width="3133" height="733" alt="image" src="https://github.com/user-attachments/assets/142e8824-22a0-4955-850e-874cc760f34a" />
