### PR TITLE
Composer: Add PHPOffice/PhpSpreadsheet for ILIAS 12

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -39,6 +39,7 @@
 		]
 	},
 	"require": {
+		"phpoffice/phpspreadsheet": "^5.3",
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
This PR suggests adding `PHPOffice/PHPSpreadSheat` (v. `5.3`) as composer dependency.

General Information:
* [X] this dependency was already used in ILIAS.
* [X] License: MIT

Usage:
* Bookingpool
* Datacollection
* Exercise
* MyStaff
* OrgUnits
* Polls
* Category
* SCORM
* StudyProgramme
* Survey
* Test
* LearningProgress
* Tracking
* Wiki
* User
* and possibly more

Wrapped By:
* `\ILIAS\Excel`

Reasoning:
* Is the de facto standard for dealing with spreadsheets in PHP.
* Is actively developed even if by only one person.
* In wide use in the code base.
* Specially `xlsx` is a very  complex standard which we should definitely NOT try to implement ourselves.

Maintenance:
- Mostly one maintainer [oleibmann](https://github.com/oleibman). Not much information about him available. Regular contributions by others. Part of `PHPOffice` with more contributors.
- Regular updates (multiple commits per day).
* The latest release is from 24.11.2025

Links:
* Packagist: https://packagist.org/packages/phpoffice/phpspreadsheet
* GitHub: https://github.com/PHPOffice/PhpSpreadsheet
* Documentation: https://phpspreadsheet.readthedocs.io/en/latest/
