### PR TITLE
ContentPage: Only Initialize Actions After Calling

### DIFF
--- a/components/ILIAS/ContentPage/classes/class.ilObjContentPageGUI.php
+++ b/components/ILIAS/ContentPage/classes/class.ilObjContentPageGUI.php
@@ -219,14 +219,6 @@ class ilObjContentPageGUI extends ilObject2GUI implements ilContentPageObjectCon
 
         $this->addToNavigationHistory();
 
-        if (!$this->in_page_editor_style_context &&
-            strtolower($nextClass) !== strtolower(ilObjectContentStyleSettingsGUI::class) &&
-            (strtolower($cmd) !== strtolower(self::UI_CMD_EDIT) || strtolower($nextClass) !== strtolower(
-                ilContentPagePageGUI::class
-            ))) {
-            $this->renderHeaderActions();
-        }
-
         switch (strtolower($nextClass)) {
             case strtolower(TranslationGUI::class):
                 $this->checkPermission('write');
@@ -417,6 +409,15 @@ class ilObjContentPageGUI extends ilObject2GUI implements ilContentPageObjectCon
 
                 parent::executeCommand();
         }
+
+        if (!$this->in_page_editor_style_context &&
+            strtolower($nextClass) !== strtolower(ilObjectContentStyleSettingsGUI::class) &&
+            (strtolower($cmd) !== strtolower(self::UI_CMD_EDIT) || strtolower($nextClass) !== strtolower(
+                ilContentPagePageGUI::class
+            ))) {
+            $this->renderHeaderActions();
+        }
+
     }
 
     protected function addToDesk(): void


### PR DESCRIPTION
Hi @mjansenDatabay 

This change would fix the problem that it is not possible to edit languages in the settings: See https://mantis.ilias.de/view.php?id=46294.

The problem here is an old friend of mine: If you initialize the headers before returning a modal that is asynchronously rendered some of the javascript is going to destroy the handling of the form in the modal. I never fully went to the bottom of it, but simply changing the order solves the problem.

Best,
@kergomard 