### PR TITLE
Chatroom: Add `uuid`

### DIFF
--- a/components/ILIAS/Chatroom/chat/package_new.json
+++ b/components/ILIAS/Chatroom/chat/package_new.json
@@ -3,6 +3,7 @@
   "description": "ILIAS CHAT",
   "version": "12.0.0",
   "dependencies": {
+    "uuid": "^13.0.0"
   },
   "extra": {
   }


### PR DESCRIPTION
This PR adds `uuid` as NPM dependency for the chatroom.

General Information:
- [x] this dependency was already used in ILIAS.
- [X] License: MIT

Usages:

- components/ILIAS/Chatroom/chat/SocketTask/Conversation.js
- components/ILIAS/Chatroom/chat/SocketTask/ConversationAddUser.js
- components/ILIAS/Chatroom/chat/SocketTask/ConversationMessage.js

Wrapped By:

- Not applicable

Reasoning:

`uuid` is be used to retrieve UUID values for the Node.js based ILIAS chat server, similar to the ramsey/uuid library we use in PHP for the ILIAS backend.

Maintenance:

`uuid` is a well maintained package with a lot of contributions. It is an active project. 
(The latest release is from 08.09.2025)

Links:

- NPM: https://www.npmjs.com/package/uuid
- GitHub: https://github.com/uuidjs/uuid
- Documentation: https://github.com/uuidjs/uuid?tab=readme-ov-file#api-summary