### PR TITLE
T&A10 44715: Implements sync back to qpl for IPE Feedback questions

### DIFF
--- a/components/ILIAS/Test/classes/class.ilObjTestGUI.php
+++ b/components/ILIAS/Test/classes/class.ilObjTestGUI.php
@@ -885,6 +885,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
                 $question->setObjId($this->getTestObject()->getId());
                 $question_gui->setObject($question);
                 $question_gui->setQuestionTabs();
+                $question_gui->setContextAllowsSyncToPool(true);
 
                 $this->addQuestionTitleToObjectTitle($question->getTitle());
 

--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionFeedbackEditingGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionFeedbackEditingGUI.php
@@ -165,10 +165,6 @@ class ilAssQuestionFeedbackEditingGUI
             return false;
         }
 
-        if ($this->question_obj->isAdditionalContentEditingModePageObject()) {
-            return false;
-        }
-
         if (!$this->question_gui->needsSyncQuery()) {
             return false;
         }

--- a/components/ILIAS/TestQuestionPool/classes/feedback/class.ilAssClozeTestFeedback.php
+++ b/components/ILIAS/TestQuestionPool/classes/feedback/class.ilAssClozeTestFeedback.php
@@ -651,10 +651,10 @@ class ilAssClozeTestFeedback extends ilAssMultiOptionQuestionFeedback
         );
     }
 
-    protected function cloneSpecificFeedback(int $originalQuestionId, int $duplicateQuestionId): void
+    protected function cloneSpecificFeedback(int $original_question_id, int $duplicate_question_id): void
     {
-        $this->cloneSpecificFeedbackSetting($originalQuestionId, $duplicateQuestionId);
-        parent::cloneSpecificFeedback($originalQuestionId, $duplicateQuestionId);
+        $this->cloneSpecificFeedbackSetting($original_question_id, $duplicate_question_id);
+        parent::cloneSpecificFeedback($original_question_id, $duplicate_question_id);
     }
 
     /**

--- a/components/ILIAS/TestQuestionPool/classes/feedback/class.ilAssMultiOptionQuestionFeedback.php
+++ b/components/ILIAS/TestQuestionPool/classes/feedback/class.ilAssMultiOptionQuestionFeedback.php
@@ -239,31 +239,28 @@ abstract class ilAssMultiOptionQuestionFeedback extends ilAssQuestionFeedback
 
     protected function cloneSpecificFeedback(int $source_question_id, int $target_question_id): void
     {
-        // delete specific feedback of the original
-        $this->db->manipulateF(
-            "DELETE FROM {$this->getSpecificFeedbackTableName()} WHERE question_fi = %s",
-            ['integer'],
+        $this->deleteFeedbackOfOriginalQuestion(
+            $this->getSpecificFeedbackTableName(),
+            $target_question_id,
+            $this->getSpecificAnswerFeedbackPageObjectType()
+        );
+
+        $res = $this->db->queryF(
+            "SELECT * FROM {$this->getSpecificFeedbackTableName()} WHERE question_fi = %s",
+            [ilDBConstants::T_INTEGER],
             [$source_question_id]
         );
 
-        // get specific feedback of the actual question
-        $res = $this->db->queryF(
-            "SELECT * FROM {$this->getSpecificFeedbackTableName()} WHERE question_fi = %s",
-            ['integer'],
-            [$target_question_id]
-        );
-
-        // save specific feedback to the original
         while ($row = $this->db->fetchAssoc($res)) {
             $next_id = $this->db->nextId($this->getSpecificFeedbackTableName());
 
             $this->db->insert($this->getSpecificFeedbackTableName(), [
-                'feedback_id' => ['integer', $next_id],
-                'question_fi' => ['integer', $source_question_id],
-                'question' => ['integer', $row['question']],
-                'answer' => ['integer', $row['answer']],
-                'feedback' => ['text', $row['feedback']],
-                'tstamp' => ['integer', time()]
+                'feedback_id' => [ilDBConstants::T_INTEGER, $next_id],
+                'question_fi' => [ilDBConstants::T_INTEGER, $target_question_id],
+                'question' => [ilDBConstants::T_INTEGER, $row['question']],
+                'answer' => [ilDBConstants::T_INTEGER, $row['answer']],
+                'feedback' => [ilDBConstants::T_TEXT, $row['feedback']],
+                'tstamp' => [ilDBConstants::T_INTEGER, time()]
             ]);
 
             if ($this->questionOBJ->isAdditionalContentEditingModePageObject()) {

--- a/components/ILIAS/TestQuestionPool/classes/feedback/class.ilAssQuestionFeedback.php
+++ b/components/ILIAS/TestQuestionPool/classes/feedback/class.ilAssQuestionFeedback.php
@@ -429,48 +429,78 @@ abstract class ilAssQuestionFeedback
      * duplicates the SPECIFIC feedback relating to the given original question id
      * and saves it for the given duplicate question id
      */
-    abstract protected function cloneSpecificFeedback(int $originalQuestionId, int $duplicateQuestionId): void;
+    abstract protected function cloneSpecificFeedback(int $source_question_id, int $target_question_id): void;
 
     /**
      * syncs the feedback from a duplicated question back to the original question
      */
-    final public function cloneFeedback(int $originalQuestionId, int $duplicateQuestionId): void
+    final public function cloneFeedback(int $original_question_id, int $duplicate_question_id): void
     {
-        $this->cloneGenericFeedback($originalQuestionId, $duplicateQuestionId);
-        $this->cloneSpecificFeedback($originalQuestionId, $duplicateQuestionId);
+        $this->cloneGenericFeedback($original_question_id, $duplicate_question_id);
+        $this->cloneSpecificFeedback($duplicate_question_id, $original_question_id);
     }
 
     /**
      * syncs the GENERIC feedback from a duplicated question back to the original question
      */
-    private function cloneGenericFeedback(int $originalQuestionId, int $duplicateQuestionId): void
+    private function cloneGenericFeedback(int $original_question_id, int $duplicate_question_id): void
     {
-        // delete generic feedback of the original question
-        $this->db->manipulateF(
-            "DELETE FROM {$this->getGenericFeedbackTableName()} WHERE question_fi = %s",
-            ['integer'],
-            [$originalQuestionId]
+        $this->deleteFeedbackOfOriginalQuestion(
+            $this->getGenericFeedbackTableName(),
+            $original_question_id,
+            $this->getGenericFeedbackPageObjectType()
         );
 
         // get generic feedback of the actual (duplicated) question
         $result = $this->db->queryF(
             "SELECT * FROM {$this->getGenericFeedbackTableName()} WHERE question_fi = %s",
-            ['integer'],
-            [$duplicateQuestionId]
+            [ilDBConstants::T_INTEGER],
+            [$duplicate_question_id]
         );
 
         // save generic feedback to the original question
         while ($row = $this->db->fetchAssoc($result)) {
-            $nextId = $this->db->nextId($this->getGenericFeedbackTableName());
+            $next_id = $this->db->nextId($this->getGenericFeedbackTableName());
 
             $this->db->insert($this->getGenericFeedbackTableName(), [
-                'feedback_id' => ['integer', $nextId],
-                'question_fi' => ['integer', $originalQuestionId],
-                'correctness' => ['text', $row['correctness']],
-                'feedback' => ['clob', $row['feedback']],
-                'tstamp' => ['integer', time()]
+                'feedback_id' => [ilDBConstants::T_INTEGER, $next_id],
+                'question_fi' => [ilDBConstants::T_INTEGER, $original_question_id],
+                'correctness' => [ilDBConstants::T_TEXT, $row['correctness']],
+                'feedback' => [ilDBConstants::T_CLOB, $row['feedback']],
+                'tstamp' => [ilDBConstants::T_INTEGER, time()]
             ]);
+
+            if ($this->questionOBJ->isAdditionalContentEditingModePageObject()) {
+                $page_object_type = $this->getGenericFeedbackPageObjectType();
+                $this->clonePageObject($page_object_type, $row['feedback_id'], $next_id, $original_question_id);
+            }
         }
+    }
+
+    protected function deleteFeedbackOfOriginalQuestion(
+        string $table_name,
+        int $original_question_id,
+        string $page_object_type
+    ): void {
+        if ($this->questionOBJ->isAdditionalContentEditingModePageObject()) {
+            $original_result = $this->db->queryF(
+                "SELECT feedback_id FROM {$table_name} WHERE question_fi = %s",
+                [ilDBConstants::T_INTEGER],
+                [$original_question_id]
+            );
+            while ($original_row = $this->db->fetchAssoc($original_result)) {
+                $this->ensurePageObjectDeleted(
+                    $page_object_type,
+                    (int) $original_row['feedback_id']
+                );
+            }
+        }
+
+        $this->db->manipulateF(
+            "DELETE FROM {$table_name} WHERE question_fi = %s",
+            [ilDBConstants::T_INTEGER],
+            [$original_question_id]
+        );
     }
 
     /**


### PR DESCRIPTION
This PR attempts to solve https://mantis.ilias.de/view.php?id=44715.

This is the ILIAS10 variant. Saving feedback back to QPL now works accordingly.

Kind regards,
@bidzanaaron 