### PR TITLE
T&A 46797: Hides matriculation number when test is anonymous in results, archive export and print view

### DIFF
--- a/components/ILIAS/Test/classes/class.ilTestArchiver.php
+++ b/components/ILIAS/Test/classes/class.ilTestArchiver.php
@@ -606,7 +606,7 @@ class ilTestArchiver
 
         $template->setVariable('TEXT_HEADING', sprintf($this->lng->txt('tst_result_user_name'), $uname));
 
-        if ($participant_data['matriculation'] !== '') {
+        if (!$test_obj->getAnonymity() && $participant_data['matriculation'] !== '') {
             $template->setVariable('USER_DATA', "{$this->lng->txt('matriculation')}: {$participant_data['matriculation']}");
         }
 

--- a/components/ILIAS/Test/classes/class.ilTestEvaluationGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestEvaluationGUI.php
@@ -426,7 +426,7 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
             $grading_message_builder->sendMessage();
         }
 
-        $user_data = $this->getAdditionalUsrDataHtmlAndPopulateWindowTitle($test_session, $active_id, true);
+        $user_data = $this->getAdditionalUsrDataHtmlAndPopulateWindowTitle($active_id);
 
         if (!$this->getObjectiveOrientedContainer()->isObjectiveOrientedPresentationRequired()) {
             if ($this->object->getAnonymity()) {
@@ -525,7 +525,7 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
         );
         $template->setVariable('PASS_DETAILS', $answers);
 
-        $user_data = $this->getAdditionalUsrDataHtmlAndPopulateWindowTitle($test_session, $active_id, true);
+        $user_data = $this->getAdditionalUsrDataHtmlAndPopulateWindowTitle($active_id);
         $template->setVariable('USER_DATA', $user_data);
         if (strlen($signature)) {
             $template->setVariable('SIGNATURE', $signature);

--- a/components/ILIAS/Test/classes/class.ilTestEvaluationGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestEvaluationGUI.php
@@ -359,7 +359,6 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
         $test_session = $this->test_session_factory->getSession();
         $active_id = $test_session->getActiveId();
         $user_id = $this->user->getId();
-        $uname = $this->object->userLookupFullName($user_id, true);
 
         if (!$this->object->canShowTestResults($test_session)) {
             $this->ctrl->redirectByClass([ilRepositoryGUI::class, ilObjTestGUI::class, ilInfoScreenGUI::class]);
@@ -426,14 +425,22 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
             $grading_message_builder->sendMessage();
         }
 
-        $user_data = $this->getAdditionalUsrDataHtmlAndPopulateWindowTitle($active_id);
-
         if (!$this->getObjectiveOrientedContainer()->isObjectiveOrientedPresentationRequired()) {
-            if ($this->object->getAnonymity()) {
+            $overwrite_anonymity = $test_session->getUserId() === $user_id;
+            if (!$overwrite_anonymity && $this->object->getAnonymity()) {
                 $template->setVariable('TEXT_HEADING', $this->lng->txt('tst_result'));
             } else {
-                $template->setVariable('TEXT_HEADING', sprintf($this->lng->txt('tst_result_user_name'), $uname));
-                $template->setVariable('USER_DATA', $user_data);
+                $template->setVariable(
+                    'TEXT_HEADING',
+                    sprintf(
+                        $this->lng->txt('tst_result_user_name'),
+                        $this->object->userLookupFullName($user_id, $overwrite_anonymity)
+                    )
+                );
+                $template->setVariable(
+                    'USER_DATA',
+                    $this->getAdditionalUsrDataHtmlAndPopulateWindowTitle($active_id, $overwrite_anonymity)
+                );
             }
         }
 
@@ -525,7 +532,10 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
         );
         $template->setVariable('PASS_DETAILS', $answers);
 
-        $user_data = $this->getAdditionalUsrDataHtmlAndPopulateWindowTitle($active_id);
+        $user_data = $this->getAdditionalUsrDataHtmlAndPopulateWindowTitle(
+            $active_id,
+            $test_session->getUserId() === $user_id
+        );
         $template->setVariable('USER_DATA', $user_data);
         if (strlen($signature)) {
             $template->setVariable('SIGNATURE', $signature);

--- a/components/ILIAS/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -2078,7 +2078,7 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
 
         $this->tpl->setCurrentBlock("adm_content");
         $this->tpl->setVariable("TXT_ANSWER_SHEET", $this->lng->txt("tst_list_of_answers"));
-        $user_data = $this->getAdditionalUsrDataHtmlAndPopulateWindowTitle($this->test_session, $active_id, true);
+        $user_data = $this->getAdditionalUsrDataHtmlAndPopulateWindowTitle($active_id);
         $signature = $this->getResultsSignature();
         $this->tpl->setVariable("USER_DETAILS", $user_data);
         $this->tpl->setVariable("SIGNATURE", $signature);

--- a/components/ILIAS/Test/classes/class.ilTestServiceGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestServiceGUI.php
@@ -550,29 +550,16 @@ class ilTestServiceGUI
 
     /**
      * Returns the user data for a test results output
-     *
-     * @param ilTestSession
-     * @param integer $user_id The user ID of the user
-     * @param boolean $overwrite_anonymity TRUE if the anonymity status should be overwritten, FALSE otherwise
-     * @return string HTML code of the user data for the test results
-     * @access public
      */
-    public function getAdditionalUsrDataHtmlAndPopulateWindowTitle($testSession, $active_id, $overwrite_anonymity = false): string
+    public function getAdditionalUsrDataHtmlAndPopulateWindowTitle(int $active_id, bool $overwrite_anonymity = false): string
     {
-        if (!is_object($testSession)) {
-            throw new InvalidArgumentException('Not an object, expected ilTestSession');
-        }
         $template = new ilTemplate("tpl.il_as_tst_results_userdata.html", true, true, "components/ILIAS/Test");
-        $user_id = $this->object->_getUserIdFromActiveId($active_id);
-        if (strlen(ilObjUser::_lookupLogin($user_id)) > 0) {
+        $user_id = ilObjTest::_getUserIdFromActiveId($active_id);
+        if (ilObjUser::_lookupLogin($user_id) !== '') {
             $user = new ilObjUser($user_id);
         } else {
             $user = new ilObjUser();
             $user->setLastname($this->lng->txt('deleted_user'));
-        }
-        $t = $testSession->getSubmittedTimestamp();
-        if (!$t) {
-            $t = $this->object->_getLastAccess($testSession->getActiveId());
         }
 
         if ($this->getObjectiveOrientedContainer()?->isObjectiveOrientedPresentationRequired()) {
@@ -584,7 +571,10 @@ class ilTestServiceGUI
         }
 
         $title_matric = "";
-        if (strlen($user->getMatriculation()) && (($this->object->getAnonymity() == false) || ($overwrite_anonymity))) {
+        if (
+            $user->getMatriculation() !== ''
+            && ($overwrite_anonymity || !$this->object->getAnonymity())
+        ) {
             $template->setCurrentBlock("matriculation");
             $template->setVariable("TXT_USR_MATRIC", $this->lng->txt("matriculation"));
             $template->setVariable("VALUE_USR_MATRIC", $user->getMatriculation());

--- a/components/ILIAS/Test/src/Participants/ParticipantTable.php
+++ b/components/ILIAS/Test/src/Participants/ParticipantTable.php
@@ -347,14 +347,17 @@ class ParticipantTable implements DataRetrieval
             'name' => $column_factory->text($this->lng->txt('name'))
                 ->withIsSortable(!$this->test_object->getAnonymity())
         ];
+
         if (!$this->test_object->getAnonymity()) {
-            $columns['login'] = $column_factory->text($this->lng->txt('login'))->withIsSortable(true);
+            $columns += [
+                'login' => $column_factory->text($this->lng->txt('login'))->withIsSortable(true),
+                'matriculation' => $column_factory->text($this->lng->txt('matriculation'))
+                    ->withIsOptional(true, false)
+                    ->withIsSortable(true)
+            ];
         }
 
         $columns += [
-            'matriculation' => $column_factory->text($this->lng->txt('matriculation'))
-                ->withIsOptional(true, false)
-                ->withIsSortable(true),
             'ip_range' => $column_factory->text($this->lng->txt('client_ip_range'))
                 ->withIsOptional(true, false)
                 ->withIsSortable(true),


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=46797

Aims to hide matriculation number when test is anonymous in results, archive export and print view.
@thojou 