### PR TITLE
T&A 46425: Fixes tab 'Export' highlights tab 'Info' and 'Scoring'

### DIFF
--- a/components/ILIAS/Test/src/Presentation/TabsManager.php
+++ b/components/ILIAS/Test/src/Presentation/TabsManager.php
@@ -95,6 +95,7 @@ class TabsManager
             case self::TAB_ID_YOUR_RESULTS:
             case self::TAB_ID_SETTINGS:
             case self::TAB_ID_TEST:
+            case self::TAB_ID_EXPORT:
             case self::TAB_ID_LEARNING_PROGRESS:
                 $this->tabs->activateTab($tab_id);
         }


### PR DESCRIPTION
This PR attempts to fix https://mantis.ilias.de/view.php?id=46425.

Adds `self::TAB_ID_EXPORT` to the switch case in the activateTab method.

Kind regards,
@bidzanaaron 