### PR TITLE
T&A 46090: Adds missing parameter to getTotalRowCount method call

### DIFF
--- a/components/ILIAS/Test/src/Questions/Presentation/QuestionsBrowserTable.php
+++ b/components/ILIAS/Test/src/Questions/Presentation/QuestionsBrowserTable.php
@@ -171,7 +171,7 @@ class QuestionsBrowserTable implements DataRetrieval
     ): int {
         $filter_data ??= [];
         $this->addFiltersToQuestionList($filter_data);
-        return $this->question_list->getTotalRowCount($filter_data, $additional_parameters);
+        return $this->question_list->getTotalRowCount($additional_viewcontrol_data, $filter_data, $additional_parameters);
     }
 
     public function loadRecords(array $filters = [], ?Order $order = null, ?Range $range = null): array


### PR DESCRIPTION
Hi everyone,

This PR refers to ticket [46090](https://mantis.ilias.de/view.php?id=46090). @matheuszych adds the missing parameter when calling the `getTotalRowCount` method.

Best,
@lukas-heinrich 