### PR TITLE
[Fix] #0046784 Mail: Placeholder Checkbox missing

### DIFF
--- a/components/ILIAS/Mail/classes/class.ilMailFormGUI.php
+++ b/components/ILIAS/Mail/classes/class.ilMailFormGUI.php
@@ -360,7 +360,7 @@ class ilMailFormGUI
             ilUtil::securePlainString($value['m_subject']),
             $value['m_message'],
             $files,
-            $value['use_placeholders'],
+            $value['use_placeholders']
         )
         ) {
             $this->showSubmissionErrors($errors);
@@ -1035,6 +1035,7 @@ class ilMailFormGUI
         $signal = null;
         if (ilMailFormCall::getContextId()) {
             $context_id = ilMailFormCall::getContextId();
+            $use_placeholder_value = true;
 
             try {
                 $context = ilMailTemplateContextService::getTemplateContextById($context_id);
@@ -1077,9 +1078,11 @@ class ilMailFormGUI
                     __METHOD__,
                     $context_id
                 ));
+                $context = new ilMailTemplateGenericContext();
             }
         } else {
             $context = new ilMailTemplateGenericContext();
+            $use_placeholder_value = $mail_data['use_placeholders'] ?? false;
         }
 
         $m_subject = $ff
@@ -1101,7 +1104,6 @@ class ilMailFormGUI
             $this->lng->txt('message_content')
         )->withValue($mail_data['m_message'] ?? '');
 
-        $use_placeholder_value = $mail_data['use_placeholders'] ?? $this->mail_form_type === self::MAIL_FORM_TYPE_ROLE;
         $mode = $use_placeholder_value ? self::MAIL_FORM_MODE_SERIAL_LETTER : self::MAIL_FORM_MODE_REGULAR_MAIL;
         $use_placeholders = $ff->hidden()->withValue($use_placeholder_value ? '1' : '0');
         $placeholders = [];
@@ -1353,14 +1355,15 @@ class ilMailFormGUI
     public function toggleMailMode(): void
     {
         $form = $this->buildForm()->withRequest($this->request);
-
         $mode = $this->getQueryParam('mail_form_mail_mode', $this->refinery->kindlyTo()->string(), self::MAIL_FORM_MODE_REGULAR_MAIL);
-        if (in_array($mode, [self::MAIL_FORM_MODE_REGULAR_MAIL, self::MAIL_FORM_MODE_SERIAL_LETTER], true)) {
+        if (!ilMailFormCall::getContextId() && in_array($mode, [self::MAIL_FORM_MODE_REGULAR_MAIL, self::MAIL_FORM_MODE_SERIAL_LETTER], true)) {
             $result = $form->getInputGroup()->getInputs()[0]->getInputs();
             $result['use_placeholders'] = $result['use_placeholders']->withValue($mode === self::MAIL_FORM_MODE_SERIAL_LETTER ? '1' : '0');
+        } elseif (ilMailFormCall::getContextId() && $mode === self::MAIL_FORM_MODE_REGULAR_MAIL) {
+            $this->tpl->setOnScreenMessage($this->tpl::MESSAGE_TYPE_FAILURE, $this->lng->txt('mail_template_context_mode_fixed'), true);
         }
-        $this->saveMailBeforeSearch($result ?? null);
 
-        $this->searchResults();
+        $this->saveMailBeforeSearch($result ?? null);
+        $this->ctrl->redirect($this, 'searchResults');
     }
 }

--- a/components/ILIAS/Mail/classes/class.ilMailFormGUI.php
+++ b/components/ILIAS/Mail/classes/class.ilMailFormGUI.php
@@ -35,6 +35,8 @@ use ILIAS\Mail\RecipientSearch\UserSearchEndpointConfigurator;
 use ILIAS\Data\Clock\ClockFactory;
 use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Mail\Folder\MailScheduleData;
+use ILIAS\UI\URLBuilder;
+use ILIAS\Data\URI;
 
 /**
  * @ilCtrl_Calls ilMailFormGUI: ilMailAttachmentGUI, ilMailSearchGUI, ilMailSearchCoursesGUI, ilMailSearchGroupsGUI, ilMailingListsGUI, ilMailFormUploadHandlerGUI
@@ -53,6 +55,8 @@ class ilMailFormGUI
     final public const string MAIL_FORM_TYPE_FORWARD = 'forward';
     final public const string MAIL_FORM_TYPE_DRAFT = 'draft';
     final public const string MAIL_FORM_TYPE_OUTBOX = 'outbox';
+    final public const string MAIL_FORM_MODE_REGULAR_MAIL = 'regular_mail';
+    final public const string MAIL_FORM_MODE_SERIAL_LETTER = 'serial_letter';
 
     private readonly ilGlobalTemplateInterface $tpl;
     private readonly ilCtrlInterface $ctrl;
@@ -275,7 +279,7 @@ class ilMailFormGUI
                     ilUtil::securePlainString($form_values['m_subject'] ?? $this->lng->txt('mail_no_subject')),
                     $sanitized_message,
                     $files,
-                    $form_values['use_placeholders'],
+                    ilSession::get('mail_mode') === self::MAIL_FORM_MODE_SERIAL_LETTER,
                     $outbox_id ?? null
                 ),
                 $form_values['use_schedule']['m_schedule']
@@ -356,7 +360,7 @@ class ilMailFormGUI
             ilUtil::securePlainString($value['m_subject']),
             $value['m_message'],
             $files,
-            $value['use_placeholders']
+            ilSession::get('mail_mode') === self::MAIL_FORM_MODE_SERIAL_LETTER,
         )
         ) {
             $this->showSubmissionErrors($errors);
@@ -456,7 +460,7 @@ class ilMailFormGUI
             $value['m_message'],
             $draft_id,
             $value['use_schedule']['m_schedule'] ?? null,
-            $value['use_placeholders'],
+            ilSession::get('mail_mode') === self::MAIL_FORM_MODE_SERIAL_LETTER,
             ilMailFormCall::getContextId(),
             ilMailFormCall::getContextParameters()
         );
@@ -746,6 +750,7 @@ class ilMailFormGUI
                 break;
 
             case self::MAIL_FORM_TYPE_NEW:
+                ilSession::clear('mail_mode');
                 ilSession::clear('draft');
                 ilSession::clear('outbox');
                 // Note: For security reasons, ILIAS only allows Plain text strings in E-Mails.
@@ -783,6 +788,7 @@ class ilMailFormGUI
                 break;
 
             case self::MAIL_FORM_TYPE_ROLE:
+                ilSession::set('mail_mode', self::MAIL_FORM_MODE_SERIAL_LETTER);
                 $roles = [];
                 if ($this->http->wrapper()->post()->has('roles')) {
                     $roles = $this->http->wrapper()->post()->retrieve(
@@ -933,7 +939,7 @@ class ilMailFormGUI
             ilUtil::securePlainString($result['m_subject']->getValue()),
             ilUtil::securePlainString($result['m_message']->getValue()),
             $resource_collection_id,
-            (bool) $result['use_placeholders']->getValue(),
+            ilSession::get('mail_mode') === self::MAIL_FORM_MODE_SERIAL_LETTER,
             ilMailFormCall::getContextId(),
             ilMailFormCall::getContextParameters()
         );
@@ -1093,24 +1099,22 @@ class ilMailFormGUI
             $this->lng->txt('message_content')
         )->withValue($mail_data['m_message'] ?? '');
 
-        $use_placeholders = $ff->hidden()->withValue('0');
+        $mode = ilSession::get('mail_mode') ?: self::MAIL_FORM_MODE_REGULAR_MAIL;
         $placeholders = [];
-        foreach ($context->getPlaceholders() as $key => $value) {
-            $placeholders[$value['placeholder']] = $value['label'];
+        if ($mode === self::MAIL_FORM_MODE_SERIAL_LETTER) {
+            foreach ($context->getPlaceholders() as $key => $value) {
+                $placeholders[$value['placeholder']] = $value['label'];
+            }
+            if (count($placeholders) > 0) {
+                $m_message = $m_message
+                    ->withMustacheVariables(
+                        $placeholders,
+                        $this->lng->txt('mail_nacc_use_placeholder') . '<br />'
+                        . sprintf($this->lng->txt('placeholders_advise'), '<br />')
+                    )
+                ;
+            }
         }
-        if (count($placeholders) > 0) {
-            $m_message = $m_message
-                ->withMustacheVariables(
-                    $placeholders,
-                    $this->lng->txt('mail_nacc_use_placeholder') . '<br />'
-                    . sprintf($this->lng->txt('placeholders_advise'), '<br />')
-                )
-            ;
-            $use_placeholders = $use_placeholders->withValue('1');
-        }
-        $use_placeholders = $use_placeholders->withAdditionalTransformation(
-            $this->refinery->kindlyTo()->bool()
-        );
 
         if ($signal !== null) {
             $m_subject = $m_subject->withAdditionalOnLoadCode(
@@ -1200,7 +1204,6 @@ class ilMailFormGUI
 
         $elements['use_schedule'] = $use_schedule_input;
 
-        $elements['use_placeholders'] = $use_placeholders;
         $section = $ff->section(
             $elements,
             $this->lng->txt('compose')
@@ -1218,16 +1221,7 @@ class ilMailFormGUI
         $action = $this->ctrl->getFormAction($this, 'searchUsers');
         $btn = $bf->standard(
             $this->lng->txt('search_recipients'),
-            ''
-        )->withAdditionalOnLoadCode(
-            function ($id) use ($action) {
-                return "document.getElementById('{$id}').addEventListener('click', function (event) {
-                    let mailform = document.querySelector('form.c-form');
-                    let btn = mailform.querySelector('button');
-                    btn.formAction = '{$action}'; 
-                    mailform.requestSubmit(btn);   
-                });";
-            }
+            $action,
         );
 
         $this->toolbar->addComponent($btn);
@@ -1235,32 +1229,14 @@ class ilMailFormGUI
         $action = $this->ctrl->getFormAction($this, 'searchCoursesTo');
         $btn = $bf->standard(
             $this->lng->txt('mail_my_courses'),
-            ''
-        )->withAdditionalOnLoadCode(
-            function ($id) use ($action) {
-                return "document.getElementById('{$id}').addEventListener('click', function (event) {
-                    let mailform = document.querySelector('form.c-form');
-                    let btn = mailform.querySelector('button');
-                    btn.formAction = '{$action}'; 
-                    mailform.requestSubmit(btn);   
-                });";
-            }
+            $action,
         );
         $this->toolbar->addComponent($btn);
 
         $action = $this->ctrl->getFormAction($this, 'searchGroupsTo');
         $btn = $bf->standard(
             $this->lng->txt('mail_my_groups'),
-            ''
-        )->withAdditionalOnLoadCode(
-            function ($id) use ($action) {
-                return "document.getElementById('{$id}').addEventListener('click', function (event) {
-                    let mailform = document.querySelector('form.c-form');
-                    let btn = mailform.querySelector('button');
-                    btn.formAction = '{$action}'; 
-                    mailform.requestSubmit(btn);   
-                });";
-            }
+            $action
         );
         $this->toolbar->addComponent($btn);
 
@@ -1268,16 +1244,7 @@ class ilMailFormGUI
             $action = $this->ctrl->getFormAction($this, 'searchMailingListsTo');
             $btn = $bf->standard(
                 $this->lng->txt('mail_my_mailing_lists'),
-                ''
-            )->withAdditionalOnLoadCode(
-                function ($id) use ($action) {
-                    return "document.getElementById('{$id}').addEventListener('click', function (event) {
-                    let mailform = document.querySelector('form.c-form');
-                    let btn = mailform.querySelector('button');
-                    btn.formAction = '{$action}'; 
-                    mailform.requestSubmit(btn);   
-                });";
-                }
+                $action
             );
             $this->toolbar->addComponent($btn);
         }
@@ -1285,17 +1252,56 @@ class ilMailFormGUI
         $action = $this->ctrl->getFormAction($this, 'editAttachments');
         $btn = $bf->standard(
             $this->lng->txt('edit_attachments'),
-            ''
-        )->withAdditionalOnLoadCode(
-            function ($id) use ($action) {
-                return "document.getElementById('{$id}').addEventListener('click', function (event) {
-                    let mailform = document.querySelector('form.c-form');
-                    let btn = mailform.querySelector('button');
-                    btn.formAction = '{$action}'; 
-                    mailform.requestSubmit(btn);   
-                });";
-            }
+            $action
         );
         $this->toolbar->addComponent($btn);
+
+        $current_mode = ilSession::get('mail_mode') ?: self::MAIL_FORM_MODE_REGULAR_MAIL;
+        $action = $this->ctrl->getFormAction($this, 'toggleMailMode');
+        $url_builder = new UrlBuilder(new URI(ILIAS_HTTP_PATH . '/' . $action));
+        [$url_builder, $mail_mode_parameter] = $url_builder->acquireParameter(['mail', 'form'], 'mail_mode');
+        $btn = $this->ui_factory->viewControl()->mode(
+            [
+                $this->lng->txt(self::MAIL_FORM_MODE_REGULAR_MAIL) => (string) $url_builder->withParameter($mail_mode_parameter, self::MAIL_FORM_MODE_REGULAR_MAIL)->buildURI(),
+                $this->lng->txt(self::MAIL_FORM_MODE_SERIAL_LETTER) => (string) $url_builder->withParameter($mail_mode_parameter, self::MAIL_FORM_MODE_SERIAL_LETTER)->buildURI(),
+            ],
+            'Modes'
+        )->withActive($this->lng->txt($current_mode));
+        $this->toolbar->addComponent($btn);
+
+        $this->tpl->addOnLoadCode(
+            "document.getElementById('{$this->toolbar->getId()}').querySelectorAll('button').forEach(function(button) {
+                button.addEventListener('click', function(event) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    event.stopImmediatePropagation();
+                    
+                    let mailform = document.querySelector('form.c-form');
+                    let action = button.getAttribute('data-action');
+                    if (action && mailform) {
+                        let submitBtn = mailform.querySelector('button[type=\"submit\"]');
+                        if (submitBtn) {
+                            submitBtn.formAction = action;
+                            mailform.requestSubmit(btn);   
+                        } else {
+                            mailform.action = action;
+                            mailform.submit();
+                        }
+                    }
+                    return false;
+                }, true);
+            });"
+        );
+    }
+
+    public function toggleMailMode(): void
+    {
+        $this->saveMailBeforeSearch();
+
+        $mode = $this->getQueryParam('mail_form_mail_mode', $this->refinery->kindlyTo()->string(), self::MAIL_FORM_MODE_REGULAR_MAIL);
+        if (in_array($mode, [self::MAIL_FORM_MODE_REGULAR_MAIL, self::MAIL_FORM_MODE_SERIAL_LETTER], true)) {
+            ilSession::set('mail_mode', $mode);
+        }
+        $this->searchResults();
     }
 }

--- a/components/ILIAS/Mail/classes/class.ilMailFormGUI.php
+++ b/components/ILIAS/Mail/classes/class.ilMailFormGUI.php
@@ -279,7 +279,7 @@ class ilMailFormGUI
                     ilUtil::securePlainString($form_values['m_subject'] ?? $this->lng->txt('mail_no_subject')),
                     $sanitized_message,
                     $files,
-                    ilSession::get('mail_mode') === self::MAIL_FORM_MODE_SERIAL_LETTER,
+                    $form_values['use_placeholders'],
                     $outbox_id ?? null
                 ),
                 $form_values['use_schedule']['m_schedule']
@@ -360,7 +360,7 @@ class ilMailFormGUI
             ilUtil::securePlainString($value['m_subject']),
             $value['m_message'],
             $files,
-            ilSession::get('mail_mode') === self::MAIL_FORM_MODE_SERIAL_LETTER,
+            $value['use_placeholders'],
         )
         ) {
             $this->showSubmissionErrors($errors);
@@ -460,7 +460,7 @@ class ilMailFormGUI
             $value['m_message'],
             $draft_id,
             $value['use_schedule']['m_schedule'] ?? null,
-            ilSession::get('mail_mode') === self::MAIL_FORM_MODE_SERIAL_LETTER,
+            $value['use_placeholders'],
             ilMailFormCall::getContextId(),
             ilMailFormCall::getContextParameters()
         );
@@ -750,7 +750,6 @@ class ilMailFormGUI
                 break;
 
             case self::MAIL_FORM_TYPE_NEW:
-                ilSession::clear('mail_mode');
                 ilSession::clear('draft');
                 ilSession::clear('outbox');
                 // Note: For security reasons, ILIAS only allows Plain text strings in E-Mails.
@@ -788,7 +787,6 @@ class ilMailFormGUI
                 break;
 
             case self::MAIL_FORM_TYPE_ROLE:
-                ilSession::set('mail_mode', self::MAIL_FORM_MODE_SERIAL_LETTER);
                 $roles = [];
                 if ($this->http->wrapper()->post()->has('roles')) {
                     $roles = $this->http->wrapper()->post()->retrieve(
@@ -856,10 +854,10 @@ class ilMailFormGUI
         }
 
         $this->tpl->parseCurrentBlock();
-        $this->addToolbarButtons();
         if ($form === null) {
             $form = $this->buildForm($mail_data);
         }
+        $this->addToolbarButtons($form);
         $this->tpl->setVariable('FORM', $this->ui_renderer->render($form));
         $this->tpl->addJavaScript('assets/js/ilMailComposeFunctions.js');
         $this->tpl->printToStdout();
@@ -915,10 +913,14 @@ class ilMailFormGUI
         $this->showForm();
     }
 
-    protected function saveMailBeforeSearch(): void
+    protected function saveMailBeforeSearch(?array $input_results = null): void
     {
-        $form = $this->buildForm()->withRequest($this->request);
-        $result = $form->getInputGroup()->getInputs()[0]->getInputs();
+        if (!$input_results) {
+            $form = $this->buildForm()->withRequest($this->request);
+            $result = $form->getInputGroup()->getInputs()[0]->getInputs();
+        } else {
+            $result = $input_results;
+        }
 
         $resource_collection_id = null;
         $attachments = $result['attachments']->getValue();
@@ -939,7 +941,7 @@ class ilMailFormGUI
             ilUtil::securePlainString($result['m_subject']->getValue()),
             ilUtil::securePlainString($result['m_message']->getValue()),
             $resource_collection_id,
-            ilSession::get('mail_mode') === self::MAIL_FORM_MODE_SERIAL_LETTER,
+            (bool) $result['use_placeholders']->getValue(),
             ilMailFormCall::getContextId(),
             ilMailFormCall::getContextParameters()
         );
@@ -1099,7 +1101,9 @@ class ilMailFormGUI
             $this->lng->txt('message_content')
         )->withValue($mail_data['m_message'] ?? '');
 
-        $mode = ilSession::get('mail_mode') ?: self::MAIL_FORM_MODE_REGULAR_MAIL;
+        $use_placeholder_value = $mail_data['use_placeholders'] ?? $this->mail_form_type === self::MAIL_FORM_TYPE_ROLE;
+        $mode = $use_placeholder_value ? self::MAIL_FORM_MODE_SERIAL_LETTER : self::MAIL_FORM_MODE_REGULAR_MAIL;
+        $use_placeholders = $ff->hidden()->withValue($use_placeholder_value ? '1' : '0');
         $placeholders = [];
         if ($mode === self::MAIL_FORM_MODE_SERIAL_LETTER) {
             foreach ($context->getPlaceholders() as $key => $value) {
@@ -1115,6 +1119,10 @@ class ilMailFormGUI
                 ;
             }
         }
+        $use_placeholders = $use_placeholders->withAdditionalTransformation(
+            $this->refinery->kindlyTo()->bool()
+        );
+
 
         if ($signal !== null) {
             $m_subject = $m_subject->withAdditionalOnLoadCode(
@@ -1204,6 +1212,7 @@ class ilMailFormGUI
 
         $elements['use_schedule'] = $use_schedule_input;
 
+        $elements['use_placeholders'] = $use_placeholders;
         $section = $ff->section(
             $elements,
             $this->lng->txt('compose')
@@ -1214,14 +1223,23 @@ class ilMailFormGUI
         ];
     }
 
-    protected function addToolbarButtons(): void
+    protected function addToolbarButtons(Form $form): void
     {
         $bf = $this->ui_factory->button();
 
         $action = $this->ctrl->getFormAction($this, 'searchUsers');
         $btn = $bf->standard(
             $this->lng->txt('search_recipients'),
-            $action,
+            '',
+        )->withAdditionalOnLoadCode(
+            function ($id) use ($action) {
+                return "document.getElementById('{$id}').addEventListener('click', function (event) {
+                    let mailform = document.querySelector('form.c-form');
+                    let btn = mailform.querySelector('button');
+                    btn.formAction = '{$action}'; 
+                    mailform.requestSubmit(btn);   
+                });";
+            }
         );
 
         $this->toolbar->addComponent($btn);
@@ -1229,14 +1247,32 @@ class ilMailFormGUI
         $action = $this->ctrl->getFormAction($this, 'searchCoursesTo');
         $btn = $bf->standard(
             $this->lng->txt('mail_my_courses'),
-            $action,
+            ''
+        )->withAdditionalOnLoadCode(
+            function ($id) use ($action) {
+                return "document.getElementById('{$id}').addEventListener('click', function (event) {
+                    let mailform = document.querySelector('form.c-form');
+                    let btn = mailform.querySelector('button');
+                    btn.formAction = '{$action}'; 
+                    mailform.requestSubmit(btn);   
+                });";
+            }
         );
         $this->toolbar->addComponent($btn);
 
         $action = $this->ctrl->getFormAction($this, 'searchGroupsTo');
         $btn = $bf->standard(
             $this->lng->txt('mail_my_groups'),
-            $action
+            ''
+        )->withAdditionalOnLoadCode(
+            function ($id) use ($action) {
+                return "document.getElementById('{$id}').addEventListener('click', function (event) {
+                    let mailform = document.querySelector('form.c-form');
+                    let btn = mailform.querySelector('button');
+                    btn.formAction = '{$action}'; 
+                    mailform.requestSubmit(btn);   
+                });";
+            }
         );
         $this->toolbar->addComponent($btn);
 
@@ -1244,7 +1280,16 @@ class ilMailFormGUI
             $action = $this->ctrl->getFormAction($this, 'searchMailingListsTo');
             $btn = $bf->standard(
                 $this->lng->txt('mail_my_mailing_lists'),
-                $action
+                ''
+            )->withAdditionalOnLoadCode(
+                function ($id) use ($action) {
+                    return "document.getElementById('{$id}').addEventListener('click', function (event) {
+                    let mailform = document.querySelector('form.c-form');
+                    let btn = mailform.querySelector('button');
+                    btn.formAction = '{$action}'; 
+                    mailform.requestSubmit(btn);   
+                });";
+                }
             );
             $this->toolbar->addComponent($btn);
         }
@@ -1252,11 +1297,21 @@ class ilMailFormGUI
         $action = $this->ctrl->getFormAction($this, 'editAttachments');
         $btn = $bf->standard(
             $this->lng->txt('edit_attachments'),
-            $action
+            ''
+        )->withAdditionalOnLoadCode(
+            function ($id) use ($action) {
+                return "document.getElementById('{$id}').addEventListener('click', function (event) {
+                    let mailform = document.querySelector('form.c-form');
+                    let btn = mailform.querySelector('button');
+                    btn.formAction = '{$action}'; 
+                    mailform.requestSubmit(btn);   
+                });";
+            }
         );
         $this->toolbar->addComponent($btn);
 
-        $current_mode = ilSession::get('mail_mode') ?: self::MAIL_FORM_MODE_REGULAR_MAIL;
+        $result = $form->getInputGroup()->getInputs()[0]->getInputs();
+        $use_placeholders = (bool) $result['use_placeholders']->getValue();
         $action = $this->ctrl->getFormAction($this, 'toggleMailMode');
         $url_builder = new UrlBuilder(new URI(ILIAS_HTTP_PATH . '/' . $action));
         [$url_builder, $mail_mode_parameter] = $url_builder->acquireParameter(['mail', 'form'], 'mail_mode');
@@ -1265,12 +1320,13 @@ class ilMailFormGUI
                 $this->lng->txt(self::MAIL_FORM_MODE_REGULAR_MAIL) => (string) $url_builder->withParameter($mail_mode_parameter, self::MAIL_FORM_MODE_REGULAR_MAIL)->buildURI(),
                 $this->lng->txt(self::MAIL_FORM_MODE_SERIAL_LETTER) => (string) $url_builder->withParameter($mail_mode_parameter, self::MAIL_FORM_MODE_SERIAL_LETTER)->buildURI(),
             ],
-            'Modes'
-        )->withActive($this->lng->txt($current_mode));
+            'mail_mode_switch_label'
+        )->withActive($this->lng->txt($use_placeholders ? self::MAIL_FORM_MODE_SERIAL_LETTER : self::MAIL_FORM_MODE_REGULAR_MAIL));
         $this->toolbar->addComponent($btn);
-
         $this->tpl->addOnLoadCode(
-            "document.getElementById('{$this->toolbar->getId()}').querySelectorAll('button').forEach(function(button) {
+            "document.getElementById('{$this->toolbar->getId()}')
+            .querySelector('div[aria-label=\"" . $this->lng->txt('mail_mode_switch_label') . "\"]')
+            .querySelectorAll('button[data-action]').forEach(function(button) {
                 button.addEventListener('click', function(event) {
                     event.preventDefault();
                     event.stopPropagation();
@@ -1296,12 +1352,15 @@ class ilMailFormGUI
 
     public function toggleMailMode(): void
     {
-        $this->saveMailBeforeSearch();
+        $form = $this->buildForm()->withRequest($this->request);
 
         $mode = $this->getQueryParam('mail_form_mail_mode', $this->refinery->kindlyTo()->string(), self::MAIL_FORM_MODE_REGULAR_MAIL);
         if (in_array($mode, [self::MAIL_FORM_MODE_REGULAR_MAIL, self::MAIL_FORM_MODE_SERIAL_LETTER], true)) {
-            ilSession::set('mail_mode', $mode);
+            $result = $form->getInputGroup()->getInputs()[0]->getInputs();
+            $result['use_placeholders'] = $result['use_placeholders']->withValue($mode === self::MAIL_FORM_MODE_SERIAL_LETTER ? '1' : '0');
         }
+        $this->saveMailBeforeSearch($result ?? null);
+
         $this->searchResults();
     }
 }

--- a/components/ILIAS/Mail/classes/class.ilMailFormGUI.php
+++ b/components/ILIAS/Mail/classes/class.ilMailFormGUI.php
@@ -854,10 +854,10 @@ class ilMailFormGUI
         }
 
         $this->tpl->parseCurrentBlock();
-        if ($form === null) {
-            $form = $this->buildForm($mail_data);
-        }
+
+        $form ??= $this->buildForm($mail_data);
         $this->addToolbarButtons($form);
+
         $this->tpl->setVariable('FORM', $this->ui_renderer->render($form));
         $this->tpl->addJavaScript('assets/js/ilMailComposeFunctions.js');
         $this->tpl->printToStdout();
@@ -913,9 +913,12 @@ class ilMailFormGUI
         $this->showForm();
     }
 
-    protected function saveMailBeforeSearch(?array $input_results = null): void
+    /**
+     * @param array<string|\ILIAS\UI\Component\Input\Input>|null $input_results
+     */
+    private function saveMailBeforeSearch(?array $input_results = null): void
     {
-        if (!$input_results) {
+        if (empty($input_results)) {
             $form = $this->buildForm()->withRequest($this->request);
             $result = $form->getInputGroup()->getInputs()[0]->getInputs();
         } else {
@@ -923,8 +926,7 @@ class ilMailFormGUI
         }
 
         $resource_collection_id = null;
-        $attachments = $result['attachments']->getValue();
-        if (count($attachments) > 0) {
+        if (!empty($result['attachments']->getValue())) {
             $files = $this->handleAttachments($result['attachments']->getValue());
             $resource_collection_id = $this->getIdforCollection($files);
         }
@@ -1033,15 +1035,17 @@ class ilMailFormGUI
 
         $template_chb = null;
         $signal = null;
+        $use_placeholder_value = false;
+        $context = new ilMailTemplateGenericContext();
         if (ilMailFormCall::getContextId()) {
             $context_id = ilMailFormCall::getContextId();
-            $use_placeholder_value = true;
 
             try {
                 $context = ilMailTemplateContextService::getTemplateContextById($context_id);
+                $use_placeholder_value = true;
 
                 $templates = $this->template_service->loadTemplatesForContextId($context->getId());
-                if (count($templates) > 0) {
+                if (!empty($templates)) {
                     $options = [];
 
                     $tmpl_value = '';
@@ -1072,16 +1076,14 @@ class ilMailFormGUI
                         ->withValue($tmpl_value)
                         ->withOnUpdate($signal);
                 }
-            } catch (Exception $e) {
+            } catch (Exception) {
                 ilLoggerFactory::getLogger('mail')->error(sprintf(
                     '%s has been called with invalid context id: %s.',
                     __METHOD__,
                     $context_id
                 ));
-                $context = new ilMailTemplateGenericContext();
             }
         } else {
-            $context = new ilMailTemplateGenericContext();
             $use_placeholder_value = $mail_data['use_placeholders'] ?? false;
         }
 
@@ -1104,14 +1106,15 @@ class ilMailFormGUI
             $this->lng->txt('message_content')
         )->withValue($mail_data['m_message'] ?? '');
 
-        $mode = $use_placeholder_value ? self::MAIL_FORM_MODE_SERIAL_LETTER : self::MAIL_FORM_MODE_REGULAR_MAIL;
         $use_placeholders = $ff->hidden()->withValue($use_placeholder_value ? '1' : '0');
+
         $placeholders = [];
-        if ($mode === self::MAIL_FORM_MODE_SERIAL_LETTER) {
-            foreach ($context->getPlaceholders() as $key => $value) {
+        $mode = $use_placeholder_value ? self::MAIL_FORM_MODE_SERIAL_LETTER : self::MAIL_FORM_MODE_REGULAR_MAIL;
+        if ($mode === self::MAIL_FORM_MODE_SERIAL_LETTER && $context) {
+            foreach ($context->getPlaceholders() as $value) {
                 $placeholders[$value['placeholder']] = $value['label'];
             }
-            if (count($placeholders) > 0) {
+            if (!empty($placeholders)) {
                 $m_message = $m_message
                     ->withMustacheVariables(
                         $placeholders,
@@ -1121,10 +1124,10 @@ class ilMailFormGUI
                 ;
             }
         }
+
         $use_placeholders = $use_placeholders->withAdditionalTransformation(
             $this->refinery->kindlyTo()->bool()
         );
-
 
         if ($signal !== null) {
             $m_subject = $m_subject->withAdditionalOnLoadCode(
@@ -1213,8 +1216,8 @@ class ilMailFormGUI
         }
 
         $elements['use_schedule'] = $use_schedule_input;
-
         $elements['use_placeholders'] = $use_placeholders;
+
         $section = $ff->section(
             $elements,
             $this->lng->txt('compose')
@@ -1232,7 +1235,7 @@ class ilMailFormGUI
         $action = $this->ctrl->getFormAction($this, 'searchUsers');
         $btn = $bf->standard(
             $this->lng->txt('search_recipients'),
-            '',
+            ''
         )->withAdditionalOnLoadCode(
             function ($id) use ($action) {
                 return "document.getElementById('{$id}').addEventListener('click', function (event) {
@@ -1317,13 +1320,23 @@ class ilMailFormGUI
         $action = $this->ctrl->getFormAction($this, 'toggleMailMode');
         $url_builder = new UrlBuilder(new URI(ILIAS_HTTP_PATH . '/' . $action));
         [$url_builder, $mail_mode_parameter] = $url_builder->acquireParameter(['mail', 'form'], 'mail_mode');
+
         $btn = $this->ui_factory->viewControl()->mode(
             [
-                $this->lng->txt(self::MAIL_FORM_MODE_REGULAR_MAIL) => (string) $url_builder->withParameter($mail_mode_parameter, self::MAIL_FORM_MODE_REGULAR_MAIL)->buildURI(),
-                $this->lng->txt(self::MAIL_FORM_MODE_SERIAL_LETTER) => (string) $url_builder->withParameter($mail_mode_parameter, self::MAIL_FORM_MODE_SERIAL_LETTER)->buildURI(),
+                $this->lng->txt(self::MAIL_FORM_MODE_REGULAR_MAIL) => (string) $url_builder->withParameter(
+                    $mail_mode_parameter,
+                    self::MAIL_FORM_MODE_REGULAR_MAIL
+                )->buildURI(),
+                $this->lng->txt(self::MAIL_FORM_MODE_SERIAL_LETTER) => (string) $url_builder->withParameter(
+                    $mail_mode_parameter,
+                    self::MAIL_FORM_MODE_SERIAL_LETTER
+                )->buildURI(),
             ],
             'mail_mode_switch_label'
-        )->withActive($this->lng->txt($use_placeholders ? self::MAIL_FORM_MODE_SERIAL_LETTER : self::MAIL_FORM_MODE_REGULAR_MAIL));
+        )->withActive(
+            $this->lng->txt($use_placeholders ? self::MAIL_FORM_MODE_SERIAL_LETTER : self::MAIL_FORM_MODE_REGULAR_MAIL)
+        );
+        $this->toolbar->addSeparator();
         $this->toolbar->addComponent($btn);
         $this->tpl->addOnLoadCode(
             "document.getElementById('{$this->toolbar->getId()}')
@@ -1352,18 +1365,39 @@ class ilMailFormGUI
         );
     }
 
-    public function toggleMailMode(): void
+    private function toggleMailMode(): never
     {
         $form = $this->buildForm()->withRequest($this->request);
-        $mode = $this->getQueryParam('mail_form_mail_mode', $this->refinery->kindlyTo()->string(), self::MAIL_FORM_MODE_REGULAR_MAIL);
-        if (!ilMailFormCall::getContextId() && in_array($mode, [self::MAIL_FORM_MODE_REGULAR_MAIL, self::MAIL_FORM_MODE_SERIAL_LETTER], true)) {
+
+        $mode = $this->getQueryParam(
+            'mail_form_mail_mode',
+            $this->refinery->kindlyTo()->string(),
+            self::MAIL_FORM_MODE_REGULAR_MAIL
+        );
+
+        $result = null;
+        if (!ilMailFormCall::getContextId() && in_array(
+            $mode,
+            [self::MAIL_FORM_MODE_REGULAR_MAIL, self::MAIL_FORM_MODE_SERIAL_LETTER],
+            true
+        )) {
             $result = $form->getInputGroup()->getInputs()[0]->getInputs();
-            $result['use_placeholders'] = $result['use_placeholders']->withValue($mode === self::MAIL_FORM_MODE_SERIAL_LETTER ? '1' : '0');
-        } elseif (ilMailFormCall::getContextId() && $mode === self::MAIL_FORM_MODE_REGULAR_MAIL) {
-            $this->tpl->setOnScreenMessage($this->tpl::MESSAGE_TYPE_FAILURE, $this->lng->txt('mail_template_context_mode_fixed'), true);
+            $result['use_placeholders'] = $result['use_placeholders']->withValue(
+                $mode === self::MAIL_FORM_MODE_SERIAL_LETTER ? '1' : '0'
+            );
+        } elseif ($mode === self::MAIL_FORM_MODE_REGULAR_MAIL && ilMailFormCall::getContextId()) {
+            $this->tpl->setOnScreenMessage(
+                $this->tpl::MESSAGE_TYPE_INFO,
+                sprintf(
+                    $this->lng->txt('mail_mode_switch_locked'),
+                    $this->lng->txt('regular_mail')
+                ),
+                true
+            );
         }
 
         $this->saveMailBeforeSearch($result ?? null);
+
         $this->ctrl->redirect($this, 'searchResults');
     }
 }

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -11772,6 +11772,7 @@ mail#:#only_inbox_trash_info#:#Falls aktiviert, werden ausschließlich Mails gel
 mail#:#orphaned_mail_body#:#Es existieren alte oder verwaiste Mails in den folgenden Ordnern. Beachten Sie, dass diese Mails in kürze automatisch gelöscht werden.
 mail#:#orphaned_mail_subject#:#Benachrichtigung über alte Mails
 mail#:#placeholders_advise#:#Persönliche Platzhalter werden nur für Personen im „An”-Feld ersetzt. Personen im „CC”-Feld und „BCC”-Feld erhalten die Mail mit nicht-ersetzten Platzhaltern.
+mail#:#regular_mail#:#Reguläre Mail
 mail#:#search_content#:#Suchergebnis
 mail#:#search_recipients#:#Personen suchen
 mail#:#second_email_missing_info#:#Auswahl nicht möglich, da keine zweite E-Mail-Adresse eingetragen wurde
@@ -11780,6 +11781,7 @@ mail#:#send_mail_admins#:#Administration
 mail#:#send_mail_members#:#Mitglied
 mail#:#send_mail_to#:#Mail an
 mail#:#send_mail_tutors#:#Kursbetreuung
+mail#:#serial_letter#:#Serienbrief
 mail#:#show_mail_settings#:#Einstellungen anzeigen
 mail#:#show_mail_settings_info#:#Aktiviert die Anzeige der Mail-Einstellungen im Bereich 'Einstellungen' oder 'Mail'. Benutzer können die Mail-Einstellungen nur ändern, wenn die Konfiguration des Benutzer-Profils dies erlaubt. Wenn Benutzer nicht berechtigt sind, die Mail-Einstellung ihrer Profils zu ändern, dann gelten die globalen Einstellungen. Dies gilt auch dann, wenn Benutzer in der Vergangenheit die Berechtigung zum Ändern der Mail-Einstellungen hatten und persönliche Einstellungen vorgenommen haben.
 mail#:#system_notification_installation_changed_by#:#Geändert durch

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -11630,6 +11630,7 @@ mail#:#mail_member_notification#:#Teilnehmerbenachrichtigung
 mail#:#mail_members_of_mailing_list#:#Mitglieder der Verteilerliste „%s“
 mail#:#mail_members_search_continue#:#Weiter
 mail#:#mail_message_send#:#Die Mail wurde versandt.
+mail#:#mail_mode_switch_label#:#Zwischen persönlicher Mail und Serienmail umschalten
 mail#:#mail_move_error#:#Beim Versuch, Ihre E-Mail zu verschieben, ist ein Fehler aufgetreten.
 mail#:#mail_move_to#:#Verschieben nach:
 mail#:#mail_move_to_folder_btn_label#:#Mail verschieben
@@ -11772,7 +11773,7 @@ mail#:#only_inbox_trash_info#:#Falls aktiviert, werden ausschließlich Mails gel
 mail#:#orphaned_mail_body#:#Es existieren alte oder verwaiste Mails in den folgenden Ordnern. Beachten Sie, dass diese Mails in kürze automatisch gelöscht werden.
 mail#:#orphaned_mail_subject#:#Benachrichtigung über alte Mails
 mail#:#placeholders_advise#:#Persönliche Platzhalter werden nur für Personen im „An”-Feld ersetzt. Personen im „CC”-Feld und „BCC”-Feld erhalten die Mail mit nicht-ersetzten Platzhaltern.
-mail#:#regular_mail#:#Reguläre Mail
+mail#:#regular_mail#:#Persönliche Mail
 mail#:#search_content#:#Suchergebnis
 mail#:#search_recipients#:#Personen suchen
 mail#:#second_email_missing_info#:#Auswahl nicht möglich, da keine zweite E-Mail-Adresse eingetragen wurde

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -11630,6 +11630,7 @@ mail#:#mail_member_notification#:#Teilnehmerbenachrichtigung
 mail#:#mail_members_of_mailing_list#:#Mitglieder der Verteilerliste „%s“
 mail#:#mail_members_search_continue#:#Weiter
 mail#:#mail_message_send#:#Die Mail wurde versandt.
+mail#:#mail_mode_fixed#:#Sie können nicht zu Persönliche Mail wechseln.
 mail#:#mail_mode_switch_label#:#Zwischen persönlicher Mail und Serienmail umschalten
 mail#:#mail_move_error#:#Beim Versuch, Ihre E-Mail zu verschieben, ist ein Fehler aufgetreten.
 mail#:#mail_move_to#:#Verschieben nach:

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -11630,8 +11630,8 @@ mail#:#mail_member_notification#:#Teilnehmerbenachrichtigung
 mail#:#mail_members_of_mailing_list#:#Mitglieder der Verteilerliste „%s“
 mail#:#mail_members_search_continue#:#Weiter
 mail#:#mail_message_send#:#Die Mail wurde versandt.
-mail#:#mail_mode_fixed#:#Sie können nicht zu Persönliche Mail wechseln.
-mail#:#mail_mode_switch_label#:#Zwischen persönlicher Mail und Serienmail umschalten
+mail#:#mail_mode_switch_label#:#Zwischen „Persönliche Mail” und „Serienbrief” umschalten
+mail#:#mail_mode_switch_locked#:#Sie können nicht zu „%s” wechseln.
 mail#:#mail_move_error#:#Beim Versuch, Ihre E-Mail zu verschieben, ist ein Fehler aufgetreten.
 mail#:#mail_move_to#:#Verschieben nach:
 mail#:#mail_move_to_folder_btn_label#:#Mail verschieben

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -11632,6 +11632,7 @@ mail#:#mail_member_notification#:#Participant Notification
 mail#:#mail_members_of_mailing_list#:#Members of Mailing List "%s"
 mail#:#mail_members_search_continue#:#Continue
 mail#:#mail_message_send#:#Message sent.
+mail#:#mail_mode_fixed#:#You cannot switch to personal mail mode.
 mail#:#mail_mode_switch_label#:#Switch between personal mail and mail merge mode
 mail#:#mail_move_error#:#An error occurred while trying to move your mail.
 mail#:#mail_move_to#:#Move to:
@@ -11775,7 +11776,7 @@ mail#:#only_inbox_trash_info#:#Only delete e-mails that are located in the Inbox
 mail#:#orphaned_mail_body#:#Your mailbox contains the following old or orphaned mails. Please note that these mails will soon be automatically deleted.
 mail#:#orphaned_mail_subject#:#Notification of old mails
 mail#:#placeholders_advise#:#Personal placeholders are only replaced with user-specific information for recipients listed in the ‘To’ field.%s Personal placeholders for recipients listed in the CC and BCC fields are NOT replaced with user-specific information and instead show up as placeholders.
-mail#:#regular_mail#:#Regular Mail
+mail#:#regular_mail#:#Personal Mail
 mail#:#search_content#:#Search Result
 mail#:#search_recipients#:#Look up Users
 mail#:#second_email_missing_info#:#Selection not possible because no second e-mail address has been entered.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -11632,6 +11632,7 @@ mail#:#mail_member_notification#:#Participant Notification
 mail#:#mail_members_of_mailing_list#:#Members of Mailing List "%s"
 mail#:#mail_members_search_continue#:#Continue
 mail#:#mail_message_send#:#Message sent.
+mail#:#mail_mode_switch_label#:#Switch between personal mail and mail merge mode
 mail#:#mail_move_error#:#An error occurred while trying to move your mail.
 mail#:#mail_move_to#:#Move to:
 mail#:#mail_move_to_folder_btn_label#:#Move Mail

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -11632,8 +11632,8 @@ mail#:#mail_member_notification#:#Participant Notification
 mail#:#mail_members_of_mailing_list#:#Members of Mailing List "%s"
 mail#:#mail_members_search_continue#:#Continue
 mail#:#mail_message_send#:#Message sent.
-mail#:#mail_mode_fixed#:#You cannot switch to personal mail mode.
-mail#:#mail_mode_switch_label#:#Switch between personal mail and mail merge mode
+mail#:#mail_mode_switch_label#:#Switch between „Personal Mail” and „Serial Letter” mode
+mail#:#mail_mode_switch_locked#:#You cannot switch to „%s” mode.
 mail#:#mail_move_error#:#An error occurred while trying to move your mail.
 mail#:#mail_move_to#:#Move to:
 mail#:#mail_move_to_folder_btn_label#:#Move Mail

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -11774,6 +11774,7 @@ mail#:#only_inbox_trash_info#:#Only delete e-mails that are located in the Inbox
 mail#:#orphaned_mail_body#:#Your mailbox contains the following old or orphaned mails. Please note that these mails will soon be automatically deleted.
 mail#:#orphaned_mail_subject#:#Notification of old mails
 mail#:#placeholders_advise#:#Personal placeholders are only replaced with user-specific information for recipients listed in the ‘To’ field.%s Personal placeholders for recipients listed in the CC and BCC fields are NOT replaced with user-specific information and instead show up as placeholders.
+mail#:#regular_mail#:#Regular Mail
 mail#:#search_content#:#Search Result
 mail#:#search_recipients#:#Look up Users
 mail#:#second_email_missing_info#:#Selection not possible because no second e-mail address has been entered.
@@ -11782,6 +11783,7 @@ mail#:#send_mail_admins#:#All Administrators
 mail#:#send_mail_members#:#All Members
 mail#:#send_mail_to#:#Mail to
 mail#:#send_mail_tutors#:#All Tutors
+mail#:#serial_letter#:#Serial Letter
 mail#:#show_mail_settings#:#Show Mail Settings
 mail#:#show_mail_settings_info#:#Enable individual users to alter their mail settings, thereby overriding the global mail settings that would otherwise apply to them. ‘Mail Settings’ are accessible via their ‘Personal Settings’ or ‘Communication > Mail’. Note: In order for users to be allowed to change their individual mail settings and thereby override the global settings, this needs to be set in the 'Standard Fields' section of the global user account administration settings. If users do not have the permission to change these profile settings, the global default is applied even if users were able to and did change their personal mail settings in the past.
 mail#:#system_notification_installation_changed_by#:#Changed by


### PR DESCRIPTION
This adds a Mode-Control when composing mails that lets the user switch between serial letter and regular mail.
And enables placeholders accordingly for Serial Letters.

[Mantis 46784](https://mantis.ilias.de/view.php?id=46784)

pick to release_11 as well