### PR TITLE
fix: Add aria-describedby to link help-blocks with form inputs.

### DIFF
--- a/components/ILIAS/Test/src/Settings/MainSettings/class.SettingsMainGUI.php
+++ b/components/ILIAS/Test/src/Settings/MainSettings/class.SettingsMainGUI.php
@@ -507,23 +507,31 @@ class SettingsMainGUI extends TestSettingsGUI
     private function getAvailabilitySettingsSection(): Section
     {
         $input_factory = $this->ui_factory->input();
+        $question_set_config_complete = $this->isQuestionSetConfigComplete();
 
         $inputs['is_online'] = $this->getIsOnlineSettingInput();
         $inputs['timebased_availability'] = $this->getTimebasedAvailabilityInputs();
 
-        return $input_factory->field()->section(
+        $section = $input_factory->field()->section(
             $inputs,
             $this->lng->txt('rep_activation_availability')
         );
+
+        if (!$question_set_config_complete) {
+            $message = $this->lng->txt('cannot_switch_to_online_no_questions_andor_no_mark_steps');
+            $section = $section->withByline(
+                '<span class="sr-only">' . htmlspecialchars($message, ENT_QUOTES, 'UTF-8') . '</span>'
+            );
+        }
+
+        return $section;
     }
 
     private function getIsOnlineSettingInput(): Checkbox
     {
         $field_factory = $this->ui_factory->input()->field();
 
-        $question_set_config_complete = $this->test_object->isComplete(
-            $this->testQuestionSetConfigFactory->getQuestionSetConfig()
-        );
+        $question_set_config_complete = $this->isQuestionSetConfigComplete();
 
         $is_online = $this->test_object->getObjectProperties()->getPropertyIsOnline()
             ->toForm($this->lng, $field_factory, $this->refinery);
@@ -541,6 +549,13 @@ class SettingsMainGUI extends TestSettingsGUI
         }
 
         return $is_online;
+    }
+
+    private function isQuestionSetConfigComplete(): bool
+    {
+        return $this->test_object->isComplete(
+            $this->testQuestionSetConfigFactory->getQuestionSetConfig()
+        );
     }
 
     private function getTimebasedAvailabilityInputs(): OptionalGroup

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
@@ -167,7 +167,6 @@ class Renderer extends AbstractComponentRenderer
         $tpl = $this->getTemplate("tpl.context_form.html", true, true);
 
         $tpl->setVariable("LABEL", $label);
-        $tpl->setVariable("INPUT", $input_html);
         $tpl->setVariable("UI_COMPONENT_NAME", $this->getComponentCanonicalNameAttribute($component));
         $tpl->setVariable("INPUT_NAME", $component->getName());
 
@@ -184,9 +183,14 @@ class Renderer extends AbstractComponentRenderer
             $tpl->touchBlock('tabindex');
         }
 
+        $described_by_ids = [];
+
         $byline = $component->getByline();
         if ($byline) {
+            $byline_id = $this->createId();
             $tpl->setVariable("BYLINE", $byline);
+            $tpl->setVariable("BYLINE_ID", $byline_id);
+            $described_by_ids[] = $byline_id;
         }
 
         $required = $component->isRequired();
@@ -206,15 +210,51 @@ class Renderer extends AbstractComponentRenderer
             $tpl->setVariable("ERROR_LABEL", $this->txt("ui_error"));
             $tpl->setVariable("ERROR_ID", $error_id);
             $tpl->setVariable("ERROR", $error);
+            $described_by_ids[] = $error_id;
             if ($id_for_label) {
                 $tpl->setVariable("ERROR_FOR_ID", $id_for_label);
             }
+        }
+
+        if (!empty($described_by_ids) && $id_for_label) {
+            $described_by_value = implode(' ', $described_by_ids);
+            $input_html = $this->addAriaDescribedByToInput($input_html, $id_for_label, $described_by_value);
+        }
+
+        $tpl->setVariable("INPUT", $input_html);
+
+        if (!empty($described_by_ids)) {
+            $tpl->setCurrentBlock('described');
+            $tpl->setVariable("DESCRIBED_BY_IDS", implode(' ', $described_by_ids));
+            $tpl->parseCurrentBlock();
         }
 
         if ($dependant_group_html) {
             $tpl->setVariable("DEPENDANT_GROUP", $dependant_group_html);
         }
         return $tpl->get();
+    }
+
+    protected function addAriaDescribedByToInput(string $input_html, string $input_id, string $described_by_value): string
+    {
+        $pattern = '/<(input|textarea|select)([^>]*id=["\']' . preg_quote($input_id, '/') . '["\'][^>]*)>/i';
+
+        return preg_replace_callback($pattern, function ($matches) use ($described_by_value) {
+            $tag = $matches[1];
+            $attributes = $matches[2];
+
+            if (strpos($attributes, 'aria-describedby') !== false) {
+                $attributes = preg_replace(
+                    '/aria-describedby=["\']([^"\']*)["\']/',
+                    'aria-describedby="$1 ' . htmlspecialchars($described_by_value, ENT_QUOTES) . '"',
+                    $attributes
+                );
+            } else {
+                $attributes .= ' aria-describedby="' . htmlspecialchars($described_by_value, ENT_QUOTES) . '"';
+            }
+
+            return '<' . $tag . $attributes . '>';
+        }, $input_html);
     }
 
     protected function applyName(FormInput $component, Template $tpl): ?string
@@ -247,6 +287,30 @@ class Renderer extends AbstractComponentRenderer
         }
         if (isset($value) && $value !== '') {
             $tpl->setVariable("VALUE", $value);
+        }
+    }
+
+    protected function getDescribedByIds(FormInput $component): array
+    {
+        $described_by_ids = [];
+
+        if ($component->getByline()) {
+            $described_by_ids[] = $this->createId();
+        }
+
+        if ($component->getError()) {
+            $described_by_ids[] = $this->createId();
+        }
+
+        return $described_by_ids;
+    }
+
+    protected function applyAriaDescribedBy(Template $tpl, array $described_by_ids): void
+    {
+        if (!empty($described_by_ids)) {
+            $tpl->setCurrentBlock('described_by');
+            $tpl->setVariable("DESCRIBED_BY_IDS", implode(' ', $described_by_ids));
+            $tpl->parseCurrentBlock();
         }
     }
 

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
@@ -223,7 +223,7 @@ class Renderer extends AbstractComponentRenderer
 
         $tpl->setVariable("INPUT", $input_html);
 
-        if (!empty($described_by_ids)) {
+        if (!empty($described_by_ids) && !$id_for_label) {
             $tpl->setCurrentBlock('described');
             $tpl->setVariable("DESCRIBED_BY_IDS", implode(' ', $described_by_ids));
             $tpl->parseCurrentBlock();

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
@@ -237,11 +237,12 @@ class Renderer extends AbstractComponentRenderer
 
     protected function addAriaDescribedByToInput(string $input_html, string $input_id, string $described_by_value): string
     {
-        $pattern = '/<(input|textarea|select)([^>]*id=["\']' . preg_quote($input_id, '/') . '["\'][^>]*)>/i';
+        $pattern = '/<(input|textarea|select)([^>]*id=["\']' . preg_quote($input_id, '/') . '["\'][^>]*?)(\s*\/)?>/i';
 
         return preg_replace_callback($pattern, function ($matches) use ($described_by_value) {
             $tag = $matches[1];
             $attributes = $matches[2];
+            $slash = $matches[3] ?? '';
 
             if (strpos($attributes, 'aria-describedby') !== false) {
                 $attributes = preg_replace(
@@ -253,7 +254,7 @@ class Renderer extends AbstractComponentRenderer
                 $attributes .= ' aria-describedby="' . htmlspecialchars($described_by_value, ENT_QUOTES) . '"';
             }
 
-            return '<' . $tag . $attributes . '>';
+            return '<' . $tag . $attributes . $slash . '>';
         }, $input_html);
     }
 
@@ -512,9 +513,9 @@ class Renderer extends AbstractComponentRenderer
 
             $f = $this->getUIFactory();
             $glyph_reveal = $f->symbol()->glyph()->eyeopen("#")
-                              ->withOnClick($sig_reveal);
+                ->withOnClick($sig_reveal);
             $glyph_mask = $f->symbol()->glyph()->eyeclosed("#")
-                            ->withOnClick($sig_mask);
+                ->withOnClick($sig_mask);
 
             $tpl->setVariable('PASSWORD_REVEAL', $default_renderer->render($glyph_reveal));
             $tpl->setVariable('PASSWORD_MASK', $default_renderer->render($glyph_mask));
@@ -801,7 +802,7 @@ class Renderer extends AbstractComponentRenderer
         $input_html = $this->wrapInFormContext($input, $input->getLabel(), $tpl->get(), $from_input_id);
 
         $input = array_shift($inputs) //until
-            ->withAdditionalPickerconfig(['useCurrent' => false]);
+        ->withAdditionalPickerconfig(['useCurrent' => false]);
         list($input, $tpl) = $this->internalRenderDateTimeField($input, $default_renderer);
         $until_input_id = $this->createId();
         $tpl->setVariable('ID', $until_input_id);

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
@@ -216,23 +216,47 @@ class Renderer extends AbstractComponentRenderer
             }
         }
 
-        if (!empty($described_by_ids) && $id_for_label) {
-            $described_by_value = implode(' ', $described_by_ids);
-            $input_html = $this->addAriaDescribedByToInput($input_html, $id_for_label, $described_by_value);
-        }
-
         $tpl->setVariable("INPUT", $input_html);
 
-        if (!empty($described_by_ids) && !$id_for_label) {
-            $tpl->setCurrentBlock('described');
-            $tpl->setVariable("DESCRIBED_BY_IDS", implode(' ', $described_by_ids));
-            $tpl->parseCurrentBlock();
+        if (!empty($described_by_ids)) {
+            if ($id_for_label) {
+                $described_by_value = implode(' ', $described_by_ids);
+                $input_html = $this->addAriaDescribedByToInput($input_html, $id_for_label, $described_by_value);
+                $tpl->setVariable("INPUT", $input_html);
+            } else {
+                $input_id = $this->createId();
+                $input_html = $this->addIdToInput($input_html, $input_id);
+                $described_by_value = implode(' ', $described_by_ids);
+                $input_html = $this->addAriaDescribedByToInput($input_html, $input_id, $described_by_value);
+                $tpl->setVariable("INPUT", $input_html);
+                
+                $tpl->setCurrentBlock('for');
+                $tpl->setVariable("ID", $input_id);
+                $tpl->parseCurrentBlock();
+            }
         }
 
         if ($dependant_group_html) {
             $tpl->setVariable("DEPENDANT_GROUP", $dependant_group_html);
         }
         return $tpl->get();
+    }
+
+    protected function addIdToInput(string $input_html, string $input_id): string
+    {
+        $pattern = '/<(input|textarea|select)([^>]*)(\s*\/)?>/i';
+        
+        return preg_replace_callback($pattern, function ($matches) use ($input_id) {
+            $tag = $matches[1];
+            $attributes = $matches[2];
+            $slash = $matches[3] ?? '';
+            
+            if (strpos($attributes, 'id=') !== false) {
+                return $matches[0];
+            }
+            
+            return '<' . $tag . $attributes . ' id="' . htmlspecialchars($input_id, ENT_QUOTES) . '"' . $slash . '>';
+        }, $input_html);
     }
 
     protected function addAriaDescribedByToInput(string $input_html, string $input_id, string $described_by_value): string
@@ -306,14 +330,7 @@ class Renderer extends AbstractComponentRenderer
         return $described_by_ids;
     }
 
-    protected function applyAriaDescribedBy(Template $tpl, array $described_by_ids): void
-    {
-        if (!empty($described_by_ids)) {
-            $tpl->setCurrentBlock('described_by');
-            $tpl->setVariable("DESCRIBED_BY_IDS", implode(' ', $described_by_ids));
-            $tpl->parseCurrentBlock();
-        }
-    }
+
 
     protected function escapeSpecialChars(): Closure
     {

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
@@ -180,7 +180,15 @@ class Renderer extends AbstractComponentRenderer
             $tpl->setVariable("ID", $id_for_label);
             $tpl->parseCurrentBlock();
         } else {
+            $label_id = $this->createId();
+            $tpl->setCurrentBlock('label_id');
+            $tpl->setVariable("LABEL_ID", $label_id);
+            $tpl->parseCurrentBlock();
+
             $tpl->touchBlock('tabindex');
+            $tpl->setCurrentBlock('fieldset_labelledby');
+            $tpl->setVariable("FIELDSET_LABEL_ID", $label_id);
+            $tpl->parseCurrentBlock();
         }
 
         $described_by_ids = [];
@@ -229,6 +237,10 @@ class Renderer extends AbstractComponentRenderer
                 $described_by_value = implode(' ', $described_by_ids);
                 $input_html = $this->addAriaDescribedByToInput($input_html, $input_id, $described_by_value);
                 $tpl->setVariable("INPUT", $input_html);
+
+                $tpl->setCurrentBlock('fieldset_describedby');
+                $tpl->setVariable("FIELDSET_DESCRIBED_BY", $described_by_value);
+                $tpl->parseCurrentBlock();
                 
                 $tpl->setCurrentBlock('for');
                 $tpl->setVariable("ID", $input_id);

--- a/components/ILIAS/UI/src/templates/default/Input/tpl.context_form.html
+++ b/components/ILIAS/UI/src/templates/default/Input/tpl.context_form.html
@@ -1,4 +1,4 @@
-<fieldset class="c-input" data-il-ui-component="{UI_COMPONENT_NAME}" data-il-ui-input-name="{INPUT_NAME}"<!-- BEGIN disabled --> disabled="disabled"<!-- END disabled --><!-- BEGIN described --> aria-describedby="{ERROR_ID}"<!-- END described --><!-- BEGIN binding --> id="{BINDING_ID}"<!-- END binding --><!-- BEGIN tabindex --> tabindex="0"<!-- END tabindex -->>
+<fieldset class="c-input" data-il-ui-component="{UI_COMPONENT_NAME}" data-il-ui-input-name="{INPUT_NAME}"<!-- BEGIN disabled --> disabled="disabled"<!-- END disabled --><!-- BEGIN described --> aria-describedby="{DESCRIBED_BY_IDS}"<!-- END described --><!-- BEGIN binding --> id="{BINDING_ID}"<!-- END binding --><!-- BEGIN tabindex --> tabindex="0"<!-- END tabindex -->>
 
 	<label <!-- BEGIN for --> for="{ID}"<!-- END for -->>{LABEL}<!-- BEGIN required --><span class="asterisk" aria-label="{REQUIRED_ARIA}">*</span><!-- END required --></label>
 
@@ -11,7 +11,7 @@
 	<!-- END error -->
 
 	<!-- BEGIN byline -->
-	<div class="c-input__help-byline">{BYLINE}</div>
+	<div class="c-input__help-byline" id="{BYLINE_ID}">{BYLINE}</div>
 	<!-- END byline -->
 
 </fieldset>

--- a/components/ILIAS/UI/src/templates/default/Input/tpl.context_form.html
+++ b/components/ILIAS/UI/src/templates/default/Input/tpl.context_form.html
@@ -1,4 +1,4 @@
-<fieldset class="c-input" data-il-ui-component="{UI_COMPONENT_NAME}" data-il-ui-input-name="{INPUT_NAME}"<!-- BEGIN disabled --> disabled="disabled"<!-- END disabled --><!-- BEGIN described --> aria-describedby="{DESCRIBED_BY_IDS}"<!-- END described --><!-- BEGIN binding --> id="{BINDING_ID}"<!-- END binding --><!-- BEGIN tabindex --> tabindex="0"<!-- END tabindex -->>
+<fieldset class="c-input" data-il-ui-component="{UI_COMPONENT_NAME}" data-il-ui-input-name="{INPUT_NAME}"<!-- BEGIN disabled --> disabled="disabled"<!-- END disabled --><!-- BEGIN binding --> id="{BINDING_ID}"<!-- END binding --><!-- BEGIN tabindex --> tabindex="0"<!-- END tabindex -->>
 
 	<label <!-- BEGIN for --> for="{ID}"<!-- END for -->>{LABEL}<!-- BEGIN required --><span class="asterisk" aria-label="{REQUIRED_ARIA}">*</span><!-- END required --></label>
 

--- a/components/ILIAS/UI/src/templates/default/Input/tpl.context_form.html
+++ b/components/ILIAS/UI/src/templates/default/Input/tpl.context_form.html
@@ -1,6 +1,6 @@
-<fieldset class="c-input" data-il-ui-component="{UI_COMPONENT_NAME}" data-il-ui-input-name="{INPUT_NAME}"<!-- BEGIN disabled --> disabled="disabled"<!-- END disabled --><!-- BEGIN binding --> id="{BINDING_ID}"<!-- END binding --><!-- BEGIN tabindex --> tabindex="0"<!-- END tabindex -->>
+<fieldset class="c-input" data-il-ui-component="{UI_COMPONENT_NAME}" data-il-ui-input-name="{INPUT_NAME}"<!-- BEGIN disabled --> disabled="disabled"<!-- END disabled --><!-- BEGIN binding --> id="{BINDING_ID}"<!-- END binding --><!-- BEGIN tabindex --> tabindex="0"<!-- END tabindex --><!-- BEGIN fieldset_labelledby --> aria-labelledby="{FIELDSET_LABEL_ID}"<!-- END fieldset_labelledby --><!-- BEGIN fieldset_describedby --> aria-describedby="{FIELDSET_DESCRIBED_BY}"<!-- END fieldset_describedby -->>
 
-	<label <!-- BEGIN for --> for="{ID}"<!-- END for -->>{LABEL}<!-- BEGIN required --><span class="asterisk" aria-label="{REQUIRED_ARIA}">*</span><!-- END required --></label>
+	<label <!-- BEGIN label_id --> id="{LABEL_ID}"<!-- END label_id --><!-- BEGIN for --> for="{ID}"<!-- END for -->>{LABEL}<!-- BEGIN required --><span class="asterisk" aria-label="{REQUIRED_ARIA}">*</span><!-- END required --></label>
 
 	<div class="c-input__field">
 		{INPUT}


### PR DESCRIPTION
During accessibility testing of ILIAS 9, help-blocks (bylines) in form fields were not being announced by screen readers. These explanatory texts were visually present but lacked proper ARIA attributes to associate them with their corresponding form inputs, causing screen reader users to miss important contextual information.

This change fixes the issue by programmatically linking help-blocks to their form inputs using the aria-describedby attribute.

Changes:
- Modified `tpl.context_form.html` template:
  - Added unique `id="{BYLINE_ID}"` attribute to help-block div elements
  - Changed fieldset's aria-describedby from single error ID to combined list of IDs

- Modified `Renderer.php` in the Input Field component:
  - Updated `wrapInFormContext()` method to generate unique IDs for bylines
  - Built array of descriptor IDs (byline + error when present)
  - Added new `addAriaDescribedByToInput()` helper method that injects aria-describedby directly into input/textarea/select elements via regex pattern matching
  - Set aria-describedby on both the input element and fieldset wrapper for maximum compatibility

Note:
These changes have broken quite a few tests that need to be fixed.

We have spent some hours fixing them before sending the PR, but due to the high volume of hours needed to complete all the corrections in the tests, we believe it is best that the solution be evaluated to avoid investing unnecessary time in case the solution requires any changes.

Ticket [43925](https://mantis.ilias.de/view.php?id=43925)