### PR TITLE
Add `@rollup/plugin-node-resolve` as npm Dependency for ILIAS 12

### DIFF
--- a/package_new.json
+++ b/package_new.json
@@ -13,6 +13,7 @@
   "dependencies": {
   },
   "devDependencies": {
+	"@rollup/plugin-node-resolve": "16.0.3",
   },
   "scripts": {
     "test": "node --test \"./components/ILIAS/**/tests/**/*.js\""


### PR DESCRIPTION
Assessment:
* This package is a plugin for our module bundler which resolves the imports of node modules to the appropriate package and file. We have at least one case since #9941.

General Information:
- Name of the dependency: `@rollup/plugin-node-resolve`
- Version: `16.0.3`
- [X] this dependency was already used in ILIAS.
- [X] the dependency's license is compatible with ILIAS' license: MIT

Type of dependency:
- [ ] composer
- [X] npm

Usage:
* Not directly applicable.

Reasoning:
* We need to resolve imports if we want to use node modules inside our JavaScript code.

Maintenance:
* Last update of the Library: 2025-10-13

Links:
* npm: https://www.npmjs.com/package/@rollup/plugin-node-resolve
* GitHub: https://github.com/rollup/plugins.git
* Documentation: https://github.com/rollup/plugins/tree/master/packages/node-resolve/#readme

Alternatives:
* There are no alternatives. This is a plugin specific to our module bundler.
