### PR TITLE
NPM: Add `linkifyjs` and `linkify-element` for ILIAS 12

### DIFF
--- a/package_new.json
+++ b/package_new.json
@@ -11,6 +11,7 @@
     "npm": "^10.9.3 || ^11.3"
   },
   "dependencies": {
+    "linkifyjs": "^4.3.2",
     "linkify-element": "^4.3.2"
   },
   "devDependencies": {
@@ -34,5 +35,9 @@
       "introduction-date": null,
       "purpose": "components/ILIAS/Link: Autolinking of external links"
     }
+  },
+  "linkifyjs": {
+    "introduction-date": null,
+    "purpose": "components/ILIAS/Link: Autolinking of external links",
   }
 }

--- a/package_new.json
+++ b/package_new.json
@@ -11,6 +11,7 @@
     "npm": "^10.9.3 || ^11.3"
   },
   "dependencies": {
+    "linkify-element": "^4.3.2"
   },
   "devDependencies": {
   },
@@ -29,5 +30,9 @@
   },
   "homepage": "https://github.com/ILIAS-eLearning/ILIAS#readme",
   "extra": {
+    "linkify-element": {
+      "introduction-date": null,
+      "purpose": "components/ILIAS/Link: Autolinking of external links"
+    }
   }
 }


### PR DESCRIPTION
This PR adds `linkifyjs` and `linkify-element` as NPM dependency.

General Information:
- [X] these dependencies were already used in ILIAS.
- [X] License: MIT

Usage:

- CoPage: Used in paragraphs
- OnScreenChat: components/ILIAS/OnScreenChat/resources/onscreenchat.js
- Chatroom: components/ILIAS/Chatroom/resources/js/src/ChatMessageArea.js

Wrapped By:

- components/ILIAS/Link/resources/js/ilExtLink.js

Reasoning:

`linkifyjs` is used by the OnScreenChat and Chatroom to transform URL-like strings into clickable HTML link elements. Without this library all kind of URL-like strings (see: https://linkify.js.org/) are not transformed anymore and our users will have to copy the strings manually into the browser address input. I doubt we can support this feature with a few regular expressions maintained by the ILIAS community.

`linkify-element` is maintained in the same repo.

Maintenance:
- `linkifyjs` is actively maintained, although it is feature-complete. In the last months a few bug fixes and improvements have been committed.
- (The latest release is from 25.07.2025)

Links:

- NPM: https://www.npmjs.com/package/linkifyjs / https://www.npmjs.com/package/linkify-element
- GitHub: https://github.com/Hypercontext/linkifyjs
- Documentation: https://linkify.js.org/docs/