### PR TITLE
T&A 46216: Fixes no access to uploaded file(s) during manual correction in Scoring by Question

### DIFF
--- a/components/ILIAS/Test/src/Scoring/Manual/class.TestScoringByQuestionGUI.php
+++ b/components/ILIAS/Test/src/Scoring/Manual/class.TestScoringByQuestionGUI.php
@@ -355,6 +355,8 @@ class TestScoringByQuestionGUI extends TestScoringByParticipantGUI
                     false,
                     false,
                     $this->object->getShowSolutionFeedback(),
+                    false,
+                    true
                 )
             )
         );
@@ -372,6 +374,8 @@ class TestScoringByQuestionGUI extends TestScoringByParticipantGUI
             false,
             false,
             $this->object->getShowSolutionFeedback(),
+            false,
+            true
         );
         if ($autosave_content === null) {
             return null;


### PR DESCRIPTION
This PR attempts to fix https://mantis.ilias.de/view.php?id=46216.

Sets show manual scoring to true when in manual scoring by question mode.

Kind regards,
@bidzanaaron 