### PR TITLE
Composer (Dev): Add `cmikey179/vfsstream` and  for ILIAS 12

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -41,7 +41,8 @@
 	"require": {
 	},
 	"require-dev": {
-	},
+      "mikey179/vfsstream": "^1.6"
+    },
 	"autoload": {
 		"psr-4" : {
 			"ILIAS\\Scripts\\" : "./scripts"


### PR DESCRIPTION
This PR suggests adding `mikey179/vfsstream` (v. `1.6`) as composer dependency.

General Information:
* [X] this dependency was already used in ILIAS.
* [X] License: BSD

Usage:
* Used when executing the ILIAS unit test suite.

Wrapped By:
* Not applicable

Reasoning:
* `vfsStream` is a stream wrapper for a virtual file system that may be helpful in unit tests to mock the real file system.

Maintenance:
* There is not much development activity (see: https://github.com/bovigo/vfsStream/graphs/commit-activity), so it might occur that there will be issues with upcoming PHP versions.
* The risk of relying on this library is small. It is a development dependency, and only a small number of unit tests rely on a mocked file system. If more and more components in ILIAS use the `IRSS`, the usage of PHP filesystem functions will decrease accordingly, so the corresponding unit tests might get obsolete.

Links:
* Packagist: https://packagist.org/packages/mikey179/vfsstream
* GitHub: https://github.com/bovigo/vfsStream
* Documentation: https://github.com/bovigo/vfsStream/wiki