### PR TITLE
Fix mantis #46056: complex if statement results in $upload_dir becoming a boolean false

### DIFF
--- a/components/ILIAS/Filesystem/classes/class.ilUploadFiles.php
+++ b/components/ILIAS/Filesystem/classes/class.ilUploadFiles.php
@@ -48,7 +48,8 @@ class ilUploadFiles
      */
     public static function _getUploadFiles(): array
     {
-        if ($upload_dir = self::_getUploadDirectory() === '' || $upload_dir = self::_getUploadDirectory() === '0') {
+        $upload_dir = self::_getUploadDirectory();
+        if ($upload_dir === '' || $upload_dir === '0') {
             return [];
         }
 


### PR DESCRIPTION
Mantis: https://mantis.ilias.de/view.php?id=46056

If a valid file was found inside of [ext_data]/upload directory, $upload_dir took an invalid boolean value of the result of the if statement (false) resulting in "readdir(): Argument #1 ($dir_handle) must be of type resource or null, false given" later on.

I suggest not to try to determine the directory path and to validate it at the same time. 
It would also prevent multiple calls of the same function as a bonus.

Should probably fix the same issue in xAPI Object creation form as well (see https://mantis.ilias.de/view.php?id=46074)

PR for ILIAS 11 & TRUNK