### PR TITLE
T&A Fix routing after saving competence settings on sync confirmation screen

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php
@@ -594,7 +594,7 @@ class ilAssQuestionSkillAssignmentsGUI
         $confirmation->setFormAction($this->ctrl->getFormAction($this));
         $confirmation->addHiddenItem('q_id', $this->request_data_collector->getQuestionId());
         $confirmation->setConfirm($this->lng->txt('yes'), self::CMD_SYNC_ORIGINAL);
-        $confirmation->setCancel($this->lng->txt('no'), self::CMD_SHOW_SKILL_QUEST_ASSIGNS);
+        $confirmation->setCancel($this->lng->txt('no'), self::CMD_EDIT_SKILL_QUEST_ASSIGNS);
 
         $this->tpl->setContent($this->ctrl->getHTML($confirmation));
     }
@@ -615,7 +615,7 @@ class ilAssQuestionSkillAssignmentsGUI
             $this->tpl->setOnScreenMessage('success', $this->lng->txt('qpl_qst_skl_assign_synced_to_orig'), true);
         }
 
-        $this->ctrl->redirect($this, self::CMD_SHOW_SKILL_QUEST_ASSIGNS);
+        $this->ctrl->redirect($this, self::CMD_EDIT_SKILL_QUEST_ASSIGNS);
     }
 
     private function buildSkillQuestionAssignmentList(): ilAssQuestionSkillAssignmentList


### PR DESCRIPTION
This PR is related to Mantis Ticket https://mantis.ilias.de/view.php?id=46415