### PR TITLE
Add `@rollup/plugin-terser` as npm Dependency for ILIAS 12

### DIFF
--- a/package_new.json
+++ b/package_new.json
@@ -13,6 +13,7 @@
   "dependencies": {
   },
   "devDependencies": {
+	"@rollup/plugin-terser": "0.4.4",
   },
   "scripts": {
     "test": "node --test \"./components/ILIAS/**/tests/**/*.js\""


### PR DESCRIPTION
Assessment:
* This package is a plugin for our module bundler, which provides minification of JavaScript assets to decrease bundle-sizes.

General Information:
- Name of the dependency: `@rollup/plugin-terser`
- Version: `0.4.4`
- [X] this dependency was already used in ILIAS.
- [X] the dependency's license is compatible with ILIAS' license: MIT

Type of dependency:
- [ ] composer
- [X] npm

Usage:
* Not directly applicable.

Reasoning:
* It makes sense to minify our JavaScript assets to decrease network traffic for ILIAS installations.
* It also makes delivered assets more cryptic and harder to reverse-engineer.

Maintenance:
* Last update of the Library: 2023-10-05

Links:
* npm: https://www.npmjs.com/package/@rollup/plugin-terser
* GitHub: https://github.com/rollup/plugins.git
* Documentation: https://github.com/rollup/plugins/tree/master/packages/terser#readme

Alternatives:
* There are no alternatives. This is a plugin specific to our module bundler.
