### PR TITLE
T&A 46814 & 46860: Fixes invalid call of withAdditionalOnLoadCode when trying to print test results

### DIFF
--- a/components/ILIAS/Test/classes/class.ilTestEvaluationGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestEvaluationGUI.php
@@ -852,11 +852,11 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
 
         if ($for_print) {
             $signal = $results_presentation_table->getExpandAllSignal();
+            $signal_options = json_encode(['options' => $signal->getOptions()]);
             $results_presentation_table = [
                 $results_presentation_table,
-                $this->ui_factory->legacy('')->withAdditionalOnLoadCode(
-                    fn(string $id): string => "$(document).trigger('{$signal->getId()}',"
-                        . '{"options" : ' . json_encode($signal->getOptions()) . '}); '
+                $this->ui_factory->legacy()->content('')->withAdditionalOnLoadCode(
+                    static fn(string $id): string => "$(document).trigger('{$signal->getId()}', $signal_options);"
                 )
             ];
         }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=46814
https://mantis.ilias.de/view.php?id=46860

Aims to fix invalid call of withAdditionalOnLoadCode when trying to print test results.
@thojou 