### PR TITLE
Tracking: Replace 'sel_country' with 'country'

### DIFF
--- a/components/ILIAS/Tracking/classes/class.ilLPTableBaseGUI.php
+++ b/components/ILIAS/Tracking/classes/class.ilLPTableBaseGUI.php
@@ -642,7 +642,6 @@ class ilLPTableBaseGUI extends ilTable2GUI
             $item = $this->getFilterItemByPostVar($id);
             switch ($id) {
                 case "title":
-                case "country":
                 case "gender":
                 case "city":
                 case "language":
@@ -657,7 +656,7 @@ class ilLPTableBaseGUI extends ilTable2GUI
                 case "zipcode":
                 case "email":
                 case "matriculation":
-                case "sel_country":
+                case "country":
                 case "query":
                 case "type":
                 case "area":

--- a/components/ILIAS/Tracking/classes/class.ilTrQuery.php
+++ b/components/ILIAS/Tracking/classes/class.ilTrQuery.php
@@ -880,9 +880,8 @@ class ilTrQuery
         }
 
         if ($valid) {
-            $result["country"] = self::getSummaryPercentages("country", $query);
-            $result["sel_country"] = self::getSummaryPercentages(
-                "sel_country",
+            $result["country"] = self::getSummaryPercentages(
+                "country",
                 $query
             );
             $result["city"] = self::getSummaryPercentages("city", $query);
@@ -1131,7 +1130,6 @@ class ilTrQuery
                     case "street":
                     case "email":
                     case "matriculation":
-                    case "country":
                     case "city":
                     case "title":
                         $where[] = $ilDB->like(
@@ -1143,7 +1141,7 @@ class ilTrQuery
 
                     case "gender":
                     case "zipcode":
-                    case "sel_country":
+                    case "country":
                         $where[] = "usr_data." . $id . " = " . $ilDB->quote(
                             $value,
                             "text"

--- a/components/ILIAS/Tracking/classes/repository_statistics/class.ilTrObjectUsersPropsTableGUI.php
+++ b/components/ILIAS/Tracking/classes/repository_statistics/class.ilTrObjectUsersPropsTableGUI.php
@@ -258,7 +258,6 @@ class ilTrObjectUsersPropsTableGUI extends ilLPTableBaseGUI
                 case "street":
                 case "zipcode":
                 case "city":
-                case "country":
                 case "email":
                 case "matriculation":
                 case "login":
@@ -326,9 +325,9 @@ class ilTrObjectUsersPropsTableGUI extends ilLPTableBaseGUI
                     $this->filter["gender"] = $item->getValue();
                     break;
 
-                case "sel_country":
+                case "country":
                     $item = $this->addFilterItemByMetaType(
-                        "sel_country",
+                        "country",
                         ilTable2GUI::FILTER_SELECT,
                         true,
                         $meta["txt"]
@@ -343,7 +342,7 @@ class ilTrObjectUsersPropsTableGUI extends ilLPTableBaseGUI
                         array("" => $this->lng->txt("trac_all")) + $options
                     );
 
-                    $this->filter["sel_country"] = $item->getValue();
+                    $this->filter["country"] = $item->getValue();
                     break;
 
                 case "status":

--- a/components/ILIAS/Tracking/classes/repository_statistics/class.ilTrSummaryTableGUI.php
+++ b/components/ILIAS/Tracking/classes/repository_statistics/class.ilTrSummaryTableGUI.php
@@ -93,7 +93,7 @@ class ilTrSummaryTableGUI extends ilLPTableBaseGUI
         $labels = $this->getSelectableColumns();
         foreach ($this->getSelectedColumns() as $c) {
             // see bug #35119; these column list percentage lists and are not sortable
-            if (in_array($c, ["status", "mark", "language", "country", "gender", "city", "sel_country"])) {
+            if (in_array($c, ["status", "mark", "language", "gender", "city", "country"])) {
                 $this->addColumn($labels[$c]["txt"]);
             } else {
                 $this->addColumn($labels[$c]["txt"], $c);
@@ -184,7 +184,7 @@ class ilTrSummaryTableGUI extends ilLPTableBaseGUI
             $all[] = "mark";
         }
 
-        $privacy = array("gender", "city", "country", "sel_country");
+        $privacy = array("gender", "city", "country");
         foreach ($privacy as $field) {
             if (
                 ($this->is_in_course && $this->setting->get("usr_settings_course_export_" . $field)) ||
@@ -386,18 +386,10 @@ class ilTrSummaryTableGUI extends ilLPTableBaseGUI
             $this->filter["city"] = $item->getValue();
         }
 
+
         if ($this->setting->get("usr_settings_course_export_country")) {
             $item = $this->addFilterItemByMetaType(
                 "country",
-                ilTable2GUI::FILTER_TEXT,
-                true
-            );
-            $this->filter["country"] = $item->getValue();
-        }
-
-        if ($this->setting->get("usr_settings_course_export_sel_country")) {
-            $item = $this->addFilterItemByMetaType(
-                "sel_country",
                 ilTable2GUI::FILTER_SELECT,
                 true
             );
@@ -407,7 +399,7 @@ class ilTrSummaryTableGUI extends ilLPTableBaseGUI
                 )
                 ) + $this->getSelCountryCodes()
             );
-            $this->filter["sel_country"] = $item->getValue();
+            $this->filter["country"] = $item->getValue();
         }
 
         $item = $this->addFilterItemByMetaType(
@@ -573,10 +565,6 @@ class ilTrSummaryTableGUI extends ilLPTableBaseGUI
 
             // percentages
             $users_no = $result["user_total"];
-            $data["set"][$idx]["country"] = $this->getItemsPercentages(
-                $result["country"],
-                $users_no
-            );
             $data["set"][$idx]["gender"] = $this->getItemsPercentages(
                 $result["gender"],
                 $users_no,
@@ -590,8 +578,8 @@ class ilTrSummaryTableGUI extends ilLPTableBaseGUI
                 $result["city"],
                 $users_no
             );
-            $data["set"][$idx]["sel_country"] = $this->getItemsPercentages(
-                $result["sel_country"],
+            $data["set"][$idx]["country"] = $this->getItemsPercentages(
+                $result["country"],
                 $users_no,
                 $this->getSelCountryCodes()
             );
@@ -830,13 +818,12 @@ class ilTrSummaryTableGUI extends ilLPTableBaseGUI
 
         foreach ($this->getSelectedColumns() as $c) {
             switch ($c) {
-                case "country":
                 case "gender":
                 case "city":
                 case "language":
                 case "status":
                 case "mark":
-                case "sel_country":
+                case "country":
                     $this->renderPercentages($c, $a_set[$c]);
                     break;
 
@@ -960,13 +947,13 @@ class ilTrSummaryTableGUI extends ilLPTableBaseGUI
     {
         if (in_array(
             $a_name,
-            array("country",
+            array(
                            "gender",
                            "city",
                            "language",
                            "status",
                            "mark",
-                           'sel_country'
+                           'country'
         )
         )) {
             return true;

--- a/components/ILIAS/Tracking/templates/default/tpl.trac_summary_row.html
+++ b/components/ILIAS/Tracking/templates/default/tpl.trac_summary_row.html
@@ -6,7 +6,7 @@
 	</div>
 	<!-- END status_bl -->
 	<!-- BEGIN simple_path_bl -->
-	<div class="il_info">{COLL_PATH}</div>	
+	<div class="il_info">{COLL_PATH}</div>
 	<!-- END simple_path_bl -->
 	</td>
 	<!-- BEGIN user_total -->
@@ -85,17 +85,6 @@
 		<!-- END country_percentages -->
 	</td>
 	<!-- END country -->
-	<!-- BEGIN sel_country -->
-	<td class="std small">
-		<!-- BEGIN sel_country_percentages -->
-		<ul style="margin:0; padding:0; padding-left: 15px;">
-			<!-- BEGIN sel_country_row -->
-			<li>{CAPTION}: {ABSOLUTE} ({PERCENTAGE}%)</li>
-			<!-- END sel_country_row -->
-		</ul>
-		<!-- END sel_country_percentages -->
-	</td>
-	<!-- END sel_country -->
 	<!-- BEGIN language -->
 	<td class="std small">
 		<!-- BEGIN language_percentages -->
@@ -123,7 +112,7 @@
 	<td class="std small">
 		<!-- BEGIN item_path -->
 		<p>{PATH_ITEM}<br/><a href="{URL_DETAILS}">{TXT_DETAILS}</a></p>
-		<!-- END item_path -->		
+		<!-- END item_path -->
 	</td>
 	<!-- BEGIN column_action -->
 	<td class="std" nowrap="nowrap">


### PR DESCRIPTION
Hi @smeyer-ilias 

This PR removes all references to "country" and replaces all references to "sel_country" by "country", but maybe this is not the right approach?

See: https://mantis.ilias.de/view.php?id=46337

Best,
@kergomard 