### PR TITLE
Fix of spelling mistake in build.sh in release_10

### DIFF
--- a/scripts/Style-To-Repo/build.sh
+++ b/scripts/Style-To-Repo/build.sh
@@ -41,8 +41,8 @@ function build() {
     cp -r "${DEFAULT_TEMPLATE_FOLDER}"/*.html "${BUILD_BASE_FOLDER}"/"${NAME}" &> /dev/null
   done
 
-  if [ -d ./components/ILIAS/Mail/templates/default/img && -d "${BUILD_BASE_FOLDER}"/Mail ]
-  them
+  if [[ -d ./components/ILIAS/Mail/templates/default/img && -d "${BUILD_BASE_FOLDER}"/Mail ]]
+  then
     cp -r ./components/ILIAS/Mail/templates/default/img "${BUILD_BASE_FOLDER}"/Mail &> /dev/null
   fi
 


### PR DESCRIPTION
After updating the build.sh there was a spelling mistake.

This PR fix this.