### PR TITLE
IGR 41366: Fixes issue in ilObjectTranslationGUI::getTableValuesByRequest with missing description

### DIFF
--- a/Services/Object/classes/Translation/class.ilObjectTranslationGUI.php
+++ b/Services/Object/classes/Translation/class.ilObjectTranslationGUI.php
@@ -144,7 +144,7 @@ class ilObjectTranslationGUI
         foreach ($titles as $k => $v) {
             $vals[] = [
                 'title' => $v,
-                'desc' => $descriptions[$k],
+                'desc' => $descriptions[$k] ?? '',
                 'lang' => $languages[$k],
                 'default' => ($default == $k)
             ];


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=41366

Aims to fix issue in ilObjectTranslationGUI::getTableValuesByRequest with missing description.

@thojou 