### PR TITLE
T&A 46205: Add column skill_path to competence skill usage table

### DIFF
--- a/components/ILIAS/TestQuestionPool/src/Skills/SkillUsagesTable.php
+++ b/components/ILIAS/TestQuestionPool/src/Skills/SkillUsagesTable.php
@@ -51,6 +51,7 @@ class SkillUsagesTable implements DataRetrieval
 
         return [
             'skill_title' => $column_factory->text($this->lng->txt('qpl_qst_skl_usg_skill_col')),
+            'skill_path' => $column_factory->text($this->lng->txt('tst_competence_tree')),
             'num_assigns' => $column_factory->number($this->lng->txt('qpl_qst_skl_usg_numq_col')),
             'max_points' => $column_factory->number($this->lng->txt('qpl_qst_skl_usg_sklpnt_col'))
         ];


### PR DESCRIPTION
This PR is related to Mantis Ticket https://mantis.ilias.de/view.php?id=46205

It introduces an additional column "Competence Tree", which displays the required value according to the new DataTable approach.

Best Regards
@thojou 