### PR TITLE
[FIX] #45569 UI: load language modules before internal use.

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Factory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Factory.php
@@ -53,21 +53,25 @@ class Factory implements I\Factory
 
     public function group(array $inputs, string $label = '', ?string $byline = null): Group
     {
+        $this->lng->loadLanguageModule('ui');
         return new Group($this->data_factory, $this->refinery, $this->lng, $inputs, $label, $byline);
     }
 
     public function optionalGroup(array $inputs, string $label, ?string $byline = null): OptionalGroup
     {
+        $this->lng->loadLanguageModule('ui');
         return new OptionalGroup($this->data_factory, $this->refinery, $this->lng, $inputs, $label, $byline);
     }
 
     public function switchableGroup(array $inputs, string $label, ?string $byline = null): SwitchableGroup
     {
+        $this->lng->loadLanguageModule('ui');
         return new SwitchableGroup($this->data_factory, $this->refinery, $this->lng, $inputs, $label, $byline);
     }
 
     public function section(array $inputs, string $label, ?string $byline = null): Section
     {
+        $this->lng->loadLanguageModule('ui');
         return new Section($this->data_factory, $this->refinery, $this->lng, $inputs, $label, $byline);
     }
 
@@ -113,6 +117,7 @@ class Factory implements I\Factory
 
     public function duration(string $label, ?string $byline = null): Duration
     {
+        $this->lng->loadLanguageModule('ui');
         return new Duration($this->data_factory, $this->refinery, $this->lng, $this, $label, $byline);
     }
 
@@ -122,6 +127,7 @@ class Factory implements I\Factory
         ?string $byline = null,
         ?FormInput $metadata_input = null
     ): File {
+        $this->lng->loadLanguageModule('ui');
         return new File(
             $this->lng,
             $this->data_factory,
@@ -142,6 +148,7 @@ class Factory implements I\Factory
         ?string $byline = null,
         ?FormInput $metadata_input = null
     ): Image {
+        $this->lng->loadLanguageModule('ui');
         return new Image(
             $this->lng,
             $this->data_factory,
@@ -163,6 +170,7 @@ class Factory implements I\Factory
 
     public function link(string $label, ?string $byline = null): Link
     {
+        $this->lng->loadLanguageModule('ui');
         return new Link($this->data_factory, $this->refinery, $this->lng, $this, $label, $byline);
     }
 
@@ -191,6 +199,7 @@ class Factory implements I\Factory
         string $label,
         ?string $byline = null
     ): TreeSelect {
+        $this->lng->loadLanguageModule('ui');
         return new TreeSelect(
             $this->lng,
             $this->data_factory,
@@ -207,6 +216,7 @@ class Factory implements I\Factory
         string $label,
         ?string $byline = null,
     ): TreeMultiSelect {
+        $this->lng->loadLanguageModule('ui');
         return new TreeMultiSelect(
             $this->lng,
             $this->data_factory,

--- a/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/Factory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/Factory.php
@@ -71,6 +71,7 @@ class Factory implements VCInterface\Factory
 
     public function group(array $view_controls): Group
     {
+        $this->language->loadLanguageModule('ui');
         return new Group(
             $this->data_factory,
             $this->refinery,


### PR DESCRIPTION
Hi all, 

This PR fixes https://mantis.ilias.de/view.php?id=45569 and all related issues by adding an `ILIAS\Language\Language::loadLanguageModule()` call before internal use.

This should be a reminder that having to call this method in order to load language variables becomes more and more cumbersome while moving towards the component bootstrap mechanism. We should not simply place a method call like this in our constructors, as they should ideally set up state, not cause behaviour. This makes testing harder, objects less predictable and DI less flexible. If we do not want to violate SOLID principles, we are forced to call this method at the earliest possible entry point of our components (the methods), of which there are possibly many.

I would be very happy if we could get rid of this complexity altogether, and would also offer my help in conceptual work. Im not aware of the performance implications here, but would it really be that bad to load and cache everything (at) once? (ping @katringross, @kevenClausenKPG, @c-knof)

Let me know if you should feel differently about this.

Kind regards,
@thibsy 