### PR TITLE
[Fix] Certificate #0046484: Change Behaviour on global BackgroundImage changes

### DIFF
--- a/components/ILIAS/Certificate/classes/Template/class.ilCertificateTemplateDatabaseRepository.php
+++ b/components/ILIAS/Certificate/classes/Template/class.ilCertificateTemplateDatabaseRepository.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\ResourceStorage\Identification\ResourceIdentification;
+
 /**
  * @author  Niels Theen <ntheen@databay.de>
  * Repository that allows interaction with the database
@@ -395,6 +397,34 @@ class ilCertificateTemplateDatabaseRepository implements ilCertificateTemplateRe
         $this->database->manipulate($sql);
 
         $this->logger->debug(sprintf('END - Certificate template deactivated for object: "%s"', $objId));
+    }
+
+    public function updateDefaultBackgroundImagePaths(
+        ResourceIdentification|string $new_rid,
+        ResourceIdentification|string $old_rid
+    ): void {
+        $this->logger->debug(sprintf(
+            'START - Update all default background image ResourceIdentifications from "%s" to "%s"',
+            $old_rid,
+            $new_rid
+        ));
+
+        $affected_rows = $this->database->manipulateF(
+            'UPDATE il_cert_template SET background_image_ident = %s WHERE currently_active = 1 AND background_image_ident = %s',
+            [
+                ilDBConstants::T_TEXT,
+                ilDBConstants::T_TEXT
+            ],
+            [
+                $new_rid instanceof ResourceIdentification ? $new_rid->serialize() : $new_rid,
+                $old_rid instanceof ResourceIdentification ? $old_rid->serialize() : $old_rid,
+            ]
+        );
+
+        $this->logger->debug(sprintf(
+            'END - Updated %s certificate templates using old ResourceIdentification',
+            $affected_rows
+        ));
     }
 
     public function isResourceUsed(string $relative_image_identification): bool

--- a/components/ILIAS/Certificate/classes/class.ilObjCertificateSettings.php
+++ b/components/ILIAS/Certificate/classes/class.ilObjCertificateSettings.php
@@ -81,6 +81,7 @@ class ilObjCertificateSettings extends ilObject
         $this->certificate_settings->set('cert_bg_image', $identification->serialize());
 
         $this->certificate_repository->updateDefaultBackgroundImagePaths($identification, $old_identification);
+        $this->resource_handler->handleResourceChange($old_identification);
 
         return $identification->serialize() !== '';
     }

--- a/components/ILIAS/Certificate/classes/class.ilObjCertificateSettings.php
+++ b/components/ILIAS/Certificate/classes/class.ilObjCertificateSettings.php
@@ -36,6 +36,7 @@ class ilObjCertificateSettings extends ilObject
     private readonly ilSetting $certificate_settings;
     private readonly ResourceStorage $irss;
     private readonly ilCertificateTemplateStakeholder $stakeholder;
+    private readonly ilCertificateTemplateDatabaseRepository $certificate_repository;
     private readonly CertificateResourceHandler $resource_handler;
 
     public function __construct(int $a_id = 0, bool $a_reference = true)
@@ -47,6 +48,7 @@ class ilObjCertificateSettings extends ilObject
         $this->certificate_settings = new ilSetting('certificate');
         $this->irss = $DIC->resourceStorage();
         $this->stakeholder = new ilCertificateTemplateStakeholder();
+        $this->certificate_repository = new ilCertificateTemplateDatabaseRepository($DIC->database());
         $this->resource_handler = new CertificateResourceHandler(
             new ilUserCertificateRepository($DIC->database()),
             new ilCertificateTemplateDatabaseRepository($DIC->database()),
@@ -66,11 +68,6 @@ class ilObjCertificateSettings extends ilObject
         return null;
     }
 
-    public function getBackgroundImageDefaultFolder(): string
-    {
-        return '/certificates/default/';
-    }
-
     /**
      * Uploads a background image for the certificate. Creates a new directory for the
      * certificate if needed. Removes an existing certificate image if necessary
@@ -79,8 +76,11 @@ class ilObjCertificateSettings extends ilObject
      */
     public function uploadBackgroundImage(UploadResult $upload_result): bool
     {
+        $old_identification = $this->getBackgroundImageIdentification() ?: '';
         $identification = $this->irss->manage()->upload($upload_result, $this->stakeholder);
         $this->certificate_settings->set('cert_bg_image', $identification->serialize());
+
+        $this->certificate_repository->updateDefaultBackgroundImagePaths($identification, $old_identification);
 
         return $identification->serialize() !== '';
     }
@@ -90,6 +90,7 @@ class ilObjCertificateSettings extends ilObject
         $rid = $this->getBackgroundImageIdentification();
         if ($rid instanceof ResourceIdentification) {
             $this->certificate_settings->set('cert_bg_image', '');
+            $this->certificate_repository->updateDefaultBackgroundImagePaths('', $rid);
             $this->resource_handler->handleResourceChange($rid);
 
             return true;


### PR DESCRIPTION
# Behaviour on Setting an Installation-Wide Default Background Image 
(https://mantis.ilias.de/view.php?id=46484)

This PR proposes to change the background image handling for certificates to align with the expected global background behavior.

In previous versions (e.g., ILIAS 9), when a global certificate background was changed, objects referencing it automatically updated as well. If the global background had been deleted, however, the object would still retain its background image.
As also documented here: https://testrail.ilias.de/index.php?/tests/view/84458

After the IRSS changes (ILIAS 11), this behavior was modified: when the global background was removed or changed, object‑level backgrounds remained unchanged. This change was introduced because IRSS allowed cleaning up files once the last template using them was deleted. A template would then be seen as a copy from the moment of saving.

This change reintroduces the previous update logic by restoring the call to
`ilCertificateTemplateDatabaseRepository::updateDefaultBackgroundImagePaths()`,
which had been previously removed with https://github.com/ILIAS-eLearning/ILIAS/commit/db03ec299a5d849dd19edda0e53c82cde2f50979#diff-bdd87c6f36d74bd9cdd7cdc2e3f5f162ec617e8bc166d6497991bbb2a7324d8bL145


### Effect:

When the global certificate background image changes, all certificate templates that use the global background will automatically update to the new global image.
When the global background image is deleted, these templates will revert to having no background image, consistent with the new global state.

### Note:

Templates that previously had no background will automatically adopt the global background once one is set. This is expected behavior, as it is currently not possible to have “no image” when a global background is defined.

### Result:

Object certificates now consistently follow the global default background rules during updates and deletions, restoring the intuitive behavior seen in earlier ILIAS versions.

Best @fhelfer