### PR TITLE
T&A Fix routing for edit competence skill assignment

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php
@@ -391,8 +391,8 @@ class ilAssQuestionSkillAssignmentsGUI
         $question_id = $this->request_data_collector->getQuestionId();
         $question_gui ??= assQuestionGUI::_getQuestionGUI('', $question_id);
 
-        $row_id_parameter = $this->request_data_collector->strArray(EditSkillsOfQuestionTableActions::FULL_ROW_ID_PARAMETER);
-        [1 => $skill_base_id, 2 => $skill_tref_id] = explode('_', $row_id_parameter[0]);
+        $row_id_parameter = $this->request_data_collector->getRowIdParameter(EditSkillsOfQuestionTableActions::FULL_ROW_ID_PARAMETER);
+        [1 => $skill_base_id, 2 => $skill_tref_id] = explode('_', $row_id_parameter);
         $assignment ??= $this->buildQuestionSkillAssignment($question_id, (int) $skill_base_id, (int) $skill_tref_id);
 
         $form ??= $this->buildSkillQuestionAssignmentPropertiesForm($question_gui->getObject(), $assignment);
@@ -407,7 +407,7 @@ class ilAssQuestionSkillAssignmentsGUI
         if ($this->isTestQuestion($question_id)) {
             $question_gui = assQuestionGUI::_getQuestionGUI('', $question_id);
 
-            $row_id_parameter = $this->request_data_collector->string(EditSkillsOfQuestionTableActions::FULL_ROW_ID_PARAMETER);
+            $row_id_parameter = $this->request_data_collector->getRowIdParameter(EditSkillsOfQuestionTableActions::FULL_ROW_ID_PARAMETER);
             [1 => $skill_base_id, 2 => $skill_tref_id] = explode('_', $row_id_parameter);
             $assignment = $this->buildQuestionSkillAssignment($question_id, (int) $skill_base_id, (int) $skill_tref_id);
 
@@ -462,7 +462,7 @@ class ilAssQuestionSkillAssignmentsGUI
             }
         }
 
-        $this->ctrl->redirect($this, self::CMD_SHOW_SKILL_QUEST_ASSIGNS);
+        $this->ctrl->redirect($this, self::CMD_EDIT_SKILL_QUEST_ASSIGNS);
     }
 
     private function buildSkillQuestionAssignmentPropertiesForm(

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssQuestionSkillAssignmentPropertyFormGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssQuestionSkillAssignmentPropertyFormGUI.php
@@ -96,12 +96,12 @@ class ilAssQuestionSkillAssignmentPropertyFormGUI extends ilPropertyFormGUI
             );
 
             $this->addCommandButton(
-                ilAssQuestionSkillAssignmentsGUI::CMD_SHOW_SKILL_QUEST_ASSIGNS,
+                ilAssQuestionSkillAssignmentsGUI::CMD_EDIT_SKILL_QUEST_ASSIGNS,
                 $this->lng->txt('cancel')
             );
         } else {
             $this->addCommandButton(
-                ilAssQuestionSkillAssignmentsGUI::CMD_SHOW_SKILL_QUEST_ASSIGNS,
+                ilAssQuestionSkillAssignmentsGUI::CMD_EDIT_SKILL_QUEST_ASSIGNS,
                 $this->lng->txt('back')
             );
         }
@@ -208,6 +208,7 @@ class ilAssQuestionSkillAssignmentPropertyFormGUI extends ilPropertyFormGUI
         $questResultSkillPoints->setMinValue(1);
         $questResultSkillPoints->allowDecimals(false);
         $questResultSkillPoints->setValue((string) $this->assignment->getSkillPoints());
+
         if (!$this->isManipulationEnabled()) {
             $questResultSkillPoints->setDisabled(true);
         }

--- a/components/ILIAS/TestQuestionPool/src/RequestDataCollector.php
+++ b/components/ILIAS/TestQuestionPool/src/RequestDataCollector.php
@@ -245,6 +245,15 @@ class RequestDataCollector implements RequestDataCollectorInterface
         return $this->retrieveArray($key, 1, $this->refinery->identity());
     }
 
+    public function getRowIdParameter(string $key): string|int
+    {
+        return $this->get($key, $this->refinery->byTrying([
+            $this->refinery->kindlyTo()->int(),
+            $this->refinery->kindlyTo()->string(),
+            $this->refinery->custom()->transformation(fn(array $v): string|int => $v[0])
+        ]));
+    }
+
     /**
      * @return array<int>|string
      */


### PR DESCRIPTION
This PR is related to the Mantis ticket: https://mantis.ilias.de/view.php?id=46201.

There was an issue when evaluating the row id parameter, depending on how it was inserted into the URL.  
The new DataTable inserts the row id parameter as an array value, while the legacy ilCtrl inserts it as a string.

Additionally, the routing after clicking **Submit** or **Cancel** has been fixed. The user is now redirected to the *Manage Competence Assignments* screen.

Best regards,  
@thojou