### PR TITLE
Add `pimple/pimple` as composer Dependency for ILIAS 12

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -39,6 +39,7 @@
 		]
 	},
 	"require": {
+		"pimple/pimple": "v3.6.0",
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
Assessment:
* This dependency provides a dependency injection container implementation.

General Information:
- Name of the dependency: `pimple/pimple`
- Version: `v3.6.0`
- [X] this dependency was already used in ILIAS.
- [X] the dependency's license is compatible with ILIAS' license: MIT

Type of dependency:
- [X] composer
- [ ] npm

Usage:
* almost all ILIAS components via `$DIC`
* `ILIAS\Component` for the bootstrap process

Reasoning:
* Pimple provides a light weight and simple dependency injection container, which is yet quite powerful to use.

Maintenance:
* Last update of the Library: 2025-11-12, PHP Version: >=7.2.5
* Feature complete, receives only PHP-version and security updates.

Links:
* Packagist: https://packagist.org/packages/pimple/pimple
* GitHub: https://github.com/silexphp/Pimple.git
* Documentation: -

Alternatives:
* We could easily implement our own DI container, but its very low priority atm.
