### PR TITLE
T&A10 45906: Fixes ilTestException thrown when submitting an answer while already locked by a previous submit

### DIFF
--- a/components/ILIAS/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -416,7 +416,8 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
 
         if ($this->isParticipantsAnswerFixed($q_id)) {
             // should only be reached by firebugging the disabled form in ui
-            throw new ilTestException('not allowed request');
+            $this->tpl->setOnScreenMessage(ilGlobalTemplateInterface::MESSAGE_TYPE_FAILURE, $this->lng->txt('tst_player_answer_saved_and_locked'), true);
+            $this->ctrl->redirect($this, ilTestPlayerCommands::SHOW_QUESTION);
         }
 
         if ($q_id === null) {


### PR DESCRIPTION
This PR attempts to fix https://mantis.ilias.de/view.php?id=45906.

If "Lock Answers After Moving to Next Question" is enabled, a fatal crash occurs when clicking "Next" a second time in another tab. Apart from the fact that this is a bad move to begin with, with these changes a proper error message is now displayed.

The version for release_9 has already been merged: https://github.com/ILIAS-eLearning/ILIAS/pull/10444.

Kind regards,
@bidzanaaron