### PR TITLE
Chatroom: Add `socket.io` and `socket.io-client`

### DIFF
--- a/components/ILIAS/Chatroom/chat/package_new.json
+++ b/components/ILIAS/Chatroom/chat/package_new.json
@@ -5,5 +5,17 @@
   "dependencies": {
   },
   "extra": {
+    "socket.io": "^4.8.1",
+    "socket.io-client": "^4.8.1"
+  },
+  "extra": {
+    "socket.io": {
+      "introduction-date": null,
+      "purpose": "WebSocket library, Server part",
+    },
+    "socket.io-client": {
+      "introduction-date": null,
+      "purpose": "WebSocket library, Client part",
+    }
   }
 }


### PR DESCRIPTION
This PR adds `socket.io` and `socket.io-client` as NPM dependency for the chatroom.

General Information:
- [X] this dependency was already used in ILIAS.
- [X] License: MIT

Usages:

- components/ILIAS/Chatroom/chat/api.js
- components/ILIAS/Chatroom/chat/Bootstrap/SetupServer.js


Wrapped By:

- il.Chatroom (see: components/ILIAS/OnScreenChat/js/chat.js)
- SetupServer see:
  - components/ILIAS/Chatroom/chat/Bootstrap/SetupServer.js

Reasoning:

`socket.io` is a library that enables low-latency, bidirectional and event-based communication between a client and a server. It is used in the Node.js based ILIAS chat server, which relies on the provided WebSocket low-level transport mechanisms. Socket.IO offers HTTP long-polling as a fallback option, which is useful in environments that don't support WebSockets.

Maintenance:

`socket.io` is a well-maintained package with major releases every few years and recent activities.
(The latest version is from 25.10.2025)

Links:

- NPM: https://www.npmjs.com/package/socket.io / https://www.npmjs.com/package/socket.io-client
- GitHub: https://github.com/socketio/socket.io (they are maintained in the same repo)
- Documentation: https://socket.io/docs/