### PR TITLE
[LTI] Fix: LTI Learning progress status and percentage

### DIFF
--- a/components/ILIAS/Init/resources/.htaccess
+++ b/components/ILIAS/Init/resources/.htaccess
@@ -26,6 +26,12 @@
 	XSendFile On
 </IfModule>
 
+<IfModule mod_setenvif.c>
+	# WebDAV and LTI specific
+	SetEnvIfNoCase Transfer-Encoding "chunked" proxy-sendcl=1
+	SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
+</IfModule>
+
 AddType video/ogg .ogv
 AddType video/mp4 .mp4
 AddType video/webm .webm

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResultService.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResultService.php
@@ -396,6 +396,7 @@ class ilLTIConsumerResultService
     private function checkSignature(string $a_key, string $a_secret): void
     {
         global $DIC;
+        $parameters = array();
         $logger = $DIC->logger()->root();
         $platform = new ilLTIPlatform();
 
@@ -415,8 +416,8 @@ class ilLTIConsumerResultService
         if (isset($request_headers['Authorization']) && str_starts_with($request_headers['Authorization'], 'OAuth ')) {
             $parameters = OAuthUtil::split_header($request_headers['Authorization']);
         }
-        $request = OAuthRequest::from_request(null, null, $parameters ?? []);
-        $logger->info("Request: " . json_encode($request));
+        $request = OAuthRequest::from_request(null, null, $parameters);
+        $logger->debug("Request: " . json_encode($request) . " parameters: " . json_encode($parameters));
         $server->verify_request($request);
     }
 

--- a/components/ILIAS/Tracking/classes/status/class.ilLPStatusLtiOutcome.php
+++ b/components/ILIAS/Tracking/classes/status/class.ilLPStatusLtiOutcome.php
@@ -54,22 +54,30 @@ class ilLPStatusLtiOutcome extends ilLPStatus
     public function determineStatus(
         int $a_obj_id,
         int $a_usr_id,
-        ?object $a_obj = null
+        object $a_obj = null
     ): int {
+        global $DIC;
+        $logger = $DIC->logger()->root();
         $ltiResult = $this->getLtiUserResult($a_obj_id, $a_usr_id);
 
         if ($ltiResult instanceof ilLTIConsumerResult) {
             $object = $this->ensureObject($a_obj_id, $a_obj);
             $ltiMasteryScore = $object->getMasteryScore();
+            $logger->info("Getting LTI result for user $a_usr_id: " . $ltiResult->getResult());
 
-            if ($ltiResult->getResult() >= $ltiMasteryScore) {
+            if ($ltiResult->getResult() === 0 || is_null($ltiResult->getResult()) && $ltiResult->isAttended()) {
+                return self::LP_STATUS_FAILED_NUM;
+            } elseif (is_null($ltiResult->getResult()) && !$ltiResult->isAttended()) {
+                return self::LP_STATUS_IN_PROGRESS_NUM;
+            } elseif ($ltiResult->getResult() >= $ltiMasteryScore) {
                 return self::LP_STATUS_COMPLETED_NUM;
+            } else {
+                return self::LP_STATUS_FAILED_NUM;
             }
-
-            return self::LP_STATUS_IN_PROGRESS_NUM;
+        } else {
+            $logger->info("No LTI result for user $a_usr_id");
+            return self::LP_STATUS_NOT_ATTEMPTED_NUM;
         }
-
-        return self::LP_STATUS_NOT_ATTEMPTED_NUM;
     }
 
     public function determinePercentage(


### PR DESCRIPTION
As with ILIAS 9 and 10, there were several errors related to learning progress
- Not transmitted correctly: This was because the .htaccess configuration prevented the authorisation headers from reaching the consumer platform, thus preventing authentication. By changing the .htaccess file, we enabled this transfer, solving the problem.
- The percentage and/or status was not reflected correctly: In previous versions, only whether it had passed or failed was transmitted, sending only 0 or 100. With this change, we send the correct percentage, also showing the corresponding status if it has failed, is in progress, or has passed successfully.

The purpose of the change in .htaccess follows the guidelines of the PR: [chore: Enable Authorization Header Forwarding in ILIAS 9 for Proper LTI 1.3 Authentication](https://github.com/ILIAS-eLearning/ILIAS/pull/10524)