### PR TITLE
Composer: Add `phpmailer/phpmailer` for ILIAS 12

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -39,7 +39,8 @@
 		]
 	},
 	"require": {
-	},
+      "phpmailer/phpmailer": "^7.0"
+    },
 	"require-dev": {
 	},
 	"autoload": {


### PR DESCRIPTION
This PR suggests adding `phpmailer/phpmailer` (v. `7.0`) as composer dependency.

General Information:
* [X] this dependency was already used in ILIAS.
* [X] License: LGPL-2.1

Usage:
* `components/ILIAS/Mail`

Wrapped By:
* `\ilMailMimeTransportBase`

Reasoning:
* `PHPMailer` is a de facto standard for sending emails with PHP. It supports multiple transport channels as SMTP, mail or sendmail. Furthermore, it supports multiple authentication methods and provides proper APIs for attachment handling (and multipart handling in general), encoding and encryption.
* We should not/do not want to reinvent the wheel in ILIAS and should rely on this library crafted by these email standard specialists.

Maintenance:
* `PHPMailer` is actively maintained by multiple contributors. There is recent activity (few days ago, see: https://github.com/PHPMailer/PHPMailer/commits/master).
* Security issues are always fixed in a timely manner followed by new releases.

Links:
* Packagist: https://packagist.org/packages/phpmailer/phpmailer
* GitHub: https://github.com/PHPMailer/PHPMailer
* Documentation: https://github.com/PHPMailer/PHPMailer/wiki / https://github.com/PHPMailer/PHPMailer/tree/master/docs / https://phpmailer.github.io/PHPMailer/