### PR TITLE
UI: show values selected in complex filter input fields (46588)

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Duration.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Duration.php
@@ -301,7 +301,19 @@ class Duration extends Group implements C\Input\Field\Duration
         return fn($id) => "var combinedDuration = function() {
 				var options = [];
 				$('#$id').find('input').each(function() {
-					options.push($(this).val());
+				    const value = $(this).val();
+				    if (value == '') {
+				        options.push('');
+				        return;
+				    }
+				    const date = new Date(value);
+				    var readable_value = '';
+				    if (value.includes('T')) {
+				        readable_value = date.toLocaleString([], { dateStyle: 'short', timeStyle: 'short' });
+				    } else {
+				    	readable_value = date.toLocaleDateString();
+				    }
+					options.push(readable_value);
 				});
 				return options.join(' - ');
 			}

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/FilterContextRenderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/FilterContextRenderer.php
@@ -158,7 +158,7 @@ class FilterContextRenderer extends Renderer
         $tpl->parseCurrentBlock();
         $tpl->setCurrentBlock("filter_field");
         if ($component->isComplex()) {
-            $tpl->setVariable("FILTER_FIELD", $this->renderProxyField($input_html, $default_renderer));
+            $tpl->setVariable("FILTER_FIELD", $this->renderProxyField($component, $input_html, $default_renderer));
         } else {
             $tpl->setVariable("FILTER_FIELD", $input_html);
         }
@@ -176,6 +176,7 @@ class FilterContextRenderer extends Renderer
     }
 
     protected function renderProxyField(
+        FormInput $component,
         string $input_html,
         RendererInterface $default_renderer
     ): string {
@@ -183,6 +184,9 @@ class FilterContextRenderer extends Renderer
         $tpl = $this->getTemplate("tpl.filter_field.html", true, true);
 
         $popover = $f->popover()->standard($f->legacy($input_html))->withVerticalPosition();
+        if ($component->getOnLoadCode() !== null) {
+            $popover = $popover->withAdditionalOnLoadCode($component->getOnLoadCode());
+        }
         $tpl->setVariable("POPOVER", $default_renderer->render($popover));
 
         $prox = new ProxyFilterField();


### PR DESCRIPTION
This PR is a possible fix for [46588](https://mantis.ilias.de/view.php?id=46588). Complex filter inputs (duration and multiselect) still properly show their selected values in ILIAS 9, but at some point that broke due to different refactorings of js binding and form rendering.

The issue is that those input fields lose the js bound to them when they are rendered into their popover in `FilterContextRenderer::renderProxyField`, so that their `updateOnLoadCode` is not executed. My somewhat blunt solution to this is to attach the `onLoadCode` to the popover, similar to what is done in `Field/Renderer::wrapInFormContext`. An alternative would be to wrap the input into something similar to `tpl.context_form.html` before rendering to the filter, but that didn't seem worth the effort to me.

Additionally, I also made a few changes to `Duration::getUpdateOnLoadCode`, so that dates (with or without time) are not shown as their raw value, but formatted similarly to how they are shown in the datetime picker.