### PR TITLE
IG 43315: Fixes objects without permissions shown in item group materials

### DIFF
--- a/Modules/ItemGroup/classes/class.ilItemGroupItems.php
+++ b/Modules/ItemGroup/classes/class.ilItemGroupItems.php
@@ -28,6 +28,7 @@ class ilItemGroupItems
     protected ilObjectDefinition $obj_def;
     protected ilObjectDataCache $obj_data_cache;
     protected ilLogger $log;
+    protected ilAccessHandler $access;
     public ilTree $tree;
     public ilLanguage $lng;
     public int $item_group_id = 0;
@@ -45,6 +46,7 @@ class ilItemGroupItems
         $this->lng = $DIC->language();
         $this->tree = $DIC->repositoryTree();
         $this->obj_def = $DIC["objDefinition"];
+        $this->access = $DIC->access();
 
         $this->setItemGroupRefId($a_item_group_ref_id);
         if ($this->getItemGroupRefId() > 0) {
@@ -145,8 +147,6 @@ class ilItemGroupItems
 
     public function getAssignableItems(): array
     {
-        $objDefinition = $this->obj_def;
-
         if ($this->getItemGroupRefId() <= 0) {
             return array();
         }
@@ -173,7 +173,11 @@ class ilItemGroupItems
                 continue;
             }
 
-            if ($objDefinition->isInactivePlugin((string) $node['type'])) {
+            if ($this->obj_def->isInactivePlugin((string) $node['type'])) {
+                continue;
+            }
+
+            if (!$this->access->checkAccess('visible', '', $node['ref_id'])) {
                 continue;
             }
 

--- a/Modules/ItemGroup/classes/class.ilObjItemGroupGUI.php
+++ b/Modules/ItemGroup/classes/class.ilObjItemGroupGUI.php
@@ -251,17 +251,17 @@ class ilObjItemGroupGUI extends ilObject2GUI
 
     public function saveItemAssignment(): void
     {
-        $ilCtrl = $this->ctrl;
-
         $this->checkPermission("write");
 
         $item_group_items = new ilItemGroupItems($this->object->getRefId());
-        $items = $this->ig_request->getItems();
+        $assignable_ref_ids = array_column($item_group_items->getAssignableItems(), 'ref_id');
+        $items = array_intersect($this->ig_request->getItems(), $assignable_ref_ids);
+
         $item_group_items->setItems($items);
         $item_group_items->update();
 
         $this->tpl->setOnScreenMessage('success', $this->lng->txt('msg_obj_modified'), true);
-        $ilCtrl->redirect($this, "listMaterials");
+        $this->ctrl->redirect($this, 'listMaterials');
     }
 
     public function getTemplate(): void


### PR DESCRIPTION
This PR attempts to fix https://mantis.ilias.de/view.php?id=43315.

Fixes objects without permissions shown in item group materials.

Kind regards,
@bidzanaaron 

/cc @thojou 