### PR TITLE
[Fix] #0046664 Rating: Wiki RatingCategories count only last Category

### DIFF
--- a/components/ILIAS/Rating/classes/class.ilRating.php
+++ b/components/ILIAS/Rating/classes/class.ilRating.php
@@ -162,6 +162,34 @@ class ilRating
         return (float) $rec["av"];
     }
 
+    public static function getNumberOfFinishedCategoryRatingsForWikis(int $a_obj_id, array $all_category_ids): int
+    {
+        global $DIC;
+
+        $ilDB = $DIC->database();
+        if (empty($all_category_ids)) {
+            return 0;
+        }
+        $category_count = count($all_category_ids);
+        $category_ids_csv = implode(",", array_map("intval", $all_category_ids));
+
+        $query = "
+        SELECT COUNT(*) cnt FROM (
+            SELECT user_id
+            FROM il_rating
+            WHERE obj_id = " . $ilDB->quote($a_obj_id, ilDBConstants::T_INTEGER) . "
+                AND obj_type = " . $ilDB->quote("wiki", ilDBConstants::T_TEXT) . "
+                AND category_id IN (" . $category_ids_csv . ")
+            GROUP BY user_id
+            HAVING count(DISTINCT category_id) = " . $ilDB->quote($category_count, "integer") . "
+        ) full_users
+    ";
+
+        $set = $ilDB->query($query);
+        $rec = $ilDB->fetchAssoc($set);
+        return (int) ($rec["cnt"] ?? 0);
+    }
+
     /**
     * Get overall rating for an object.
     *

--- a/components/ILIAS/Rating/classes/class.ilRatingGUI.php
+++ b/components/ILIAS/Rating/classes/class.ilRatingGUI.php
@@ -333,6 +333,11 @@ class ilRatingGUI implements ilCtrlSecurityInterface
                 "avg" => 0,
                 "cnt" => 0
             ];
+
+            // Collect all category IDs
+            $category_ids = array_column($a_categories, "id");
+            $overall_count = ilRating::getNumberOfFinishedCategoryRatingsForWikis($this->obj_id, $category_ids);
+
             foreach ($a_categories as $category) {
                 $user_rating = round(ilRating::getRatingForUserAndObject(
                     $this->obj_id,
@@ -434,9 +439,9 @@ class ilRatingGUI implements ilCtrlSecurityInterface
                 $ttpl->parseCurrentBlock();
             }
 
-            if ($overall_rating["cnt"] > 0) {
+            if ($overall_count > 0) {
                 $ttpl->setCurrentBlock("votes_number_bl");
-                $ttpl->setVariable("NUMBER_VOTES", sprintf($lng->txt("rating_number_votes"), $overall_rating["cnt"]));
+                $ttpl->setVariable("NUMBER_VOTES", sprintf($lng->txt("rating_number_votes"), $overall_count));
                 $ttpl->parseCurrentBlock();
             }
 


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=46664

This PR adjusts the wiki rating statistics so that only users who have rated all rating categories are counted in the total number of votes, as defined in the existing test case.
A new helper method `getNumberOfFinishedCategoryRatingsForWikis()` was introduced to calculate the number of fully completed ratings per wiki, and ilRatingGUI now uses this value when rendering the vote count, while per‑category averages continue to be computed via `getOverallRatingForObject()`. Since every category is calculated on its own.