### PR TITLE
NPM: Add `jquery`for ILIAS 12

### DIFF
--- a/package_new.json
+++ b/package_new.json
@@ -8,9 +8,10 @@
   },
   "engines": {
     "node": "^22.18 || ^24.0",
-    "npm": "^10.9.3 || ^11.3"
+    "npm": "^10.9.3 || ^11.3",
   },
   "dependencies": {
+    "jquery": "^3.7.1"
   },
   "devDependencies": {
   },
@@ -29,5 +30,9 @@
   },
   "homepage": "https://github.com/ILIAS-eLearning/ILIAS#readme",
   "extra": {
+    "jquery": {
+      "introduction-date": null,
+      "purpose": "We still use jQuery for many JS-related actions in ILIAS, unfortunately.",
+    }
   }
 }


### PR DESCRIPTION
This PR adds `jQuery` as NPM dependency.

Usage:
* In many components, searching for `$(` results in 3700+ occurrences

Wrapped By:
* Not applicable

Reasoning:
* `jQuery` is a long-standing dependency in ILIAS, providing DOM manipulation, event handling, and AJAX utilities.  
While modern browsers now support most of these features natively, a full migration away from jQuery would require significant effort across many components.  
For now, keeping it ensures compatibility and avoids regressions in a large number of modules.

Maintenance:
* `jQuery` remains actively maintained and has an existing security policy (https://github.com/jquery/jquery/blob/02cf4ee090debded3da4b0e3f59bd33f516125ea/SECURITY.md).
* (The latest release is from 28.08.2023)
* Currently v4 is being released in Beta with the last update from 11.08.2025)

Links:
* NPM: https://www.npmjs.com/package/jquery
* GitHub: https://github.com/jquery/jquery
* Documentation: https://api.jquery.com/