### PR TITLE
T&A 46470: Store settings when copying test objects

### DIFF
--- a/components/ILIAS/Test/classes/class.ilObjTest.php
+++ b/components/ILIAS/Test/classes/class.ilObjTest.php
@@ -3945,7 +3945,7 @@ class ilObjTest extends ilObject
                 $this->getMainSettings()->getFinishingSettings()->withConcludingRemarksPageId(
                     $this->cloneConcludingRemarks()
                 )
-            );
+            )->withId(0);
 
         $new_main_settings = $this->getMainSettingsRepository()->store($new_main_settings, $new_obj->getTestId());
         $this->getScoreSettingsRepository()->store(


### PR DESCRIPTION
Hi everyone,

This PR is in reference to ticket [46470](https://mantis.ilias.de/view.php?id=46470), which elaborates on the loss of settings during the copying of a test. 
To resolve the problem, I have adjusted the corresponding method in the `ilObjTest` class. The changes now ensure that the cloned test settings are stored in the database. In my opinion, this eliminates the necessity of employing an additional method for cloning test settings.

As always, please feel free to comment or give me feedback on this proposal. The changes have been tested and reviewed internally.

Best
@lukas-heinrich 