### PR TITLE
Mantis 46846 / Reverting rounding mode to support PHP 8.3

### DIFF
--- a/components/ILIAS/ResourceStorage/classes/Collections/View/RequestToDataTable.php
+++ b/components/ILIAS/ResourceStorage/classes/Collections/View/RequestToDataTable.php
@@ -145,7 +145,7 @@ class RequestToDataTable implements RequestToComponents, DataRetrieval
 
         $start = $range->getStart();
         $length = $range->getLength();
-        $this->data_provider->getViewRequest()->setPage((int) round($start / $length, 0, \RoundingMode::HalfTowardsZero));
+        $this->data_provider->getViewRequest()->setPage((int) round($start / $length, 0, PHP_ROUND_HALF_DOWN));
         $this->data_provider->getViewRequest()->setItemsPerPage($length);
 
         switch ($sort_field . '_' . $sort_direction) {

--- a/components/ILIAS/ResourceStorage/classes/Container/View/RequestToDataTable.php
+++ b/components/ILIAS/ResourceStorage/classes/Container/View/RequestToDataTable.php
@@ -282,7 +282,7 @@ class RequestToDataTable implements RequestToComponents, DataRetrieval
 
         $start = $range->getStart();
         $length = $range->getLength();
-        $this->data_provider->getViewRequest()->setPage((int) round($start / $length, 0, \RoundingMode::HalfTowardsZero));
+        $this->data_provider->getViewRequest()->setPage((int) round($start / $length, 0, PHP_ROUND_HALF_DOWN));
         $this->data_provider->getViewRequest()->setItemsPerPage($length);
 
         switch ($sort_field . '_' . $sort_direction) {


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=46846

In Rev. 91a54643b5a34f81da6c754129f535a39c898f1a
use of RoundingMode was introduced
$this->data_provider->getViewRequest()->setPage((int) round($start / $length, 0, \RoundingMode::HalfTowardsZero));

but it should be
$this->data_provider->getViewRequest()->setPage((int) round($start / $length, 0, PHP_ROUND_HALF_DOWN));

in order to also support PHP 8.3, because RoundingMode comes with >= 8.4.0
(See https://www.php.net/manual/de/enum.roundingmode.php )