### PR TITLE
T&A 46417: Fixes Failed test - Create test export as XML (with Participant Results)

### DIFF
--- a/components/ILIAS/Test/classes/class.ilObjTestAccess.php
+++ b/components/ILIAS/Test/classes/class.ilObjTestAccess.php
@@ -328,7 +328,8 @@ class ilObjTestAccess extends ilObjectAccess implements ilConditionHandling
         $row_test = $ilDB->fetchAssoc($result_test);
         $obj_id = $row_test['obj_fi'];
 
-        if (ilObjTest::_lookupAnonymity($obj_id)) {
+        $test_obj = new ilObjTest($obj_id, false);
+        if ($test_obj->getAnonymity()) {
             return $lng->txt('anonymous');
         }
 


### PR DESCRIPTION
This PR attempts to fix https://mantis.ilias.de/view.php?id=46417.

The previous `_lookupAnonymity` method was removed from ILIAS and therefore resulted in an error. This has now been corrected.

Kind regards,
@bidzanaaron 