### PR TITLE
Language: change path case in README

### DIFF
--- a/lang/customizing/README.md
+++ b/lang/customizing/README.md
@@ -3,8 +3,8 @@
 You may change terms used in the user interface of ILIAS. To do this, use the
 same format as is used in the language files in directory `/lang`. Store the
 values to be overwritten in files ending with `.lang.local` and put them into
-the `/lang/Customizing` directory.
+the `/lang/customizing` directory.
 
 ```
-/lang/Customizing/ilias_<lang_code>.lang.local
+/lang/customizing/ilias_<lang_code>.lang.local
 ```


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=46828

The paths given in lang/customizing/README.md have an uppercase "Customizing" which should be changed to lowercase to match the real path.