### PR TITLE
[LTI] fix: lang var in user management filter

### DIFF
--- a/Services/LTI/classes/InternalProvider/class.ilAuthProviderLTI.php
+++ b/Services/LTI/classes/InternalProvider/class.ilAuthProviderLTI.php
@@ -118,14 +118,18 @@ class ilAuthProviderLTI extends \ilAuthProvider implements \ilAuthProviderInterf
      */
     public static function lookupConsumer(int $a_sid): string
     {
+        global $DIC;
+        $lng = $DIC->language();
+        $lng->loadLanguageModule('common');
         $connector = new ilLTIDataConnector();
         $consumer = ilLTIPlatform::fromRecordId($a_sid, $connector);
+
         $title = "";
         try {
             $object = ilObjectFactory::getInstanceByRefId($consumer->getRefId());
             $title = $object->getTitle();
         } catch (ilDatabaseException|ilObjectNotFoundException $e) {
-            $title = "Object not found refId: " . $consumer->getRefId();
+            $title = $lng->txt("obj_not_found") . " - RefId: " . $consumer->getRefId();
         }
         return $consumer->getTitle() . " - " . $title;
     }


### PR DESCRIPTION
After fix the issue https://mantis.ilias.de/view.php?id=46740 with the PR: https://github.com/ILIAS-eLearning/ILIAS/pull/10846 we add this change in order to render the message in the user language.