### PR TITLE
Fix copying the image for mail template.

### DIFF
--- a/scripts/Style-To-Repo/build.sh
+++ b/scripts/Style-To-Repo/build.sh
@@ -41,9 +41,8 @@ function build() {
     cp -r "${DEFAULT_TEMPLATE_FOLDER}"/*.html "${BUILD_BASE_FOLDER}"/"${NAME}" &> /dev/null
   done
 
-  if [[ -d ./components/ILIAS/Mail/templates/default/img && -d "${BUILD_BASE_FOLDER}"/Mail ]]
-  then
-    cp -r ./components/ILIAS/Mail/templates/default/img "${BUILD_BASE_FOLDER}"/Mail &> /dev/null
+  if [[ -d "./components/ILIAS/Mail/templates/default/img" && -d "${BUILD_BASE_FOLDER}/components/ILIAS/Mail" ]]; then
+      cp -r "./components/ILIAS/Mail/templates/default/img" "${BUILD_BASE_FOLDER}/components/ILIAS/Mail" &> /dev/null
   fi
 
   mv ${BUILD_BASE_FOLDER}/delos/template.xml ${BUILD_BASE_FOLDER}/template.xml


### PR DESCRIPTION
The target directory structure in the `if` statement for the mail image is incorrect. `/components/ILIAS` was missing before the `mail`.

This fix corrects the directory in the `if` statement so that the file is copied correctly.