### PR TITLE
IGR9 46401: Fixes issue with item groups in page editor due to missing keys

### DIFF
--- a/Services/COPage/PC/Resources/class.ilPCResourcesGUI.php
+++ b/Services/COPage/PC/Resources/class.ilPCResourcesGUI.php
@@ -169,7 +169,7 @@ class ilPCResourcesGUI extends ilPageContentGUI
         if ($this->supportsItemGroups() && count($item_groups) > 0) {
             // item groups
             $options = $item_groups;
-            sort($options);
+            asort($options);
             $si = new ilSelectInputGUI($this->lng->txt("obj_itgr"), "itgr");
             $si->setOptions($options);
             $selected = ($a_insert)


### PR DESCRIPTION
This PR attempts to fix https://mantis.ilias.de/view.php?id=46401.

Retains the index assignment when sorting.

Kind regards,
@bidzanaaron 