### PR TITLE
[FIX] 45445 UI: remove wrong media query

### DIFF
--- a/templates/default/070-components/UI-framework/Item/_ui-component_item.scss
+++ b/templates/default/070-components/UI-framework/Item/_ui-component_item.scss
@@ -208,44 +208,6 @@ $il-item-gap-xs: 1px;
 	}
 }
 
-@media only screen and (min-width: ($il-grid-float-breakpoint-max + 1px)) {
-
-	.panel-secondary .il-item {
-		width: 100%;
-
-		.il-item-title {
-			word-break: break-word;
-		}
-
-		.il-item-description {
-			padding-top: 0;
-			word-break: break-word;
-		}
-
-		.il-item-divider {
-			padding: $il-padding-large-vertical 0 0 0;
-			margin: 0 0 $il-margin-large-vertical 0;
-		}
-
-		.col-sm-3 {
-			margin-top: $il-margin-base-vertical;
-			margin-left: 0;
-			width: 45px;
-			img {
-				width: 40px;
-			}
-		}
-
-		.col-sm-9{
-			width: calc(100% - 45px);
-		}
-		.col-md-6{
-			width: 100%;
-		}
-
-	}
-}
-
 /* otherwise dropdowns in items with icon do not work */
 .il-std-item .media .media-body, .il-std-item .media, .il-notification-item .media, .il-notification-item .media .media-body {
 	overflow: visible;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -4609,36 +4609,6 @@ td.form-inline > div.form-group {
   gap: 6px;
 }
 
-@media only screen and (min-width: 992px) {
-  .panel-secondary .il-item {
-    width: 100%;
-  }
-  .panel-secondary .il-item .il-item-title {
-    word-break: break-word;
-  }
-  .panel-secondary .il-item .il-item-description {
-    padding-top: 0;
-    word-break: break-word;
-  }
-  .panel-secondary .il-item .il-item-divider {
-    padding: 6px 0 0 0;
-    margin: 0 0 6px 0;
-  }
-  .panel-secondary .il-item .col-sm-3 {
-    margin-top: 3px;
-    margin-left: 0;
-    width: 45px;
-  }
-  .panel-secondary .il-item .col-sm-3 img {
-    width: 40px;
-  }
-  .panel-secondary .il-item .col-sm-9 {
-    width: calc(100% - 45px);
-  }
-  .panel-secondary .il-item .col-md-6 {
-    width: 100%;
-  }
-}
 /* otherwise dropdowns in items with icon do not work */
 .il-std-item .media .media-body, .il-std-item .media, .il-notification-item .media, .il-notification-item .media .media-body {
   overflow: visible;


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45445

I removed the whole media query since it looks very odd. I assume this was meant to be for a special case of mobile responsive handling but falsely was set for big screens. Further, it has some very special handling on some very generic classes.