### PR TITLE
T&A 46308: Fixes Test Passed - learning progress status is not changing as expected

### DIFF
--- a/components/ILIAS/Tracking/classes/status/class.ilLPStatusTestPassed.php
+++ b/components/ILIAS/Tracking/classes/status/class.ilLPStatusTestPassed.php
@@ -19,6 +19,7 @@
 declare(strict_types=0);
 
 use ILIAS\Test\Results\Data\Repository;
+use ILIAS\Test\Participants\ParticipantRepository;
 use ILIAS\Test\TestDIC;
 
 /**
@@ -71,9 +72,27 @@ class ilLPStatusTestPassed extends ilLPStatus
 
     public static function _getStatusInfo(int $a_obj_id): array
     {
-        /** @var Repository $test_result_repository */
-        $test_result_repository = TestDIC::dic()['results.data.repository'];
-        $status_info['results'] = $test_result_repository->getPassedParticipants($a_obj_id);
+        /** @var ParticipantRepository $participant_repository */
+        $participant_repository = TestDIC::dic()['participant.repository'];
+        $test_id = ilObjTestAccess::_getTestIDFromObjectID($a_obj_id);
+
+        $lp_status = new self($a_obj_id);
+        $results = [];
+
+        foreach ($participant_repository->getParticipants($test_id) as $participant) {
+            $user_id = $participant->getUserId();
+            $status = $lp_status->determineStatus($a_obj_id, $user_id);
+
+            $results[] = [
+                'user_id' => $user_id,
+                'passed' => ($status === self::LP_STATUS_COMPLETED_NUM),
+                'failed' => ($status === self::LP_STATUS_FAILED_NUM),
+                'in_progress' => ($status === self::LP_STATUS_IN_PROGRESS_NUM),
+                'not_attempted' => ($status === self::LP_STATUS_NOT_ATTEMPTED_NUM)
+            ];
+        }
+
+        $status_info['results'] = $results;
         return $status_info;
     }
 


### PR DESCRIPTION
This PR attempts to fix https://mantis.ilias.de/view.php?id=46308.

`_getStatusInfo` now considers all statuses instead of just the passed ones.

Kind regards,
@bidzanaaron 