### PR TITLE
[LTI] fix: save phpSessionId after authentication

### DIFF
--- a/Services/Init/classes/class.ilStartUpGUI.php
+++ b/Services/Init/classes/class.ilStartUpGUI.php
@@ -648,6 +648,15 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
         );
         $frontend->authenticate();
 
+        setcookie(session_name(), session_id(), [
+            'expires' => 0,
+            'path' => rtrim(IL_COOKIE_PATH, '/'),
+            'domain' => IL_COOKIE_DOMAIN,
+            'secure' => true,
+            'httponly' => true,
+            'samesite' => 'None'
+        ]);
+
         switch ($status->getStatus()) {
             case ilAuthStatus::STATUS_AUTHENTICATED:
                 ilLoggerFactory::getLogger('auth')->debug('Authentication successful; Redirecting to starting page.');


### PR DESCRIPTION
In ILIAS 10, the community found an error related with LTI connections between platforms allocated in different domains. In these cases ILIAS wasn't able to connect to another ILIAS platform if they were hosted in different domains. The reason was the privacy policy of the browsers. For that reason we set the session's cookie during the authentication in ilStartUpGUI. The error was found in ILIAS 9, for that reason we propose the same change for ILIAS 9.

The change 

In ILIAS 10, the PR was https://github.com/ILIAS-eLearning/ILIAS/pull/9179

I assign as a reviewer to @mjansenDatabay because he was the reviewer the last time. 

Best regards