### PR TITLE
Fix Mantis #46886: $compThresh must be of type float, string given

### DIFF
--- a/Modules/Scorm2004/classes/adlparser/SeqTreeBuilder.php
+++ b/Modules/Scorm2004/classes/adlparser/SeqTreeBuilder.php
@@ -167,8 +167,8 @@ class SeqTreeBuilder
                 } elseif ($curNode->localName === "completionThreshold") {
                     $tempVal = $curNode->getAttribute("minProgressMeasure");
 
-                    if ($tempVal) {
-                        $act->setCompletionThreshold($tempVal);
+                    if ($tempVal != null && $tempVal != '') {
+                        $act->setCompletionThreshold((float) $tempVal);
                     } elseif ($curNode->nodeValue != null && $curNode->nodeValue != '') {
                         $act->setCompletionThreshold((float) $curNode->nodeValue);
                     }


### PR DESCRIPTION
Mantis: https://mantis.ilias.de/view.php?id=46886

Error is thrown when the completion_threshold is defined by an attribute in imsmanifest.xml 
`<adlcp:completionThreshold completedByMeasure="true" minProgressMeasure="0.8"/>`

PR for 9, 10, 11 and TRUNK