### PR TITLE
UI: also allow 0 as comparison for progress meter (45179)

### DIFF
--- a/src/UI/Component/Chart/ProgressMeter/Standard.php
+++ b/src/UI/Component/Chart/ProgressMeter/Standard.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Component\Chart\ProgressMeter;
 

--- a/src/UI/Component/Chart/ProgressMeter/Standard.php
+++ b/src/UI/Component/Chart/ProgressMeter/Standard.php
@@ -30,10 +30,13 @@ interface Standard extends ProgressMeter
      * Get comparison value
      *
      * This value is represented as the second progress meter bar.
-     *
-     * @return int|float|null
      */
-    public function getComparison();
+    public function getComparison(): int;
+
+    /**
+     * Should a second progress meter bar be shown?
+     */
+    public function hasComparison(): bool;
 
     /**
      * Get clone of Progress Meter with main text

--- a/src/UI/Implementation/Component/Chart/ProgressMeter/ProgressMeter.php
+++ b/src/UI/Implementation/Component/Chart/ProgressMeter/ProgressMeter.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Chart\ProgressMeter;
 

--- a/src/UI/Implementation/Component/Chart/ProgressMeter/ProgressMeter.php
+++ b/src/UI/Implementation/Component/Chart/ProgressMeter/ProgressMeter.php
@@ -35,6 +35,7 @@ class ProgressMeter implements C\Chart\ProgressMeter\ProgressMeter
     private int $required;
     protected int $main;
     protected int $comparison;
+    protected bool $has_comparison;
 
     public function __construct(int $maximum, int $main, int $required = null, int $comparison = null)
     {
@@ -46,9 +47,11 @@ class ProgressMeter implements C\Chart\ProgressMeter\ProgressMeter
         } else {
             $this->required = $this->getSafe($maximum);
         }
-        if ($comparison != null) {
+        if ($comparison !== null) {
+            $this->has_comparison = true;
             $this->comparison = $this->getSafe($comparison);
         } else {
+            $this->has_comparison = false;
             $this->comparison = 0;
         }
     }

--- a/src/UI/Implementation/Component/Chart/ProgressMeter/Renderer.php
+++ b/src/UI/Implementation/Component/Chart/ProgressMeter/Renderer.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Chart\ProgressMeter;
 

--- a/src/UI/Implementation/Component/Chart/ProgressMeter/Renderer.php
+++ b/src/UI/Implementation/Component/Chart/ProgressMeter/Renderer.php
@@ -64,10 +64,9 @@ class Renderer extends AbstractComponentRenderer
      */
     protected function renderStandard(Component\Chart\ProgressMeter\Standard $component): string
     {
-        $hasComparison = ($component->getComparison() != null && $component->getComparison() > 0);
         $tpl = $this->getTemplate("tpl.progressmeter.html", true, true);
 
-        $tpl = $this->getDefaultGraphicByComponent($component, $tpl, $hasComparison);
+        $tpl = $this->getDefaultGraphicByComponent($component, $tpl, $component->hasComparison());
 
         return $tpl->get();
     }
@@ -77,14 +76,13 @@ class Renderer extends AbstractComponentRenderer
      */
     protected function renderFixedSize(Component\Chart\ProgressMeter\FixedSize $component): string
     {
-        $hasComparison = ($component->getComparison() != null && $component->getComparison() > 0);
         $tpl = $this->getTemplate("tpl.progressmeter.html", true, true);
 
         $tpl->setCurrentBlock('fixed');
         $tpl->setVariable('FIXED_CLASS', 'fixed-size');
         $tpl->parseCurrentBlock();
 
-        $tpl = $this->getDefaultGraphicByComponent($component, $tpl, $hasComparison);
+        $tpl = $this->getDefaultGraphicByComponent($component, $tpl, $component->hasComparison());
 
         return $tpl->get();
     }

--- a/src/UI/Implementation/Component/Chart/ProgressMeter/Standard.php
+++ b/src/UI/Implementation/Component/Chart/ProgressMeter/Standard.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Chart\ProgressMeter;
 

--- a/src/UI/Implementation/Component/Chart/ProgressMeter/Standard.php
+++ b/src/UI/Implementation/Component/Chart/ProgressMeter/Standard.php
@@ -34,9 +34,14 @@ class Standard extends ProgressMeter implements C\Chart\ProgressMeter\Standard
     /**
      * @inheritdoc
      */
-    public function getComparison()
+    public function getComparison(): int
     {
         return $this->getSafe($this->comparison);
+    }
+
+    public function hasComparison(): bool
+    {
+        return $this->has_comparison;
     }
 
     /**

--- a/tests/UI/Component/Chart/ProgressMeter/ChartProgressMeterTest.php
+++ b/tests/UI/Component/Chart/ProgressMeter/ChartProgressMeterTest.php
@@ -136,6 +136,47 @@ class ChartProgressMeterTest extends ILIAS_UI_TestBase
         $this->assertHTMLEquals($expected_html, $html);
     }
 
+    public function testRenderStandardTwoBarWithZeroComparison(): void
+    {
+        $r = $this->getDefaultRenderer();
+        $f = $this->getFactory();
+        $standard = $f->standard(100, 75, null, 0);
+
+        $this->assertInstanceOf("ILIAS\\UI\\Component\\Chart\\ProgressMeter\\Standard", $standard);
+
+        $html = $r->render($standard);
+
+        $expected_html =
+            '<div class="il-chart-progressmeter-box ">' .
+            '<div class="il-chart-progressmeter-container">' .
+            '<svg viewBox="0 0 50 40" class="il-chart-progressmeter-viewbox">' .
+            '<path class="il-chart-progressmeter-circle-bg" stroke-dasharray="100, 100" ' .
+            'd="M10.4646,37.0354 q-5.858,-5.858 -5.858,-14.142 a1,1 0 1,1 40,0 q0,8.284 -5.858,14.142"></path>' .
+            '<g class="il-chart-progressmeter-multicircle">' .
+            '<path class="il-chart-progressmeter-circle no-success" ' .
+            'd="M9.6514,37.8486 q-6.1948,-6.1948 -6.1948,-14.9552 a1,1 0 1,1 42.30,0 q0,8.7604 -6.1948,14.9552" ' .
+            'stroke-dasharray="75, 100"></path>' .
+            '<path class="il-chart-progressmeter-circle active" ' .
+            'd="M11.2778,36.2222 q-5.5212,-5.5212 -5.5212,-13.3288 a1,1 0 1,1 37.70,0 q0,7.8076 -5.5212,13.3288" ' .
+            'stroke-dasharray="0, 100"></path>' .
+            '</g>' .
+            '<g class="il-chart-progressmeter-text">' .
+            '<text class="text-score-info" x="25" y="16"></text>' .
+            '<text class="text-score" x="25" y="25">75 %</text>' .
+            '<text class="text-comparision" x="25" y="31"></text>' .
+            '<text class="text-comparision-info" x="25" y="34"></text>' .
+            '</g>' .
+            '<g class="il-chart-progressmeter-needle no-needle" style="transform: rotate(deg)">' .
+            '<polygon class="il-chart-progressmeter-needle-border" points="23.5,0.1 25,2.3 26.5,0.1"></polygon>' .
+            '<polygon class="il-chart-progressmeter-needle-fill" points="23.5,0 25,2.2 26.5,0"></polygon>' .
+            '</g>' .
+            '</svg>' .
+            '</div>' .
+            '</div>';
+
+        $this->assertHTMLEquals($expected_html, $html);
+    }
+
     public function testRenderFixedSizeOneBar(): void
     {
         $r = $this->getDefaultRenderer();


### PR DESCRIPTION
This PR fixes [45179](https://mantis.ilias.de/view.php?id=45179) by having KS progress meters treat `0` as `comparison` differently from `null`.

I decided to introduce a new flag `has_comparison`, rather than making `comparison` explicitely `?int`, since there is some processing applied to `comparison` to make sure it is between zero and the maximum. A nullable `comparison` would have meant circumventing that processing for `null`, the additional flag seemed cleaner to me.

I also added a unit test that covers the new behavior.

Cheers, Tim