### PR TITLE
Chatroom: Add `express`

### DIFF
--- a/components/ILIAS/Chatroom/chat/package_new.json
+++ b/components/ILIAS/Chatroom/chat/package_new.json
@@ -3,7 +3,14 @@
   "description": "ILIAS CHAT",
   "version": "12.0.0",
   "dependencies": {
+    "express": "^5.1.0"
   },
   "extra": {
+    "express": {
+      "introduction-date": null,
+      "approved-by": "Jour Fix",
+      "purpose": "Web application framework for nodejs",
+      "last-update-for-ilias": "12.0"
+    }
   }
 }


### PR DESCRIPTION
This PR adds `express` as NPM dependency for the chatroom

General Information:
- [X] this dependency was already used in ILIAS.
- [X] License: MIT

Usages:

- components/ILIAS/Chatroom/chat/Bootstrap/index.js
- components/ILIAS/Chatroom/chat/api.js
- components/ILIAS/Chatroom/chat/Bootstrap/SetupExpressApi.js

Wrapped by:

- Not applicable

Reasoning:

`express` is a web application framework for Node.js. It is used to provide a HTTP(S) API for the ILIAS backend for administrative purposes (mainly for the repository chat). It is used to map HTTP resource paths to corresponding JS callbacks/actions.

Maintenance:

Express is a well maintained package with a lot of contributions. Security procedures are outlined here: https://github.com/expressjs/express?tab=security-ov-file#readme.
(The latest version is from 31.03.2025)

Links:

- NPM: https://www.npmjs.com/package/express
- GitHub: https://github.com/expressjs/express
- Documentation: https://expressjs.com/