### PR TITLE
[Admin] 46680: Footerlink „Technische Betreuung kontaktieren“

### DIFF
--- a/components/ILIAS/SystemFolder/classes/class.ilSystemSupportContactsGUI.php
+++ b/components/ILIAS/SystemFolder/classes/class.ilSystemSupportContactsGUI.php
@@ -76,59 +76,90 @@ class ilSystemSupportContactsGUI implements ilCtrlBaseClassInterface
         $this->tpl->loadStandardTemplate();
         $this->tpl->setTitle($this->lng->txt("adm_support_contacts"));
 
-        $html = "";
-        foreach (ilSystemSupportContacts::getValidSupportContactIds() as $c) {
-            $pgui = new ilPublicUserProfileGUI($c);
-            //$pgui->setBackUrl($this->ctrl->getLinkTargetByClass("ilinfoscreengui"));
-            $pgui->setEmbedded(true);
-            $html .= $pgui->getHTML();
-        }
-
-        $f = $this->ui->factory();
-        $r = $this->ui->renderer();
-        $p = $f->panel()->standard(
-            $this->lng->txt("adm_support_contacts"),
-            $f->legacy($html)
-        );
-
-        $this->tpl->setContent($r->render($p));
-        $this->tpl->printToStdout();
-    }
-
-    public static function getFooterLink(): null|URI|string
-    {
-        global $DIC;
-
-        $ilCtrl = $DIC->ctrl();
-        $ilUser = $DIC->user();
-        $uri = $DIC->http()->request()->getUri();
-
-        $users = ilSystemSupportContacts::getValidSupportContactIds();
-        if (count($users) > 0) {
-            // #17847 - we cannot use a proper GUI on the login screen
-            if (!$ilUser->getId() || $ilUser->getId() == ANONYMOUS_USER_ID) {
-                return "mailto:" . ilLegacyFormElementsUtil::prepareFormOutput(
-                    ilSystemSupportContacts::getMailsToAddress()
-                );
-            } else {
-                $path = $ilCtrl->getLinkTargetByClass("ilsystemsupportcontactsgui", "", "", false, false);
-                return new URI($uri->getScheme() . '://' . $uri->getHost() . '/' . $path);
+        $content = [];
+        if (self::isAnonymous() && !self::globalProfilesEnabled()) {
+            $mails = [];
+            foreach (ilSystemSupportContacts::getValidSupportContactIds() as $user_id) {
+                $mail = ilObjUser::_lookupEmail($user_id);
+                if ($mail) {
+                    $mails[] = $mail;
+                }
+            }
+            $content[] = $this->ui->factory()->listing()->unordered(array_unique($mails));
+        } else {
+            foreach (ilSystemSupportContacts::getValidSupportContactIds() as $user_id) {
+                if (self::isProfileVisible($user_id)) {
+                    $pgui = new ilPublicUserProfileGUI($user_id);
+                    $pgui->setEmbedded(true);
+                    $content[] = $this->ui->factory()->legacy($pgui->getHTML());
+                }
             }
         }
 
+        $panel = $this->ui->factory()->panel()->standard(
+            $this->lng->txt("adm_support_contacts"),
+            $content
+        );
+
+        $this->tpl->setContent($this->ui->renderer()->render($panel));
+        $this->tpl->printToStdout();
+    }
+
+
+    /**
+     * Get a contact link to be shown in the footer
+     */
+    public static function getFooterLink(): ?string
+    {
+        global $DIC;
+        if (!empty(ilSystemSupportContacts::getValidSupportContactIds())) {
+            return $DIC->ctrl()->getLinkTargetByClass(self::class);
+        }
         return null;
     }
 
     /**
-     * Get footer text
-     *
-     * @return string footer text
+     * Get the text for a contact link to be shown in the footer
      */
-    public static function getFooterText()
+    public static function getFooterText(): string
     {
         global $DIC;
+        return $DIC->language()->txt("contact_sysadmin");
+    }
 
-        $lng = $DIC->language();
-        return $lng->txt("contact_sysadmin");
+    /**
+     * Check if the profile of a user can be shown
+     * - if it is published for www
+     * - OR if it is published for users and the current user is logged in
+     */
+    public static function isProfileVisible(int $user_id): bool
+    {
+        $user = new ilObjUser($user_id);
+        $public = $user->getPref('public_profile');
+
+        if (self::isAnonymous()) {
+            return $public === 'g' && self::globalProfilesEnabled();
+        } else {
+            return $public === 'g' || $public === 'y';
+        }
+    }
+
+    /**
+     * Check if the current user is anonymous
+     */
+    private static function isAnonymous(): bool
+    {
+        global $DIC;
+        $current_user_id = $DIC->user()->getId();
+        return $current_user_id === 0 || $current_user_id === ANONYMOUS_USER_ID;
+    }
+
+    /**
+     * Check if user profiles can be shown to anonymous users
+     */
+    private static function globalProfilesEnabled(): bool
+    {
+        global $DIC;
+        return $DIC->settings()->get('enable_global_profiles');
     }
 }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=46680

This PR removes the workaround of showing a "mailto:" address in the footer to anonymous user, since:

- mailto addresses are not supported by the footer
- a global profile GUI can be shown to anonymous users, if global profles are enabled

If technical contacts are configured, the link in the footer will always lead to a GUI for showing them.

- Logged in users will see the profiles of technical contacts that are published for users or www
- The anonymous user will see the profiles of contacts that are published for www

If a user is not logged in and global profiles are disabled for anonymous access, the GUI will just list the e-mail addresses of the technical contacts, even if they haven't published their profiles. This equals to the previous behavior and to their usage for "mailto:" links in the self registration and the user agreement.


