### PR TITLE
Fix shibboleth sso logout

### DIFF
--- a/components/ILIAS/AuthShibboleth/classes/class.ilAuthProviderShibboleth.php
+++ b/components/ILIAS/AuthShibboleth/classes/class.ilAuthProviderShibboleth.php
@@ -107,6 +107,7 @@ class ilAuthProviderShibboleth extends ilAuthProvider
             return false;
         }
 
+        ilSession::set('shibboleth_session_id', $_SERVER['Shib-Session-ID']);
         return true;
     }
 }

--- a/components/ILIAS/AuthShibboleth/resources/shib_logout.php
+++ b/components/ILIAS/AuthShibboleth/resources/shib_logout.php
@@ -41,7 +41,7 @@ if (
 //       stored in the application's session data.
 //       See function LogoutNotification below
 
-elseif (!empty($HTTP_RAW_POST_DATA)) {
+elseif (!empty(file_get_contents('php://input'))) {
     ilContext::init(ilContext::CONTEXT_SOAP);
 
     // Load ILIAS libraries and initialise ILIAS in non-web context

--- a/components/ILIAS/AuthShibboleth/resources/shib_logout.php
+++ b/components/ILIAS/AuthShibboleth/resources/shib_logout.php
@@ -138,20 +138,15 @@ function LogoutNotification($SessionID)
     $q = "SELECT session_id, data FROM usr_session WHERE expires > 'NOW()'";
     $r = $ilDB->query($q);
 
-    while ($session_entry = $r->fetchRow(ilDBConstants::FETCHMODE_ASSOC)) {
-        $user_session = unserializesession($session_entry['data']);
-
-        // Look for session with matching Shibboleth session id
-        // and then delete this ilias session
-        foreach ($user_session as $user_session_entry) {
-            if (is_array($user_session_entry)
-                && array_key_exists('shibboleth_session_id', $user_session_entry)
-                && $user_session_entry['shibboleth_session_id'] == $SessionID
-            ) {
-                // Delete this session entry
-                if (ilSession::_destroy($session_entry['session_id']) !== true) {
-                    return new SoapFault('LogoutError', 'Could not delete session entry in database.');
-                }
+    while ($session = $r->fetchRow(ilDBConstants::FETCHMODE_ASSOC)) {
+        $session_data = unserializesession($session['data']);
+        if (is_array($session_data)
+            && array_key_exists('shibboleth_session_id', $session_data)
+            && $session_data['shibboleth_session_id'] == $SessionID
+        ) {
+            // Delete this session entry
+            if (ilSession::_destroy($session['session_id']) !== true) {
+                return new SoapFault('LogoutError', 'Could not delete session entry in database.');
             }
         }
     }

--- a/components/ILIAS/AuthShibboleth/resources/shib_logout.php
+++ b/components/ILIAS/AuthShibboleth/resources/shib_logout.php
@@ -67,16 +67,15 @@ else {
 
     echo <<<WSDL
 <?xml version ="1.0" encoding ="UTF-8" ?>
-<definitions name="LogoutNotification"
-  targetNamespace="urn:mace:shibboleth:2.0:sp:notify"
-  xmlns:notify="urn:mace:shibboleth:2.0:sp:notify"
-  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
-  xmlns="http://schemas.xmlsoap.org/wsdl/">
+<definitions name="LogoutNotification" targetNamespace="urn:mace:shibboleth:2.0:sp:notify"
+	xmlns:notify="urn:mace:shibboleth:2.0:sp:notify"
+	xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+	xmlns="http://schemas.xmlsoap.org/wsdl/">
 
 	<types>
-	   <schema targetNamespace="urn:mace:shibboleth:2.0:sp:notify"
-		   xmlns="http://www.w3.org/2000/10/XMLSchema"
-		   xmlns:notify="urn:mace:shibboleth:2.0:sp:notify">
+		<schema targetNamespace="urn:mace:shibboleth:2.0:sp:notify"
+			xmlns="http://www.w3.org/2000/10/XMLSchema"
+			xmlns:notify="urn:mace:shibboleth:2.0:sp:notify">
 
 			<simpleType name="string">
 				<restriction base="string">
@@ -96,7 +95,7 @@ else {
 		<part name="SessionID" type="notify:string" />
 	</message>
 
-	<message name="getLogoutNotificationResponse" >
+	<message name="getLogoutNotificationResponse">
 		<part name="OK"/>
 	</message>
 
@@ -115,9 +114,9 @@ else {
 	</binding>
 
 	<service name="LogoutNotificationService">
-		  <port name="LogoutNotificationPort" binding="notify:LogoutNotificationBinding">
+		<port name="LogoutNotificationPort" binding="notify:LogoutNotificationBinding">
 			<soap:address location="{$url}"/>
-		  </port>
+		</port>
 	</service>
 </definitions>
 WSDL;

--- a/components/ILIAS/AuthShibboleth/resources/shib_logout.php
+++ b/components/ILIAS/AuthShibboleth/resources/shib_logout.php
@@ -14,7 +14,10 @@
  *****************************************************************************/
 /** @noRector */
 require_once("../vendor/composer/vendor/autoload.php");
+ilContext::init(ilContext::CONTEXT_SHIBBOLETH);
+ilInitialisation::initILIAS();
 global $DIC;
+
 $q = $DIC->http()->wrapper()->query();
 if (
     $q->has('return')


### PR DESCRIPTION
As mentioned [here](https://mantis.ilias.de/view.php?id=45624) (and now also [here](https://mantis.ilias.de/view.php?id=46592)), there are a bunch of issues with the `shib_logout.php` SSO/global logout handling.

The initial HTTP 500 error was already fixed in 9.x, but not applied to 10.
This PR now also fixes all other outstanding bugs/issues that prevented shibboleth SSO logout to work here.

Note that this was tested with our own ILIAS 9 instance, but since no other changes apart from directory structure have happened between 9 and 10 this should also work.

Commits have been split into the issues they fix:
1. Fixes HTTP 500 php error, because `$DIC->http()` is only available after ILIAS was initialized
1. The variable `$HTTP_RAW_POST_DATA` has been deprecated since PHP 5.5 and prevented this IF statement from ever being triggered, but is vital for SSO via shibboleth back channel to work
1. Is an optional commit to fix indentation of fallback soap response
1.  Adds the missing `shibboleth_session_id` $_SESSION information that will be stored by `ilSession` as data column into the `usr_session` table. This information is required by `shib_logout.php` to find the correct session to destroy upon sso logout.
1. Fixes an issue where `shib_logout.php` treated the data field fetched from the  `usr_session` table as an array of arrays, but it just contains the key/value content of previous `$_SESSION` variable, no for loop required. This also does a small cosmetic change to some variable names.

**EDIT:** Fixed include path for ILIAS10.