### PR TITLE
Add `eslint` as npm Dependency for ILIAS 12

### DIFF
--- a/package_new.json
+++ b/package_new.json
@@ -13,6 +13,7 @@
   "dependencies": {
   },
   "devDependencies": {
+	"eslint": "9.39.1",
   },
   "scripts": {
     "test": "node --test \"./components/ILIAS/**/tests/**/*.js\""


### PR DESCRIPTION
Assessment:
* This package is the equivalent of the PHP-CS-Fixer for JavaScript. It is used in ILIAS to enforce our [JavaScript code-style](https://github.com/ILIAS-eLearning/ILIAS/blob/d6674b38ecd16d8625a15a33c8943c20338125bb/docs/development/js-coding-style.md) and automatically reformat code correspondingly.

General Information:
- Name of the dependency: `eslint`
- Version: `9.39.1`
- [X] this dependency was already used in ILIAS.
- [X] the dependency's license is compatible with ILIAS' license: MIT

Type of dependency:
- [ ] composer
- [X] npm

Usage:
* `components/ILIAS/*` (all components should use this)

Reasoning:
* The code-style can be checked.
* The code-style can be applied.
* The code can be analysed.

Maintenance:
* Last update of the Library: 2025-11-03

Links:
* npm: https://www.npmjs.com/package/eslint
* GitHub: https://github.com/eslint/eslint.git
* Documentation: https://eslint.org

Alternatives:
There are alternatives, but it would be too much of an effort to exchange the lintter. Besides, they all achieve the same thing.
* `@biomejs/biome`
* `prettier`
