### PR TITLE
News 46801: Fix news item not found exception

### DIFF
--- a/Services/News/classes/class.ilNewsForContextBlockGUI.php
+++ b/Services/News/classes/class.ilNewsForContextBlockGUI.php
@@ -16,6 +16,7 @@
  *
  *********************************************************************/
 
+use ILIAS\News\Access\NewsAccess;
 use ILIAS\News\Data\NewsCollection;
 use ILIAS\News\Data\NewsContext;
 use ILIAS\News\Data\NewsCriteria;
@@ -23,7 +24,6 @@ use ILIAS\News\Data\NewsItem;
 use ILIAS\News\InternalDomainService;
 use ILIAS\News\InternalGUIService;
 use ILIAS\News\StandardGUIRequest;
-use ILIAS\News\Access\NewsAccess;
 
 /**
  * BlockGUI class for block NewsForContext
@@ -137,7 +137,8 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
             $info = $this->getNewsForId($data[0]);
         } catch (\Exception $e) {
             $this->logger->error($e->getMessage());
-            return $this->ui->factory()->item()->standard($this->lng->txt('news_sorry_not_accessible_anymore'));
+            return $this->ui->factory()->item()->standard($this->lng->txt('news_not_available'))
+                ->withDescription($this->lng->txt('news_sorry_not_accessible_anymore'));
         }
 
 

--- a/Services/News/classes/class.ilNewsForContextBlockGUI.php
+++ b/Services/News/classes/class.ilNewsForContextBlockGUI.php
@@ -51,6 +51,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
     protected ilHelpGUI $help;
     protected ilSetting $settings;
     protected ilTabsGUI $tabs;
+    protected ilLogger $logger;
 
     protected StandardGUIRequest $std_request;
     protected InternalDomainService $domain;
@@ -68,6 +69,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
         $this->help = $DIC["ilHelp"];
         $this->settings = $DIC->settings();
         $this->tabs = $DIC->tabs();
+        $this->logger = $DIC->logger()->news();
 
         $locator = $DIC->news()->internal();
         $this->std_request = $locator->gui()->standardRequest();
@@ -131,7 +133,13 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
 
     protected function getListItemForData(array $data): ?\ILIAS\UI\Component\Item\Item
     {
-        $info = $this->getNewsForId($data[0]);
+        try {
+            $info = $this->getNewsForId($data[0]);
+        } catch (\Exception $e) {
+            $this->logger->error($e->getMessage());
+            return $this->ui->factory()->item()->standard($this->lng->txt('news_sorry_not_accessible_anymore'));
+        }
+
 
         $props = [
             $this->lng->txt('date') => $info['creation_date'] ?? ''

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -12707,6 +12707,7 @@ news#:#news_news_item_visibility_info#:#Öffentliche Neuigkeiten können von au�
 news#:#news_news_items#:#Neuigkeit(en)
 news#:#news_no_js_click_here#:#Werden die Neuigkeiten nicht angezeigt, klicken Sie bitte hier.
 news#:#news_no_news_items#:#Es sind keine Neuigkeiten für Sie vorhanden.
+news#:#news_not_available#:#Neuigkeit nicht verfügbar
 news#:#news_notifications#:#Benachrichtigungen
 news#:#news_notifications_public#:#Öffentliche Benachrichtigungen
 news#:#news_notifications_public_info#:#Wenn diese Option gewählt wird, können Benachrichtigungen auch außerhalb von ILIAS über den persönlichen Newsfeed empfangen werden. Beachten Sie bitte, dass diese Benachrichtigungen ohne Authentifizierung zugänglich sind.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -12707,6 +12707,7 @@ news#:#news_news_item_visibility_info#:#Public news can be accessed without auth
 news#:#news_news_items#:#News Item(s)
 news#:#news_no_js_click_here#:#If news are not displayed, click here.
 news#:#news_no_news_items#:#No news available.
+news#:#news_not_available#:#Unavailable News
 news#:#news_notifications#:#Notifications
 news#:#news_notifications_public#:#Public Notifications
 news#:#news_notifications_public_info#:#If this option is enabled, notifications can be obtained by personal RSS feeds outside of ILIAS. Please note that this makes notifications accessible without authentication.


### PR DESCRIPTION
Hi everyone,

This PR refers to [46801](https://mantis.ilias.de/view.php?id=46801). The ticket describes an exception caused by a missing news item on the dashboard. This behavior can be observed when the news cache is enabled but the news item has been deleted meanwhile.

In this PR, this behavior is adjusted, and instead of a program crash, an info message will be shown in the block.

Best,
@lukas-heinrich 