### PR TITLE
T&A 46392: Streamline usage of getAdditionalTableName

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.assQuestion.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assQuestion.php
@@ -851,20 +851,14 @@ abstract class assQuestion implements Question
 
     public function deleteAdditionalTableData(int $question_id): void
     {
-        $additional_table_name = $this->getAdditionalTableName();
+        $table_name = $this->getAdditionalTableName();
 
-        if (!is_array($additional_table_name)) {
-            $additional_table_name = [$additional_table_name];
-        }
-
-        foreach ($additional_table_name as $table) {
-            if (strlen($table)) {
-                $this->db->manipulateF(
-                    "DELETE FROM $table WHERE question_fi = %s",
-                    ['integer'],
-                    [$question_id]
-                );
-            }
+        if (strlen($table_name)) {
+            $this->db->manipulateF(
+                "DELETE FROM $table_name WHERE question_fi = %s",
+                [ilDBConstants::T_INTEGER],
+                [$question_id]
+            );
         }
     }
 


### PR DESCRIPTION
This PR relates to Mantis issue https://mantis.ilias.de/view.php?id=46392.

As discussed in the ticket, there is only one method in the core that can handle an `array` return type for the `getAdditionalTableName` method. All other usages assume the return type to be a `string`.  
Given that, we streamline the behavior and also expect a `string` return type in `deleteAdditionalTableData`.

With this change, there may be implications for plugin developers. However, since the signature has already been changed, the main BC adjustments have already been introduced.

If a question type plugin requires multiple additional tables, the plugin developer must:

a) refactor their database structure into a single additional table  
b) override methods to read and write additional data.

Best regards,  
@thojou