### PR TITLE
Mail/A11Y: Use proper label for "Adopt Attachments" table action

### DIFF
--- a/components/ILIAS/Mail/classes/Attachments/MailAttachmentTableGUI.php
+++ b/components/ILIAS/Mail/classes/Attachments/MailAttachmentTableGUI.php
@@ -119,7 +119,7 @@ class MailAttachmentTableGUI implements \ILIAS\UI\Component\Table\DataRetrieval,
 
         if ($this->mode === AttachmentManagement::CONSUME) {
             $actions['saveAttachments'] = $this->ui_factory->table()->action()->multi(
-                $this->lng->txt('adopt'),
+                $this->lng->txt('mail_adopt_selected_attachements'),
                 $this->url_builder->withParameter(
                     $this->action_parameter_token,
                     self::TABLE_ACTION_SAVE_ATTACHMENTS

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -11480,6 +11480,7 @@ mail#:#mail_add_folder#:#Neuen Ordner erstellen
 mail#:#mail_add_recipient#:#Bitte geben Sie an, wer die Mail erhalten soll. Geben Sie ILIAS-Anmeldenamen oder gültige E-Mail-Adressen an.
 mail#:#mail_add_subfolder#:#Unterordner hinzufügen
 mail#:#mail_add_subject#:#Bitte geben Sie einen Betreff ein
+mail#:#mail_adopt_selected_attachements#:#Ausgewählte Anhänge übernehmen
 mail#:#mail_all_in_trash#:#Alle im Papierkorb
 mail#:#mail_allow_external#:#Externe E-Mails
 mail#:#mail_allow_external_info#:#Die Zustellung von externen E-Mails (via SMTP) zulassen. Falls nicht aktiviert, wird der Versand von externen E-Mails (via SMTP) global unterdrückt.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -11481,6 +11481,7 @@ mail#:#mail_add_folder#:#Add New Sub-Folder
 mail#:#mail_add_recipient#:#Please enter a recipient in the form of a valid e-mail address or ILIAS username.
 mail#:#mail_add_subfolder#:#Add Sub-Folder
 mail#:#mail_add_subject#:#Please enter a subject.
+mail#:#mail_adopt_selected_attachements#:#Adopt selected Attachments
 mail#:#mail_all_in_trash#:#All in Trash
 mail#:#mail_allow_external#:#External E-Mails
 mail#:#mail_allow_external_info#:#Allow the delivery of external e-mails (via-SMTP). Unchecking this box will prevent external mails being sent globally across this installation.


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=36765