### PR TITLE
UIComponent: Add PHP code for glyphs: select, unselect & clear

### DIFF
--- a/components/ILIAS/UI/src/Component/Symbol/Glyph/Factory.php
+++ b/components/ILIAS/UI/src/Component/Symbol/Glyph/Factory.php
@@ -1831,4 +1831,76 @@ interface Factory
      * @return  \ILIAS\UI\Component\Symbol\Glyph\Glyph
      */
     public function location(): Glyph;
+
+    /**
+     * ---
+     * description:
+     *   purpose: >
+     *      The Select Glyph indicates a chosen status (e.g. selected/included).
+     *   composition: >
+     *      The Select Glyph uses a checkmark.
+     * context:
+     *    - The Select Glyph can be used in combination with the Unselect Glyph & Clear Glyph to display a selection state of multiple items.
+     * rules:
+     *   accessibility:
+     *      1: >
+     *         The aria-label MUST be 'select'.
+     *   style:
+     *      1: >
+     *         The Select Glyph SHOULD display a checkmark.
+     *   usage:
+     *      1: >
+     *         The Select Glyph SHOULD be used to display a selection of multiple items.
+     * ---
+     * @return  \ILIAS\UI\Component\Symbol\Glyph\Glyph
+     */
+    public function select(): Glyph;
+
+    /**
+     * ---
+     * description:
+     *   purpose: >
+     *      The Unselect Glyph indicates that something does not belong to a selection or that nothing is selected.
+     *   composition: >
+     *      The Unselect Glyph uses an empty box.
+     * context:
+     *    - The Unselect Glyph can be used in combination with the Select & Clear Glyph to display a selection state of multiple items.
+     * rules:
+     *   accessibility:
+     *      1: >
+     *         The aria-label MUST be 'unselect'.
+     *   style:
+     *      1: >
+     *         The Unselect Glyph SHOULD display an empty box.
+     *   usage:
+     *      1: >
+     *         The Unselect Glyph SHOULD be used to display a selection state of multiple items.
+     * ---
+     * @return  \ILIAS\UI\Component\Symbol\Glyph\Glyph
+     */
+    public function unselect(): Glyph;
+
+    /**
+     * ---
+     * description:
+     *   purpose: >
+     *      The Clear Glyph indicates that a selection can be cleared.
+     *   composition: >
+     *      The Clear Glyph uses a horizontal line.
+     * context:
+     *    - The Clear Glyph can be used in combination with the Select & Unselect Glyph to display a selection state of multiple items.
+     * rules:
+     *   accessibility:
+     *      1: >
+     *         The aria-label MUST be 'clear'.
+     *   style:
+     *      1: >
+     *         The Clear Glyph SHOULD display a horizontal line.
+     *   usage:
+     *      1: >
+     *         The Clear Glyph SHOULD be used to display a selection state of multiple items.
+     * ---
+     * @return  \ILIAS\UI\Component\Symbol\Glyph\Glyph
+     */
+    public function clear(): Glyph;
 }

--- a/components/ILIAS/UI/src/Component/Symbol/Glyph/Glyph.php
+++ b/components/ILIAS/UI/src/Component/Symbol/Glyph/Glyph.php
@@ -88,6 +88,9 @@ interface Glyph extends Symbol, Clickable
     public const DRAG_HANDLE = "dragHandle";
     public const CHECKED = "checked";
     public const UNCHECKED = "unchecked";
+    public const SELECT = 'select';
+    public const UNSELECT = 'unselect';
+    public const CLEAR = 'clear';
 
     /**
      * Get the type of the glyph.

--- a/components/ILIAS/UI/src/Component/Symbol/Glyph/Glyph.php
+++ b/components/ILIAS/UI/src/Component/Symbol/Glyph/Glyph.php
@@ -90,6 +90,9 @@ interface Glyph extends Symbol
     public const OWNER = "owner";
     public const DATE = "date";
     public const LOCATION = "location";
+    public const SELECT = 'select';
+    public const UNSELECT = 'unselect';
+    public const CLEAR = 'clear';
 
     /**
      * Override the default label text with a more specific one

--- a/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/Factory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/Factory.php
@@ -323,4 +323,19 @@ class Factory implements G\Factory
     {
         return new Glyph(G\Glyph::UNCHECKED, "unchecked");
     }
+
+    public function select(): G\Glyph
+    {
+        return new Glyph(G\Glyph::SELECT, 'select');
+    }
+
+    public function unselect(): G\Glyph
+    {
+        return new Glyph(G\Glyph::UNSELECT, 'unselect');
+    }
+
+    public function clear(): G\Glyph
+    {
+        return new Glyph(G\Glyph::CLEAR, 'clear');
+    }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/Factory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/Factory.php
@@ -348,4 +348,19 @@ class Factory implements G\Factory
     {
         return new Glyph(G\Glyph::LOCATION, "location");
     }
+
+    public function select(): G\Glyph
+    {
+        return new Glyph(G\Glyph::SELECT, 'select');
+    }
+
+    public function unselect(): G\Glyph
+    {
+        return new Glyph(G\Glyph::UNSELECT, 'unselect');
+    }
+
+    public function clear(): G\Glyph
+    {
+        return new Glyph(G\Glyph::CLEAR, 'clear');
+    }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/Glyph.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/Glyph.php
@@ -94,6 +94,9 @@ class Glyph implements C\Symbol\Glyph\Glyph
         self::DRAG_HANDLE,
         self::CHECKED,
         self::UNCHECKED,
+        self::SELECT,
+        self::UNSELECT,
+        self::CLEAR,
     ];
 
     private string $type;

--- a/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/Glyph.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/Glyph.php
@@ -95,6 +95,9 @@ class Glyph implements C\Symbol\Glyph\Glyph
         self::OWNER,
         self::DATE,
         self::LOCATION,
+        self::SELECT,
+        self::UNSELECT,
+        self::CLEAR,
     ];
 
     private string $type;

--- a/components/ILIAS/UI/src/examples/Symbol/Glyph/Clear/clear.php
+++ b/components/ILIAS/UI/src/examples/Symbol/Glyph/Clear/clear.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Symbol\Glyph\Clear;
+
+/**
+ * ---
+ * description: >
+ *   Example for rendering a clear glyph.
+ *
+ * expected output: >
+ *   Standard output:
+ *   ILIAS shows a box with a horizontal line.
+ *
+ *   Highlighted:
+ *   ILIAS shows the same symbol, but it's highlighted particularly.
+ * ---
+ */
+function clear()
+{
+    global $DIC;
+
+    $f = $DIC->ui()->factory();
+    $glyph = $f->symbol()->glyph()->clear();
+
+    return $DIC->ui()->renderer()->render($f->listing()->descriptive([
+        'Standard' => $glyph,
+        'Highlighted' => $glyph->withHighlight(),
+    ]));
+}

--- a/components/ILIAS/UI/src/examples/Symbol/Glyph/Select/select.php
+++ b/components/ILIAS/UI/src/examples/Symbol/Glyph/Select/select.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Symbol\Glyph\Select;
+
+/**
+ * ---
+ * description: >
+ *   Example for rendering a select glyph.
+ *
+ * expected output: >
+ *   Standard output:
+ *   ILIAS shows a checkbox.
+ *
+ *   Highlighted:
+ *   ILIAS shows the same symbol, but it's highlighted particularly.
+ * ---
+ */
+function select()
+{
+    global $DIC;
+
+    $f = $DIC->ui()->factory();
+    $glyph = $f->symbol()->glyph()->select();
+
+    return $DIC->ui()->renderer()->render($f->listing()->descriptive([
+        'Standard' => $glyph,
+        'Highlighted' => $glyph->withHighlight(),
+    ]));
+}

--- a/components/ILIAS/UI/src/examples/Symbol/Glyph/Unselect/unselect.php
+++ b/components/ILIAS/UI/src/examples/Symbol/Glyph/Unselect/unselect.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Symbol\Glyph\Unselect;
+
+/**
+ * ---
+ * description: >
+ *   Example for rendering an unselect glyph.
+ *
+ * expected output: >
+ *   Standard output:
+ *   ILIAS shows an empty box.
+ *
+ *   Highlighted:
+ *   ILIAS shows the same symbol, but it's highlighted particularly.
+ * ---
+ */
+function unselect()
+{
+    global $DIC;
+
+    $f = $DIC->ui()->factory();
+    $glyph = $f->symbol()->glyph()->unselect();
+
+    return $DIC->ui()->renderer()->render($f->listing()->descriptive([
+        'Standard' => $glyph,
+        'Highlighted' => $glyph->withHighlight(),
+    ]));
+}

--- a/components/ILIAS/UI/src/templates/default/Symbol/tpl.glyph.html
+++ b/components/ILIAS/UI/src/templates/default/Symbol/tpl.glyph.html
@@ -59,6 +59,9 @@
 <!-- BEGIN dragHandle --> glyphicon-dragHandle<!-- END dragHandle -->
 <!-- BEGIN checked --> glyphicon-checked<!-- END checked -->
 <!-- BEGIN unchecked --> glyphicon-unchecked<!-- END unchecked -->
+<!-- BEGIN select --> glyphicon-select<!-- END select -->
+<!-- BEGIN unselect --> glyphicon-unselect<!-- END unselect -->
+<!-- BEGIN clear --> glyphicon-clear<!-- END clear -->
 " aria-hidden="true"></span>
 
 <!-- BEGIN counter_status -->

--- a/components/ILIAS/UI/src/templates/default/Symbol/tpl.glyph.html
+++ b/components/ILIAS/UI/src/templates/default/Symbol/tpl.glyph.html
@@ -63,6 +63,9 @@
 <!-- BEGIN presenter --> glyphicon-presenter<!-- END presenter -->
 <!-- BEGIN date --> glyphicon-date<!-- END date -->
 <!-- BEGIN location --> glyphicon-location<!-- END location -->
+<!-- BEGIN select --> glyphicon-select<!-- END select -->
+<!-- BEGIN unselect --> glyphicon-unselect<!-- END unselect -->
+<!-- BEGIN clear --> glyphicon-clear<!-- END clear -->
 " aria-hidden="true"></span>
 
 <!-- BEGIN counter_status -->

--- a/components/ILIAS/UI/tests/Component/Symbol/Glyph/GlyphTest.php
+++ b/components/ILIAS/UI/tests/Component/Symbol/Glyph/GlyphTest.php
@@ -106,6 +106,9 @@ class GlyphTest extends ILIAS_UI_TestBase
         G\Glyph::DRAG_HANDLE => "glyphicon glyphicon-dragHandle",
         G\Glyph::CHECKED => "glyphicon glyphicon-checked",
         G\Glyph::UNCHECKED => "glyphicon glyphicon-unchecked",
+        G\Glyph::SELECT => 'glyphicon glyphicon-select',
+        G\Glyph::UNSELECT => 'glyphicon glyphicon-unselect',
+        G\Glyph::CLEAR => 'glyphicon glyphicon-clear',
     );
 
     public static array $aria_labels = array(
@@ -169,6 +172,9 @@ class GlyphTest extends ILIAS_UI_TestBase
         G\Glyph::DRAG_HANDLE => "drag_handle",
         G\Glyph::CHECKED => "checked",
         G\Glyph::UNCHECKED => "unchecked",
+        G\Glyph::SELECT => 'select',
+        G\Glyph::UNSELECT => 'unselect',
+        G\Glyph::CLEAR => 'clear',
     );
 
     #[\PHPUnit\Framework\Attributes\DataProvider('getGlyphTypeProvider')]

--- a/components/ILIAS/UI/tests/Component/Symbol/Glyph/GlyphTest.php
+++ b/components/ILIAS/UI/tests/Component/Symbol/Glyph/GlyphTest.php
@@ -112,6 +112,9 @@ class GlyphTest extends ILIAS_UI_TestBase
         G\Glyph::OWNER => "glyphicon glyphicon-owner",
         G\Glyph::DATE => "glyphicon glyphicon-date",
         G\Glyph::LOCATION => "glyphicon glyphicon-location",
+        G\Glyph::SELECT => 'glyphicon glyphicon-select',
+        G\Glyph::UNSELECT => 'glyphicon glyphicon-unselect',
+        G\Glyph::CLEAR => 'glyphicon glyphicon-clear',
     );
 
     public static array $aria_labels = array(
@@ -179,6 +182,9 @@ class GlyphTest extends ILIAS_UI_TestBase
         G\Glyph::OWNER => "owner",
         G\Glyph::DATE => "date",
         G\Glyph::LOCATION => "location",
+        G\Glyph::SELECT => 'select',
+        G\Glyph::UNSELECT => 'unselect',
+        G\Glyph::CLEAR => 'clear',
     );
 
     #[\PHPUnit\Framework\Attributes\DataProvider('getGlyphTypeProvider')]


### PR DESCRIPTION
This PR adds the existing glyphs `select`, `unselect` & `clear` to the corresponding code places, so they can be used within PHP.

This issue implements one part of: https://mantis.ilias.de/view.php?id=40579
A second part to resolve the mantis issue will follow. 