### PR TITLE
Chatroom: Add `mariadb`

### DIFF
--- a/components/ILIAS/Chatroom/chat/package_new.json
+++ b/components/ILIAS/Chatroom/chat/package_new.json
@@ -3,7 +3,11 @@
   "description": "ILIAS CHAT",
   "version": "12.0.0",
   "dependencies": {
+    "mariadb": "^3.4.0"
   },
   "extra": {
+    "mariadb": {
+      "purpose": "Mysql driver for nodejs",
+    }
   }
 }


### PR DESCRIPTION
### mariadb

This PR adds `mariadb` as NPM dependency for the chatroom.

**General Information:**
- [x] this dependency was already used in ILIAS.  
- [x] License: MIT  

**Usages:**
- `components/ILIAS/Chatroom/chat/Persistence/Database.js`

**Wrapped By:**
- `Database` (see: `components/ILIAS/Chatroom/chat/Persistence/Database.js`)

**Reasoning:**

This dependency replaces the previously used `mysql2` driver and has already been included with ILAIS 11.
`mariadb` is a modern, actively maintained Node.js driver for MariaDB servers and is fully compatible with MariaDB server features. 
The driver is used in the chatroom backend to communicate with the database

**Maintenance:**

`mariadb` is actively maintained and regularly updated.  
The package receives security and compatibility updates in line with current Node.js versions.
(The latest version is from 23.07.2025.)

**Links:**
- NPM: [https://www.npmjs.com/package/mariadb](https://www.npmjs.com/package/mariadb)  
- GitHub: [https://github.com/mariadb-corporation/mariadb-connector-nodejs](https://github.com/mariadb-corporation/mariadb-connector-nodejs)  
- Documentation: [https://mariadb.com/kb/en/mariadb-connector-nodejs/](https://mariadb.com/kb/en/mariadb-connector-nodejs/)