### PR TITLE
[LTI] fix: show multiple LTI users in Authentication and Registration section

### DIFF
--- a/Services/Authentication/classes/class.ilObjAuthSettingsGUI.php
+++ b/Services/Authentication/classes/class.ilObjAuthSettingsGUI.php
@@ -194,7 +194,7 @@ class ilObjAuthSettingsGUI extends ilObjectGUI
                     || $auth_name === 'saml'
                     || $auth_name === "shibboleth" || $auth_name === 'ldap'
                     || $auth_name === 'apache' || $auth_name === "ecs"
-                    || $auth_name === "openid" || substr($auth_name,0,4) === "lti_") {
+                    || $auth_name === "openid" || substr($auth_name, 0, 4) === "lti_") {
                     continue;
                 }
 

--- a/Services/Authentication/classes/class.ilObjAuthSettingsGUI.php
+++ b/Services/Authentication/classes/class.ilObjAuthSettingsGUI.php
@@ -194,7 +194,7 @@ class ilObjAuthSettingsGUI extends ilObjectGUI
                     || $auth_name === 'saml'
                     || $auth_name === "shibboleth" || $auth_name === 'ldap'
                     || $auth_name === 'apache' || $auth_name === "ecs"
-                    || $auth_name === "openid") {
+                    || $auth_name === "openid" || substr($auth_name,0,4) === "lti_") {
                     continue;
                 }
 


### PR DESCRIPTION
This change fix the report https://mantis.ilias.de/view.php?id=38537 which happens in ILIAS 9 and ILIAS 10.

We shouldn't show every lti access in this section.

I assign to @mjansenDatabay and  because they are the maintainers of Login, Auth & Registration.