### PR TITLE
Add `jsdom` as npm Dependency for ILIAS 12

### DIFF
--- a/package_new.json
+++ b/package_new.json
@@ -13,6 +13,7 @@
   "dependencies": {
   },
   "devDependencies": {
+	"jsdom": "27.2.0",
   },
   "scripts": {
     "test": "node --test \"./components/ILIAS/**/tests/**/*.js\""


### PR DESCRIPTION
Assessment:
* This package is a JavaScript implementation of various web standards, for use with the Node.js environment.

General Information:
- Name of the dependency: `jsdom`
- Version: `27.2.0`
- [X] this dependency was already used in ILIAS.
- [X] the dependency's license is compatible with ILIAS' license: MIT

Type of dependency:
- [ ] composer
- [X] npm

Usage:
* various JS unit tests in `components/ILIAS/UI`

Reasoning:
* This package implements the web-standard of browsers and provides objects like window and document, which are unknown to the Node.js environment. These objects can be injected into our components to perform/test desired actions.

Maintenance:
* Last update of the Library: 2025-11-12

Links:
* npm: https://www.npmjs.com/package/jsdom
* GitHub: https://github.com/jsdom/jsdom.git
* Documentation: https://github.com/jsdom/jsdom#readme

Alternatives:
* `linkedom`: however, its not as widely used (~15K) and [does not do the exact same thing.](https://github.com/WebReflection/linkedom?tab=readme-ov-file#how-does-it-work)
