### PR TITLE
CSS: Change tooltip container to be only relative when tooltip is shown

### DIFF
--- a/templates/default/070-components/UI-framework/_ui-component_tooltip.scss
+++ b/templates/default/070-components/UI-framework/_ui-component_tooltip.scss
@@ -12,8 +12,11 @@ $c-tooltip-arrow-background-color: $c-tooltip-border-color;
 $c-tooltip-z-index: 9999;
 
 .c-tooltip__container {
-	position: relative;
 	display: inline-block;
+}
+
+.c-tooltip__container.c-tooltip--visible {
+	position: relative;
 }
 
 // Arrow

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -2504,8 +2504,11 @@ code {
 */
 /* UI Framework */
 .c-tooltip__container {
-  position: relative;
   display: inline-block;
+}
+
+.c-tooltip__container.c-tooltip--visible {
+  position: relative;
 }
 
 .c-tooltip__container::before {


### PR DESCRIPTION
This PR fixes Mantis Bug: https://mantis.ilias.de/view.php?id=46262
As the Permanent link makes use of the Help Topics (so the same issue occurs if a button with Help Topics is displayed below a dropdown).

This PR changes that the help topics container (where the corresponding element lies) will only be made `relative` when it is active, as `relative` breaks the normal `z-index` rules and will always be displayed on top of other objects.

As the `relative` property is only used to position the active tooltip, this doesn't break anything else of the help topic.