### PR TITLE
NW 46260: Fixes TypeError when trying to access feed url

### DIFF
--- a/components/ILIAS/User/classes/class.ilObjUser.php
+++ b/components/ILIAS/User/classes/class.ilObjUser.php
@@ -3123,7 +3123,7 @@ class ilObjUser extends ilObject
                 [$a_user_id]
             );
             if ($rec = $ilDB->fetchAssoc($set)) {
-                if (strlen($rec['feed_hash']) == 32) {
+                if (strlen($rec['feed_hash'] ?? '') == 32) {
                     return $rec['feed_hash'];
                 } elseif ($a_create) {
                     $hash = md5(random_int(1, 9999999) + str_replace(' ', '', microtime()));


### PR DESCRIPTION
This PR attempts to fix https://mantis.ilias.de/view.php?id=46260.

Calls legacy entry_point for feed and private news feed.

@thojou 

Kind regards,
@bidzanaaron 