### PR TITLE
Composer: Add getid3 as dependency for ILIAS 12

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -39,6 +39,7 @@
 		]
 	},
 	"require": {
+		"james-heinrich/getid3": "^1.9.24"
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
Usage:

The lib provides methods to extract media length from common media files like mp3 or mp4.

Wrapped By:

components/ILIAS/MediaObjects (used internally)

Reasoning:

The length of media files is being presented in several views, e.g. the mediacasts. Entering this value manually would downgrade user experience when creating the media objects.

Maintenance:

The lib is on github since > 10 years, always got maintenance (last changes last month), has around 50 contributors, James Heinrich is still the main contributor

Links:

Packagist: https://packagist.org/packages/james-heinrich/getid3
GitHub: https://github.com/JamesHeinrich/getID3

License: GPL1-3
