### PR TITLE
[PROPOSAL] Change of Data Authorities

### DIFF
--- a/components/ILIAS/Data/maintenance.json
+++ b/components/ILIAS/Data/maintenance.json
@@ -1,7 +1,7 @@
 {
     "maintenance_model": "Classic",
-    "first_maintainer": "rklees(34047)",
-    "second_maintainer": "",
+    "first_maintainer": "lscharmer(87863)",
+    "second_maintainer": "mjansen(8784)",
     "implicit_maintainers": [],
     "coordinator": [
         ""

--- a/docs/development/maintenance.md
+++ b/docs/development/maintenance.md
@@ -493,12 +493,12 @@ of ILIAS. The file contains the following fields:
 [//]: # (BEGIN Data)
 
 * **Data**
-    * Authority to Sign off on Conceptual Changes: [MISSING]
-    * Authority to Sign off on Code Changes: [MISSING]
+    * Authority to Sign off on Conceptual Changes: [lscharmer](https://docu.ilias.de/go/usr/87863), [mjansen](https://docu.ilias.de/go/usr/8784)
+    * Authority to Sign off on Code Changes: [lscharmer](https://docu.ilias.de/go/usr/87863), [mjansen](https://docu.ilias.de/go/usr/8784)
     * Authority to Curate Test Cases: [MISSING]
-    * Authority to (De-)Assign Authorities: [MISSING]
-    * Assignee for Security Reports: [MISSING]
-    * Assignee for Security Issues: [MISSING]
+    * Authority to (De-)Assign Authorities: [lscharmer](https://docu.ilias.de/go/usr/87863), [mjansen](https://docu.ilias.de/go/usr/8784)
+    * Assignee for Security Reports: [lscharmer](https://docu.ilias.de/go/usr/87863), [mjansen](https://docu.ilias.de/go/usr/8784)
+    * Assignee for Security Issues: [lscharmer](https://docu.ilias.de/go/usr/87863), [mjansen](https://docu.ilias.de/go/usr/8784)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Data)


### PR DESCRIPTION
This PR proposes to add @mjansen and myself to the following Data authorities:

- Authority to Sign off on Conceptual Changes
- Authority to Sign off on Code Changes
- Authority to (De-)Assign Authorities
- Assignee for Security Reports
- Assignee for Security Issues
