### PR TITLE
T&A 45268: Fixes use previous answers for file upload question

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assFileUpload.php
+++ b/Modules/TestQuestionPool/classes/class.assFileUpload.php
@@ -18,6 +18,7 @@
 
 use ILIAS\FileDelivery\Delivery\Disposition;
 use ILIAS\FileUpload\Exception\IllegalStateException;
+use ILIAS\ResourceStorage\Identification\ResourceIdentification;
 
 require_once './Modules/Test/classes/inc.AssessmentConstants.php';
 
@@ -686,6 +687,7 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
             $upload_handling_required = $this->current_cmd !== 'submitSolution'
                 && $this->current_cmd !== 'showInstantResponse'
                 && !$this->isFileDeletionAction()
+                && !$this->isFileReuseAction()
                 && $this->isFileUploadAvailable()
                 && $this->checkUpload();
         } catch (IllegalStateException $e) {
@@ -728,46 +730,12 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
                     $this->forceExistingIntermediateSolution($active_id, $pass, true);
                 }
 
-                if ($this->isFileDeletionAction()) {
-                    if ($this->isFileDeletionSubmitAvailable()) {
-                        foreach ($_POST[self::DELETE_FILES_TBL_POSTVAR] as $solution_id) {
-                            $this->removeSolutionRecordById($solution_id);
-                        }
-                    } else {
-                        $this->tpl->setOnScreenMessage('info', $this->lng->txt('no_checkbox'), true);
-                    }
-                } else {
-                    if ($this->isFileReuseHandlingRequired()) {
-                        foreach ($_POST[self::REUSE_FILES_TBL_POSTVAR] as $solutionId) {
-                            $solution = $this->getSolutionRecordById($solutionId);
-
-                            $this->saveCurrentSolution(
-                                $active_id,
-                                $pass,
-                                $solution['value1'],
-                                $solution['value2'],
-                                false,
-                                $solution['tstamp']
-                            );
-                        }
-                    }
-
-                    if ($upload_handling_required && $rid !== null) {
-
-                        $revision = $this->irss->manage()->getCurrentRevision($rid);
-
-                        $this->saveCurrentSolution(
-                            $active_id,
-                            $pass,
-                            $rid->serialize(),
-                            'rid',
-                            false,
-                            time()
-                        );
-
-                        $entered_values = true;
-                    }
-                }
+                $entered_values = $this->processFileAction(
+                    $active_id,
+                    $pass,
+                    $upload_handling_required,
+                    $rid
+                ) || $entered_values;
 
                 if ($authorized === true && $this->intermediateSolutionExists($active_id, $pass)) {
                     // remove the dummy record of the intermediate solution
@@ -813,10 +781,12 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
     {
         $rids_to_delete = [];
         if ($this->isFileDeletionAction() && $this->isFileDeletionSubmitAvailable()) {
+            $solution_ids = $this->getSolutionIdsFromPost(self::DELETE_FILES_TBL_POSTVAR);
+
             $res = $this->db->query(
                 "SELECT value1 FROM tst_solutions WHERE value2 = 'rid' AND " . $this->db->in(
                     'solution_id',
-                    $_POST[self::DELETE_FILES_TBL_POSTVAR],
+                    $solution_ids,
                     false,
                     'integer'
                 )
@@ -1119,17 +1089,17 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
 
     protected function isFileDeletionAction(): bool
     {
-        return $this->getQuestionAction() == assFileUploadGUI::DELETE_FILES_ACTION;
+        return $this->getQuestionAction() === assFileUploadGUI::DELETE_FILES_ACTION;
+    }
+
+    protected function isFileReuseAction(): bool
+    {
+        return $this->getQuestionAction() === assFileUploadGUI::REUSE_FILES_ACTION;
     }
 
     protected function isFileDeletionSubmitAvailable(): bool
     {
         return $this->isNonEmptyItemListPostSubmission(self::DELETE_FILES_TBL_POSTVAR);
-    }
-
-    protected function isFileReuseSubmitAvailable(): bool
-    {
-        return $this->isNonEmptyItemListPostSubmission(self::REUSE_FILES_TBL_POSTVAR);
     }
 
     protected function isFileReuseHandlingRequired(): bool
@@ -1138,11 +1108,82 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
             return false;
         }
 
-        if (!$this->isFileReuseSubmitAvailable()) {
+        if (!$this->isFileReuseAction()) {
             return false;
         }
 
         return true;
+    }
+
+    protected function getSolutionIdsFromPost(string $post_var): array
+    {
+        return $this->http->wrapper()->post()->retrieve(
+            $post_var,
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->int()),
+                $this->refinery->always([])
+            ])
+        );
+    }
+
+    protected function reuseSelectedFilesFromPreviousSolution(int $active_id, int $pass): void
+    {
+        $solution_ids = $this->getSolutionIdsFromPost(self::REUSE_FILES_TBL_POSTVAR);
+
+        if ($solution_ids === []) {
+            $this->tpl->setOnScreenMessage('info', $this->lng->txt('no_checkbox'), true);
+            return;
+        }
+
+        foreach ($solution_ids as $solution_id) {
+            $solution = $this->getSolutionRecordById($solution_id);
+
+            $this->saveCurrentSolution(
+                $active_id,
+                $pass,
+                $solution['value1'],
+                $solution['value2'],
+                false,
+                $solution['tstamp']
+            );
+        }
+    }
+
+    protected function processFileAction(int $active_id, int $pass, bool $upload_handling_required, ?ResourceIdentification $rid): bool
+    {
+        if ($this->isFileDeletionAction()) {
+            if (!$this->isFileDeletionSubmitAvailable()) {
+                $this->tpl->setOnScreenMessage('info', $this->lng->txt('no_checkbox'), true);
+                return false;
+            }
+
+            $solution_ids = $this->getSolutionIdsFromPost(self::DELETE_FILES_TBL_POSTVAR);
+
+            foreach ($solution_ids as $solution_id) {
+                $this->removeSolutionRecordById($solution_id);
+            }
+            return false;
+        }
+
+        if ($this->isFileReuseHandlingRequired()) {
+            $this->reuseSelectedFilesFromPreviousSolution($active_id, $pass);
+            return true;
+        }
+
+        if ($upload_handling_required && $rid !== null) {
+            $this->saveCurrentSolution(
+                $active_id,
+                $pass,
+                $rid->serialize(),
+                'rid',
+                false,
+                time()
+            );
+
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -510,6 +510,7 @@ assessment#:#ass_create_export_file_with_results#:#Erstelle Exportdatei (inkl. T
 assessment#:#ass_create_export_test_archive#:#Erstelle Archivdatei für Test
 assessment#:#ass_create_export_test_results#:#Erstelle Ergebnisdatei
 assessment#:#ass_create_question#:#Frage erstellen
+assessment#:#ass_file_upload_reuse_btn#:#Ausgewählte Dateien wiederverwenden
 assessment#:#ass_imap_hint#:#Hinweis (angezeigt als Tooltip)
 assessment#:#ass_imap_map_file_not_readable#:#Die hochgeladene Imagemap kann nicht gelesen werden.
 assessment#:#ass_imap_no_map_found#:#In der hochgeladenen Imagemap konnte keine unterstützte Form gefunden werden.
@@ -1989,6 +1990,7 @@ assessment#:#unlock#:#Entsperren
 assessment#:#uploaded_material#:#Hochgeladene Materialien
 assessment#:#use_previous_solution#:#Verwende vorherige Lösung
 assessment#:#use_previous_solution_advice#:#Die angezeigte Lösung wurde vormals von Ihnen abgegeben. Sie müssen die Übernahme dieser Lösung unterhalb der Frage bestätigen, falls Sie die Lösung ohne Änderungen übernehmen wollen.
+assessment#:#use_previous_solution_advice_file_upload#:#Die angezeigten Dateien für die Frage sind Ihre zuvor hochgeladenen. Wählen Sie die Dateien aus, die Sie wiederverwenden möchten, und klicken Sie auf die Schaltfläche zur Bestätigung.
 assessment#:#user_has_finished_a_test#:#Ein Teilnehmer hat einen Test beendet.
 assessment#:#user_not_invited#:#Sie sind kein Teilnehmer der Prüfung.
 assessment#:#user_wrong_clientip#:#Falsche Client IP

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -510,6 +510,7 @@ assessment#:#ass_create_export_file_with_results#:#Create Test Export File (incl
 assessment#:#ass_create_export_test_archive#:#Create Test Archive File
 assessment#:#ass_create_export_test_results#:#Create Test Results Export File
 assessment#:#ass_create_question#:#Create Question
+assessment#:#ass_file_upload_reuse_btn#:#Reuse Selected Files
 assessment#:#ass_imap_hint#:#Hint to be shown as Tooltip
 assessment#:#ass_imap_map_file_not_readable#:#The uploaded image map could not be read.
 assessment#:#ass_imap_no_map_found#:#Could not find any form in the uploaded image map.
@@ -1989,6 +1990,7 @@ assessment#:#unlock#:#Unlock
 assessment#:#uploaded_material#:#Uploaded Material
 assessment#:#use_previous_solution#:#Use Previous Solution
 assessment#:#use_previous_solution_advice#:#The shown solution for the question is your previously given one. You have to confirm the adoption of the solution, if you like to use it without any change.
+assessment#:#use_previous_solution_advice_file_upload#:#The shown files for the question are your previously uploaded ones. Select the files you want to reuse and click the button to confirm.
 assessment#:#user_has_finished_a_test#:#A participant has finished a test.
 assessment#:#user_not_invited#:#You are not supposed to take this test.
 assessment#:#user_wrong_clientip#:#You don't have the right IP address to access this test.


### PR DESCRIPTION
This PR attempts to fix https://mantis.ilias.de/view.php?id=45268.

Implements use previous answers for file upload questions. Also adds the corresponding language variables.
I've implemented this feature instead of removing it because all other questions also have.

Kind regards,
@bidzanaaron 