### PR TITLE
Badge/Authorities: Suggest change of "Badge" authorities

### DIFF
--- a/docs/development/maintenance.md
+++ b/docs/development/maintenance.md
@@ -231,12 +231,12 @@ of ILIAS. The file contains the following fields:
 [//]: # (BEGIN Badges)
 
 * **Badges**
-    * Authority to Sign off on Conceptual Changes: [mjansen](https://docu.ilias.de/go/usr/8784)
-    * Authority to Sign off on Code Changes: [mjansen](https://docu.ilias.de/go/usr/8784)
+    * Authority to Sign off on Conceptual Changes: [fhelfer](https://docu.ilias.de/go/usr/93367)
+    * Authority to Sign off on Code Changes: [fhelfer](https://docu.ilias.de/go/usr/93367), [mjansen](https://docu.ilias.de/go/usr/8784)
     * Authority to Curate Test Cases: [atoedt](https://docu.ilias.de/go/usr/3139)
     * Authority to (De-)Assign Authorities: [mjansen (Databay AG)](https://docu.ilias.de/go/usr/8784)
-    * Assignee for Security Reports: [mjansen](https://docu.ilias.de/go/usr/8784)
-    * Assignee for Security Issues: [mjansen](https://docu.ilias.de/go/usr/8784)
+    * Assignee for Security Reports: [fhelfer](https://docu.ilias.de/go/usr/93367)
+    * Assignee for Security Issues: [fhelfer](https://docu.ilias.de/go/usr/93367)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Badges)


### PR DESCRIPTION
Following our authority process ...

> If the person with `Authority to (De-)Assign Authorities` for a `Component` wants
to remove someone from an assignment to an `Authority` in said `Component`, she should
open a PR against the `trunk`-branch of the [official ILIAS Repository](https://github.com/ILIAS-eLearning/ILIAS)
and tag it with `authorities`, `documentation` and `jour fixe`. The change will
then be announced on the next Jour Fixe.

..., I hereby suggest the following 'Badge'-related authority-changes:

Removals:
* Remove @mjansenDatabay from the "Authority to Sign off on Conceptual Changes"
* Remove @mjansenDatabay as "Assignee for Security Report"
* Remove @mjansenDatabay as "Assignee for Security Issues"

@mjansenDatabay will still be assigned to "Authority to Sign off on Code Changes".

Additions:
* Add my colleague @fhelfer to  the "Authority to Sign off on Conceptual Changes"
* Add my colleague @fhelfer to  the "Authority to Sign off on Code Changes"
* Add my colleague @fhelfer as "Assignee for Security Report"
* Add my colleague @fhelfer as "Assignee for Security Issues"



