### PR TITLE
[Improvement] UI ViewControl\Mode: Add option to disable specific actions

### DIFF
--- a/components/ILIAS/UI/src/Component/ViewControl/Mode.php
+++ b/components/ILIAS/UI/src/Component/ViewControl/Mode.php
@@ -35,6 +35,34 @@ interface Mode extends Component
     public function withActive(string $label): Mode;
 
     /**
+     * disable/enable all actions/buttons of the mode control.
+     *
+     * @param bool $disabled. true to disable, false to enable
+     */
+    public function withDisableAllActions(bool $disabled = true): Mode;
+    /**
+     * disable/enable a specific action/button by label.
+     *
+     * @param string $label. The label of the button to disable/enable
+     * @param bool $disabled. true to disable, false to enable
+     */
+    public function withDisableAction(string $label, bool $disabled = true): Mode;
+    /**
+     * disable/enable multiple actions/buttons by label.
+     *
+     * @param array<string, bool> $label_disable_map. An array with labels as keys and booleans as values (true to disable, false to enable)
+     */
+    public function withDisableActions(array $label_disable_map): Mode;
+
+    /**
+     * check if a specific action/button is disabled by a label.
+     *
+     * @param string $label. The label of the button to check
+     * @return bool true if the action/button is disabled, false otherwise
+     */
+    public function isActionDisabled(string $label): bool;
+
+    /**
      * get the label of the currently active/engaged button of the mode control
      *
      * @return string the label of the currently active button of the mode control

--- a/components/ILIAS/UI/src/Implementation/Component/ViewControl/Mode.php
+++ b/components/ILIAS/UI/src/Implementation/Component/ViewControl/Mode.php
@@ -22,6 +22,7 @@ namespace ILIAS\UI\Implementation\Component\ViewControl;
 
 use ILIAS\UI\Component as C;
 use ILIAS\UI\Implementation\Component\ComponentHelper;
+use InvalidArgumentException;
 
 class Mode implements C\ViewControl\Mode
 {
@@ -30,6 +31,8 @@ class Mode implements C\ViewControl\Mode
     protected array $labeled_actions;
     protected string $aria_label;
     protected ?string $active = null;
+    /** @var bool[] */
+    protected array $disabled_actions = [];
 
     public function __construct($labelled_actions, string $aria_label)
     {
@@ -57,5 +60,39 @@ class Mode implements C\ViewControl\Mode
     public function getAriaLabel(): string
     {
         return $this->aria_label;
+    }
+
+    public function isActionDisabled(string $label): bool
+    {
+        return $this->disabled_actions[$label] ?? false;
+    }
+
+    public function withDisableAllActions(bool $disabled = true): C\ViewControl\Mode
+    {
+        return $this->withDisableActions(array_fill_keys(array_keys($this->labeled_actions), $disabled));
+    }
+
+    public function withDisableAction(string $label, bool $disabled = true): C\ViewControl\Mode
+    {
+        $clone = clone $this;
+        $this->checkLabelExists($label);
+        $clone->disabled_actions[$label] = $disabled;
+        return $clone;
+    }
+
+    public function withDisableActions(array $label_disable_map): C\ViewControl\Mode
+    {
+        $clone = clone $this;
+        foreach ($label_disable_map as $label => $disabled) {
+            $clone = $clone->withDisableAction($label, $disabled);
+        }
+        return $clone;
+    }
+
+    private function checkLabelExists(string $label): void
+    {
+        if (!array_key_exists($label, $this->labeled_actions)) {
+            throw new InvalidArgumentException("Label '$label' does not exist in Mode control.");
+        }
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/ViewControl/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/ViewControl/Renderer.php
@@ -82,6 +82,7 @@ class Renderer extends AbstractComponentRenderer
             } else {
                 $button = $button->withEngagedState(false);
             }
+            $button = $button->withUnavailableAction($component->isActionDisabled($label));
             $tpl->setVariable("BUTTON", $default_renderer->render($button));
             $tpl->parseCurrentBlock();
         }


### PR DESCRIPTION
Similar to https://github.com/ILIAS-eLearning/ILIAS/pull/10844 we encountered, while fixing Mail [(Mantis #0046784)](https://mantis.ilias.de/view.php?id=46784), a need to disable specific/all actions of the ViewControl\Mode Element.

In the scenario of creating a new serial mail (e.g. via Mail to Members from inside a course), it should be impossible for the user to switch to "Personal Mail" and disable placeholders.

To achieve this, Mode now supports disabling the buttons inside the ViewControl

It would be nice to also pick this down to ILIAS 11.

Best @fhelfer 