### PR TITLE
T&A 46414: Fixes click on the tab 'Question/Competence Assignment' leads to error

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php
@@ -165,6 +165,8 @@ class ilAssQuestionSkillAssignmentsGUI
             $this->ctrl->redirect($this, self::CMD_SHOW_SKILL_QUEST_ASSIGNS);
         }
 
+        $this->keepAssignmentParameters();
+
         if (in_array($command, [self::CMD_EDIT_SKILL_QUEST_ASSIGNS])) {
             $this->modifyTabs();
         }

--- a/components/ILIAS/TestQuestionPool/src/Skills/EditSkillsOfQuestionTable.php
+++ b/components/ILIAS/TestQuestionPool/src/Skills/EditSkillsOfQuestionTable.php
@@ -46,7 +46,7 @@ class EditSkillsOfQuestionTable implements DataRetrieval
      */
     public function getComponents(URLBuilder $url_builder): array
     {
-        $question = \assQuestionGUI::_getQuestionGUI('', $this->pool_request->getQuestionId())->getObject();
+        $question = \assQuestion::instantiateQuestion($this->pool_request->getQuestionId());
         return [
             $this->ui_factory->table()->data(
                 $this,


### PR DESCRIPTION
This PR attempts to fix https://mantis.ilias.de/view.php?id=46414.

Keeps assignment parameters when building subtabs.

Kind regards,
@bidzanaaron 