### PR TITLE
T&A 46802: Fixes insert action link building incorrect url due to proxy http protocol mismatch

### DIFF
--- a/components/ILIAS/Test/src/Questions/Presentation/QuestionsBrowserTable.php
+++ b/components/ILIAS/Test/src/Questions/Presentation/QuestionsBrowserTable.php
@@ -124,10 +124,10 @@ class QuestionsBrowserTable implements DataRetrieval
     private function getInsertAction(): TableAction
     {
         $url_builder = new URLBuilder($this->data_factory->uri(
-            ServerRequest::getUriFromGlobals() . $this->ctrl->getLinkTargetByClass(
+            ILIAS_HTTP_PATH . "/{$this->ctrl->getLinkTargetByClass(
                 ilTestQuestionBrowserTableGUI::class,
                 ilTestQuestionBrowserTableGUI::CMD_INSERT_QUESTIONS
-            )
+            )}"
         ));
 
         [$url_builder, $row_id_token] = $url_builder->acquireParameters(['qlist'], 'q_id');


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=46802

Aims to fix insert action link building incorrect url due to proxy http protocol mismatch.
@thojou 