### PR TITLE
[FIX] #46596 UI: Fix wrongly stripped tags

### DIFF
--- a/components/ILIAS/UI/src/Component/Input/Field/Factory.php
+++ b/components/ILIAS/UI/src/Component/Input/Field/Factory.php
@@ -293,6 +293,9 @@ interface Factory
      *      A Tag Input MUST NOT be used when a User has to choose from a finite list of options
      *      which can't be extended by users Input, a Multi Select MUST be used in this case
      *     5: The tags provided SHOULD NOT have long titles (50 characters).
+     *     6: >
+     *      If withoutStripTags is set, the consumer MUST make sure the value
+     *      is proberly sanitized before outputing it.
      *
      * ---
      * @param string      $label

--- a/components/ILIAS/UI/src/Component/Input/Field/Tag.php
+++ b/components/ILIAS/UI/src/Component/Input/Field/Tag.php
@@ -70,6 +70,11 @@ interface Tag extends FormInput
      */
     public function withAsyncAutocomplete(URLBuilder $autocomplete_endpoint, URLBuilderToken $term_token): self;
 
+    /**
+     * Disable stripping tags from user input.
+     */
+    public function withoutStripTags(): self;
+
     // Events
 
     public function withAdditionalOnTagAdded(Signal $signal): self;

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Tag.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Tag.php
@@ -34,6 +34,7 @@ use ILIAS\UI\Implementation\Component\JavaScriptBindable;
 use ILIAS\UI\Implementation\Component\Triggerer;
 use ILIAS\UI\URLBuilder;
 use ILIAS\UI\URLBuilderToken;
+use Generator;
 
 /**
  * Class TagInput
@@ -59,6 +60,8 @@ class Tag extends FormInput implements C\Input\Field\Tag
     protected ?URLBuilder $async_autocomplete_endpoint = null;
     protected ?URLBuilderToken $async_autocomplete_token = null;
 
+    private bool $strip_tags = true;
+
     public function __construct(
         DataFactory $data_factory,
         \ILIAS\Refinery\Factory $refinery,
@@ -74,14 +77,8 @@ class Tag extends FormInput implements C\Input\Field\Tag
 
     protected function addAdditionalTransformations(): void
     {
-        $this->setAdditionalTransformation($this->refinery->string()->splitString(','));
-        $this->setAdditionalTransformation($this->refinery->custom()->transformation(function (array $v) {
-            if (count($v) == 1 && $v[0] === '') {
-                return [];
-            }
-            $array = array_map('rawurldecode', $v);
-            return array_map('strip_tags', $array);
-        }));
+        $map = static fn(string $s): array => array_filter(array_map('rawurldecode', explode(',', $s)));
+        $this->setAdditionalTransformation($this->refinery->custom()->transformation($map));
     }
 
     public function getConfiguration(): stdClass
@@ -348,5 +345,22 @@ class Tag extends FormInput implements C\Input\Field\Tag
 				il.UI.input.onFieldUpdate(event, '$id', $('#$id').val());
 			});
 			il.UI.input.onFieldUpdate(event, '$id', $('#$id').val());";
+    }
+
+    public function withoutStripTags(): self
+    {
+        $clone = clone $this;
+        $clone->strip_tags = false;
+        return $clone;
+    }
+
+    protected function getOperations(): Generator
+    {
+        yield from parent::getOperations();
+        if ($this->strip_tags) {
+            yield $this->refinery->container()->mapValues(
+                $this->refinery->custom()->transformation(strip_tags(...))
+            );
+        }
     }
 }

--- a/components/ILIAS/UI/tests/Component/Input/Field/TagInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/TagInputTest.php
@@ -303,4 +303,16 @@ class TagInputTest extends ILIAS_UI_TestBase
         $renderer = $this->getDefaultRenderer();
         $renderer->render($tag);
     }
+
+    public function testWithoutStripTags(): void
+    {
+        $tag = $this->getFieldFactory()->tag('my_tag', [])
+            ->withoutStripTags()
+            ->withNameFrom($this->name_source)
+            ->withInput(new DefInputData(['name_0' => '<member>']));
+
+        $result = $tag->getContent();
+        $this->assertTrue($result->isOk());
+        $this->assertSame(['<member>'], $result->value());
+    }
 }


### PR DESCRIPTION
This PR fixes Mantis Bug: https://mantis.ilias.de/view.php?id=46596

This PR removes the `strip_tags` call when transforming the tag input.
The value is escaped properly in the renderer as well so it can be removed in the Tag class itself (it is used in JS and there encoded as JSON):

<img width="669" height="241" alt="Screenshot 2026-01-06 at 14-25-54 Neue Nachricht ILIAS" src="https://github.com/user-attachments/assets/e7610c62-4c56-46fa-89ed-2c4518ee758e" />
