### PR TITLE
T&A 46471: Changes label of Edit Assignment Properties action to View Assignment Properties if needed

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php
@@ -556,7 +556,13 @@ class ilAssQuestionSkillAssignmentsGUI
             $this->lng,
             (new EditSkillsOfQuestionTableActions(
                 $this->tpl,
-                [EditSkillsOfQuestionTableEditAction::ACTION_ID => new EditSkillsOfQuestionTableEditAction($this->ui_factory, $this->lng)]
+                [
+                    EditSkillsOfQuestionTableEditAction::ACTION_ID => new EditSkillsOfQuestionTableEditAction(
+                        $this->ui_factory,
+                        $this->lng,
+                        $this->isAssignmentEditingEnabled()
+                    )
+                ]
             ))
         ))->getComponents(new URLBuilder($edit_uri));
 

--- a/components/ILIAS/TestQuestionPool/src/Skills/EditSkillsOfQuestionTableEditAction.php
+++ b/components/ILIAS/TestQuestionPool/src/Skills/EditSkillsOfQuestionTableEditAction.php
@@ -31,7 +31,8 @@ class EditSkillsOfQuestionTableEditAction implements EditSkillsOfQuestionTableAc
 
     public function __construct(
         private readonly UIFactory $ui_factory,
-        private readonly \ilLanguage $lng
+        private readonly \ilLanguage $lng,
+        private readonly bool $assignment_editing_enabled
     ) {
     }
 
@@ -52,7 +53,7 @@ class EditSkillsOfQuestionTableEditAction implements EditSkillsOfQuestionTableAc
         URLBuilderToken $action_type_token
     ): Action {
         return $this->ui_factory->table()->action()->single(
-            $this->lng->txt('tst_edit_competence_assign'),
+            $this->lng->txt($this->assignment_editing_enabled ? 'tst_edit_competence_assign' : 'tst_view_competence_assign'),
             $url_builder
                 ->withParameter($action_token, self::ACTION_ID)
                 ->withParameter($action_type_token, EditSkillsOfQuestionTableActions::SHOW_ACTION),


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=46471

Aims to change the label of the "Edit Assignment Properties" action to "View Assignment Properties" if needed.

Already reviewed by @thojou.