### PR TITLE
Mail: Prevent unintended `Markdown` heading conversion

### DIFF
--- a/components/ILIAS/Mail/classes/class.ilMailNotification.php
+++ b/components/ILIAS/Mail/classes/class.ilMailNotification.php
@@ -311,6 +311,7 @@ abstract class ilMailNotification
 
     public function getBlockBorder(): string
     {
-        return "----------------------------------------\n";
+        // Hyphen-only lines were interpreted as Setext-style headings by the Markdown mail renderer, resulting in unintended <h2> output.
+        return "════════════════════════════════════════\n";
     }
 }


### PR DESCRIPTION
This commit suggests replacing the "Block Border" character sequence (`----------------------------------------`) in `ilMailNotification` with Unicode box-drawing
(`════════════════════════════════════════`) to avoid Setext-style heading parsing in Markdown-enabled mails.

See: https://mantis.ilias.de/view.php?id=46555