### PR TITLE
Fix Mantis #38803: Contradictory SCORM Learning Progress

### DIFF
--- a/Services/Tracking/classes/class.ilTrQuery.php
+++ b/Services/Tracking/classes/class.ilTrQuery.php
@@ -185,24 +185,24 @@ class ilTrQuery
         foreach ($a_sco_ids as $sco_id) {
             // #9719 - can have in_progress AND failed/completed
             if (in_array($a_user_id, $status_info["failed"][$sco_id])) {
-                $status = ilLPStatus::LP_STATUS_FAILED;
+                $status = ilLPStatus::LP_STATUS_FAILED_NUM;
             } elseif (in_array(
                 $a_user_id,
                 $status_info["completed"][$sco_id]
             )) {
-                $status = ilLPStatus::LP_STATUS_COMPLETED;
+                $status = ilLPStatus::LP_STATUS_COMPLETED_NUM;
             } elseif (in_array(
                 $a_user_id,
                 $status_info["in_progress"][$sco_id]
             )) {
-                $status = ilLPStatus::LP_STATUS_IN_PROGRESS;
+                $status = ilLPStatus::LP_STATUS_IN_PROGRESS_NUM;
             } else {
-                $status = ilLPStatus::LP_STATUS_NOT_ATTEMPTED;
+                $status = ilLPStatus::LP_STATUS_NOT_ATTEMPTED_NUM;
             }
 
             $items[$sco_id] = array(
                 "title" => $status_info["scos_title"][$sco_id],
-                "status" => (int) $status,
+                "status" => $status,
                 "type" => "sahs",
                 "score" => (int) ($scores[$sco_id] ?? 0)
             );


### PR DESCRIPTION
Mantis: 
- https://mantis.ilias.de/view.php?id=38803
- https://mantis.ilias.de/view.php?id=40169

Usage of wrong constants resulted in type-casting every status to 0

PR for 9+

Please cherry-pick to 10, 11 and trunk. There should be no conflicts.