### PR TITLE
User: ilUserAutoComplete::getList ensure items are encoded as JS arrays

### DIFF
--- a/Services/User/classes/class.ilUserAutoComplete.php
+++ b/Services/User/classes/class.ilUserAutoComplete.php
@@ -231,12 +231,11 @@ class ilUserAutoComplete
         }
 
         $max = $this->getLimit() ?: ilSearchSettings::getInstance()->getAutoCompleteLength();
-        $cnt = 0;
         $more_results = false;
         $result = [];
         $recs = [];
         $usrIds = [];
-        while (($rec = $ilDB->fetchAssoc($res)) && $cnt < ($max + 1)) {
+        for ($cnt = 0; ($rec = $ilDB->fetchAssoc($res)) && $cnt < ($max + 1); $cnt++) {
             if ($cnt >= $max && $this->isMoreLinkAvailable()) {
                 $more_results = true;
                 break;
@@ -266,10 +265,11 @@ class ilUserAutoComplete
                 $label .= ', ' . $rec['second_email'];
             }
 
-            $result[$cnt]['value'] = (string) $rec[$this->result_field];
-            $result[$cnt]['label'] = $label;
-            $result[$cnt]['id'] = $rec['usr_id'];
-            $cnt++;
+            $result[] = [
+                'value' => (string) $rec[$this->result_field],
+                'label' => $label,
+                'id' => $rec['usr_id'],
+            ];
         }
 
         $result_json['items'] = $result;


### PR DESCRIPTION
This PR fixes that `ilUserAutoComplete::getList(...)` returns the json_encoded items as a proper array (`[a, b, c]`) instead of an object (`{3: a, 4: b, 5: c}`). As it is no proper JS array anymore it causes a JS error in the Chatroom.

This bug was introduced in commit: https://github.com/ILIAS-eLearning/ILIAS/commit/4ee51763a8c82c51a928f2cf31d94ee904fdd33c

The variable `$cnt` is used twice as a counter but the second time it is not reset to `0`.
To decouple the two loops from each other I moved `$cnt` to the first loop and replaced `$cnt` in the second loop with `$array[] = ...`.