### PR TITLE
UI: fix passing additional parameters in data table (46098)

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Table/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Renderer.php
@@ -204,7 +204,6 @@ class Renderer extends AbstractComponentRenderer
         $component = $this->registerActions($component);
 
         [$component, $view_controls] = $component->applyViewControls(
-            $component->getAdditionalViewControlData(),
             $component->getFilter(),
             $component->getAdditionalParameters()
         );


### PR DESCRIPTION
This PR fixes [46098](https://mantis.ilias.de/view.php?id=46098). The KS does not pass on additional parameters properly on their way to `DataRetrieval::getTotalRowCount`, `Implementation\Component\Table\Data::applyViewControls` takes 2 parameters, but the table renderer passes 3.