### PR TITLE
Init: Introduce dedicated URL handler

### DIFF
--- a/components/ILIAS/Init/classes/class.ilPasswordAssistanceGUI.php
+++ b/components/ILIAS/Init/classes/class.ilPasswordAssistanceGUI.php
@@ -23,13 +23,13 @@ use ILIAS\HTTP\Services as HTTPServices;
 
 class ilPasswordAssistanceGUI implements ilCtrlSecurityInterface
 {
-    private const PERMANENT_LINK_TARGET_PW = 'pwassist';
-    private const PERMANENT_LINK_TARGET_NAME = 'nameassist';
+    private const string PERMANENT_LINK_TARGET_PW = 'password';
+    private const string PERMANENT_LINK_TARGET_NAME = 'username';
 
-    private const PROP_USERNAME = 'username';
-    private const PROP_EMAIL = 'email';
-    private const PROP_PASSWORD = 'password';
-    private const PROP_KEY = 'key';
+    private const string PROP_USERNAME = 'username';
+    private const string PROP_EMAIL = 'email';
+    private const string PROP_PASSWORD = 'password';
+    private const string PROP_KEY = 'key';
 
     private ilCtrlInterface $ctrl;
     private ilLanguage $lng;
@@ -852,6 +852,6 @@ class ilPasswordAssistanceGUI implements ilCtrlSecurityInterface
 
     private function fillPermanentLink(string $context): void
     {
-        $this->tpl->setPermanentLink('usr', null, $context);
+        $this->tpl->setPermanentLink('assistant', null, $context);
     }
 }

--- a/components/ILIAS/Init/src/URL/StaticUrlHandler.php
+++ b/components/ILIAS/Init/src/URL/StaticUrlHandler.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Init\URL;
+
+use ILIAS\StaticURL\Handler\BaseHandler;
+use ILIAS\StaticURL\Handler\Handler;
+use ILIAS\StaticURL\Request\Request;
+use ILIAS\StaticURL\Context;
+use ILIAS\StaticURL\Response\Factory;
+use ILIAS\StaticURL\Response\Response;
+
+class StaticUrlHandler extends BaseHandler implements Handler
+{
+    public const string NAMESPACE = 'assistant';
+
+    public function getNamespace(): string
+    {
+        return self::NAMESPACE;
+    }
+
+    public function handle(Request $request, Context $context, Factory $response_factory): Response
+    {
+        $settings = new \ilSetting();
+        if (!$settings->get('password_assistance', '0')) {
+            return $response_factory->cannot();
+        }
+
+        $path = implode('/', $request->getAdditionalParameters() ?? []);
+
+        return match ($path) {
+            'password' => $response_factory->can(
+                $context->ctrl()->getLinkTargetByClass(
+                    [
+                        \ilStartUpGUI::class,
+                        \ilPasswordAssistanceGUI::class
+                    ]
+                )
+            ),
+            'username' => $response_factory->can(
+                $context->ctrl()->getLinkTargetByClass(
+                    [
+                        \ilStartUpGUI::class,
+                        \ilPasswordAssistanceGUI::class
+                    ],
+                    'showUsernameAssistanceForm'
+                )
+            ),
+            default => $response_factory->cannot(),
+        };
+    }
+}


### PR DESCRIPTION
Previously, links for the password and username assistant were handled by the "User" component.
This change adds a dedicated handler for the "Init" component, which slightly modifies the supported/expected URL path segments.

Password Assistant:
- Old Static URL: /go/usr/pwassist
- New Static URL: /go/assistant/password

Username Assistant:
- Old Static URL: /go/usr/nameassist
- New Static URL: /go/assistant/username

This PR can be merged **after** JF approval.

Feature Request: https://docu.ilias.de/go/wiki/wpage_8817_1357