### PR TITLE
Add `psr/http-message` as composer Dependency for ILIAS 12

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -39,6 +39,7 @@
 		]
 	},
 	"require": {
+		"psr/http-message": "2.0",
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
Assessment:


General Information:
- Name of the dependency: `psr/http-message`
- Version: `2.0`
- [X] this dependency was already used in ILIAS.
- [X] the dependency's license is compatible with ILIAS' license: MIT

Type of dependency:
- [X] composer
- [ ] npm

Usage:
* `components/ILIAS/HTTP`
* `components/ILIAS/UI`
* (many other components)`

Reasoning:
* Our codebase already heavily relies on the PSR-7 HTTP message interfaces.
* Adding the package explicitly makes this requirement clear and prevents possible issues that arise when depending on a transitive dependency.
* The message interfaces are the de-facto standard for working with HTTP in PHP.

Maintenance:
* Last update of the Library: 2023-04-04, PHP Version: ^7.2 || ^8.0

Links:
* Packagist: https://packagist.org/packages/psr/http-message
* GitHub: https://github.com/php-fig/http-message.git
* Documentation: https://github.com/php-fig/http-message

Alternatives:
* Framework-specific abstractions (e.g., Symfony, Guzzle)
