### PR TITLE
User/Badge: Fix handling of static badge URLs

### DIFF
--- a/components/ILIAS/User/src/StaticURLHandler.php
+++ b/components/ILIAS/User/src/StaticURLHandler.php
@@ -157,7 +157,7 @@ class StaticURLHandler extends BaseHandler implements Handler
         ?ReferenceId $target_user_id,
         string $cmd
     ): string {
-        if (substr($cmd, -4) == '_bdg') {
+        if (str_starts_with($cmd, '_bdg')) {
             return $ctrl->getLinkTargetByClass(\ilDashboardGUI::class, 'jumpToBadges');
         }
 


### PR DESCRIPTION
This commit suggests fixing the handling of static URLs like this: http://my.ilias.org/goto.php/usr/6/_bdg?osd_id=6

See: https://mantis.ilias.de/view.php?id=46690

If approved, this has to be picked to `trunk` as well.

I introduced a dedicated `badge`-related URL handler with #10792 and used corresponding static URLs when emitting new notifications.

Nevetheless, I suggest keeping the "legacy badge URL handling" in the user component for a while (e.g. one or two more releases).