### PR TITLE
[Improvement] UI: Adds onloadCode to ViewControl Mode

### DIFF
--- a/components/ILIAS/UI/src/Component/ViewControl/Mode.php
+++ b/components/ILIAS/UI/src/Component/ViewControl/Mode.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 namespace ILIAS\UI\Component\ViewControl;
 
 use ILIAS\UI\Component\Component;
+use ILIAS\UI\Component\JavaScriptBindable;
+use Closure;
 
 /**
  * This describes a Mode Control
@@ -52,4 +54,19 @@ interface Mode extends Component
     * Get the aria-label on the ViewControl
     */
     public function getAriaLabel(): string;
+
+    public function withOnLoadCodeForAction(string $label, Closure $binder): static;
+    public function withAdditionalOnLoadCodeForAction(string $label, Closure $binder): static;
+
+    /**
+     * @param array<string, Closure> $label_binder_map
+     */
+    public function withOnLoadCodeForActions(array $label_binder_map): static;
+
+    /**
+     * @param array<string, Closure> $label_binder_map
+     */
+    public function withAdditionalOnLoadCodeForActions(array $label_binder_map): static;
+
+    public function getOnLoadCodeForAction(string $label): ?Closure;
 }

--- a/components/ILIAS/UI/src/Implementation/Component/ViewControl/Mode.php
+++ b/components/ILIAS/UI/src/Implementation/Component/ViewControl/Mode.php
@@ -22,6 +22,10 @@ namespace ILIAS\UI\Implementation\Component\ViewControl;
 
 use ILIAS\UI\Component as C;
 use ILIAS\UI\Implementation\Component\ComponentHelper;
+use Closure;
+use ILIAS\UI\Implementation\Component\JavaScriptBindable;
+use ReflectionFunction;
+use InvalidArgumentException;
 
 class Mode implements C\ViewControl\Mode
 {
@@ -30,6 +34,8 @@ class Mode implements C\ViewControl\Mode
     protected array $labeled_actions;
     protected string $aria_label;
     protected ?string $active = null;
+    /** @var Closure[] */
+    private array $on_load_code_binder_by_label = [];
 
     public function __construct($labelled_actions, string $aria_label)
     {
@@ -57,5 +63,71 @@ class Mode implements C\ViewControl\Mode
     public function getAriaLabel(): string
     {
         return $this->aria_label;
+    }
+
+    public function withOnLoadCodeForAction(string $label, Closure $binder): static
+    {
+        $this->checkLabelExists($label);
+        $this->checkBinder($binder);
+        $clone = clone $this;
+        $clone->on_load_code_binder_by_label[$label] = $binder;
+        return $clone;
+    }
+
+    public function withAdditionalOnLoadCodeForAction(string $label, Closure $binder): static
+    {
+        $current_binder = $this->getOnLoadCodeForAction($label);
+        if ($current_binder === null) {
+            return $this->withOnLoadCodeForAction($label, $binder);
+        }
+
+        $this->checkLabelExists($label);
+        $this->checkBinder($binder);
+        return $this->withOnLoadCodeForAction($label, static fn($id) => $binder($id) . "\n" . $current_binder($id));
+    }
+
+    public function getOnLoadCodeForAction(string $label): ?Closure
+    {
+        return $this->on_load_code_binder_by_label[$label] ?? null;
+    }
+
+    /**
+     * @throws \InvalidArgumentException if closure does not take one argument
+     */
+    private function checkBinder(Closure $binder): void
+    {
+        $refl = new ReflectionFunction($binder);
+        $args = array_map(static fn($arg) => $arg->name, $refl->getParameters());
+        if (array("id") !== $args) {
+            throw new InvalidArgumentException('Expected closure "$binder" to have exactly one argument "$id".');
+        }
+    }
+
+    /**
+     * @throws InvalidArgumentException if the label does not exist
+     */
+    private function checkLabelExists(string $label): void
+    {
+        if (!array_key_exists($label, $this->labeled_actions)) {
+            throw new InvalidArgumentException("Label '$label' does not exist in Mode control.");
+        }
+    }
+
+    public function withOnLoadCodeForActions(array $label_binder_map): static
+    {
+        $clone = clone $this;
+        foreach ($label_binder_map as $label => $binder) {
+            $clone = $clone->withOnLoadCodeForAction($label, $binder);
+        }
+        return $clone;
+    }
+
+    public function withAdditionalOnLoadCodeForActions(array $label_binder_map): static
+    {
+        $clone = clone $this;
+        foreach ($label_binder_map as $label => $binder) {
+            $clone = $clone->withAdditionalOnLoadCodeForAction($label, $binder);
+        }
+        return $clone;
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/ViewControl/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/ViewControl/Renderer.php
@@ -74,6 +74,9 @@ class Renderer extends AbstractComponentRenderer
             $tpl->setCurrentBlock("view_control");
 
             $button = $f->button()->standard($label, $action);
+            if ($action = $component->getOnLoadCodeForAction($label)) {
+                $button = $button->withOnLoadCode($action);
+            }
             if ($activate_first_item) {
                 $button = $button->withEngagedState(true);
                 $activate_first_item = false;


### PR DESCRIPTION
While implementing a bugfix for Mail [(Mantis #0046784)](https://mantis.ilias.de/view.php?id=46784), we encountered a need to add JavaScript onloadCode handling in the ViewControl\Mode class.

In this case, the Mode switch must trigger form submission when changing modes (e.g. saving a draft before switching).

To achieve this, Mode now supports adding onloadCode snippets to the underlying buttons/labels rendered by the control.

Instead of making Mode itself JavaScript-bindable, we delegate the JS functionality to its child elements (Buttons), which already support JS bindings.

During rendering, Mode injects the respective event bindings into the buttons, enabling custom behavior without altering the existing control structure.

FYI @mjansenDatabay 

It would be nice to have this for release_11 as well

Best @fhelfer