### PR TITLE
cleaned up maintenance assignees

### DIFF
--- a/docs/development/maintenance.md
+++ b/docs/development/maintenance.md
@@ -471,12 +471,12 @@ of ILIAS. The file contains the following fields:
 [//]: # (BEGIN CSSAndTemplates)
 
 * **CSS / Templates**
-    * Authority to Sign off on Conceptual Changes: [BettyFromHH](https://docu.ilias.de/go/usr/9657)
-    * Authority to Sign off on Code Changes: [BettyFromHH](https://docu.ilias.de/go/usr/9657), [rotegras](https://docu.ilias.de/go/usr/88399)
-    * Authority to Curate Test Cases: [BettyFromHH](https://docu.ilias.de/go/usr/9657)
-    * Authority to (De-)Assign Authorities: [BettyFromHH](https://docu.ilias.de/go/usr/9657)
-    * Assignee for Issues: [BettyFromHH](https://docu.ilias.de/go/usr/9657)
-    * Assignee for Security Reports: [BettyFromHH](https://docu.ilias.de/go/usr/9657)
+    * Authority to Sign off on Conceptual Changes: [BettyFromHH](https://docu.ilias.de/go/usr/96573)
+    * Authority to Sign off on Code Changes: [BettyFromHH](https://docu.ilias.de/go/usr/96573), [rotegras](https://docu.ilias.de/go/usr/88399)
+    * Authority to Curate Test Cases: [BettyFromHH](https://docu.ilias.de/go/usr/96573)
+    * Authority to (De-)Assign Authorities: [BettyFromHH](https://docu.ilias.de/go/usr/96573)
+    * Assignee for Issues: [BettyFromHH](https://docu.ilias.de/go/usr/96573)
+    * Assignee for Security Reports: [BettyFromHH](https://docu.ilias.de/go/usr/96573)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END CSSAndTemplates)

--- a/docs/development/maintenance.md
+++ b/docs/development/maintenance.md
@@ -1588,7 +1588,6 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Authority to Sign off Testcase Changes: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Authority to (De-)Assign Authorities: [fschmid](https://docu.ilias.de/go/usr/21087)
-	* Testcases: [fschmid](https://docu.ilias.de/go/usr/70029)
     * Assignee for Issues: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Assignee for Security Reports: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')

--- a/docs/development/maintenance.md
+++ b/docs/development/maintenance.md
@@ -180,8 +180,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: MISSING
     * Authority to Curate Test Cases: MISSING
     * Authority to (De-)Assign Authorities: MISSING
+    * Assignee for Issues: MISSING
     * Assignee for Security Reports: MISSING
-    * Assignee for Security Issues: MISSING
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END ActiveRecord)
@@ -196,8 +196,8 @@ of ILIAS. The file contains the following fields:
         , [kunkel](https://docu.ilias.de/go/usr/115)
     * Authority to (De-)Assign Authorities: [fneumann (Databay AG)](https://docu.ilias.de/go/usr/1560)
         , [lscharmer (Databay AG)](https://docu.ilias.de/go/usr/87863)
+    * Assignee for Issues: [fneumann](https://docu.ilias.de/go/usr/1560)
     * Assignee for Security Reports: [fneumann](https://docu.ilias.de/go/usr/1560)
-    * Assignee for Security Issues: [fneumann](https://docu.ilias.de/go/usr/1560)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Administration)
@@ -209,8 +209,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Authority to Curate Test Cases: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Authority to (De-)Assign Authorities: [fschmid](https://docu.ilias.de/go/usr/21087)
+    * Assignee for Issues: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Assignee for Security Reports: [fschmid](https://docu.ilias.de/go/usr/21087)
-    * Assignee for Security Issues: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END AdministrativeNotifications)
@@ -222,8 +222,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [tjoussen](https://docu.ilias.de/go/usr/103745), [mjansen](https://docu.ilias.de/go/usr/8784)
     * Authority to Curate Test Cases: MISSING
     * Authority to (De-)Assign Authorities: [tjoussen (Databay AG)](https://docu.ilias.de/go/usr/103745)
+    * Assignee for Issues: [tjoussen](https://docu.ilias.de/go/usr/103745)
     * Assignee for Security Reports: [tjoussen](https://docu.ilias.de/go/usr/103745)
-    * Assignee for Security Issues: [tjoussen](https://docu.ilias.de/go/usr/103745)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END BackgroundTasks)
@@ -235,8 +235,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [fhelfer](https://docu.ilias.de/go/usr/93367), [mjansen](https://docu.ilias.de/go/usr/8784)
     * Authority to Curate Test Cases: [atoedt](https://docu.ilias.de/go/usr/3139)
     * Authority to (De-)Assign Authorities: [mjansen (Databay AG)](https://docu.ilias.de/go/usr/8784)
+    * Assignee for Issues: [fhelfer](https://docu.ilias.de/go/usr/93367)
     * Assignee for Security Reports: [fhelfer](https://docu.ilias.de/go/usr/93367)
-    * Assignee for Security Issues: [fhelfer](https://docu.ilias.de/go/usr/93367)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Badges)
@@ -249,8 +249,8 @@ of ILIAS. The file contains the following fields:
     , [smeyer](https://docu.ilias.de/go/usr/191)
   * Authority to Curate Test Cases: [fschmid](https://docu.ilias.de/go/usr/21087)
   * Authority to (De-)Assign Authorities: [fschmid](https://docu.ilias.de/go/usr/21087)
+  * Assignee for Issues: [fschmid](https://docu.ilias.de/go/usr/21087)
   * Assignee for Security Reports: [fschmid](https://docu.ilias.de/go/usr/21087)
-  * Assignee for Security Issues: [fschmid](https://docu.ilias.de/go/usr/21087)
   * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Benchmark)
@@ -262,8 +262,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Authority to Curate Test Cases: MISSING
     * Authority to (De-)Assign Authorities: MISSING
+    * Assignee for Issues: MISSING
     * Assignee for Security Reports: MISSING
-    * Assignee for Security Issues: MISSING
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END BibliographicListItem)
@@ -275,8 +275,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [akill](https://docu.ilias.de/go/usr/149)
     * Authority to Curate Test Cases: [akill](https://docu.ilias.de/go/usr/149)
     * Authority to (De-)Assign Authorities: [akill](https://docu.ilias.de/go/usr/149)
+    * Assignee for Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Assignee for Security Reports: [akill](https://docu.ilias.de/go/usr/149)
-    * Assignee for Security Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Blog)
@@ -288,8 +288,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [tjoussen](https://docu.ilias.de/go/usr/103745)
     * Authority to Curate Test Cases: [simon.lowe](https://docu.ilias.de/go/usr/79091), [tjoussen](https://docu.ilias.de/go/usr/103745)
     * Authority to (De-)Assign Authorities: [simon.lowe (Databay AG)](https://docu.ilias.de/go/usr/79091), [oliver.samoila (Databay AG)](https://docu.ilias.de/go/usr/26160)
+    * Assignee for Issues: [tjoussen](https://docu.ilias.de/go/usr/103745)
     * Assignee for Security Reports: [tjoussen](https://docu.ilias.de/go/usr/103745)
-    * Assignee for Security Issues: [tjoussen](https://docu.ilias.de/go/usr/103745)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END BookingPool)
@@ -302,8 +302,8 @@ of ILIAS. The file contains the following fields:
         , [akill](https://docu.ilias.de/go/usr/149)
     * Authority to Curate Test Cases: [MISSING]
     * Authority to (De-)Assign Authorities: [smeyer](https://docu.ilias.de/go/usr/191)
+    * Assignee for Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Assignee for Security Reports: [smeyer](https://docu.ilias.de/go/usr/191)
-    * Assignee for Security Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Calendar)
@@ -316,8 +316,8 @@ of ILIAS. The file contains the following fields:
         ,  [smeyer](https://docu.ilias.de/go/usr/191)
     * Authority to Curate Test Cases: [atoedt](https://docu.ilias.de/go/usr/3139)
     * Authority to (De-)Assign Authorities: [akill](https://docu.ilias.de/go/usr/149)
+    * Assignee for Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Assignee for Security Reports: [akill](https://docu.ilias.de/go/usr/149)
-    * Assignee for Security Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END CategoryAndRepository)
@@ -329,8 +329,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [mjansen](https://docu.ilias.de/go/usr/8784)
   * Authority to Curate Test Cases: [mjansen](https://docu.ilias.de/go/usr/8784), [ChrisPotter](https://docu.ilias.de/go/usr/90855)
     * Authority to (De-)Assign Authorities: [mjansen (Databay AG)](https://docu.ilias.de/go/usr/8784)
+    * Assignee for Issues: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Assignee for Security Reports: [mjansen](https://docu.ilias.de/go/usr/8784)
-    * Assignee for Security Issues: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Certificate)
@@ -343,8 +343,8 @@ of ILIAS. The file contains the following fields:
         , [mbecker](https://docu.ilias.de/go/usr/27266)
     * Authority to Curate Test Cases: [kunkel](https://docu.ilias.de/go/usr/115)
     * Authority to (De-)Assign Authorities: [mjansen (Databay AG)](https://docu.ilias.de/go/usr/8784)
+    * Assignee for Issues: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Assignee for Security Reports: [mjansen](https://docu.ilias.de/go/usr/8784)
-    * Assignee for Security Issues: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Chat)
@@ -356,8 +356,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [akill](https://docu.ilias.de/go/usr/149)
     * Authority to Curate Test Cases: [skaiser](https://docu.ilias.de/go/usr/17260)
     * Authority to (De-)Assign Authorities: [akill](https://docu.ilias.de/go/usr/149)
+    * Assignee for Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Assignee for Security Reports: [akill](https://docu.ilias.de/go/usr/149)
-    * Assignee for Security Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Comments)
@@ -370,8 +370,8 @@ of ILIAS. The file contains the following fields:
         , [akill](https://docu.ilias.de/go/usr/149)
     * Authority to Curate Test Cases: [atoedt](https://docu.ilias.de/go/usr/3139)
     * Authority to (De-)Assign Authorities: [cludolf](https://docu.ilias.de/go/usr/97658)
+    * Assignee for Issues: [cludolf](https://docu.ilias.de/go/usr/97658)
     * Assignee for Security Reports: [cludolf](https://docu.ilias.de/go/usr/97658)
-    * Assignee for Security Issues: [cludolf](https://docu.ilias.de/go/usr/97658)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END CompetenceManagement)
@@ -383,8 +383,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [fschmid](https://docu.ilias.de/go/usr/21087), [tfuhrer](https://docu.ilias.de/go/usr/81947)
     * Authority to Curate Test Cases: [MISSING]
     * Authority to (De-)Assign Authorities: [fschmid](https://docu.ilias.de/go/usr/21087), [tfuhrer](https://docu.ilias.de/go/usr/81947)
+    * Assignee for Issues: [fschmid](https://docu.ilias.de/go/usr/21087), [tfuhrer](https://docu.ilias.de/go/usr/81947)
     * Assignee for Security Reports: [fschmid](https://docu.ilias.de/go/usr/21087), [tfuhrer](https://docu.ilias.de/go/usr/81947)
-    * Assignee for Security Issues: [fschmid](https://docu.ilias.de/go/usr/21087), [tfuhrer](https://docu.ilias.de/go/usr/81947)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Component)
@@ -396,8 +396,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Authority to Curate Test Cases: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Authority to (De-)Assign Authorities: [mjansen (Databay AG)](https://docu.ilias.de/go/usr/8784)
+    * Assignee for Issues: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Assignee for Security Reports: [mjansen](https://docu.ilias.de/go/usr/8784)
-    * Assignee for Security Issues: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Contacts)
@@ -409,8 +409,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Authority to Curate Test Cases: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Authority to (De-)Assign Authorities: [mjansen (Databay AG)](https://docu.ilias.de/go/usr/8784)
+    * Assignee for Issues: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Assignee for Security Reports: [mjansen](https://docu.ilias.de/go/usr/8784)
-    * Assignee for Security Issues: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END ContentPage)
@@ -422,8 +422,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [MISSING]
     * Authority to Curate Test Cases: [MISSING]
     * Authority to (De-)Assign Authorities: [MISSING]
+    * Assignee for Issues: [MISSING]
     * Assignee for Security Reports: [MISSING]
-    * Assignee for Security Issues: [MISSING]
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Context)
@@ -435,8 +435,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [akill](https://docu.ilias.de/go/usr/149)
     * Authority to Curate Test Cases: [ezenzen](https://docu.ilias.de/go/usr/42910)
     * Authority to (De-)Assign Authorities: [akill](https://docu.ilias.de/go/usr/149)
+    * Assignee for Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Assignee for Security Reports: [akill](https://docu.ilias.de/go/usr/149)
-    * Assignee for Security Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END ILIASPageEditor)
@@ -449,8 +449,8 @@ of ILIAS. The file contains the following fields:
         , [akill](https://docu.ilias.de/go/usr/149)
     * Authority to Curate Test Cases: [MISSING]
     * Authority to (De-)Assign Authorities: [smeyer](https://docu.ilias.de/go/usr/191)
+    * Assignee for Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Assignee for Security Reports: [smeyer](https://docu.ilias.de/go/usr/191)
-    * Assignee for Security Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END CourseManagement)
@@ -462,8 +462,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Authority to Curate Test Cases: [kunkel](https://docu.ilias.de/go/usr/115)
     * Authority to (De-)Assign Authorities: [mjansen (Databay AG)](https://docu.ilias.de/go/usr/8784)
+    * Assignee for Issues: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Assignee for Security Reports: [mjansen](https://docu.ilias.de/go/usr/8784)
-    * Assignee for Security Issues: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END CronService)
@@ -471,12 +471,12 @@ of ILIAS. The file contains the following fields:
 [//]: # (BEGIN CSSAndTemplates)
 
 * **CSS / Templates**
-    * Authority to Sign off on Conceptual Changes: [BettyFromHH](https://docu.ilias.de/go/usr/96573)
-    * Authority to Sign off on Code Changes: [BettyFromHH](https://docu.ilias.de/go/usr/96573), [rotegras](https://docu.ilias.de/go/usr/88399)
-    * Authority to Curate Test Cases: [BettyFromHH](https://docu.ilias.de/go/usr/96573)
-    * Authority to (De-)Assign Authorities: [BettyFromHH](https://docu.ilias.de/go/usr/96573)
-    * Assignee for Security Reports: [BettyFromHH](https://docu.ilias.de/go/usr/96573)
-    * Assignee for Security Issues: [BettyFromHH](https://docu.ilias.de/go/usr/96573)
+    * Authority to Sign off on Conceptual Changes: [BettyFromHH](https://docu.ilias.de/go/usr/9657)
+    * Authority to Sign off on Code Changes: [BettyFromHH](https://docu.ilias.de/go/usr/9657), [rotegras](https://docu.ilias.de/go/usr/88399)
+    * Authority to Curate Test Cases: [BettyFromHH](https://docu.ilias.de/go/usr/9657)
+    * Authority to (De-)Assign Authorities: [BettyFromHH](https://docu.ilias.de/go/usr/9657)
+    * Assignee for Issues: [BettyFromHH](https://docu.ilias.de/go/usr/9657)
+    * Assignee for Security Reports: [BettyFromHH](https://docu.ilias.de/go/usr/9657)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END CSSAndTemplates)
@@ -492,8 +492,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Curate Test Cases: [kunkel](https://docu.ilias.de/go/usr/115)
     * Authority to (De-)Assign Authorities: [iszmais (Databay AG)](https://docu.ilias.de/go/usr/65630)
         , [lscharmer (Databay AG)](https://docu.ilias.de/go/usr/87863)
+    * Assignee for Issues: [iszmais](https://docu.ilias.de/go/usr/65630)
     * Assignee for Security Reports: [iszmais](https://docu.ilias.de/go/usr/65630)
-    * Assignee for Security Issues: [iszmais](https://docu.ilias.de/go/usr/65630)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Dashboard)
@@ -505,8 +505,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [lscharmer](https://docu.ilias.de/go/usr/87863), [mjansen](https://docu.ilias.de/go/usr/8784)
     * Authority to Curate Test Cases: [MISSING]
     * Authority to (De-)Assign Authorities: [lscharmer](https://docu.ilias.de/go/usr/87863), [mjansen](https://docu.ilias.de/go/usr/8784)
+    * Assignee for Issues: [lscharmer](https://docu.ilias.de/go/usr/87863), [mjansen](https://docu.ilias.de/go/usr/8784)
     * Assignee for Security Reports: [lscharmer](https://docu.ilias.de/go/usr/87863), [mjansen](https://docu.ilias.de/go/usr/8784)
-    * Assignee for Security Issues: [lscharmer](https://docu.ilias.de/go/usr/87863), [mjansen](https://docu.ilias.de/go/usr/8784)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Data)
@@ -518,8 +518,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [iszmais](https://docu.ilias.de/go/usr/65630)
     * Authority to Curate Test Cases: [oliver.samoila](https://docu.ilias.de/go/usr/26160)
     * Authority to (De-)Assign Authorities: [oliver.samoila (Databay AG)](https://docu.ilias.de/go/usr/26160)
+    * Assignee for Issues: [iszmais](https://docu.ilias.de/go/usr/65630)
     * Assignee for Security Reports: [iszmais](https://docu.ilias.de/go/usr/65630)
-    * Assignee for Security Issues: [iszmais](https://docu.ilias.de/go/usr/65630)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END DataCollection)
@@ -532,8 +532,8 @@ of ILIAS. The file contains the following fields:
         , [lscharmer](https://docu.ilias.de/go/usr/87863)
     * Authority to Curate Test Cases: [AUTHOR MISSING](https://docu.ilias.de/go/pg/64423_4793)
     * Authority to (De-)Assign Authorities: [mjansen (Databay AG)](https://docu.ilias.de/go/usr/8784)
+    * Assignee for Issues: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Assignee for Security Reports: [mjansen](https://docu.ilias.de/go/usr/8784)
-    * Assignee for Security Issues: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END DataProtection)
@@ -546,8 +546,8 @@ of ILIAS. The file contains the following fields:
         , [smeyer](https://docu.ilias.de/go/usr/191)
     * Authority to Curate Test Cases: MISSING
     * Authority to (De-)Assign Authorities: [lscharmer](https://docu.ilias.de/go/usr/87863)
+    * Assignee for Issues: [lscharmer](https://docu.ilias.de/go/usr/87863)
     * Assignee for Security Reports: [lscharmer](https://docu.ilias.de/go/usr/87863)
-    * Assignee for Security Issues: [lscharmer](https://docu.ilias.de/go/usr/87863)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Database)
@@ -559,8 +559,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [smeyer](https://docu.ilias.de/go/usr/191)
     * Authority to Curate Test Cases: [atoedt](https://docu.ilias.de/go/usr/3139)
     * Authority to (De-)Assign Authorities: [smeyer](https://docu.ilias.de/go/usr/191)
+    * Assignee for Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Assignee for Security Reports: [smeyer](https://docu.ilias.de/go/usr/191)
-    * Assignee for Security Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END DidacticTemplates)
@@ -572,8 +572,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [sdyhr](https://docu.ilias.de/go/usr/102107)
     * Authority to Curate Test Cases: [jheim](https://docu.ilias.de/go/usr/40167), [SIG CampusConnect und ECS(A)](https://docu.ilias.de/go/grp/7893)
     * Authority to (De-)Assign Authorities: [bogen](https://docu.ilias.de/go/usr/13815), [mglaubitz](https://docu.ilias.de/go/usr/28309)
+    * Assignee for Issues: [sdyhr](https://docu.ilias.de/go/usr/102107)
     * Assignee for Security Reports: [sdyhr](https://docu.ilias.de/go/usr/102107)
-    * Assignee for Security Issues: [sdyhr](https://docu.ilias.de/go/usr/102107)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END ECSInterface)
@@ -585,8 +585,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [tschmitz](https://docu.ilias.de/go/usr/92591)
     * Authority to Curate Test Cases: [tschmitz](https://docu.ilias.de/go/usr/92591)
     * Authority to (De-)Assign Authorities: [tschmitz](https://docu.ilias.de/go/usr/92591)
+    * Assignee for Issues: [tschmitz](https://docu.ilias.de/go/usr/92591)
     * Assignee for Security Reports: [tschmitz](https://docu.ilias.de/go/usr/92591)
-    * Assignee for Security Issues: [tschmitz](https://docu.ilias.de/go/usr/92591)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END EmployeeTalk)
@@ -598,8 +598,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Authority to Curate Test Cases: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Authority to (De-)Assign Authorities: [fschmid](https://docu.ilias.de/go/usr/21087)
+    * Assignee for Issues: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Assignee for Security Reports: [fschmid](https://docu.ilias.de/go/usr/21087)
-    * Assignee for Security Issues: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END EventHandling)
@@ -611,8 +611,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [skergomard](https://docu.ilias.de/goto_docu_usr_44474.html)
     * Authority to Curate Test Cases: [dstrassner](https://docu.ilias.de/goto_docu_usr_48931.html)
     * Authority to (De-)Assign Authorities: [dstrassner](https://docu.ilias.de/goto_docu_usr_48931.html)
+    * Assignee for Issues: [dstrassner](https://docu.ilias.de/goto_docu_usr_48931.html)
     * Assignee for Security Reports: [dstrassner](https://docu.ilias.de/goto_docu_usr_48931.html)
-    * Assignee for Security Issues: [dstrassner](https://docu.ilias.de/goto_docu_usr_48931.html)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Excel)
@@ -624,8 +624,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [akill](https://docu.ilias.de/go/usr/149)
     * Authority to Curate Test Cases: [atoedt](https://docu.ilias.de/go/usr/3139)
     * Authority to (De-)Assign Authorities: [akill](https://docu.ilias.de/go/usr/149)
+    * Assignee for Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Assignee for Security Reports: [akill](https://docu.ilias.de/go/usr/149)
-    * Assignee for Security Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Exercise)
@@ -637,8 +637,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [smeyer](https://docu.ilias.de/go/usr/191)
     * Authority to Curate Test Cases: [Fabian](https://docu.ilias.de/go/usr/27631)
     * Authority to (De-)Assign Authorities: [smeyer](https://docu.ilias.de/go/usr/191)
+    * Assignee for Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Assignee for Security Reports: [smeyer](https://docu.ilias.de/go/usr/191)
-    * Assignee for Security Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Export)
@@ -650,8 +650,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [iszmais](https://docu.ilias.de/go/usr/65630)
     * Authority to Curate Test Cases: [iszmais](https://docu.ilias.de/go/usr/65630)
     * Authority to (De-)Assign Authorities: [iszmais](https://docu.ilias.de/go/usr/65630)
+    * Assignee for Issues: [iszmais](https://docu.ilias.de/go/usr/65630)
     * Assignee for Security Reports: [iszmais](https://docu.ilias.de/go/usr/65630)
-    * Assignee for Security Issues: [iszmais](https://docu.ilias.de/go/usr/65630)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Favourites)
@@ -663,8 +663,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [akill](https://docu.ilias.de/go/usr/149)
     * Authority to Curate Test Cases: [kunkel](https://docu.ilias.de/go/usr/115)
     * Authority to (De-)Assign Authorities: [akill](https://docu.ilias.de/go/usr/149)
+    * Assignee for Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Assignee for Security Reports: [akill](https://docu.ilias.de/go/usr/149)
-    * Assignee for Security Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END WebFeed)
@@ -676,8 +676,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Authority to Curate Test Cases: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Authority to (De-)Assign Authorities: [fschmid](https://docu.ilias.de/go/usr/21087)
+    * Assignee for Issues: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Assignee for Security Reports: [fschmid](https://docu.ilias.de/go/usr/21087)
-    * Assignee for Security Issues: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END File)
@@ -689,8 +689,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Authority to Curate Test Cases: FH Aachen
     * Authority to (De-)Assign Authorities: [mjansen (Databay AG)](https://docu.ilias.de/go/usr/8784)
+    * Assignee for Issues: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Assignee for Security Reports: [mjansen](https://docu.ilias.de/go/usr/8784)
-    * Assignee for Security Issues: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Forum)
@@ -702,8 +702,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Authority to Curate Test Cases: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Authority to (De-)Assign Authorities: [fschmid](https://docu.ilias.de/go/usr/21087)
+    * Assignee for Issues: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Assignee for Security Reports: [fschmid](https://docu.ilias.de/go/usr/21087)
-    * Assignee for Security Issues: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END GlobalCache)
@@ -715,8 +715,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Authority to Curate Test Cases: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Authority to (De-)Assign Authorities: [fschmid](https://docu.ilias.de/go/usr/21087)
+    * Assignee for Issues: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Assignee for Security Reports: [fschmid](https://docu.ilias.de/go/usr/21087)
-    * Assignee for Security Issues: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END GlobalScreen)
@@ -728,8 +728,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [akill](https://docu.ilias.de/go/usr/149)
     * Authority to Curate Test Cases: [ezenzen](https://docu.ilias.de/go/usr/42910)
     * Authority to (De-)Assign Authorities: [akill](https://docu.ilias.de/go/usr/149)
+    * Assignee for Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Assignee for Security Reports: [akill](https://docu.ilias.de/go/usr/149)
-    * Assignee for Security Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Glossary)
@@ -742,8 +742,8 @@ of ILIAS. The file contains the following fields:
         , [akill](https://docu.ilias.de/go/usr/149)
     * Authority to Curate Test Cases: [MISSING]
     * Authority to (De-)Assign Authorities: [smeyer](https://docu.ilias.de/go/usr/191)
+    * Assignee for Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Assignee for Security Reports: [smeyer](https://docu.ilias.de/go/usr/191)
-    * Assignee for Security Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Group)
@@ -756,8 +756,8 @@ of ILIAS. The file contains the following fields:
         , [smeyer](https://docu.ilias.de/go/usr/191)
     * Authority to Curate Test Cases: [atoedt](https://docu.ilias.de/go/usr/3139)
     * Authority to (De-)Assign Authorities: [akill](https://docu.ilias.de/go/usr/149)
+    * Assignee for Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Assignee for Security Reports: [akill](https://docu.ilias.de/go/usr/149)
-    * Assignee for Security Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END OnlineHelp)
@@ -769,8 +769,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Authority to Curate Test Cases: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Authority to (De-)Assign Authorities: [fschmid](https://docu.ilias.de/go/usr/21087)
+    * Assignee for Issues: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Assignee for Security Reports: [fschmid](https://docu.ilias.de/go/usr/21087)
-    * Assignee for Security Issues: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END HTTP-Request)
@@ -782,8 +782,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [mbecker](https://docu.ilias.de/go/usr/27266)
     * Authority to Curate Test Cases: [mbecker](https://docu.ilias.de/go/usr/27266)
     * Authority to (De-)Assign Authorities: [mbecker](https://docu.ilias.de/go/usr/27266)
+    * Assignee for Issues: [mbecker](https://docu.ilias.de/go/usr/27266)
     * Assignee for Security Reports: [mbecker](https://docu.ilias.de/go/usr/27266)
-    * Assignee for Security Issues: [mbecker](https://docu.ilias.de/go/usr/27266)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END IndividualAssessment)
@@ -796,8 +796,8 @@ of ILIAS. The file contains the following fields:
         , [smeyer](https://docu.ilias.de/go/usr/191)
     * Authority to Curate Test Cases: [akill](https://docu.ilias.de/go/usr/149)
     * Authority to (De-)Assign Authorities: [akill](https://docu.ilias.de/go/usr/149)
+    * Assignee for Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Assignee for Security Reports: [akill](https://docu.ilias.de/go/usr/149)
-    * Assignee for Security Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END InfoPage)
@@ -809,8 +809,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [mjansen](https://docu.ilias.de/go/usr/8784), [tfuhrer](https://docu.ilias.de/go/usr/81947), [fschmid](https://docu.ilias.de/go/usr/21087)
     * Authority to Curate Test Cases: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Authority to (De-)Assign Authorities: [mjansen](https://docu.ilias.de/go/usr/8784)
+    * Assignee for Issues: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Assignee for Security Reports: [mjansen](https://docu.ilias.de/go/usr/8784)
-    * Assignee for Security Issues: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END InitialisationService)
@@ -822,8 +822,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [tjoussen](https://docu.ilias.de/go/usr/103745)
     * Authority to Curate Test Cases: [oliver.samoila](https://docu.ilias.de/go/usr/26160), [tjoussen](https://docu.ilias.de/go/usr/103745)
     * Authority to (De-)Assign Authorities: [oliver.samoila (Databay AG)](https://docu.ilias.de/go/usr/26160)
+    * Assignee for Issues: [tjoussen](https://docu.ilias.de/go/usr/103745)
     * Assignee for Security Reports: [tjoussen](https://docu.ilias.de/go/usr/103745)
-    * Assignee for Security Issues: [tjoussen](https://docu.ilias.de/go/usr/103745)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END ItemGroup)
@@ -835,8 +835,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [keven.clausen](https://docu.ilias.de/go/usr/100316), [katrin.grosskopf](https://docu.ilias.de/go/usr/68340), [jeanine.auerbach](https://docu.ilias.de/go/usr/101332),[cknof](https://docu.ilias.de/go/usr/90890)
     * Authority to Curate Test Cases: [jeanine.auerbach](https://docu.ilias.de/go/usr/101332)
     * Authority to (De-)Assign Authorities: [katrin.grosskopf](https://docu.ilias.de/go/usr/68340)
-    * Assignee for Security Reports: [katrin.grosskopf](https://docu.ilias.de/go/usr/68340)
-    * Assignee for Security Issues: [keven.clausen](https://docu.ilias.de/go/usr/100316)
+    * Assignee for Issues: [katrin.grosskopf](https://docu.ilias.de/go/usr/68340)
+    * Assignee for Security Reports: [keven.clausen](https://docu.ilias.de/go/usr/100316)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END GeneralKiosk-Mode)
@@ -848,8 +848,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [mkunkel](https://docu.ilias.de/go/usr/115), [katrin.grosskopf](https://docu.ilias.de/go/usr/68340), [ChrisPotter](https://docu.ilias.de/go/usr/90855), [keven.clausen](https://docu.ilias.de/go/usr/100316), [cknof](https://docu.ilias.de/go/usr/90890) 
     * Authority to Curate Test Cases: [ChrisPotter](https://docu.ilias.de/go/usr/90855)
     * Authority to (De-)Assign Authorities: [mkunkel](https://docu.ilias.de/go/usr/115)
+    * Assignee for Issues: [mkunkel](https://docu.ilias.de/go/usr/115)
     * Assignee for Security Reports: [mkunkel](https://docu.ilias.de/go/usr/115)
-    * Assignee for Security Issues: [mkunkel](https://docu.ilias.de/go/usr/115)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END LanguageHandling)
@@ -861,8 +861,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [akill](https://docu.ilias.de/go/usr/149)
     * Authority to Curate Test Cases: [ezenzen](https://docu.ilias.de/go/usr/42910)
     * Authority to (De-)Assign Authorities: [akill](https://docu.ilias.de/go/usr/149)
+    * Assignee for Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Assignee for Security Reports: [akill](https://docu.ilias.de/go/usr/149)
-    * Assignee for Security Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END LearningHistory)
@@ -874,8 +874,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [mbecker](https://docu.ilias.de/go/usr/27266)
     * Authority to Curate Test Cases: [mbecker](https://docu.ilias.de/go/usr/27266)
     * Authority to (De-)Assign Authorities: [mbecker](https://docu.ilias.de/go/usr/27266)
+    * Assignee for Issues: [mbecker](https://docu.ilias.de/go/usr/27266)
     * Assignee for Security Reports: [mbecker](https://docu.ilias.de/go/usr/27266)
-    * Assignee for Security Issues: [mbecker](https://docu.ilias.de/go/usr/27266)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END LearningModuleHTML)
@@ -887,8 +887,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [akill](https://docu.ilias.de/go/usr/149)
     * Authority to Curate Test Cases: [Balliel](https://docu.ilias.de/go/usr/18365)
     * Authority to (De-)Assign Authorities: [akill](https://docu.ilias.de/go/usr/149)
+    * Assignee for Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Assignee for Security Reports: [akill](https://docu.ilias.de/go/usr/149)
-    * Assignee for Security Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END LearningModuleILIAS)
@@ -900,8 +900,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [keven.clausen](https://docu.ilias.de/go/usr/100316), [katrin.grosskopf](https://docu.ilias.de/go/usr/68340), [jeanine.auerbach](https://docu.ilias.de/go/usr/101332)
     * Authority to Curate Test Cases: [jeanine.auerbach](https://docu.ilias.de/go/usr/101332)
     * Authority to (De-)Assign Authorities: [katrin.grosskopf](https://docu.ilias.de/go/usr/68340)
-    * Assignee for Security Reports: [katrin.grosskopf](https://docu.ilias.de/go/usr/68340)
-    * Assignee for Security Issues: [keven.clausen](https://docu.ilias.de/go/usr/100316)
+    * Assignee for Issues: [katrin.grosskopf](https://docu.ilias.de/go/usr/68340)
+    * Assignee for Security Reports: [keven.clausen](https://docu.ilias.de/go/usr/100316)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END LearningSequence)
@@ -914,8 +914,8 @@ of ILIAS. The file contains the following fields:
         , [lscharmer](https://docu.ilias.de/go/usr/87863)
     * Authority to Curate Test Cases: [AUTHOR MISSING](https://docu.ilias.de/go/pg/64423_4793)
     * Authority to (De-)Assign Authorities: [mjansen (Databay AG)](https://docu.ilias.de/go/usr/34047)
+    * Assignee for Issues: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Assignee for Security Reports: [mjansen](https://docu.ilias.de/go/usr/8784)
-    * Assignee for Security Issues: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END LegalDocuments)
@@ -927,8 +927,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [fhelfer](https://docu.ilias.de/go/usr/93367), [tjoussen](https://docu.ilias.de/go/usr/103745)
     * Authority to Curate Test Cases: [fhelfer](https://docu.ilias.de/go/usr/93367), [tjoussen](https://docu.ilias.de/go/usr/103745), [oliver.samoila](https://docu.ilias.de/go/usr/26160)
     * Authority to (De-)Assign Authorities: [oliver.samoila (Databay AG)](https://docu.ilias.de/go/usr/26160)
+    * Assignee for Issues: [fhelfer](https://docu.ilias.de/go/usr/93367)
     * Assignee for Security Reports: [fhelfer](https://docu.ilias.de/go/usr/93367)
-    * Assignee for Security Issues: [fhelfer](https://docu.ilias.de/go/usr/93367)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Like)
@@ -940,8 +940,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [smeyer](https://docu.ilias.de/go/usr/191)
     * Authority to Curate Test Cases: [smeyer](https://docu.ilias.de/go/usr/191)
     * Authority to (De-)Assign Authorities: [smeyer](https://docu.ilias.de/go/usr/191)
+    * Assignee for Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Assignee for Security Reports: [smeyer](https://docu.ilias.de/go/usr/191)
-    * Assignee for Security Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Logging)
@@ -955,8 +955,8 @@ of ILIAS. The file contains the following fields:
         , [tjoussen](https://docu.ilias.de/go/usr/103745)
     * Authority to Curate Test Cases: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Authority to (De-)Assign Authorities: [mjansen (Databay AG)](https://docu.ilias.de/go/usr/8784)
+    * Assignee for Issues: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Assignee for Security Reports: [mjansen](https://docu.ilias.de/go/usr/8784)
-    * Assignee for Security Issues: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END LoginAuthAndRegistration)
@@ -968,8 +968,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [Zallax](https://docu.ilias.de/go/usr/101102), [sdiaz](https://docu.ilias.de/go/usr/105654), [sergiosantiago02](https://docu.ilias.de/go/usr/110174)
     * Authority to Curate Test Cases: [jcop](https://docu.ilias.de/go/usr/30511)
     * Authority to (De-)Assign Authorities: [jcop](https://docu.ilias.de/go/usr/30511)
+    * Assignee for Issues: [jcop](https://docu.ilias.de/go/usr/30511)
     * Assignee for Security Reports: [jcop](https://docu.ilias.de/go/usr/30511)
-    * Assignee for Security Issues: [jcop](https://docu.ilias.de/go/usr/30511)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END LTIConsumer)
@@ -981,8 +981,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [Zallax](https://docu.ilias.de/go/usr/101102), [sdiaz](https://docu.ilias.de/go/usr/105654), [smeyer](https://docu.ilias.de/goto_docu_usr_191.html), [sergiosantiago02](https://docu.ilias.de/go/usr/110174)
     * Authority to Curate Test Cases: [jcop](https://docu.ilias.de/go/usr/30511)
     * Authority to (De-)Assign Authorities: [jcop](https://docu.ilias.de/go/usr/30511)
+    * Assignee for Issues: [jcop](https://docu.ilias.de/go/usr/30511)
     * Assignee for Security Reports: [jcop](https://docu.ilias.de/go/usr/30511)
-    * Assignee for Security Issues: [jcop](https://docu.ilias.de/go/usr/30511)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END LTI)
@@ -994,8 +994,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Authority to Curate Test Cases: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Authority to (De-)Assign Authorities: [mjansen (Databay AG)](https://docu.ilias.de/go/usr/8784)
+    * Assignee for Issues: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Assignee for Security Reports: [mjansen](https://docu.ilias.de/go/usr/8784)
-    * Assignee for Security Issues: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Mail)
@@ -1007,8 +1007,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Authority to Curate Test Cases: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Authority to (De-)Assign Authorities: [fschmid](https://docu.ilias.de/go/usr/21087)
+    * Assignee for Issues: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Assignee for Security Reports: [fschmid](https://docu.ilias.de/go/usr/21087)
-    * Assignee for Security Issues: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END MainMenu)
@@ -1020,8 +1020,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [keven.clausen](https://docu.ilias.de/go/usr/100316), [katrin.grosskopf](https://docu.ilias.de/go/usr/68340), [jeanine.auerbach](https://docu.ilias.de/go/usr/101332)
     * Authority to Curate Test Cases: [jeanine.auerbach](https://docu.ilias.de/go/usr/101332)
     * Authority to (De-)Assign Authorities: [jeanine.auerbach](https://docu.ilias.de/go/usr/101332)
-    * Assignee for Security Reports: [jeanine.auerbach](https://docu.ilias.de/go/usr/101332)
-    * Assignee for Security Issues: [keven.clausen](https://docu.ilias.de/go/usr/100316)
+    * Assignee for Issues: [jeanine.auerbach](https://docu.ilias.de/go/usr/101332)
+    * Assignee for Security Reports: [keven.clausen](https://docu.ilias.de/go/usr/100316)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Maps)
@@ -1033,8 +1033,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [fneumann](https://docu.ilias.de/go/usr/1560)
     * Authority to Curate Test Cases: [fneumann](https://docu.ilias.de/go/usr/1560)
     * Authority to (De-)Assign Authorities: [fneumann](https://docu.ilias.de/go/usr/1560)
+    * Assignee for Issues: [fneumann](https://docu.ilias.de/go/usr/1560)
     * Assignee for Security Reports: [fneumann](https://docu.ilias.de/go/usr/1560)
-    * Assignee for Security Issues: [fneumann](https://docu.ilias.de/go/usr/1560)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END MathJax)
@@ -1046,8 +1046,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [akill](https://docu.ilias.de/go/usr/149)
     * Authority to Curate Test Cases: [kunkel](https://docu.ilias.de/go/usr/115)
     * Authority to (De-)Assign Authorities: [akill](https://docu.ilias.de/go/usr/149)
+    * Assignee for Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Assignee for Security Reports: [akill](https://docu.ilias.de/go/usr/149)
-    * Assignee for Security Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END MediaObjects)
@@ -1059,8 +1059,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [akill](https://docu.ilias.de/go/usr/149)
     * Authority to Curate Test Cases: [atoedt](https://docu.ilias.de/go/usr/3139)
     * Authority to (De-)Assign Authorities: [akill](https://docu.ilias.de/go/usr/149)
+    * Assignee for Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Assignee for Security Reports: [akill](https://docu.ilias.de/go/usr/149)
-    * Assignee for Security Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END MediaPool)
@@ -1072,8 +1072,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [akill](https://docu.ilias.de/go/usr/149)
     * Authority to Curate Test Cases: [berggold](https://docu.ilias.de/go/usr/22199)
     * Authority to (De-)Assign Authorities: [akill](https://docu.ilias.de/go/usr/149)
+    * Assignee for Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Assignee for Security Reports: [akill](https://docu.ilias.de/go/usr/149)
-    * Assignee for Security Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END MediaCast)
@@ -1085,8 +1085,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [smeyer](https://docu.ilias.de/go/usr/191)
     * Authority to Curate Test Cases: [smeyer](https://docu.ilias.de/go/usr/191)
     * Authority to (De-)Assign Authorities: [smeyer](https://docu.ilias.de/go/usr/191)
+    * Assignee for Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Assignee for Security Reports: [smeyer](https://docu.ilias.de/go/usr/191)
-    * Assignee for Security Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Membership)
@@ -1098,8 +1098,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [smeyer](https://docu.ilias.de/go/usr/191), [tschmitz](https://docu.ilias.de/go/usr/92591)
     * Authority to Curate Test Cases: [Alexandra Tödt](https://docu.ilias.de/go/usr/3139)
     * Authority to (De-)Assign Authorities: [smeyer](https://docu.ilias.de/go/usr/191)
+    * Assignee for Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Assignee for Security Reports: [smeyer](https://docu.ilias.de/go/usr/191)
-    * Assignee for Security Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Metadata)
@@ -1111,8 +1111,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [tjoussen](https://docu.ilias.de/go/usr/103745)
     * Authority to Curate Test Cases: [tjoussen](https://docu.ilias.de/go/usr/103745), [oliver.samoila](https://docu.ilias.de/go/usr/26160)
     * Authority to (De-)Assign Authorities: [oliver.samoila (Databay AG)](https://docu.ilias.de/go/usr/26160)
+    * Assignee for Issues: [tjoussen](https://docu.ilias.de/go/usr/103745)
     * Assignee for Security Reports: [tjoussen](https://docu.ilias.de/go/usr/103745)
-    * Assignee for Security Issues: [tjoussen](https://docu.ilias.de/go/usr/103745)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END News)
@@ -1124,8 +1124,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [akill](https://docu.ilias.de/go/usr/149)
     * Authority to Curate Test Cases: [skaiser](https://docu.ilias.de/go/usr/17260)
     * Authority to (De-)Assign Authorities: [akill](https://docu.ilias.de/go/usr/149)
+    * Assignee for Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Assignee for Security Reports: [akill](https://docu.ilias.de/go/usr/149)
-    * Assignee for Security Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END NotesAndComments)
@@ -1137,8 +1137,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [mjansen](https://docu.ilias.de/goto_docu_usr_8784.html), [iszmais](https://docu.ilias.de/goto_docu_usr_65630.html)
     * Authority to Curate Test Cases: [mjansen](https://docu.ilias.de/goto_docu_usr_8784.html), [oliver.samoila](https://docu.ilias.de/go/usr/26160), [iszmais](https://docu.ilias.de/goto_docu_usr_65630.html)
     * Authority to (De-)Assign Authorities: [oliver.samoila (Databay AG)](https://docu.ilias.de/go/usr/26160)
+    * Assignee for Issues: [mjansen](https://docu.ilias.de/goto_docu_usr_8784.html)
     * Assignee for Security Reports: [mjansen](https://docu.ilias.de/goto_docu_usr_8784.html)
-    * Assignee for Security Issues: [mjansen](https://docu.ilias.de/goto_docu_usr_8784.html)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Notification)
@@ -1153,8 +1153,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Curate Test Cases: [mjansen](https://docu.ilias.de/go/usr/8784)
         , [iszmais](https://docu.ilias.de/go/usr/65630)
     * Authority to (De-)Assign Authorities: [mjansen (Databay AG)](https://docu.ilias.de/go/usr/8784)
+    * Assignee for Issues: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Assignee for Security Reports: [mjansen](https://docu.ilias.de/go/usr/8784)
-    * Assignee for Security Issues: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Notifications)
@@ -1166,8 +1166,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [skergomard](https://docu.ilias.de/go/usr/44474)
     * Authority to Curate Test Cases: [skergomard](https://docu.ilias.de/go/usr/44474)
     * Authority to (De-)Assign Authorities: [skergomard](https://docu.ilias.de/go/usr/44474)
+    * Assignee for Issues: [skergomard](https://docu.ilias.de/go/usr/44474)
     * Assignee for Security Reports: [skergomard](https://docu.ilias.de/go/usr/44474)
-    * Assignee for Security Issues: [skergomard](https://docu.ilias.de/go/usr/44474)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END ObjectService)
@@ -1179,8 +1179,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [smeyer](https://docu.ilias.de/go/usr/191)
     * Authority to Curate Test Cases: [smeyer](https://docu.ilias.de/go/usr/191)
     * Authority to (De-)Assign Authorities: [smeyer](https://docu.ilias.de/go/usr/191)
+    * Assignee for Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Assignee for Security Reports: [smeyer](https://docu.ilias.de/go/usr/191)
-    * Assignee for Security Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END OpenIdConect)
@@ -1192,8 +1192,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Authority to Curate Test Cases: [wischniak](https://docu.ilias.de/go/usr/21896)
     * Authority to (De-)Assign Authorities: [MISSING]
-    * Assignee for Security Reports: [MISSING] 
-	* Assignee for Security Issues: [MISSING]
+    * Assignee for Issues: [MISSING] 
+	* Assignee for Security Reports: [MISSING]
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END OrganisationalUnits)
@@ -1205,8 +1205,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [akill](https://docu.ilias.de/go/usr/149)
     * Authority to Curate Test Cases: [akill](https://docu.ilias.de/go/usr/149)
     * Authority to (De-)Assign Authorities: [akill](https://docu.ilias.de/go/usr/149)
+    * Assignee for Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Assignee for Security Reports: [akill](https://docu.ilias.de/go/usr/149)
-    * Assignee for Security Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END PersonalAndSharedResources)
@@ -1219,8 +1219,8 @@ of ILIAS. The file contains the following fields:
         , [tschmitz](https://docu.ilias.de/go/usr/92591)
     * Authority to Curate Test Cases: [smeyer](https://docu.ilias.de/go/usr/191)
     * Authority to (De-)Assign Authorities: [smeyer](https://docu.ilias.de/go/usr/191)
+    * Assignee for Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Assignee for Security Reports: [smeyer](https://docu.ilias.de/go/usr/191)
-    * Assignee for Security Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Poll)
@@ -1232,8 +1232,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [akill](https://docu.ilias.de/go/usr/149)
     * Authority to Curate Test Cases: [ezenzen](https://docu.ilias.de/go/usr/42910)
     * Authority to (De-)Assign Authorities: [akill](https://docu.ilias.de/go/usr/149)
+    * Assignee for Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Assignee for Security Reports: [akill](https://docu.ilias.de/go/usr/149)
-    * Assignee for Security Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Portfolio)
@@ -1245,8 +1245,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [smeyer](https://docu.ilias.de/go/usr/191)
     * Authority to Curate Test Cases: [smeyer](https://docu.ilias.de/go/usr/191)
     * Authority to (De-)Assign Authorities: [smeyer](https://docu.ilias.de/go/usr/191)
+    * Assignee for Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Assignee for Security Reports: [smeyer](https://docu.ilias.de/go/usr/191)
-    * Assignee for Security Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END PreconditionHandling)
@@ -1258,8 +1258,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [fhelfer](https://docu.ilias.de/go/usr/93367)
     * Authority to Curate Test Cases: [fhelfer](https://docu.ilias.de/go/usr/93367), [oliver.samoila](https://docu.ilias.de/go/usr/26160)
     * Authority to (De-)Assign Authorities: [oliver.samoila (Databay AG)](https://docu.ilias.de/go/usr/26160)
+    * Assignee for Issues: [fhelfer](https://docu.ilias.de/go/usr/93367)
     * Assignee for Security Reports: [fhelfer](https://docu.ilias.de/go/usr/93367)
-    * Assignee for Security Issues: [fhelfer](https://docu.ilias.de/go/usr/93367)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Rating)
@@ -1271,8 +1271,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [skergomard](https://docu.ilias.de/go/usr/44474)
     * Authority to Curate Test Cases: [kunkel](https://docu.ilias.de/go/usr/115)
     * Authority to (De-)Assign Authorities: [skergomard](https://docu.ilias.de/go/usr/44474)
+    * Assignee for Issues: [skergomard](https://docu.ilias.de/go/usr/44474)
     * Assignee for Security Reports: [skergomard](https://docu.ilias.de/go/usr/44474)
-    * Assignee for Security Issues: [skergomard](https://docu.ilias.de/go/usr/44474)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END RBAC)
@@ -1284,8 +1284,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [mjansen](https://docu.ilias.de/go/usr/8784), [lscharmer](https://docu.ilias.de/go/usr/87863)
     * Authority to Curate Test Cases: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Authority to (De-)Assign Authorities: [mjansen (Databay AG)](https://docu.ilias.de/go/usr/8784)
+    * Assignee for Issues: [mjansen](https://docu.ilias.de/go/usr/8784), [lscharmer](https://docu.ilias.de/go/usr/87863)
     * Assignee for Security Reports: [mjansen](https://docu.ilias.de/go/usr/8784), [lscharmer](https://docu.ilias.de/go/usr/87863)
-    * Assignee for Security Issues: [mjansen](https://docu.ilias.de/go/usr/8784), [lscharmer](https://docu.ilias.de/go/usr/87863)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Refinery)
@@ -1297,8 +1297,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Authority to Curate Test Cases: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Authority to (De-)Assign Authorities: [mjansen (Databay AG)](https://docu.ilias.de/go/usr/8784)
+    * Assignee for Issues: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Assignee for Security Reports: [mjansen](https://docu.ilias.de/go/usr/8784)
-    * Assignee for Security Issues: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END SAML)
@@ -1310,8 +1310,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [qualitus.dahme](https://docu.ilias.de/go/usr/99160), [qualitus.hartwig](https://docu.ilias.de/go/usr/104063)
     * Authority to Curate Test Cases: [emix](https://docu.ilias.de/go/usr/57311)
     * Authority to (De-)Assign Authorities: [wischniak](https://docu.ilias.de/go/usr/21896)
+    * Assignee for Issues: [wischniak](https://docu.ilias.de/go/usr/21896)
     * Assignee for Security Reports: [wischniak](https://docu.ilias.de/go/usr/21896)
-    * Assignee for Security Issues: [wischniak](https://docu.ilias.de/go/usr/21896)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END LearningModuleSCORM)
@@ -1323,8 +1323,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [smeyer](https://docu.ilias.de/go/usr/191)
     * Authority to Curate Test Cases: [smeyer](https://docu.ilias.de/go/usr/191)
     * Authority to (De-)Assign Authorities: [smeyer](https://docu.ilias.de/go/usr/191)
+    * Assignee for Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Assignee for Security Reports: [smeyer](https://docu.ilias.de/go/usr/191)
-    * Assignee for Security Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Search)
@@ -1336,8 +1336,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [smeyer](https://docu.ilias.de/go/usr/191)
     * Authority to Curate Test Cases: [MISSING]
     * Authority to (De-)Assign Authorities: [smeyer](https://docu.ilias.de/go/usr/191)
+    * Assignee for Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Assignee for Security Reports: [smeyer](https://docu.ilias.de/go/usr/191)
-    * Assignee for Security Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Session)
@@ -1349,8 +1349,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [tfuhrer](https://docu.ilias.de/go/usr/81947), [fschmid](https://docu.ilias.de/go/usr/21087)
     * Authority to Curate Test Cases: [kunkel](https://docu.ilias.de/go/usr/115)
     * Authority to (De-)Assign Authorities: [tfuhrer](https://docu.ilias.de/go/usr/81947), [fschmid](https://docu.ilias.de/go/usr/21087)
+    * Assignee for Issues: [tfuhrer](https://docu.ilias.de/go/usr/81947), [fschmid](https://docu.ilias.de/go/usr/21087)
     * Assignee for Security Reports: [tfuhrer](https://docu.ilias.de/go/usr/81947), [fschmid](https://docu.ilias.de/go/usr/21087)
-    * Assignee for Security Issues: [tfuhrer](https://docu.ilias.de/go/usr/81947), [fschmid](https://docu.ilias.de/go/usr/21087)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Setup)
@@ -1362,8 +1362,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Authority to Curate Test Cases: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Authority to (De-)Assign Authorities: [fschmid](https://docu.ilias.de/go/usr/21087)
+    * Assignee for Issues: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Assignee for Security Reports: [fschmid](https://docu.ilias.de/go/usr/21087)
-    * Assignee for Security Issues: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END ShibbolethAuthentication)
@@ -1375,8 +1375,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [tschmitz](https://docu.ilias.de/go/usr/92591)
     * Authority to Curate Test Cases: [tschmitz](https://docu.ilias.de/go/usr/92591)
     * Authority to (De-)Assign Authorities: [tschmitz](https://docu.ilias.de/go/usr/92591)
+    * Assignee for Issues: [tschmitz](https://docu.ilias.de/go/usr/92591)
     * Assignee for Security Reports: [tschmitz](https://docu.ilias.de/go/usr/92591)
-    * Assignee for Security Issues: [tschmitz](https://docu.ilias.de/go/usr/92591)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Staff)
@@ -1388,8 +1388,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [smeyer](https://docu.ilias.de/go/usr/191)
     * Authority to Curate Test Cases: [AUTHOR MISSING](https://docu.ilias.de/go/pg/64423_4793)
     * Authority to (De-)Assign Authorities: [smeyer](https://docu.ilias.de/go/usr/191)
+    * Assignee for Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Assignee for Security Reports: [smeyer](https://docu.ilias.de/go/usr/191)
-    * Assignee for Security Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END StatisticsAndLearningProgress)
@@ -1401,8 +1401,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [MISSING]
     * Authority to Curate Test Cases: [MISSING]
     * Authority to (De-)Assign Authorities: [MISSING]
+    * Assignee for Issues: [MISSING]
     * Assignee for Security Reports: [MISSING]
-    * Assignee for Security Issues: [MISSING]
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END StudyProgramme)
@@ -1414,8 +1414,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [sergiosant02](https://docu.ilias.de/go/usr/110174), [abrahammordev](https://docu.ilias.de/go/usr/110909), [juanma1331](https://docu.ilias.de/go/usr/107249)
     * Authority to Curate Test Cases: [ezenzen](https://docu.ilias.de/go/usr/42910)
     * Authority to (De-)Assign Authorities: [jcopado](https://docu.ilias.de/go/usr/30511)
+    * Assignee for Issues: [jcopado](https://docu.ilias.de/go/usr/30511)
     * Assignee for Security Reports: [jcopado](https://docu.ilias.de/go/usr/30511)
-    * Assignee for Security Issues: [jcopado](https://docu.ilias.de/go/usr/30511)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Survey)
@@ -1427,8 +1427,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [smeyer](https://docu.ilias.de/go/usr/191)
     * Authority to Curate Test Cases: [smeyer](https://docu.ilias.de/go/usr/191)
     * Authority to (De-)Assign Authorities: [smeyer](https://docu.ilias.de/go/usr/191)
+    * Assignee for Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Assignee for Security Reports: [smeyer](https://docu.ilias.de/go/usr/191)
-    * Assignee for Security Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END SystemCheck)
@@ -1440,8 +1440,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [akill](https://docu.ilias.de/go/usr/149)
     * Authority to Curate Test Cases: [skaiser](https://docu.ilias.de/go/usr/17260)
     * Authority to (De-)Assign Authorities: [akill](https://docu.ilias.de/go/usr/149)
+    * Assignee for Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Assignee for Security Reports: [akill](https://docu.ilias.de/go/usr/149)
-    * Assignee for Security Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Tagging)
@@ -1453,8 +1453,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [akill](https://docu.ilias.de/go/usr/149)
     * Authority to Curate Test Cases: [akill](https://docu.ilias.de/go/usr/149)
     * Authority to (De-)Assign Authorities: [akill](https://docu.ilias.de/go/usr/149)
+    * Assignee for Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Assignee for Security Reports: [akill](https://docu.ilias.de/go/usr/149)
-    * Assignee for Security Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Tasks)
@@ -1466,8 +1466,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [akill](https://docu.ilias.de/go/usr/149)
     * Authority to Curate Test Cases: Tested separately in each module that supports taxonomies
     * Authority to (De-)Assign Authorities: [akill](https://docu.ilias.de/go/usr/149)
+    * Assignee for Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Assignee for Security Reports: [akill](https://docu.ilias.de/go/usr/149)
-    * Assignee for Security Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Taxonomy)
@@ -1480,8 +1480,8 @@ of ILIAS. The file contains the following fields:
         [lscharmer](https://docu.ilias.de/go/usr/87863)
     * Authority to Curate Test Cases: [AUTHOR MISSING](https://docu.ilias.de/go/pg/64423_4793)
     * Authority to (De-)Assign Authorities: [mjansen (Databay AG)](https://docu.ilias.de/go/usr/8784)
+    * Assignee for Issues: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Assignee for Security Reports: [mjansen](https://docu.ilias.de/go/usr/8784)
-    * Assignee for Security Issues: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END TermsOfService)
@@ -1496,8 +1496,8 @@ of ILIAS. The file contains the following fields:
         , [tjoussen](https://docu.ilias.de/go/usr/103745)
     * Authority to Curate Test Cases: [dstrassner](https://docu.ilias.de/go/usr/48931)
     * Authority to (De-)Assign Authorities: [dstrassner](https://docu.ilias.de/go/usr/48931)
+    * Assignee for Issues: [dstrassner](https://docu.ilias.de/go/usr/48931)
     * Assignee for Security Reports: [dstrassner](https://docu.ilias.de/go/usr/48931)
-    * Assignee for Security Issues: [dstrassner](https://docu.ilias.de/go/usr/48931)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END TestAndAssessment)
@@ -1509,8 +1509,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [Fabian Wolf](https://docu.ilias.de/go/usr/29018)
     * Authority to Curate Test Cases: [Fabian Wolf](https://docu.ilias.de/go/usr/29018)
     * Authority to (De-)Assign Authorities: [Fabian Wolf](https://docu.ilias.de/go/usr/29018)
+    * Assignee for Issues: [Fabian Wolf](https://docu.ilias.de/go/usr/29018)
     * Assignee for Security Reports: [Fabian Wolf](https://docu.ilias.de/go/usr/29018)
-    * Assignee for Security Issues: [Fabian Wolf](https://docu.ilias.de/go/usr/29018)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Tree)
@@ -1522,8 +1522,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [skergomard](https://docu.ilias.de/go/usr/44474)
     * Authority to Curate Test Cases: [skergomard](https://docu.ilias.de/go/usr/44474)
     * Authority to (De-)Assign Authorities: [skergomard](https://docu.ilias.de/go/usr/44474)
+    * Assignee for Issues: [skergomard](https://docu.ilias.de/go/usr/44474)
     * Assignee for Security Reports: [skergomard](https://docu.ilias.de/go/usr/44474)
-    * Assignee for Security Issues: [skergomard](https://docu.ilias.de/go/usr/44474)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END UserService)
@@ -1536,8 +1536,8 @@ of ILIAS. The file contains the following fields:
         , [fschmid](https://docu.ilias.de/go/usr/21087)
     * Authority to Curate Test Cases: [tfuhrer](https://docu.ilias.de/go/usr/81947)
     * Authority to (De-)Assign Authorities: [tfuhrer](https://docu.ilias.de/go/usr/81947)
+    * Assignee for Issues: [tfuhrer](https://docu.ilias.de/go/usr/81947)
     * Assignee for Security Reports: [tfuhrer](https://docu.ilias.de/go/usr/81947)
-    * Assignee for Security Issues: [tfuhrer](https://docu.ilias.de/go/usr/81947)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END UICore)
@@ -1549,8 +1549,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [tfuhrer](https://docu.ilias.de/go/usr/81947), [oliver.samoila](https://docu.ilias.de/go/usr/26160)
     * Authority to Curate Test Cases: [Fabian](https://docu.ilias.de/go/usr/27631)
     * Authority to (De-)Assign Authorities: [tfuhrer](https://docu.ilias.de/go/usr/81947), [oliver.samoila](https://docu.ilias.de/go/usr/26160)
+    * Assignee for Issues: [oliver.samoila](https://docu.ilias.de/go/usr/26160)
     * Assignee for Security Reports: [oliver.samoila](https://docu.ilias.de/go/usr/26160)
-    * Assignee for Security Issues: [oliver.samoila](https://docu.ilias.de/go/usr/26160)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END UI-Service)
@@ -1562,8 +1562,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [rschenk](https://docu.ilias.de/go/usr/18065)
     * Authority to Curate Test Cases: [rschenk](https://docu.ilias.de/go/usr/18065)
     * Authority to (De-)Assign Authorities: [rschenk (Databay AG)](https://docu.ilias.de/go/usr/18065)
+    * Assignee for Issues: [rschenk](https://docu.ilias.de/go/usr/18065)
     * Assignee for Security Reports: [rschenk](https://docu.ilias.de/go/usr/18065)
-    * Assignee for Security Issues: [rschenk](https://docu.ilias.de/go/usr/18065)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END VirusScanner)
@@ -1575,8 +1575,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [ukohnle](https://docu.ilias.de/go/usr/21855)
     * Authority to Curate Test Cases: [AUTHOR MISSING](https://docu.ilias.de/go/pg/64423_4793)
     * Authority to (De-)Assign Authorities: MISSING
+    * Assignee for Issues: MISSING
     * Assignee for Security Reports: MISSING
-    * Assignee for Security Issues: MISSING
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END WebAccessChecker)
@@ -1589,8 +1589,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off Testcase Changes: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Authority to (De-)Assign Authorities: [fschmid](https://docu.ilias.de/go/usr/21087)
 	* Testcases: [fschmid](https://docu.ilias.de/go/usr/70029)
+    * Assignee for Issues: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Assignee for Security Reports: [fschmid](https://docu.ilias.de/go/usr/21087)
-    * Assignee for Security Issues: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END WebDAV)
@@ -1602,8 +1602,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [smeyer](https://docu.ilias.de/go/usr/191)
     * Authority to Curate Test Cases: [nadine.bauser](https://docu.ilias.de/go/usr/34662)
     * Authority to (De-)Assign Authorities: [smeyer](https://docu.ilias.de/go/usr/191)
+    * Assignee for Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Assignee for Security Reports: [smeyer](https://docu.ilias.de/go/usr/191)
-    * Assignee for Security Issues: [smeyer](https://docu.ilias.de/go/usr/191)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Weblink)
@@ -1615,8 +1615,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [githamo](https://docu.ilias.de/go/usr/115389), [sKarki999](https://docu.ilias.de/go/usr/112949)
     * Authority to Curate Test Cases: [sKarki999](https://docu.ilias.de/go/usr/112949)
     * Authority to (De-)Assign Authorities: [TimoScheuer](https://docu.ilias.de/go/usr/102976)
+    * Assignee for Issues: [sKarki999](https://docu.ilias.de/go/usr/112949)
     * Assignee for Security Reports: [sKarki999](https://docu.ilias.de/go/usr/112949)
-    * Assignee for Security Issues: [sKarki999](https://docu.ilias.de/go/usr/112949)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Webservices)
@@ -1628,8 +1628,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [akill](https://docu.ilias.de/go/usr/149)
     * Authority to Curate Test Cases: [atoedt](https://docu.ilias.de/go/usr/3139)
     * Authority to (De-)Assign Authorities: [akill](https://docu.ilias.de/go/usr/149)
+    * Assignee for Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Assignee for Security Reports: [akill](https://docu.ilias.de/go/usr/149)
-    * Assignee for Security Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END WhoIsOnline)
@@ -1641,8 +1641,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [akill](https://docu.ilias.de/go/usr/149)
     * Authority to Curate Test Cases: n.n., Uni Köln
     * Authority to (De-)Assign Authorities: [akill](https://docu.ilias.de/go/usr/149)
+    * Assignee for Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Assignee for Security Reports: [akill](https://docu.ilias.de/go/usr/149)
-    * Assignee for Security Issues: [akill](https://docu.ilias.de/go/usr/149)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END Wiki)
@@ -1654,8 +1654,8 @@ of ILIAS. The file contains the following fields:
     * Authority to Sign off on Code Changes: [[ukohnle](https://docu.ilias.de/go/usr/21855)]
     * Authority to Curate Test Cases: [[ukohnle](https://docu.ilias.de/go/usr/21855)]
     * Authority to (De-)Assign Authorities: [[ukohnle](https://docu.ilias.de/go/usr/21855)]
+    * Assignee for Issues: [ukohnle](https://docu.ilias.de/go/usr/21855)
     * Assignee for Security Reports: [ukohnle](https://docu.ilias.de/go/usr/21855)
-    * Assignee for Security Issues: [ukohnle](https://docu.ilias.de/go/usr/21855)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END xAPIAndcmi5)


### PR DESCRIPTION
Hi @matthiaskunkel ,

this should tidy up the maintenance.md Issue and Security Report case that we talked about. I hope this is fine for you:
As stated in the top of the file (https://github.com/ILIAS-eLearning/ILIAS/blob/10ecf596665c34777c6245975c02503e280cfdca/docs/development/maintenance.md?plain=1#L164) this introduces an "Assignee for Issues" and an "Assignee for Security Reports". 
The only three authorities I am unsure about are: 

- General Kiosk Mode
- Learning Sequence
- Maps

The default assignments in mantis match my PR, the security assignments seem to be missing currently? Could you verify this? 
Feel free to edit, dismiss or merge this PR, @matthiaskunkel  :-) . 