### PR TITLE
[LTI] Fix: LTI avoid duplicates in User Management

### DIFF
--- a/Services/LTI/classes/InternalProvider/class.ilAuthProviderLTI.php
+++ b/Services/LTI/classes/InternalProvider/class.ilAuthProviderLTI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * OAuth based lti authentication

--- a/Services/LTI/classes/InternalProvider/class.ilAuthProviderLTI.php
+++ b/Services/LTI/classes/InternalProvider/class.ilAuthProviderLTI.php
@@ -107,7 +107,8 @@ class ilAuthProviderLTI extends \ilAuthProvider implements \ilAuthProviderInterf
     {
         $connector = new ilLTIDataConnector();
         $consumer = ilLTIPlatform::fromRecordId($a_sid, $connector);
-        return $consumer->getTitle();
+        $object = ilObjectFactory::getInstanceByRefId($consumer->getRefId());
+        return $consumer->getTitle() . " - " . $object->getTitle();
     }
 
     /**

--- a/Services/LTI/classes/InternalProvider/class.ilAuthProviderLTI.php
+++ b/Services/LTI/classes/InternalProvider/class.ilAuthProviderLTI.php
@@ -428,12 +428,12 @@ class ilAuthProviderLTI extends \ilAuthProvider implements \ilAuthProviderInterf
         $local_user = ilAuthUtils::_generateLogin($consumer->getPrefix() . '_' . $this->getCredentials()->getUsername());
 
         $newUser["login"] = $local_user;
-        if(isset($this->messageParameters['lis_person_name_given'])) {
+        if (isset($this->messageParameters['lis_person_name_given'])) {
             $newUser["firstname"] = $this->messageParameters['lis_person_name_given'];
         } else {
             $newUser["firstname"] = '-';
         }
-        if(isset($this->messageParameters['lis_person_name_family'])) {
+        if (isset($this->messageParameters['lis_person_name_family'])) {
             $newUser["lastname"] = $this->messageParameters['lis_person_name_family'];
         } else {
             $newUser["lastname"] = '-';


### PR DESCRIPTION
With this change, we fix the ticket [0041165](https://mantis.ilias.de/view.php?id=41165)

The suggested solution could not be fully implemented because the duplicate names shown in the image are the names of LTI providers (those configured at the platform level), which were displayed once for each resource that used them to provide content. Therefore, instead of the suggested change, we will now display the name of the provider together with the name of the resource it provides in order to avoid confusion.

<img width="1703" height="1155" alt="image" src="https://github.com/user-attachments/assets/dc910455-622d-4c83-b5aa-0a2ca0292381" />
