### PR TITLE
Learning Module 46655: Vorwärtsblättern im Lernmodul nicht mehr möglich

### DIFF
--- a/Services/COPage/PC/Question/class.ilPCQuestion.php
+++ b/Services/COPage/PC/Question/class.ilPCQuestion.php
@@ -333,8 +333,13 @@ class ilPCQuestion extends ilPageContent
         if ($get_stored_tries) {
             if (count($q_ids) > 0) {
                 foreach ($q_ids as $q_id) {
-                    $as = ilPageQuestionProcessor::getAnswerStatus($q_id, $ilUser->getId());
-                    $code[] = "ilias.questions.initAnswer(" . $q_id . ", " . (int) ($as["try"] ?? 0) . ", " . ($as["passed"] ? "true" : "null") . ", " . ($as["points"] ?? "null") . ");";
+                    $status = ilPageQuestionProcessor::getAnswerStatus($q_id, $ilUser->getId());
+                    $status = $status[$q_id] ?? $status;
+
+                    $try = (int) ($status["try"] ?? 0);
+                    $passed = isset($status["passed"]) && $status["passed"] ? "true" : "null";
+                    $points = $status["points"] ?? "null";
+                    $code[] = "ilias.questions.initAnswer(" . $q_id . ", " . $try . ", " . $passed . ", " . $points . ");";
                 }
             }
         }

--- a/Services/COPage/classes/class.ilPageQuestionProcessor.php
+++ b/Services/COPage/classes/class.ilPageQuestionProcessor.php
@@ -302,10 +302,12 @@ class ilPageQuestionProcessor
             $and
         );
 
-        if ($a_user_id === 0) {
+        if (is_array($a_q_id) || $a_user_id == 0) {
             $recs = array();
             while ($rec = $ilDB->fetchAssoc($set)) {
-                $key = "{$rec["qst_id"]}:{$rec["user_id"]}";
+                $key = ($a_user_id == 0)
+                    ? $rec["qst_id"] . ":" . $rec["user_id"]
+                    : $rec["qst_id"];
                 $recs[$key] = $rec;
             }
             return $recs;


### PR DESCRIPTION
Hi everyone, 

This PR refers to the issue from ticket [46655](https://mantis.ilias.de/view.php?id=46655). Some of the modifications from #10562 that caused the issue are undone by this PR. We have ensured that the bug that was supposed to be fixed by the original change will not be reproduced.

We are currently checking whether these changes could also resolve the issue from [46657](https://mantis.ilias.de/view.php?id=46657) and [46591](https://mantis.ilias.de/view.php?id=46591).

Best
@lukas-heinrich 