### PR TITLE
T&A 46113: Fixes long menu question options modal not showing up

### DIFF
--- a/components/ILIAS/TestQuestionPool/resources/js/dist/longMenuQuestion.js
+++ b/components/ILIAS/TestQuestionPool/resources/js/dist/longMenuQuestion.js
@@ -382,7 +382,7 @@ var longMenuQuestion = (function () {
 	pro.redrawAnswerList = function(question_id)
 	{
 		pro.checkAnswersArray(question_id);
-    const answer_options_element = document.querySelector('#ilGapModal .modal_answer_options');
+    const answer_options_element = document.querySelector(`#${pub.gap_modal_id} .modal_answer_options`);
     answer_options_element.innerHTML = '';
 
     if (pro.inputFieldsStillPossible(question_id))


### PR DESCRIPTION
This PR attempts to fix https://mantis.ilias.de/view.php?id=46113.

The long menu question options modal now gets correctly addressed.

Kind regards,
@bidzanaaron 