### PR TITLE
Add `guzzlehttp/psr7` as composer Dependency for ILIAS 12

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -39,6 +39,7 @@
 		]
 	},
 	"require": {
+		"guzzlehttp/psr7": "2.7.0"
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
Assessment:
guzzlehttp/psr7 is a widely used PHP library that provides a robust and PSR-7-compliant implementation for handling HTTP requests and responses, offering tools for managing HTTP messages in a standardized and flexible way.

General Information:
- Name of the dependency: `guzzlehttp/psr7`
- Version: `2.7.0`
- [X] this dependency was already used in ILIAS.
- [X] the dependency's license is compatible with ILIAS' license: MIT

Type of dependency:
- [X] composer
- [ ] npm

Usage:
* `\ILIAS\HTTP\Services`

Reasoning:
The library ensures interoperability with other PSR-7-compliant libraries and frameworks, making it an essential component for ILIAS projects that need to manage HTTP communication, while also offering a streamlined and reliable API for tasks such as handling cookies, headers, and bodies.

Maintenance:
Last update of the Library: 2024-07-18, PHP Version: ^7.2.5 || ^8.0

Links:
* Packagist: https://packagist.org/packages/guzzlehttp/psr7
* GitHub: https://github.com/guzzle/psr7.git
* Documentation: 

Alternatives:
Alternatives like nyholm/psr7 are lightweight but may lack some advanced features, while laminas/laminas-diactoros is another PSR-7 implementation but may feel heavier and more complex compared to the streamlined and well-supported guzzlehttp/psr7, which is a better fit for ILIAS due to its comprehensive functionality and active community.
