### PR TITLE
References: Fix Custom Icon

### DIFF
--- a/components/ILIAS/CategoryReference/ObjectProperties/CategoryReferenceObjectProperties.php
+++ b/components/ILIAS/CategoryReference/ObjectProperties/CategoryReferenceObjectProperties.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\Object\Properties\ObjectTypeSpecificProperties\AbstractObjectTypeSpecificProperties;
+use ILIAS\Object\Properties\ObjectTypeSpecificProperties\ilObjectTypeSpecificPropertyProviders;
+
+class CategoryReferenceObjectProperties extends AbstractObjectTypeSpecificProperties
+{
+    protected ?CategoryReferenceObjectPropertiesProviders $providers = null;
+
+    public function getObjectTypeString(): string
+    {
+        return 'catr';
+    }
+
+    public function getProviders(): ilObjectTypeSpecificPropertyProviders
+    {
+        if ($this->providers === null) {
+            $this->providers = new CategoryReferenceObjectPropertiesProviders();
+        }
+        return $this->providers;
+    }
+
+    public function preload(array $object_ids): void
+    {
+        return;
+    }
+}

--- a/components/ILIAS/CategoryReference/ObjectProperties/CategoryReferenceObjectPropertiesProviders.php
+++ b/components/ILIAS/CategoryReference/ObjectProperties/CategoryReferenceObjectPropertiesProviders.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\Object\Properties\ObjectTypeSpecificProperties\ilObjectTypeSpecificPropertyProviders;
+use ILIAS\UI\Component\Symbol\Icon\Custom as CustomIcon;
+use ILIAS\UI\Component\Symbol\Icon\Factory as IconFactory;
+use ILIAS\UI\Component\Image\Image;
+use ILIAS\UI\Component\Image\Factory as ImageFactory;
+use ILIAS\ResourceStorage\Services as StorageService;
+
+class CategoryReferenceObjectPropertiesProviders implements ilObjectTypeSpecificPropertyProviders
+{
+    public function getObjectTypeSpecificTileImage(
+        int $obj_id,
+        ImageFactory $factory,
+        StorageService $irss
+    ): ?Image {
+        return null;
+    }
+
+    public function getObjectTypeSpecificIcon(
+        int $obj_id,
+        IconFactory $icon_factory,
+        StorageService $irss
+    ): ?CustomIcon {
+        $category = new ilObjCategory(
+            ilContainerReference::_lookupTargetId($obj_id),
+            false
+        );
+
+        /** @var ilObjectCustomIcon $custom_icon */
+        $custom_icon = $category->getObjectProperties()->getPropertyIcon()->getCustomIcon();
+        if ($custom_icon?->exists()) {
+            return $icon_factory->custom(
+                $custom_icon->getFullPath(),
+                ''
+            );
+        }
+
+        return null;
+    }
+}

--- a/components/ILIAS/CourseReference/ObjectProperties/CourseReferenceObjectProperties.php
+++ b/components/ILIAS/CourseReference/ObjectProperties/CourseReferenceObjectProperties.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\Object\Properties\ObjectTypeSpecificProperties\AbstractObjectTypeSpecificProperties;
+use ILIAS\Object\Properties\ObjectTypeSpecificProperties\ilObjectTypeSpecificPropertyProviders;
+
+class CourseReferenceObjectProperties extends AbstractObjectTypeSpecificProperties
+{
+    protected ?CourseReferenceObjectPropertiesProviders $providers = null;
+
+    public function getObjectTypeString(): string
+    {
+        return 'crsr';
+    }
+
+    public function getProviders(): ilObjectTypeSpecificPropertyProviders
+    {
+        if ($this->providers === null) {
+            $this->providers = new CourseReferenceObjectPropertiesProviders();
+        }
+        return $this->providers;
+    }
+
+    public function preload(array $object_ids): void
+    {
+        return;
+    }
+}

--- a/components/ILIAS/CourseReference/ObjectProperties/CourseReferenceObjectPropertiesProviders.php
+++ b/components/ILIAS/CourseReference/ObjectProperties/CourseReferenceObjectPropertiesProviders.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\Object\Properties\ObjectTypeSpecificProperties\ilObjectTypeSpecificPropertyProviders;
+use ILIAS\UI\Component\Symbol\Icon\Custom as CustomIcon;
+use ILIAS\UI\Component\Symbol\Icon\Factory as IconFactory;
+use ILIAS\UI\Component\Image\Image;
+use ILIAS\UI\Component\Image\Factory as ImageFactory;
+use ILIAS\ResourceStorage\Services as StorageService;
+
+class CourseReferenceObjectPropertiesProviders implements ilObjectTypeSpecificPropertyProviders
+{
+    public function getObjectTypeSpecificTileImage(
+        int $obj_id,
+        ImageFactory $factory,
+        StorageService $irss
+    ): ?Image {
+        return null;
+    }
+
+    public function getObjectTypeSpecificIcon(
+        int $obj_id,
+        IconFactory $icon_factory,
+        StorageService $irss
+    ): ?CustomIcon {
+        $category = new ilObjCourse(
+            ilObjCategoryReference::_lookupTargetId($obj_id),
+            false
+        );
+
+        /** @var ilObjectCustomIcon $custom_icon */
+        $custom_icon = $category->getObjectProperties()->getPropertyIcon()->getCustomIcon();
+        if ($custom_icon?->exists()) {
+            return $icon_factory->custom(
+                $custom_icon->getFullPath(),
+                ''
+            );
+        }
+
+        return null;
+    }
+}

--- a/components/ILIAS/GroupReference/ObjectProperties/GroupReferenceObjectProperties.php
+++ b/components/ILIAS/GroupReference/ObjectProperties/GroupReferenceObjectProperties.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\Object\Properties\ObjectTypeSpecificProperties\AbstractObjectTypeSpecificProperties;
+use ILIAS\Object\Properties\ObjectTypeSpecificProperties\ilObjectTypeSpecificPropertyProviders;
+
+class GroupReferenceObjectProperties extends AbstractObjectTypeSpecificProperties
+{
+    protected ?GroupReferenceObjectPropertiesProviders $providers = null;
+
+    public function getObjectTypeString(): string
+    {
+        return 'grpr';
+    }
+
+    public function getProviders(): ilObjectTypeSpecificPropertyProviders
+    {
+        if ($this->providers === null) {
+            $this->providers = new GroupReferenceObjectPropertiesProviders();
+        }
+        return $this->providers;
+    }
+
+    public function preload(array $object_ids): void
+    {
+        return;
+    }
+}

--- a/components/ILIAS/GroupReference/ObjectProperties/GroupReferenceObjectPropertiesProviders.php
+++ b/components/ILIAS/GroupReference/ObjectProperties/GroupReferenceObjectPropertiesProviders.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\Object\Properties\ObjectTypeSpecificProperties\ilObjectTypeSpecificPropertyProviders;
+use ILIAS\UI\Component\Symbol\Icon\Custom as CustomIcon;
+use ILIAS\UI\Component\Symbol\Icon\Factory as IconFactory;
+use ILIAS\UI\Component\Image\Image;
+use ILIAS\UI\Component\Image\Factory as ImageFactory;
+use ILIAS\ResourceStorage\Services as StorageService;
+
+class GroupReferenceObjectPropertiesProviders implements ilObjectTypeSpecificPropertyProviders
+{
+    public function getObjectTypeSpecificTileImage(
+        int $obj_id,
+        ImageFactory $factory,
+        StorageService $irss
+    ): ?Image {
+        return null;
+    }
+
+    public function getObjectTypeSpecificIcon(
+        int $obj_id,
+        IconFactory $icon_factory,
+        StorageService $irss
+    ): ?CustomIcon {
+        $category = new ilObjGroup(
+            ilContainerReference::_lookupTargetId($obj_id),
+            false
+        );
+
+        /** @var ilObjectCustomIcon $custom_icon */
+        $custom_icon = $category->getObjectProperties()->getPropertyIcon()->getCustomIcon();
+        if ($custom_icon?->exists()) {
+            return $icon_factory->custom(
+                $custom_icon->getFullPath(),
+                ''
+            );
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Hi @smeyer-ilias  and @alex40724 

This adds object type specific properties, so that the references of the Group, Course, and Category show the CustomIcon of the referenced object, if one is available.

See: https://mantis.ilias.de/view.php?id=46848

Best,
@kergomard 