### PR TITLE
Composer: Add phiki as dependency for ILIAS 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,8 @@
 		"symfony/console" : "^6.4",
 		"psr/http-message": "^2.0",
 		"jumbojett/openid-connect-php": "dev-master#bc719cc9930990a4a9916cc127b839b4ed1c89ad",
-		"phpunit/phpunit": "^11.5"
+		"phpunit/phpunit": "^11.5",
+		"phiki/phiki": "^2.0"
 	},
 	"require-dev": {
 		"captainhook/captainhook": "^5.24",


### PR DESCRIPTION
Assessment:

Phiki is a syntax highlighter written in PHP. It uses TextMate grammar files and Visual Studio Code themes to generate syntax highlighted code for the web.

General Information:

- Name of the dependency: phiki/phiki
- Version: 2.0.5
- [ ]  this dependency was already used in ILIAS.
- [x]  the dependency's license is compatible with ILIAS' license: MIT

Type of dependency:

- [x] composer
- [ ] npm 

Usage:

- components/ILIAS/COPage

Reasoning:

We abandonded the previous geshi library due to lacking maintenance. The syntax highlighter is being used in the page editor for code paragraphs. Having a syntax highlighter greatly improves readability of code snippets fostering teaching and learning of programming languages.

Maintenance:

- Last release of the Library: 2025-11-04
- One main developer, 11 contributors
- Monthly releases since Oct 2024

Links:

    Packagist: https://packagist.org/packages/phiki/phiki
    GitHub: https://github.com/phikiphp/phiki
    Documentation: https://phiki.dev/

Alternatives:

There are several alternatives like Geshi or other libs. This however seems to be the most active currently maintained alternative.