### PR TITLE
Mantis#46885 Make ILIAS object caching great again

### DIFF
--- a/Services/Object/classes/class.ilCachedObjectDefinition.php
+++ b/Services/Object/classes/class.ilCachedObjectDefinition.php
@@ -72,6 +72,7 @@ class ilCachedObjectDefinition implements Request
         $this->grouped_rep_obj_types = $data['grouped_rep_obj_types'];
         $this->il_object_group = $data['il_object_group'];
         $this->il_object_sub_type = $data['il_object_sub_type'];
+        $this->cached_results = $data['cached_results'];
     }
 
     protected function getRawData(): array
@@ -82,6 +83,7 @@ class ilCachedObjectDefinition implements Request
             'grouped_rep_obj_types' => $this->grouped_rep_obj_types,
             'il_object_group' => $this->il_object_group,
             'il_object_sub_type' => $this->il_object_sub_type,
+            'cached_results' => $this->cached_results,
         ];
     }
 
@@ -161,6 +163,7 @@ class ilCachedObjectDefinition implements Request
         while ($rec = $db->fetchAssoc($set)) {
             $data['il_object_sub_type'][$rec['obj_type']][] = $rec;
         }
+        $data['cached_results'] = [];
         $this->loadFromRawData($data);
     }
 


### PR DESCRIPTION
Actually cache `ilCachedObjectDefinition::cached_results` so that cache does not have to be rewritten with each request and we can avoid recomputing `subobj_for_parent` and `grouped_rep_obj_types` with each request.

This should save ~150ms on larger ILIAS instances.

https://mantis.ilias.de/view.php?id=46885

I don't care if this can't be merged to 9.x; just close this PR then. [I'll submit one for 10.x but that one will be untested by us.](./10885) (#10885)