### PR TITLE
Mail/A11Y: Use proper label for "Select Files" button in "Dropzone"

### DIFF
--- a/components/ILIAS/Mail/classes/class.ilMailAttachmentGUI.php
+++ b/components/ILIAS/Mail/classes/class.ilMailAttachmentGUI.php
@@ -273,7 +273,7 @@ class ilMailAttachmentGUI extends AbstractCtrlAwareUploadHandler implements
                 ->withBulky(true)
                 ->withUploadButton(
                     $this->ui_factory->button()->shy(
-                        $this->lng->txt('upload'),
+                        $this->lng->txt('select_files_from_computer'),
                         '#'
                     )
                 );


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=36765