### PR TITLE
[PROPOSAL] Change of BackgroundTasks Authorities

### DIFF
--- a/components/ILIAS/BackgroundTasks/maintenance.json
+++ b/components/ILIAS/BackgroundTasks/maintenance.json
@@ -1,7 +1,7 @@
 {
 	"maintenance_model":    "Classic",
-	"first_maintainer":     "fschmid(21087)",
-	"second_maintainer":    "",
+	"first_maintainer":     "tjoussen(103745)",
+	"second_maintainer":    "mjansen(8784)",
 	"implicit_maintainers": [],
 	"coordinator":          [
 		""

--- a/components/ILIAS/BackgroundTasks_/maintenance.json
+++ b/components/ILIAS/BackgroundTasks_/maintenance.json
@@ -1,7 +1,7 @@
 {
     "maintenance_model": "Classic",
-    "first_maintainer": "fschmid(21087)",
-    "second_maintainer": "",
+    "first_maintainer": "tjoussen(103745)",
+    "second_maintainer": "mjansen(8784)",
     "implicit_maintainers": [],
     "coordinator": [
         ""

--- a/docs/development/maintenance.md
+++ b/docs/development/maintenance.md
@@ -217,12 +217,12 @@ of ILIAS. The file contains the following fields:
 [//]: # (BEGIN BackgroundTasks)
 
 * **BackgroundTasks**
-    * Authority to Sign off on Conceptual Changes: MISSING
-    * Authority to Sign off on Code Changes: MISSING
+    * Authority to Sign off on Conceptual Changes: [tjoussen](https://docu.ilias.de/go/usr/103745), [mjansen](https://docu.ilias.de/go/usr/8784)
+    * Authority to Sign off on Code Changes: [tjoussen](https://docu.ilias.de/go/usr/103745), [mjansen](https://docu.ilias.de/go/usr/8784)
     * Authority to Curate Test Cases: MISSING
-    * Authority to (De-)Assign Authorities: MISSING
-    * Assignee for Security Reports: MISSING
-    * Assignee for Security Issues: MISSING
+    * Authority to (De-)Assign Authorities: [tjoussen (Databay AG)](https://docu.ilias.de/go/usr/103745)
+    * Assignee for Security Reports: [tjoussen](https://docu.ilias.de/go/usr/103745)
+    * Assignee for Security Issues: [tjoussen](https://docu.ilias.de/go/usr/103745)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END BackgroundTasks)


### PR DESCRIPTION
This PR proposes to add @mjansenDatabay and me (@thojou) to the following BackgroundTasks authorities:

For @thojou:
* Authority to Sign off on Conceptual Changes
* Authority to Sign off on Code Changes
* Authority to (De-)Assign Authorities (Databay AG)
* Assignee for Security Reports
* Assignee for Security Issues

For @mjansenDatabay
* Authority to Sign off on Conceptual Changes
* Authority to Sign off on Code Changes