### PR TITLE
T&A 46415: Disable competence selection for questions in test if results are available

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php
@@ -545,7 +545,7 @@ class ilAssQuestionSkillAssignmentsGUI
                     [ilAssQuestionSkillAssignmentsGUI::class],
                     self::CMD_SHOW_SKILL_SELECT
                 )
-            )
+            )->withUnavailableAction(!$this->isAssignmentEditingEnabled())
         );
         $this->ctrl->setParameterByClass(ilAssQuestionSkillAssignmentsGUI::class, 'q_id', null);
 


### PR DESCRIPTION
This PR is related to the Mantis Ticket https://mantis.ilias.de/view.php?id=46415.

The button for competence selection will be disabled, once results are available.

Best Regards,
@thojou 