### PR TITLE
Add `symfony/console` as composer Dependency for ILIAS 12

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -39,6 +39,7 @@
 		]
 	},
 	"require": {
+		"symfony/console": "v6.4.23"
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
Assessment:
This library is the quasi standard for CLI applications with PHP. We use the infrastructure for the setup and build process in ILIAS.

General Information:
- Name of the dependency: `symfony/console`
- Version: `v6.4.23`
- [X] this dependency was already used in ILIAS.
- [X] the dependency's license is compatible with ILIAS' license: MIT

Type of dependency:
- [X] composer
- [ ] npm

Usage:
* `Setup, Build`

Reasoning:
The library provides the entire infrastructure needed to write reliable and fast applications for the CLI.

Maintenance:
Last update of the Library: 2025-06-27, PHP Version: >=8.1

Links:
* Packagist: https://packagist.org/packages/symfony/console
* GitHub: https://github.com/symfony/console.git
* Documentation: https://symfony.com

Alternatives:
http://getopt-php.github.io/getopt-php/
