### PR TITLE
T&A9 46797: Hides matriculation number when test is anonymous in results, archive export and print view

### DIFF
--- a/Modules/Test/classes/class.ilTestEvaluationGUI.php
+++ b/Modules/Test/classes/class.ilTestEvaluationGUI.php
@@ -1121,7 +1121,7 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
             $template->parseCurrentBlock();
         }
 
-        $user_data = $this->getAdditionalUsrDataHtmlAndPopulateWindowTitle($testSession, $active_id, true);
+        $user_data = $this->getAdditionalUsrDataHtmlAndPopulateWindowTitle($active_id);
         $user_id = $this->object->_getUserIdFromActiveId($active_id);
 
         if (!$this->getObjectiveOrientedContainer()->isObjectiveOrientedPresentationRequired()) {
@@ -1340,7 +1340,7 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
             $gradingMessageBuilder->sendMessage();
         }
 
-        $user_data = $this->getAdditionalUsrDataHtmlAndPopulateWindowTitle($testSession, $active_id, true);
+        $user_data = $this->getAdditionalUsrDataHtmlAndPopulateWindowTitle($active_id);
 
         if (!$this->getObjectiveOrientedContainer()->isObjectiveOrientedPresentationRequired()) {
             if ($this->object->getAnonymity()) {
@@ -1432,7 +1432,7 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
         $template->setVariable("PRINT_TEXT", $this->lng->txt("print"));
         $template->setVariable("PRINT_URL", "javascript:window.print();");
 
-        $user_data = $this->getAdditionalUsrDataHtmlAndPopulateWindowTitle($testSession, $active_id, true);
+        $user_data = $this->getAdditionalUsrDataHtmlAndPopulateWindowTitle($active_id);
         $template->setVariable("USER_DATA", $user_data);
         $template->setVariable("TEXT_LIST_OF_ANSWERS", $this->lng->txt("tst_list_of_answers"));
         if (strlen($signature)) {

--- a/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -1423,7 +1423,7 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
 
         $this->tpl->setCurrentBlock("adm_content");
         $this->tpl->setVariable("TXT_ANSWER_SHEET", $this->lng->txt("tst_list_of_answers"));
-        $user_data = $this->getAdditionalUsrDataHtmlAndPopulateWindowTitle($this->test_session, $active_id, true);
+        $user_data = $this->getAdditionalUsrDataHtmlAndPopulateWindowTitle($active_id);
         $signature = $this->getResultsSignature();
         $this->tpl->setVariable("USER_DETAILS", $user_data);
         $this->tpl->setVariable("SIGNATURE", $signature);
@@ -1431,9 +1431,11 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
         $this->tpl->setVariable("TXT_TEST_PROLOG", $this->lng->txt("tst_your_answers"));
         $invited_user = &$this->object->getInvitedUsers($this->user->getId());
         $pagetitle = $this->object->getTitle() . " - " . $this->lng->txt("clientip") .
-            ": " . $invited_user[$this->user->getId()]["clientip"] . " - " .
-            $this->lng->txt("matriculation") . ": " .
-            $invited_user[$this->user->getId()]["matriculation"];
+            ": " . $invited_user[$this->user->getId()]["clientip"];
+        if (!$this->object->getAnonymity()) {
+            $pagetitle .= " - " . $this->lng->txt("matriculation") . ": " .
+                $invited_user[$this->user->getId()]["matriculation"];
+        }
         $this->tpl->setVariable("PAGETITLE", $pagetitle);
         $this->tpl->parseCurrentBlock();
     }

--- a/Modules/Test/classes/class.ilTestServiceGUI.php
+++ b/Modules/Test/classes/class.ilTestServiceGUI.php
@@ -629,33 +629,20 @@ class ilTestServiceGUI
 
     /**
      * Returns the user data for a test results output
-     *
-     * @param ilTestSession
-     * @param integer $user_id The user ID of the user
-     * @param boolean $overwrite_anonymity TRUE if the anonymity status should be overwritten, FALSE otherwise
-     * @return string HTML code of the user data for the test results
-     * @access public
      */
-    public function getAdditionalUsrDataHtmlAndPopulateWindowTitle($testSession, $active_id, $overwrite_anonymity = false): string
+    public function getAdditionalUsrDataHtmlAndPopulateWindowTitle(int $active_id): string
     {
-        if (!is_object($testSession)) {
-            throw new InvalidArgumentException('Not an object, expected ilTestSession');
-        }
         $template = new ilTemplate("tpl.il_as_tst_results_userdata.html", true, true, "Modules/Test");
-        $user_id = $this->object->_getUserIdFromActiveId($active_id);
-        if (strlen(ilObjUser::_lookupLogin($user_id)) > 0) {
+        $user_id = ilObjTest::_getUserIdFromActiveId($active_id);
+        if (ilObjUser::_lookupLogin($user_id) !== '') {
             $user = new ilObjUser($user_id);
         } else {
             $user = new ilObjUser();
             $user->setLastname($this->lng->txt("deleted_user"));
         }
-        $t = $testSession->getSubmittedTimestamp();
-        if (!$t) {
-            $t = $this->object->_getLastAccess($testSession->getActiveId());
-        }
 
         if ($this->getObjectiveOrientedContainer()->isObjectiveOrientedPresentationRequired()) {
-            $uname = $this->object->userLookupFullName($user_id, $overwrite_anonymity);
+            $uname = $this->object->userLookupFullName($user_id, false);
             $template->setCurrentBlock("name");
             $template->setVariable('TXT_USR_NAME', $this->lng->txt("name"));
             $template->setVariable('VALUE_USR_NAME', $uname);
@@ -663,7 +650,7 @@ class ilTestServiceGUI
         }
 
         $title_matric = "";
-        if (strlen($user->getMatriculation()) && (($this->object->getAnonymity() == false) || ($overwrite_anonymity))) {
+        if ($user->getMatriculation() !== '' && !$this->object->getAnonymity()) {
             $template->setCurrentBlock("matriculation");
             $template->setVariable("TXT_USR_MATRIC", $this->lng->txt("matriculation"));
             $template->setVariable("VALUE_USR_MATRIC", $user->getMatriculation());
@@ -885,7 +872,7 @@ class ilTestServiceGUI
         }
 
 
-        $user_data = $this->getAdditionalUsrDataHtmlAndPopulateWindowTitle($testSession, $active_id, true);
+        $user_data = $this->getAdditionalUsrDataHtmlAndPopulateWindowTitle($active_id);
         $template->setVariable("TEXT_HEADING", sprintf($this->lng->txt("tst_result_user_name"), $uname));
         $template->setVariable("USER_DATA", $user_data);
 


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=46797

Aims to hide matriculation number when test is anonymous in results, archive export and print view.
@thojou 