### PR TITLE
[LTI] fix: redirection after terms of service

### DIFF
--- a/Services/Init/classes/class.ilStartUpGUI.php
+++ b/Services/Init/classes/class.ilStartUpGUI.php
@@ -657,6 +657,14 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
             'samesite' => 'None'
         ]);
 
+        $lti_context_ids = ilSession::get("lti_context_ids");
+
+        if (is_array($lti_context_ids) && isset($lti_context_ids[0])) {
+            $ref_id = $lti_context_ids[0];
+            $obj_type = ilObject::_lookupType($ref_id, true);
+            ilSession::set('orig_request_target', "goto.php?target=" . $obj_type . "_" . $ref_id . "&lti_context_id=" . $ref_id);
+        }
+
         switch ($status->getStatus()) {
             case ilAuthStatus::STATUS_AUTHENTICATED:
                 ilLoggerFactory::getLogger('auth')->debug('Authentication successful; Redirecting to starting page.');


### PR DESCRIPTION
When the provider platform has terms of service the consumer is redirected to the page to accept or not this terms, but when the consumer accept them ILIAS is not able to arrive to the correct shared object. This is because LTI doesn't save the original target. For that reason we propose save that original direction when the user logs in. The same change was introduced in ILIAS 10 in the PR: https://github.com/ILIAS-eLearning/ILIAS/pull/9250

Related with the report [0039629](https://mantis.ilias.de/view.php?id=39629)

I assign to @mjansenDatabay because he was who checked this change the last time.

Thanks for your time.