### PR TITLE
T&A 46737: Fixes taxonomy filtering error for random tests

### DIFF
--- a/components/ILIAS/Test/classes/class.ilTestRandomQuestionSetSourcePoolDefinition.php
+++ b/components/ILIAS/Test/classes/class.ilTestRandomQuestionSetSourcePoolDefinition.php
@@ -183,7 +183,7 @@ class ilTestRandomQuestionSetSourcePoolDefinition
                     $mapped_node_ids[] = $mapped_node_id;
                 }
             }
-            $this->mapped_taxonomy_filter[] = $mapped_node_ids;
+            $this->mapped_taxonomy_filter[$mapped_taxonomy_id] = $mapped_node_ids;
         }
     }
 


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=46737

Aims to fix taxonomy filtering error for random tests.
@thojou 