### PR TITLE
T&A 46492: Allows answertext of cloze question to only be a string instead of also null

### DIFF
--- a/components/ILIAS/Test/src/Setup/Test11DBUpdateSteps.php
+++ b/components/ILIAS/Test/src/Setup/Test11DBUpdateSteps.php
@@ -155,4 +155,14 @@ class Test11DBUpdateSteps implements \ilDatabaseUpdateSteps
             $this->db->modifyTableColumn('tst_test_settings', $column, ['length' => 8]);
         }
     }
+
+    public function step_4(): void
+    {
+        $table = 'qpl_a_cloze';
+        $column = 'answertext';
+        if ($this->db->tableExists($table) && $this->db->tableColumnExists($table, $column)) {
+            $this->db->manipulate("UPDATE {$table} SET {$column} = '' WHERE {$column} IS NULL");
+            $this->db->modifyTableColumn($table, $column, ['default' => '', 'notnull' => true]);
+        }
+    }
 }

--- a/components/ILIAS/TestQuestionPool/classes/class.assClozeTest.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assClozeTest.php
@@ -311,24 +311,24 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
         $this->db->manipulateF(
             'INSERT INTO qpl_a_cloze (answer_id, question_fi, gap_id, answertext, points, aorder, cloze_type, gap_size) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)',
             [
-                'integer',
-                'integer',
-                'integer',
-                'text',
-                'float',
-                'integer',
-                'text',
-                'integer'
+                ilDBConstants::T_INTEGER,
+                ilDBConstants::T_INTEGER,
+                ilDBConstants::T_INTEGER,
+                ilDBConstants::T_TEXT,
+                ilDBConstants::T_FLOAT,
+                ilDBConstants::T_INTEGER,
+                ilDBConstants::T_TEXT,
+                ilDBConstants::T_INTEGER
             ],
             [
                 $next_id,
                 $this->getId(),
                 $key,
-                strlen($item->getAnswertext()) ? $item->getAnswertext() : '',
+                $item->getAnswertext(),
                 $item->getPoints(),
                 $item->getOrder(),
                 $gap->getType(),
-                (int) $gap->getGapSize()
+                $gap->getGapSize()
             ]
         );
     }
@@ -342,24 +342,24 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
         $this->db->manipulateF(
             'INSERT INTO qpl_a_cloze (answer_id, question_fi, gap_id, answertext, points, aorder, cloze_type, shuffle) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)',
             [
-                'integer',
-                'integer',
-                'integer',
-                'text',
-                'float',
-                'integer',
-                'text',
-                'text'
+                ilDBConstants::T_INTEGER,
+                ilDBConstants::T_INTEGER,
+                ilDBConstants::T_INTEGER,
+                ilDBConstants::T_TEXT,
+                ilDBConstants::T_FLOAT,
+                ilDBConstants::T_INTEGER,
+                ilDBConstants::T_TEXT,
+                ilDBConstants::T_TEXT
             ],
             [
                 $next_id,
                 $this->getId(),
                 $key,
-                strlen($item->getAnswertext()) ? $item->getAnswertext() : '',
+                $item->getAnswertext(),
                 $item->getPoints(),
                 $item->getOrder(),
                 $gap->getType(),
-                ($gap->getShuffle()) ? '1' : '0'
+                $gap->getShuffle() ? '1' : '0'
             ]
         );
     }
@@ -375,32 +375,32 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
         $this->db->manipulateF(
             'INSERT INTO qpl_a_cloze (answer_id, question_fi, gap_id, answertext, points, aorder, cloze_type, lowerlimit, upperlimit, gap_size) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)',
             [
-                'integer',
-                'integer',
-                'integer',
-                'text',
-                'float',
-                'integer',
-                'text',
-                'text',
-                'text',
-                'integer'
+                ilDBConstants::T_INTEGER,
+                ilDBConstants::T_INTEGER,
+                ilDBConstants::T_INTEGER,
+                ilDBConstants::T_TEXT,
+                ilDBConstants::T_FLOAT,
+                ilDBConstants::T_INTEGER,
+                ilDBConstants::T_TEXT,
+                ilDBConstants::T_TEXT,
+                ilDBConstants::T_TEXT,
+                ilDBConstants::T_INTEGER
             ],
             [
                 $next_id,
                 $this->getId(),
                 $key,
-                strlen($item->getAnswertext()) ? $item->getAnswertext() : '',
+                $item->getAnswertext(),
                 $item->getPoints(),
                 $item->getOrder(),
                 $gap->getType(),
-                ($eval->e($item->getLowerBound()) !== false && strlen(
-                    $item->getLowerBound()
-                ) > 0) ? $item->getLowerBound() : $item->getAnswertext(),
-                ($eval->e($item->getUpperBound()) !== false && strlen(
-                    $item->getUpperBound()
-                ) > 0) ? $item->getUpperBound() : $item->getAnswertext(),
-                (int) $gap->getGapSize()
+                ($eval->e($item->getLowerBound()) !== false && ($item->getLowerBound() ?? '') !== '')
+                    ? $item->getLowerBound()
+                    : $item->getAnswertext(),
+                ($eval->e($item->getUpperBound()) !== false && ($item->getUpperBound() ?? '') !== '')
+                    ? $item->getUpperBound()
+                    : $item->getAnswertext(),
+                $gap->getGapSize()
             ]
         );
     }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=46492

Aims to allow answertext of cloze question to only be a string instead of also null.

@thojou 