### PR TITLE
Contact: Add dedicated URL handler for `contact` namespace

### DIFF
--- a/components/ILIAS/Contact/BuddySystem/classes/class.ilBuddySystemNotification.php
+++ b/components/ILIAS/Contact/BuddySystem/classes/class.ilBuddySystemNotification.php
@@ -24,34 +24,31 @@ use ILIAS\Notifications\Model\ilNotificationLink;
 use ILIAS\Notifications\Model\ilNotificationParameter;
 use ILIAS\Contact\Provider\ContactNotificationProvider;
 
-/**
- * Class ilBuddyList
- * @author Michael Jansen <mjansen@databay.de>
- */
 class ilBuddySystemNotification
 {
-    public const CONTACT_REQUEST_KEY = 'contact_requested_by';
-    /** @var int[] */
-    protected array $recipientIds = [];
+    public const string CONTACT_REQUEST_KEY = 'contact_requested_by';
+
+    /** @var list<int> */
+    protected array $recipient_ids = [];
 
     public function __construct(protected ilObjUser $sender, protected ilSetting $settings)
     {
     }
 
     /**
-     * @return int[]
+     * @return list<int>
      */
     public function getRecipientIds(): array
     {
-        return $this->recipientIds;
+        return $this->recipient_ids;
     }
 
     /**
-     * @param int[] $recipientIds
+     * @param list<int> $recipient_ids
      */
-    public function setRecipientIds(array $recipientIds): void
+    public function setRecipientIds(array $recipient_ids): void
     {
-        $this->recipientIds = array_map('intval', $recipientIds);
+        $this->recipient_ids = array_map('\intval', $recipient_ids);
     }
 
     public function send(): void
@@ -59,14 +56,17 @@ class ilBuddySystemNotification
         foreach ($this->getRecipientIds() as $usr_id) {
             $user = new ilObjUser($usr_id);
 
-            $recipientLanguage = ilLanguageFactory::_getLanguage($user->getLanguage());
-            $recipientLanguage->loadLanguageModule('buddysystem');
+            $recipient_language = ilLanguageFactory::_getLanguage($user->getLanguage());
+            $recipient_language->loadLanguageModule('buddysystem');
 
             $notification = new ilNotificationConfig(ContactNotificationProvider::NOTIFICATION_TYPE);
 
-            $personalProfileLink = $recipientLanguage->txt('buddy_noti_cr_profile_not_published');
+            $approve_url = ilLink::_getLink($this->sender->getId(), 'contact', ['approve']);
+            $ignore_url = ilLink::_getLink($this->sender->getId(), 'contact', ['ignore']);
+
+            $profile_url = $recipient_language->txt('buddy_noti_cr_profile_not_published');
             if ($this->hasPublicProfile($this->sender->getId())) {
-                $personalProfileLink = ilLink::_getStaticLink($this->sender->getId(), 'usr', true);
+                $profile_url = ilLink::_getStaticLink($this->sender->getId(), 'usr', true);
 
                 $links[] = new ilNotificationLink(
                     new ilNotificationParameter(
@@ -74,41 +74,31 @@ class ilBuddySystemNotification
                         $this->sender->getLastname() . ' ' .
                         $this->sender->getLogin()
                     ),
-                    $personalProfileLink
+                    $profile_url
                 );
             }
             $links[] = new ilNotificationLink(
                 new ilNotificationParameter('buddy_notification_contact_request_link_osd', [], 'buddysystem'),
-                ilLink::_getStaticLink(
-                    $this->sender->getId(),
-                    'usr',
-                    true,
-                    '_contact_approved'
-                )
+                $approve_url
             );
             $links[] = new ilNotificationLink(
                 new ilNotificationParameter('buddy_notification_contact_request_ignore_osd', [], 'buddysystem'),
-                ilLink::_getStaticLink(
-                    $this->sender->getId(),
-                    'usr',
-                    true,
-                    '_contact_ignored'
-                )
+                $ignore_url
             );
 
-            $bodyParams = [
-                'SALUTATION' => ilMail::getSalutation($user->getId(), $recipientLanguage),
+            $body_params = [
+                'SALUTATION' => ilMail::getSalutation($user->getId(), $recipient_language),
                 'BR' => "\n",
-                'APPROVE_REQUEST' => ilLink::_getStaticLink($this->sender->getId(), 'usr', true, '_contact_approved'),
-                'APPROVE_REQUEST_TXT' => $recipientLanguage->txt('buddy_notification_contact_request_link'),
-                'IGNORE_REQUEST' => ilLink::_getStaticLink($this->sender->getId(), 'usr', true, '_contact_ignored'),
-                'IGNORE_REQUEST_TXT' => $recipientLanguage->txt('buddy_notification_contact_request_ignore'),
+                'APPROVE_REQUEST' => $approve_url,
+                'APPROVE_REQUEST_TXT' => $recipient_language->txt('buddy_notification_contact_request_link'),
+                'IGNORE_REQUEST' => $ignore_url,
+                'IGNORE_REQUEST_TXT' => $recipient_language->txt('buddy_notification_contact_request_ignore'),
                 'REQUESTING_USER' => ilUserUtil::getNamePresentation($this->sender->getId()),
-                'PERSONAL_PROFILE_LINK' => $personalProfileLink,
+                'PERSONAL_PROFILE_LINK' => $profile_url,
             ];
             $notification->setTitleVar('buddy_notification_contact_request', [], 'buddysystem');
-            $notification->setShortDescriptionVar('buddy_notification_contact_request_short', $bodyParams, 'buddysystem');
-            $notification->setLongDescriptionVar('buddy_notification_contact_request_long', $bodyParams, 'buddysystem');
+            $notification->setShortDescriptionVar('buddy_notification_contact_request_short', $body_params, 'buddysystem');
+            $notification->setLongDescriptionVar('buddy_notification_contact_request_long', $body_params, 'buddysystem');
             $notification->setLinks($links);
             $notification->setValidForSeconds(ilNotificationConfig::TTL_LONG);
             $notification->setVisibleForSeconds(ilNotificationConfig::DEFAULT_TTS);
@@ -125,9 +115,9 @@ class ilBuddySystemNotification
 
     protected function hasPublicProfile(int $recipientUsrId): bool
     {
-        $portfolioId = ilObjPortfolio::getDefaultPortfolio($this->sender->getId());
-        if (is_numeric($portfolioId) && $portfolioId > 0) {
-            return (new ilPortfolioAccessHandler())->checkAccessOfUser($recipientUsrId, 'read', '', $portfolioId);
+        $portfolio_id = ilObjPortfolio::getDefaultPortfolio($this->sender->getId());
+        if (is_numeric($portfolio_id) && $portfolio_id > 0) {
+            return (new ilPortfolioAccessHandler())->checkAccessOfUser($recipientUsrId, 'read', '', $portfolio_id);
         }
 
         return (

--- a/components/ILIAS/Contact/src/URL/StaticUrlHandler.php
+++ b/components/ILIAS/Contact/src/URL/StaticUrlHandler.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Contact\URL;
+
+use ILIAS\StaticURL\Handler\BaseHandler;
+use ILIAS\StaticURL\Handler\Handler;
+use ILIAS\StaticURL\Request\Request;
+use ILIAS\StaticURL\Context;
+use ILIAS\StaticURL\Response\Factory;
+use ILIAS\StaticURL\Response\Response;
+use ILIAS\Data\ReferenceId;
+use ILIAS\User\Profile\PublicProfileGUI;
+
+class StaticUrlHandler extends BaseHandler implements Handler
+{
+    public const string NAMESPACE = 'contact';
+
+    private readonly \ilCtrlInterface $ctrl;
+    private readonly \ilObjUser $user;
+
+    public function __construct(
+        ?\ilCtrlInterface $ctrl = null,
+        ?\ilObjUser $user = null
+    ) {
+        global $DIC;
+
+        $this->ctrl = $ctrl ?? $DIC->ctrl();
+        $this->user = $user ?? $DIC->user();
+
+        parent::__construct();
+    }
+
+    public function getNamespace(): string
+    {
+        return self::NAMESPACE;
+    }
+
+    public function handle(Request $request, Context $context, Factory $response_factory): Response
+    {
+        if ($this->user->isAnonymous() || !$this->user->getId()) {
+            return $response_factory->loginFirst();
+        }
+
+        if (!\ilBuddySystem::getInstance()->isEnabled()) {
+            return $response_factory->cannot();
+        }
+
+        $params = implode('/', $request->getAdditionalParameters() ?? []);
+        $path = parse_url($params, PHP_URL_PATH);
+
+        return match ($path) {
+            'approve' => $response_factory->can($this->buildProfileUrl(
+                $context->ctrl(),
+                $request->getReferenceId(),
+                'approveContactRequest'
+            )),
+            'ignore' => $response_factory->can($this->buildProfileUrl(
+                $context->ctrl(),
+                $request->getReferenceId(),
+                'ignoreContactRequest'
+            )),
+            default => $response_factory->cannot(),
+        };
+    }
+
+    private function buildProfileUrl(
+        \ilCtrl $ctrl,
+        ?ReferenceId $target_user_id,
+        string $cmd
+    ): string {
+        if ($target_user_id === null) {
+            return $ctrl->getLinkTargetByClass(
+                [\ilDashboardGUI::class],
+                'jumpToProfile'
+            );
+        }
+
+        $ctrl->setParameterByClass(PublicProfileGUI::class, 'user_id', $target_user_id->toInt());
+
+        return $ctrl->getLinkTargetByClass([\ilPublicProfileBaseClassGUI::class, PublicProfileGUI::class], $cmd);
+    }
+}


### PR DESCRIPTION
This PR adds a dedicated "Contact"-specific URL handler for requests like `goto.php/contact/6/approve` or `goto.php/contact/6/ignore?osd_id=11` (initiated from a click on the HTML link elements in a "UI > Toast").

Currently, requests to approve or a ignore a contact request are handled by the "User" component. With this PR, all generated URLs in notifications will be handled by the "Contact" component.