### PR TITLE
GlobalScreen: Don't convert mailto:email to http(s)://mailto:email

### DIFF
--- a/components/ILIAS/GlobalScreen_/classes/UI/Footer/class.ilFooterStandardGroupsProvider.php
+++ b/components/ILIAS/GlobalScreen_/classes/UI/Footer/class.ilFooterStandardGroupsProvider.php
@@ -92,14 +92,14 @@ final class ilFooterStandardGroupsProvider extends AbstractStaticFooterProvider
         }
 
         // system support contacts
-        if (($system_support_url = \ilSystemSupportContactsGUI::getFooterLink()) !== '') {
+        if (($system_support_url = \ilSystemSupportContactsGUI::getFooterLink()) !== null) {
             $system_support_title = \ilSystemSupportContactsGUI::getFooterText();
             $entries[] = $this->item_factory
                 ->link(
                     $this->id_factory->identifier('system_support'),
                     $system_support_title
                 )
-                ->withAction($this->buildURI($system_support_url))
+                ->withAction($system_support_url)
                 ->withParent($this->getIdentificationFor(ilFooterStandardGroups::SUPPORT));
         }
 

--- a/components/ILIAS/SystemFolder/classes/class.ilSystemSupportContactsGUI.php
+++ b/components/ILIAS/SystemFolder/classes/class.ilSystemSupportContactsGUI.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+use ILIAS\Data\URI;
+
 /**
  * System support contacts
  *
@@ -93,18 +95,13 @@ class ilSystemSupportContactsGUI implements ilCtrlBaseClassInterface
         $this->tpl->printToStdout();
     }
 
-
-    /**
-     * Get footer link
-     *
-     * @return string footer link
-     */
-    public static function getFooterLink()
+    public static function getFooterLink(): null|URI|string
     {
         global $DIC;
 
         $ilCtrl = $DIC->ctrl();
         $ilUser = $DIC->user();
+        $uri = $DIC->http()->request()->getUri();
 
         $users = ilSystemSupportContacts::getValidSupportContactIds();
         if (count($users) > 0) {
@@ -114,11 +111,12 @@ class ilSystemSupportContactsGUI implements ilCtrlBaseClassInterface
                     ilSystemSupportContacts::getMailsToAddress()
                 );
             } else {
-                return $ilCtrl->getLinkTargetByClass("ilsystemsupportcontactsgui", "", "", false, false);
+                $path = $ilCtrl->getLinkTargetByClass("ilsystemsupportcontactsgui", "", "", false, false);
+                return new URI($uri->getScheme() . '://' . $uri->getHost() . '/' . $path);
             }
         }
 
-        return "";
+        return null;
     }
 
     /**


### PR DESCRIPTION
The support contact uses `mailto:email` syntax which is always converted into `http(s)://hostname:/mailto:email` when displayed in the footer under _Contact Technical Support_ which breaks this syntax.

This PR changes this, so that the correct URL or `mailto:...` value is already returned from `ilSystemSupportContactsGUI::getFooterLink(...)` (the footer items also support `string` and `URI`).

This PR _also_ fixes https://github.com/ILIAS-eLearning/ILIAS/pull/10043#issuecomment-3636702633 in ILIAS 12 as the email is not falsely used in the an uri path anymore.