### PR TITLE
Composer: Add `ramsey/uuid` for ILIAS 12

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -39,7 +39,8 @@
 		]
 	},
 	"require": {
-	},
+      "ramsey/uuid": "^4.9"
+    },
 	"require-dev": {
 	},
 	"autoload": {


### PR DESCRIPTION
This PR suggests adding `ramsey/uuid` (v. `4.9`) as composer dependency.

General Information:
* [X] this dependency was already used in ILIAS.
* [X] License: MIT

Usage:
* `component/ILIAS/Certificate`
* `component/ILIAS/CoPage`
* `component/ILIAS/ResourceStorage`

Wrapped By:
* `\ILIAS\Data\UUID\RamseyUuidWrapper`

Reasoning:
* `ramsey/uuid` With 513,691,061 usages and 12,470 stars on packagist, "ramsey" is the most widely used library for creating UUIDs and is the basis for many other implementations.

Maintenance:
* `ramsey/uuid` is actively maintained by multiple contributors. There is recent activity in past weeks: https://github.com/ramsey/uuid/commits/4.x.
* The latest release is from 04.09.2025

Links:
* Packagist: https://packagist.org/packages/ramsey/uuid
* GitHub: https://github.com/ramsey/uuid
* Documentation: https://uuid.ramsey.dev/en/stable/