### PR TITLE
T&A 46097: Loads missing administration language module

### DIFF
--- a/components/ILIAS/Administration/classes/class.ilAdministrationGUI.php
+++ b/components/ILIAS/Administration/classes/class.ilAdministrationGUI.php
@@ -98,6 +98,7 @@ class ilAdministrationGUI implements ilCtrlBaseClassInterface
         $this->ctrl = $DIC->ctrl();
         $this->global_screen = $DIC->globalScreen();
 
+        $this->lng->loadLanguageModule('administration');
         $this->lng->loadLanguageModule('benchmark');
 
         $context = $this->global_screen->tool()->context();


### PR DESCRIPTION
This PR attempts to solve https://mantis.ilias.de/view.php?id=46097.

This PR also corrects the missing language variables for `Administration > Repository and Objects > Blog`.

Kind regards,
@bidzanaaron 