### PR TITLE
Add `phpstan/phpstan` as composer Dependency for ILIAS 12

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -41,6 +41,7 @@
 	"require": {
 	},
 	"require-dev": {
+		"phpstan/phpstan": "2.1.17"
 	},
 	"autoload": {
 		"psr-4" : {


### PR DESCRIPTION
Assessment:
You typically add the phpstan/phpstan library as a development dependency because it is a static analysis tool used only during development to detect potential bugs, type issues, and code inconsistencies before they reach production. Keeping it in the development environment ensures that the production build remains lightweight, while still allowing developers to benefit from improved code quality, early error detection, and safer refactoring during the development process.

General Information:
- Name of the dependency: `phpstan/phpstan`
- Version: `2.1.17`
- [X] this dependency was already used in ILIAS.
- [X] the dependency's license is compatible with ILIAS' license

Type of dependency:
- [X] composer
- [ ] npm

Usage:
* `LUI-Reports`

Reasoning:
We use phpstan e.g. for our LUI Reports

Maintenance:
Last update of the Library: 2025-05-21, PHP Version: ^7.4|^8.0

Links:
* Packagist: https://packagist.org/packages/phpstan/phpstan
* GitHub: https://github.com/phpstan/phpstan.git
* Documentation: 

Alternatives:
no
