### PR TITLE
NPM: Add `mathjax` for ILIAS 12

### DIFF
--- a/package_new.json
+++ b/package_new.json
@@ -11,6 +11,7 @@
     "npm": "^10.9.3 || ^11.3"
   },
   "dependencies": {
+    "mathjax": "^3.2.2"
   },
   "devDependencies": {
   },
@@ -29,5 +30,7 @@
   },
   "homepage": "https://github.com/ILIAS-eLearning/ILIAS#readme",
   "extra": {
+    "introduction-date": null,
+    "purpose": "Mathematical formular formatting"
   }
 }


### PR DESCRIPTION
This PR adds `mathjax` as NPM dependency.

General Information:
- [X] This dependencies is already used in ILIAS.
- [X] License: Apache-2.0


Usage:

- Page editor: text content
- Forum: thread, post, reply
- Test Questions: question text, feedback, hints
- Cloze Question: cloze text
- Kprim Question: answers
- Matching Question: terms, definitions
- SC Question: answers
- MC Question: answers
- Ordering Question: answers

Wrapped By:
- \ILIAS\UI\Component\Legacy\LatexContent
- \ILIAS\UI\Implementation\Component\Legacy\Renderer::registerResources

Reasoning:

See Feature Request [Streamline Latex Usage](https://docu.ilias.de/go/wiki/wpage_5614_1357)

MathJax is needed to display mathematical formula and is widely used in installations of universities and schools. Since ILIAS 11 MathJax is delivered as an NPM dependency with a unique configuration, This makes the behavior predictable. Furthermore, an HTML export of learning modules includes MathJax instead of linking it from a CDN.

Maintenance:

MathJax is the de-facto standard for rendering LaTeX on web pages. It is supported by strong partners (IEEE, Elsevier). It is actively developed. The [source repository](https://github.com/mathjax/MathJax-src/activity) had 80 activities in the last month. The newest version [4.0.0](https://docs.mathjax.org/en/latest/upgrading/whats-new-4.0.html) was published in August 2025. It is an opt-in update and version 3 is still supported. For the beginning of the ILIAS 12 development I propose to keep version [3.2.2](https://www.npmjs.com/package/mathjax/v/3.2.2) and discuss with the SIG Mathe Digital if an update to version 4 is possible.

Links:

NPM: https://www.npmjs.com/package/mathjax
GitHub: https://github.com/mathjax
Documentation: https://www.mathjax.org