### PR TITLE
fix: Deprecated function "utf8_decode"

### DIFF
--- a/Services/LTI/src/ToolProvider/Http/HttpMessage.php
+++ b/Services/LTI/src/ToolProvider/Http/HttpMessage.php
@@ -283,7 +283,7 @@ class HttpMessage
                 $links = explode(',', $matches[2][$i]);
                 foreach ($links as $link) {
                     if (preg_match('/^\<([^\>]+)\>; *rel=([^ ]+)$/', trim($link), $match)) {
-                        $rel = strtolower(utf8_decode($match[2]));
+                        $rel = strtolower(mb_convert_encoding($match[2], 'ISO-8859-1', 'UTF-8'));
                         if ((strpos($rel, '"') === 0) || (strpos($rel, '?') === 0)) {
                             $rel = substr($rel, 1, strlen($rel) - 2);
                         }


### PR DESCRIPTION
PHP 8.2+ deprecates utf8_decode(), which caused warnings during LTI operations. This commit removes the deprecated function and replaces it with a safe and standards-compliant alternative (mb_convert_encoding / appropriate UTF-8 handling).