### PR TITLE
Add `eslint-plugin-import` as npm Dependency for ILIAS 12

### DIFF
--- a/package_new.json
+++ b/package_new.json
@@ -13,6 +13,7 @@
   "dependencies": {
   },
   "devDependencies": {
+	"eslint-plugin-import": "2.32.0",
   },
   "scripts": {
     "test": "node --test \"./components/ILIAS/**/tests/**/*.js\""


### PR DESCRIPTION
Assessment:
* This package is responsible to validate ES6 import/export statements and is primarily used by the Airbnb code-style base

General Information:
- Name of the dependency: `eslint-plugin-import`
- Version: `2.32.0`
- [X] this dependency was already used in ILIAS.
- [X] the dependency's license is compatible with ILIAS' license: MIT

Type of dependency:
- [ ] composer
- [X] npm

Usage:
* `.eslintrc.json`

Reasoning:
* Without this package the code-style of ES6 import/export statements cannot be checked.

Maintenance:
* Last update of the Library: 2025-06-20

Links:
* npm: https://www.npmjs.com/package/eslint-plugin-import
* GitHub: https://github.com/import-js/eslint-plugin-import.git
* Documentation: https://github.com/import-js/eslint-plugin-import

Alternatives:
* There are no alternatives. This is a plugin specific to our JavaScript code formatter.
