### PR TITLE
Mantis #30823: add Course AboStatus to XML export & import

### DIFF
--- a/Modules/Course/classes/class.ilCourseXMLParser.php
+++ b/Modules/Course/classes/class.ilCourseXMLParser.php
@@ -662,6 +662,10 @@ class ilCourseXMLParser extends ilMDSaxParser implements ilSaxSubsetParser
                 $this->course_obj->setTimingMode((int) $this->cdata);
                 break;
 
+            case 'AboStatus':
+                $this->course_obj->setAboStatus((int) $this->cdata);
+                break;
+
             case 'StatusDetermination':
                 $this->course_obj->setStatusDetermination((int) $this->cdata);
                 break;

--- a/Modules/Course/classes/class.ilCourseXMLParser.php
+++ b/Modules/Course/classes/class.ilCourseXMLParser.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=0);
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -16,6 +15,8 @@ declare(strict_types=0);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=0);
 
 /**
  * Course XML Parser

--- a/Modules/Course/classes/class.ilCourseXMLWriter.php
+++ b/Modules/Course/classes/class.ilCourseXMLWriter.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=0);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=0);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=0);
 
 /**
  * XML writer class

--- a/Modules/Course/classes/class.ilCourseXMLWriter.php
+++ b/Modules/Course/classes/class.ilCourseXMLWriter.php
@@ -333,6 +333,8 @@ class ilCourseXMLWriter extends ilXmlWriter
             $this->xmlElement('TimingMode', null, $this->course_obj->getTimingMode());
         }
 
+        $this->xmlElement('AboStatus', null, $this->course_obj->getAboStatus() ? 1 : 0);
+
         $this->xmlElement(
             'SessionLimit',
             [

--- a/xml/SchemaValidation/ilias_crs_9_0.xsd
+++ b/xml/SchemaValidation/ilias_crs_9_0.xsd
@@ -65,6 +65,7 @@
                 <xs:element minOccurs="1" maxOccurs="1" name="MinMembers" type="xs:integer"/>
                 <xs:element minOccurs="1" maxOccurs="1" name="ViewMode" type="xs:integer"/>
                 <xs:element minOccurs="0" maxOccurs="1" name="TimingMode" type="xs:integer"/>
+                <xs:element minOccurs="1" maxOccurs="1" name="AboStatus" type="xs:integer"/>
                 <xs:element minOccurs="1" maxOccurs="1" ref="SessionLimit"/>
                 <xs:element minOccurs="1" maxOccurs="1" ref="WelcomeMail"/>
                 <xs:element minOccurs="1" maxOccurs="1" name="StatusDetermination" type="xs:integer"/>


### PR DESCRIPTION
This PR addresses the issue outlined in Mantis ticket [#30823](https://mantis.ilias.de/view.php?id=30823), where XML course export is missing the `<AboStatus>` element, and the XML import ignores it.

---

⚠️ PR is for `release_9`, and due to differing XML schema validations across versions, separate pull requests are necessary for  `release_10`, `release_11`, and `trunk`.

**Please advise on how to proceed with these PRs.**

---

### Key changes:

1.  **`class.ilCourseXMLWriter.php`**: updated to include the `<AboStatus>` element in the exported XML file. It retrieves the subscription status from the course object and writes it into the XML.
2.  **`class.ilCourseXMLParser.php`**: updated to handle the new `<AboStatus>` element. During import, it reads the value from the XML and sets the subscription status on the newly created course object.
3.  **`ilias_crs_9_0.xsd`**: updated to include the `AboStatus` element. This makes the element a valid and required part of the course XML structure for ILIAS 9, ensuring that exports are compliant with the schema. _(If not done for each version, any course import with `<AboStatus>`  would fail)_

---

### Test Steps:

1. Export an existing course.
2. Open the generated export file (e.g., Modules/Course/set_1/export.xml) and verify that the <AboStatus/> element is present within the course data.
3. Modify the <AboStatus> value in the XML and import the course to confirm correct import behavior.
