### PR TITLE
BT10 46409: Loads missing exc language module in booking pool

### DIFF
--- a/components/ILIAS/BookingManager/Participants/class.ilBookingParticipantGUI.php
+++ b/components/ILIAS/BookingManager/Participants/class.ilBookingParticipantGUI.php
@@ -76,7 +76,7 @@ class ilBookingParticipantGUI
                         $a_user_id
                     );
                 });
-                $rep_search->setTitle($this->lng->txt("exc_add_participant"));
+                $rep_search->setTitle($this->lng->txt("book_add_participant"));
                 $rep_search->setCallback($this, 'addParticipantObject');
                 $this->ctrl->setReturn($this, 'render');
                 $this->ctrl->forwardCommand($rep_search);

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -2574,6 +2574,7 @@ blog#:#blog_whole_blog#:#Gesamtes Blog
 book#:#X_reservations_of#:#%s Buchungen von
 book#:#book_add#:#Buchungspool anlegen
 book#:#book_add_object#:#Angebot hinzufügen
+book#:#book_add_participant#:#Teilnehmer hinzufügen
 book#:#book_add_schedule#:#Zeitplan hinzufügen
 book#:#book_additional_info_file#:#Zusätzliche Beschreibung
 book#:#book_all#:#Alle anzeigen

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -2575,6 +2575,7 @@ blog#:#blog_whole_blog#:#Whole blog
 book#:#X_reservations_of#:#%s booking(s) of
 book#:#book_add#:#Add Booking Pool
 book#:#book_add_object#:#Add Item
+book#:#book_add_participant#:#Add Participant
 book#:#book_add_schedule#:#Add Schedule
 book#:#book_additional_info_file#:#Additional Description
 book#:#book_all#:#Show all


### PR DESCRIPTION
This PR attempts to fix https://mantis.ilias.de/view.php?id=46409.

Introduces own booking module language variable for participant

This is the ILIAS10 version of the PR.
Original PR: #10694 

Kind regards,
@bidzanaaron