### PR TITLE
Chatroom: Add `winston`

### DIFF
--- a/components/ILIAS/Chatroom/chat/package_new.json
+++ b/components/ILIAS/Chatroom/chat/package_new.json
@@ -3,7 +3,12 @@
   "description": "ILIAS CHAT",
   "version": "12.0.0",
   "dependencies": {
+    "winston": "^3.18.0"
   },
   "extra": {
+    "winston": {
+      "introduction-date": null,
+      "purpose": "Logging library for nodejs",
+    }
   }
 }


### PR DESCRIPTION
This PR adds `winston` as NPM dependency for the chatroom.

General Information:
- [X] this dependency was already used in ILIAS.
- [X] License: MIT
 
Usages:

- components/ILIAS/Chatroom/chat/Bootstrap/SetupEnvironment.js (instance creation and configuration)
- components/ILIAS/Chatroom/chat/* The logger instance is used in many JS files.

Wrapped By:

- Not applicable

Reasoning:

`winston` is a logging library for the Node.js based ILIAS chat server, similar to Monolog, which we use in ILIAS for server-side logging. It supports multiple transport channels and logging levels (compliant to RFC5424, see: https://datatracker.ietf.org/doc/html/rfc5424).

Maintenance:

`winston` is a well maintained package with major releases every few years. It is an active project.
(The latest release is from the 01.10.2025)

Links:

- NPM: https://www.npmjs.com/package/winston
- GitHub: https://github.com/winstonjs/winston
- Documentation: https://github.com/winstonjs/winston?tab=readme-ov-file#usage