### PR TITLE
[PROPOSAL] Change of Database Authorities

### DIFF
--- a/components/ILIAS/Database/maintenance.json
+++ b/components/ILIAS/Database/maintenance.json
@@ -1,6 +1,6 @@
 {
     "maintenance_model": "Classic",
-    "first_maintainer": "fschmid(21087)",
+    "first_maintainer": "lscharmer(87863)",
     "second_maintainer": "smeyer(191)",
     "implicit_maintainers": [],
     "coordinator": [

--- a/docs/development/maintenance.md
+++ b/docs/development/maintenance.md
@@ -540,12 +540,13 @@ of ILIAS. The file contains the following fields:
 [//]: # (BEGIN Database)
 
 * **Database**
-    * Authority to Sign off on Conceptual Changes: MISSING
-    * Authority to Sign off on Code Changes: [smeyer](https://docu.ilias.de/go/usr/191)
+    * Authority to Sign off on Conceptual Changes: [lscharmer](https://docu.ilias.de/go/usr/87863), [mjansen](https://docu.ilias.de/go/usr/8784)
+    * Authority to Sign off on Code Changes: [lscharmer](https://docu.ilias.de/go/usr/87863), [mjansen](https://docu.ilias.de/go/usr/8784)
+        , [smeyer](https://docu.ilias.de/go/usr/191)
     * Authority to Curate Test Cases: MISSING
-    * Authority to (De-)Assign Authorities: MISSING
-    * Assignee for Security Reports: MISSING
-    * Assignee for Security Issues: MISSING
+    * Authority to (De-)Assign Authorities: [lscharmer](https://docu.ilias.de/go/usr/87863)
+    * Assignee for Security Reports: [lscharmer](https://docu.ilias.de/go/usr/87863)
+    * Assignee for Security Issues: [lscharmer](https://docu.ilias.de/go/usr/87863)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Database)


### PR DESCRIPTION
This PR proposes to add myself to the following Database authorities:

- Authority to Sign off on Conceptual Changes
- Authority to Sign off on Code Changes
- Authority to (De-)Assign Authorities
- Assignee for Security Reports
- Assignee for Security Issues

and @mjansen to the following Database authorities:
- Authority to Sign off on Conceptual Changes
- Authority to Sign off on Code Changes