### PR TITLE
BT 46409: Loads missing exc language module in booking pool

### DIFF
--- a/components/ILIAS/BookingManager/Participants/class.ilBookingParticipantGUI.php
+++ b/components/ILIAS/BookingManager/Participants/class.ilBookingParticipantGUI.php
@@ -58,6 +58,7 @@ class ilBookingParticipantGUI
         $this->pool_id = $a_parent_obj->getObject()->getId();
 
         $this->lng->loadLanguageModule("book");
+        $this->lng->loadLanguageModule("exc");
     }
 
     public function executeCommand(): void


### PR DESCRIPTION
This PR attempts to fix https://mantis.ilias.de/view.php?id=46409.

Loads missing exc language module in booking pool.

Kind regards,
@bidzanaaron 