### PR TITLE
T&A 46483: Fixes tab Scoring also highlights when accessing Info, History or Metadata tab

### DIFF
--- a/components/ILIAS/Test/src/Presentation/TabsManager.php
+++ b/components/ILIAS/Test/src/Presentation/TabsManager.php
@@ -97,6 +97,9 @@ class TabsManager
             case self::TAB_ID_TEST:
             case self::TAB_ID_EXPORT:
             case self::TAB_ID_LEARNING_PROGRESS:
+            case self::TAB_ID_META_DATA:
+            case self::TAB_ID_HISTORY:
+            case self::TAB_ID_INFOSCREEN:
                 $this->tabs->activateTab($tab_id);
         }
     }


### PR DESCRIPTION
This PR attempts to fix https://mantis.ilias.de/view.php?id=46483.

Adds the Info, Metadata, and History tabs as options in the Activate Tab function.

Kind regards,
@bidzanaaron 