### PR TITLE
Style: Fix permission checks in Adminstration > Layout

### DIFF
--- a/components/ILIAS/Style/Content/classes/class.ilContentStyleSettingsGUI.php
+++ b/components/ILIAS/Style/Content/classes/class.ilContentStyleSettingsGUI.php
@@ -143,7 +143,7 @@ class ilContentStyleSettingsGUI
      */
     public function edit(): void
     {
-        $this->checkPermission("visible,read");
+        $this->checkPermission("read,sty_write_content");
 
         // @todo: check these, they are checked later, but never (ILIAS 6) set
         $fixed_style = 0;

--- a/components/ILIAS/Style/System/classes/class.ilSystemStyleMainGUI.php
+++ b/components/ILIAS/Style/System/classes/class.ilSystemStyleMainGUI.php
@@ -144,7 +144,6 @@ class ilSystemStyleMainGUI
                     $this->setTabs($skin_id, $style_id);
                     $this->tabs->activateSubTab('documentation');
                     $this->help->setSubScreenId('documentation');
-                    $read_only = !$this->checkPermission('sty_management', false);
                     $node_id = '';
                     if ($this->request_wrapper->query()->has('node_id')) {
                         $node_id = $this->request_wrapper->query()->retrieve(
@@ -188,7 +187,7 @@ class ilSystemStyleMainGUI
         $this->help->setSubScreenId('overview');
         $this->setTabs($skin_id, $style_id);
         $this->tabs->activateSubTab('overview');
-        $this->checkPermission('visible,read');
+        $this->checkPermission('read');
         $read_only = !$this->checkPermission('sty_write_system', false);
         $management_enabled = true;//$this->checkPermission('sty_management', false);
         $system_styles_overview = new ilSystemStyleOverviewGUI(
@@ -231,15 +230,19 @@ class ilSystemStyleMainGUI
         return true;
     }
 
-    protected function setTabs(string $skin_id, string $style_id, string $active = '') {
+    protected function setTabs(string $skin_id, string $style_id, string $active = '')
+    {
         $this->ctrl->setParameterByClass(ilSystemStyleDocumentationGUI::class, 'skin_id', $skin_id);
         $this->ctrl->setParameterByClass(ilSystemStyleDocumentationGUI::class, 'style_id', $style_id);
 
         $this->tabs->addSubTab(
             'overview',
             $this->lng->txt('overview'),
-            $this->ctrl->getLinkTargetByClass(self::class), 'documentation');
-        $this->tabs->addSubTab('documentation',
+            $this->ctrl->getLinkTargetByClass(self::class),
+            'documentation'
+        );
+        $this->tabs->addSubTab(
+            'documentation',
             $this->lng->txt('documentation'),
             $this->ctrl->getLinkTargetByClass(ilSystemStyleDocumentationGUI::class, 'entries')
         );

--- a/components/ILIAS/Style/classes/class.ilObjStyleSettingsGUI.php
+++ b/components/ILIAS/Style/classes/class.ilObjStyleSettingsGUI.php
@@ -126,13 +126,18 @@ class ilObjStyleSettingsGUI extends ilObjectGUI
                 $this->lng->txt("system_styles"),
                 $this->ctrl->getLinkTargetByClass("ilsystemstylemaingui")
             );
+        }
 
+        if ($this->rbac_system->checkAccess('read,sty_write_content', $this->object->getRefId())) {
             $this->tabs_gui->addTab(
                 "content_styles",
                 $this->lng->txt("content_styles"),
                 $this->ctrl->getLinkTargetByClass("ilcontentstylesettingsgui", "edit")
             );
 
+        }
+
+        if ($this->rbac_system->checkAccess('read,sty_write_page_layout', $this->object->getRefId())) {
             $this->tabs_gui->addTab(
                 "page_layouts",
                 $this->lng->txt("page_layouts"),


### PR DESCRIPTION
See https://mantis.ilias.de/view.php?id=46419

This PR fixes the permission checks in Administration > Layout

- The "Visible" is no longer checked because it doesn't exist
- The "Read" permission is sufficient to view the kitchen sink documentation and the overview of the system styles
- The "Edit System Styles" permission is needed to activate/deactivate system styles
- The "Edit Content Styles" is needed to view the content styles and to show their tab
- The "Edit Page Layouts" is needed to view the page layouts and to show their tab

This PR does not yet unbundle the access to the kitchen sink documentation from read access to the system styles. That is proposed in the FR [More Visibility for Kitchen Sink](https://docu.ilias.de/go/wiki/wpage_8732_1357)