### PR TITLE
Mantis #42939: Fix SOAP ilTestParticipantAccessFilter Not Found SoapFault

### DIFF
--- a/webservice/soap/classes/class.ilSoapTestAdministration.php
+++ b/webservice/soap/classes/class.ilSoapTestAdministration.php
@@ -563,6 +563,7 @@ class ilSoapTestAdministration extends ilSoapAdministration
             );
         }
 
+        /** @var ilObjTest|null $tst */
         if (!$tst = ilObjectFactory::getInstanceByRefId($test_ref_id, false)) {
             return $this->raiseError('No test found for id: ' . $test_ref_id, 'Client');
         }
@@ -580,11 +581,10 @@ class ilSoapTestAdministration extends ilSoapAdministration
 
         include_once './Modules/Test/classes/class.ilObjTest.php';
         include_once './Modules/Test/classes/class.ilTestParticipantData.php';
-        require_once 'Modules/Test/classes/class.ilTestParticipantAccessFilter.php';
+
+        $accessFilter = $this->getAccessResultsUserFilter($test_ref_id);
         $part = new ilTestParticipantData($GLOBALS['DIC']['ilDB'], $GLOBALS['DIC']['lng']);
-        $part->setParticipantAccessFilter(
-            ilTestParticipantAccessFilter::getManageParticipantsUserFilter($test_ref_id)
-        );
+        $part->setParticipantAccessFilter($accessFilter);
         $part->setUserIdsFilter((array) $a_user_ids);
         $part->load($tst->getTestId());
         $tst->removeTestResults($part);
@@ -612,8 +612,9 @@ class ilSoapTestAdministration extends ilSoapAdministration
         global $DIC;
 
         $rbacsystem = $DIC['rbacsystem'];
-        $tree = $DIC['tree'];
-        $ilLog = $DIC['ilLog'];
+        $il_user = $DIC['ilUser'];
+        $il_lng = $DIC['lng'];
+        $il_db = $DIC['ilDB'];
 
         if (ilObject::_isInTrash($test_ref_id)) {
             return $this->raiseError(
@@ -658,13 +659,17 @@ class ilSoapTestAdministration extends ilSoapAdministration
         $xmlResultSet->addColumn("matriculation");
 
         include_once './Modules/Test/classes/class.ilObjTest.php';
+        require_once 'Modules/Test/classes/class.ilTestParticipantList.php';
+
         $test_obj = new ilObjTest($obj_id, false);
         $participants = $test_obj->getTestParticipants();
-
-        require_once 'Modules/Test/classes/class.ilTestParticipantAccessFilter.php';
-        require_once 'Modules/Test/classes/class.ilTestParticipantList.php';
-        $accessFilter = ilTestParticipantAccessFilter::getAccessResultsUserFilter($test_ref_id);
-        $participantList = new ilTestParticipantList($test_obj);
+        $accessFilter = $this->getAccessResultsUserFilter($test_ref_id);
+        $participantList = new ilTestParticipantList(
+            $test_obj,
+            $il_user,
+            $il_lng,
+            $il_db,
+        );
         $participantList->initializeFromDbRows($participants);
         $participantList = $participantList->getAccessFilteredList($accessFilter);
         $participantList = $participantList->getScoredParticipantList();
@@ -742,5 +747,18 @@ class ilSoapTestAdministration extends ilSoapAdministration
 
         $testId = ilObjTestAccess::_getTestIDFromObjectID(ilObject::_lookupObjectId($refId));
         return new ilTestAccess($refId, $testId);
+    }
+
+    private function getAccessResultsUserFilter(int $ref_id): \Closure
+    {
+        require_once 'Modules/Test/classes/class.ilTestParticipantAccessFilter.php';
+
+        global $DIC;
+
+        $ilAccess = $DIC['ilAccess'];
+
+        $factory = new ilTestParticipantAccessFilterFactory($ilAccess);
+
+        return $factory->getAccessResultsUserFilter($ref_id);
     }
 }


### PR DESCRIPTION
This PR addresses the issue outlined in Mantis ticket [#42939](https://mantis.ilias.de/view.php?id=42939), where a SOAP request to the `getTestResults` or `removeTestResults` endpoints was returning a SOAP-ENV:Server error due to "`ilTestParticipantAccessFilter` Not Found" error.

---

The code within the `ilSoapTestAdministration` class has been refactored to properly use `ilTestParticipantAccessFilterFactory` that was presented in the commit https://github.com/ILIAS-eLearning/ILIAS/commit/4880070f8f431832ea686d8d742541b3247b9d1a#diff-36868eb1baf7e25211b77c4b61f9504796e98a622019d95e0170048fb4075954.

---

⚠️ **PR is for release_9 but should be cherry-picked in `release_10`, `release_11` and `trunk`.**

---

### Key changes:

1. Introduced a new private method, `getAccessResultsUserFilter`, which uses the `ilTestParticipantAccessFilterFactory` to create and return the appropriate user filter.
2. Updated `getTestResults`:
    - to use the new getAccessResultsUserFilter method.
    - to pass the correct required dependencies (`ilUser`, `lng`, `ilDB`) during `ilTestParticipantList` initiation
    - remove unused variables ($tree, $ilLog) have been removed.
3. Updated `removeTestResults`  to use the new getAccessResultsUserFilter method.


---

### Test Steps:

- Enable SOAP on the ILIAS server.
- Make a SOAP request with the following body:

```
<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:ilUserAdministration">
   <soapenv:Header/>
   <soapenv:Body>
      <urn:getTestResults soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
         <sid xsi:type="xsd:string">REPLACE_WITH_SID::REPLACE_WITH_CLIENT_NAME</sid>
         <ref_id xsi:type="xsd:int">REPLACE_WITH_EXISTING_REF_ID</ref_id>
         <sum_only xsi:type="xsd:bool">true</sum_only>
      </urn:getTestResults>
   </soapenv:Body>
</soapenv:Envelope>
```

#### Expected Result:

A 200 OK response with the following example XML:

```
<SOAP-ENV:Body>
        <ns1:getTestResultsResponse>
            <xml xsi:type="xsd:string">&lt;?xml version="1.0" encoding="utf-8"?&gt;&lt;!DOCTYPE result PUBLIC "-//ILIAS//DTD XMLResultSet//EN" "http://ilias.local/xml/ilias_xml_resultset_3_7.dtd"&gt;&lt;!--Generated by ILIAS XmlWriter--&gt;&lt;result&gt;&lt;colspecs&gt;&lt;colspec idx="0" name="user_id"/&gt;&lt;colspec idx="1" name="login"/&gt;&lt;colspec idx="2" name="firstname"/&gt;&lt;colspec idx="3" name="lastname"/&gt;&lt;colspec idx="4" name="matriculation"/&gt;&lt;colspec idx="5" name="question_id"/&gt;&lt;colspec idx="6" name="question_title"/&gt;&lt;colspec idx="7" name="maximum_points"/&gt;&lt;colspec idx="8" name="received_points"/&gt;&lt;colspec idx="9" name="passed"/&gt;&lt;/colspecs&gt;&lt;rows&gt;&lt;/rows&gt;&lt;/result&gt;</xml>
        </ns1:getTestResultsResponse>
</SOAP-ENV:Body>
```

#### Actual Result Before Fix:

The request results in the following error:

```
<SOAP-ENV:Fault>
    <faultcode>SOAP-ENV:Server</faultcode>
    <faultstring>Class "ilTestParticipantAccessFilter" not found</faultstring>
</SOAP-ENV:Fault>
```



