### PR TITLE
Add `rollup` as npm Dependency for ILIAS 12

### DIFF
--- a/package_new.json
+++ b/package_new.json
@@ -13,6 +13,7 @@
   "dependencies": {
   },
   "devDependencies": {
+	"rollup": "4.53.3",
   },
   "scripts": {
     "test": "node --test \"./components/ILIAS/**/tests/**/*.js\""


### PR DESCRIPTION
Assessment:
* Rollup is a JavaScript module bundler, which is used to compile small pieces of code into one big file that should be used or delivered to the client.

General Information:
- Name of the dependency: `rollup`
- Version: `4.53.3`
- [X] this dependency was already used in ILIAS.
- [X] the dependency's license is compatible with ILIAS' license: MIT

Type of dependency:
- [ ] composer
- [X] npm

Usage:
* `components/ILIAS/UI/resources/js/*` (many usages)

Reasoning:
* We need a module bundler to create bundled JavaScript assets which are shipped to the client.
* Rollup has a plugin eco-system, which provides some plugins we need to properly create our bundles.

Maintenance:
* Last update of the Library: 2025-11-19

Links:
* npm: https://www.npmjs.com/package/rollup
* GitHub: https://github.com/rollup/rollup.git
* Documentation: https://rollupjs.org/

Alternatives:
There are several alternatives. However, for the time being, it would be too much of an effort to exchange the module bundler since we maintain many small bundles instead of one big one, so many config files would need to be rewritten. Besides, the differences between module bundlers are very small.
* `webpack`
* `parcel`
* `vite`
