### PR TITLE
[LTI] fix: get object by refId throw a null

### DIFF
--- a/Services/LTI/classes/InternalProvider/class.ilAuthProviderLTI.php
+++ b/Services/LTI/classes/InternalProvider/class.ilAuthProviderLTI.php
@@ -120,8 +120,14 @@ class ilAuthProviderLTI extends \ilAuthProvider implements \ilAuthProviderInterf
     {
         $connector = new ilLTIDataConnector();
         $consumer = ilLTIPlatform::fromRecordId($a_sid, $connector);
-        $object = ilObjectFactory::getInstanceByRefId($consumer->getRefId());
-        return $consumer->getTitle() . " - " . $object->getTitle();
+        $title = "";
+        try {
+            $object = ilObjectFactory::getInstanceByRefId($consumer->getRefId());
+            $title = $object->getTitle();
+        } catch (ilDatabaseException|ilObjectNotFoundException $e) {
+            $title = "Object not found refId: " . $consumer->getRefId();
+        }
+        return $consumer->getTitle() . " - " . $title;
     }
 
     /**


### PR DESCRIPTION
Recently, we made a fix in order to show the name of the resource that the provider share linked to provider name at the user management site in the filter by Authentication Mode. However, when the resource is removed from the repository and the trash this change throw an exception, this was reported in [Mantis 0025011](https://mantis.ilias.de/view.php?id=25011). With this change we improve how we do that search in order to provide a correct title without errors.