### PR TITLE
NPM: Add `webui-popover` for ILIAS 12

### DIFF
--- a/package_new.json
+++ b/package_new.json
@@ -11,6 +11,7 @@
     "npm": "^10.9.3 || ^11.3"
   },
   "dependencies": {
+    "webui-popover": "^1.2.18"
   },
   "devDependencies": {
   },


### PR DESCRIPTION
**This commit readds webui-popover v. 1.2.18 as npm dependency to ILIAS 11.**

## Usage

ILIAS/UI

## Reasoning

The library is used to create popovers in the UI-framework. This applies to the initial Popover component, as well as to other components, such as Filters, Rating, that use the Popover component.

## Maintenance

There are 26 contributors to the library. The last commit to the library is 9 years old, as well as the last released version. The last open issue is from Oct '21, as well as the last closed issue. Last closed PR is from 2023. The open issues seem to be either feature requests or rather specific bugs.

It seems as if the development of the library has stopped, be it because its feature complete, be it because interest vanished.

## Links

* NPM: https://www.npmjs.com/package/webui-popover
* GitHub: https://github.com/sandywalker/webui-popover
* Documentation: https://www.npmjs.com/package/webui-popover?activeTab=readme

## Alternatives

There are plenty of alternatives to this library in the JS library space. Also, the HTML standard itself has gotten facilities to create popovers, although they are not enough to replace this library.

## Assessment

It is essential to include this library during development, as it is centrally used in the UI and its absence would leave parts of ILIAS in a broken state.
We are working on a solution for Release 12 that will no longer rely on it. You may note that there is currently quite a lot going on in the `UI Service / KitchenSink` area. Once we have found this solution, we are happy to remove the dependency.