### PR TITLE
Composer: Add `jumbojett/openid-connect-php` for ILIAS 12

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -39,7 +39,8 @@
 		]
 	},
 	"require": {
-	},
+      "jumbojett/openid-connect-php": "dev-master#bc719cc9930990a4a9916cc127b839b4ed1c89ad"
+    },
 	"require-dev": {
 	},
 	"autoload": {


### PR DESCRIPTION
This PR adds `jumbojett/openid-connect-php` v. `1.0.2` (from `master` branch as `dev-master` package with PHP 8.4 support) as composer dependency for ILIAS 12.

General Information:
* Name of the dependency: `jumbojett/openid-connect-php`
* Version: `v1.0.2`(from `master` branch as `dev-master` package with PHP 8.4 support)
* [X] this dependency was already used in ILIAS.
* [X] the dependency's license is compatible with ILIAS' license: Apache-2.0 License

Type of dependency:
* [x] composer
* [ ] npm

Usage:
* `components/ILIAS/OpenIDConnect`

Reasoning:
* The library is used for `OpenID Connect`-based logins in ILIAS.
* When searching the web, it is the most recommended library.

Maintenance:
* There are 87 contributors.
* While there seemed to be pauses in development and some specification implementation issues during the 0.* releases, development has **resumed** since end of 2023 with the first major release. Version 1.0.2 was released in mid of September 2024.
* The library is actively maintained, there are recent commits and releases (e.g., to ensure the PHP 8.4 compatibility and to fix specification issues)
* It basically consists of one file and has 1 composer dependency (smallish), so we see ourselves in a position to maintain it if the actual maintainers stop their activities.

Links:
* Packagist: https://packagist.org/packages/jumbojett/openid-connect-php
* GitHub: https://github.com/jumbojett/OpenID-Connect-PHP
* Documentation: https://github.com/jumbojett/OpenID-Connect-PHP/blob/master/README.md

Alternatives:
* Actually, we don't see any real alternatives for ILIAS 12.
* Many of the packages listed when searching (via https://packagist.org/ or search engines) are derivatives of the suggested library. Other libraries (like the ones checked below) have other drawbacks and are more complicated in their usage.
* https://packagist.org/packages/league/oauth2-client - We had considered proposing this library for ILIAS 12 and even explored funding options among some of our customers. However, there were no volunteers to support the integration or a new implementation. Since it's primarily an OAuth library, significant OIDC-specific functionality would still need to be implemented on our side. As such, funding is required. Note that it also introduces `paragonie/random_compat` as a transitive dependency.
* https://github.com/socialconnect/auth : Worse maintenance, fewer contributors, huge package (the code and structure look indeed cleaner) with a lot of (unnecessary) code and more transitive dependencies.
* https://github.com/facile-it/php-openid-client/commits/master/ : Only 5 contributors, huge package with more transitive dependencies, little activity, but the code and structure look cleaner.
* https://bitbucket.org/PEOFIAMP/phpoidc/src/master/ No comment :-)
* Of course we can spend weeks to implement our own OpenID Connect client, but this will further or later result in other libraries being suggested like `\Firebase\JWT\JWT` etc.pp. To be honest, we don't want that.