### PR TITLE
UICore: Suggest that `ilCtrlInteface` will `never` return in "redirec…

### DIFF
--- a/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/RoutingTest.php
+++ b/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/RoutingTest.php
@@ -97,6 +97,8 @@ class RoutingTest extends TestCase
         $ctrl = $this->mock(ilCtrl::class);
         $ctrl->expects(self::once())->method('redirectToURL')->with('some url');
 
+        $this->expectException(\PHPUnit\Framework\MockObject\NeverReturningMethodException::class);
+
         (new Routing(
             $ctrl,
             $session,

--- a/components/ILIAS/LegalDocuments/tests/Provide/ProvideWithdrawalTest.php
+++ b/components/ILIAS/LegalDocuments/tests/Provide/ProvideWithdrawalTest.php
@@ -59,8 +59,6 @@ class ProvideWithdrawalTest extends TestCase
 
     public function testFinishAndLogout(): void
     {
-        $called = false;
-
         $auth_session = $this->mock(ilAuthSession::class);
         $auth_session->expects(self::once())->method('logout');
 
@@ -72,14 +70,13 @@ class ProvideWithdrawalTest extends TestCase
             $ctrl,
             $auth_session,
             $this->fail(...),
-            function (int $x) use (&$called) {
+            function (int $x) {
                 $this->assertSame(ilSession::SESSION_CLOSE_USER, $x);
-                $called = true;
             }
         );
 
-        $instance->finishAndLogout(['bar' => 'baz']);
+        $this->expectException(\PHPUnit\Framework\MockObject\NeverReturningMethodException::class);
 
-        $this->assertTrue($called);
+        $instance->finishAndLogout(['bar' => 'baz']);
     }
 }

--- a/components/ILIAS/LegalDocuments/tests/StartUpStepTest.php
+++ b/components/ILIAS/LegalDocuments/tests/StartUpStepTest.php
@@ -65,6 +65,8 @@ class StartUpStepTest extends TestCase
             $this->mockTree(Intercept::class, ['intercept' => true, 'id' => 'baz', 'target' => ['guiName' => 'foo', 'guiPath' => ['foo'], 'command' => 'bar']]),
         ]]));
 
+        $this->expectException(\PHPUnit\Framework\MockObject\NeverReturningMethodException::class);
+
         $instance->execute();
     }
 

--- a/components/ILIAS/Mail/tests/gui/ilMailOptionsGUITest.php
+++ b/components/ILIAS/Mail/tests/gui/ilMailOptionsGUITest.php
@@ -122,6 +122,9 @@ class ilMailOptionsGUITest extends ilMailBaseTestCase
 
         $gui = $this->getMailOptionsGUI($http, $ctrl, $options);
         $gui->setForm($form);
+
+        $this->expectException(\PHPUnit\Framework\MockObject\NeverReturningMethodException::class);
+
         $gui->executeCommand();
     }
 

--- a/components/ILIAS/Test/tests/ilObjTestGUITest.php
+++ b/components/ILIAS/Test/tests/ilObjTestGUITest.php
@@ -85,6 +85,8 @@ class ilObjTestGUITest extends ilTestBaseTestCase
             ->method('redirectByClass')
             ->with([ilRepositoryGUI::class, ilObjTestGUI::class, ilInfoScreenGUI::class]);
 
+        $this->expectException(\PHPUnit\Framework\MockObject\NeverReturningMethodException::class);
+
         $testObj->runObject();
     }
 
@@ -96,8 +98,10 @@ class ilObjTestGUITest extends ilTestBaseTestCase
         $ctrl_mock
             ->expects($this->once())
             ->method('redirect')
-            ->with($testObj, ilObjTestGUI::SHOW_QUESTIONS_CMD)
-        ;
+            ->with($testObj, ilObjTestGUI::SHOW_QUESTIONS_CMD);
+
+        $this->expectException(\PHPUnit\Framework\MockObject\NeverReturningMethodException::class);
+
         $testObj->cancelCreateQuestionObject();
     }
 }

--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionAbstractPageObjectCommandForwarder.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionAbstractPageObjectCommandForwarder.php
@@ -31,18 +31,9 @@ abstract class ilAssQuestionAbstractPageObjectCommandForwarder
 {
     protected RequestDataCollector $request;
 
-    /**
-     * Constructor
-     *
-     * @access public
-     * @param assQuestion $questionOBJ
-     * @param ilCtrl $ctrl
-     * @param ilTabsGUI $tabs
-     * @param ilLanguage $lng
-     */
     public function __construct(
         protected assQuestion $questionOBJ,
-        protected readonly ilCtrl $ctrl,
+        protected readonly ilCtrlInterface $ctrl,
         protected readonly ilTabsGUI $tabs,
         protected ilLanguage $lng
     ) {

--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionFeedbackPageObjectCommandForwarder.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionFeedbackPageObjectCommandForwarder.php
@@ -26,16 +26,7 @@
  */
 class ilAssQuestionFeedbackPageObjectCommandForwarder extends ilAssQuestionAbstractPageObjectCommandForwarder
 {
-    /**
-     * Constructor
-     *
-     * @access public
-     * @param assQuestion $questionOBJ
-     * @param ilCtrl $ctrl
-     * @param ilTabsGUI $tabs
-     * @param ilLanguage $lng
-     */
-    public function __construct(assQuestion $questionOBJ, ilCtrl $ctrl, ilTabsGUI $tabs, ilLanguage $lng)
+    public function __construct(assQuestion $questionOBJ, ilCtrlInterface $ctrl, ilTabsGUI $tabs, ilLanguage $lng)
     {
         global $DIC;
         $main_tpl = $DIC->ui()->mainTemplate();

--- a/components/ILIAS/TestQuestionPool/tests/ilAssQuestionAbstractPageObjectCommandForwarderTest.php
+++ b/components/ILIAS/TestQuestionPool/tests/ilAssQuestionAbstractPageObjectCommandForwarderTest.php
@@ -36,7 +36,7 @@ class ilAssQuestionAbstractPageObjectCommandForwarderTest extends assBaseTestCas
         parent::setUp();
 
         $questionOBJ = $this->createMock(assQuestion::class);
-        $ctrl = $this->createMock(ilCtrl::class);
+        $ctrl = $this->createMock(ilCtrlInterface::class);
         $tabs = $this->createMock(ilTabsGUI::class);
         $lng = $this->createMock(ilLanguage::class);
 

--- a/components/ILIAS/TestQuestionPool/tests/ilAssQuestionFeedbackPageObjectCommandForwarderTest.php
+++ b/components/ILIAS/TestQuestionPool/tests/ilAssQuestionFeedbackPageObjectCommandForwarderTest.php
@@ -31,20 +31,15 @@ class ilAssQuestionFeedbackPageObjectCommandForwarderTest extends assBaseTestCas
 
     private ilAssQuestionFeedbackPageObjectCommandForwarder $object;
 
-    protected function setUp(): void
+    public function testConstructRedirectsWithErrorOnInvalidFeedbackId(): void
     {
-        parent::setUp();
-
         $questionOBJ = $this->createMock(assQuestion::class);
-        $ctrl = $this->createMock(ilCtrl::class);
+        $ctrl = $this->createMock(ilCtrlInterface::class);
         $tabs = $this->createMock(ilTabsGUI::class);
         $lng = $this->createMock(ilLanguage::class);
 
-        $this->object = new ilAssQuestionFeedbackPageObjectCommandForwarder($questionOBJ, $ctrl, $tabs, $lng);
-    }
+        $this->expectException(\PHPUnit\Framework\MockObject\NeverReturningMethodException::class);
 
-    public function testConstruct(): void
-    {
-        $this->assertInstanceOf(ilAssQuestionFeedbackPageObjectCommandForwarder::class, $this->object);
+        new ilAssQuestionFeedbackPageObjectCommandForwarder($questionOBJ, $ctrl, $tabs, $lng);
     }
 }

--- a/components/ILIAS/UICore/classes/class.ilCtrl.php
+++ b/components/ILIAS/UICore/classes/class.ilCtrl.php
@@ -56,7 +56,7 @@ class ilCtrl implements ilCtrlInterface
         protected Refinery $refinery,
         protected ilComponentFactory $component_factory,
         protected ilCtrlSubject $subject,
-        protected  ilCtrlQueryParserInterface $query_parser,
+        protected ilCtrlQueryParserInterface $query_parser
     ) {
     }
 
@@ -395,7 +395,7 @@ class ilCtrl implements ilCtrlInterface
         ?string $a_cmd = null,
         ?string $a_anchor = null,
         bool $is_async = false
-    ): void {
+    ): never {
         $this->redirectByClass(
             $this->getClassByObject($a_gui_obj),
             $a_cmd,
@@ -412,7 +412,7 @@ class ilCtrl implements ilCtrlInterface
         ?string $a_cmd = null,
         ?string $a_anchor = null,
         bool $is_async = false
-    ): void {
+    ): never {
         $this->redirectToURL(
             $this->getLinkTargetByClass(
                 $a_class,
@@ -426,7 +426,7 @@ class ilCtrl implements ilCtrlInterface
     /**
      * @inheritDoc
      */
-    public function redirectToURL(string $target_url): void
+    public function redirectToURL(string $target_url): never
     {
         // prepend the ILIAS HTTP path if it wasn't already.
         if (defined("ILIAS_HTTP_PATH") &&

--- a/components/ILIAS/UICore/interfaces/interface.ilCtrlInterface.php
+++ b/components/ILIAS/UICore/interfaces/interface.ilCtrlInterface.php
@@ -305,7 +305,7 @@ interface ilCtrlInterface
         ?string $a_cmd = null,
         ?string $a_anchor = null,
         bool $is_async = false
-    ): void;
+    ): never;
 
     /**
      * Redirects to the provided GUI class.
@@ -321,14 +321,14 @@ interface ilCtrlInterface
         ?string $a_cmd = null,
         ?string $a_anchor = null,
         bool $is_async = false
-    ): void;
+    ): never;
 
     /**
      * Redirects to the given target URL.
      *
      * @param string $target_url
      */
-    public function redirectToURL(string $target_url): void;
+    public function redirectToURL(string $target_url): never;
 
     /**
      * Sets the current object (id and type) of ilCtrl's context.


### PR DESCRIPTION
…t*" methods

To achieve this, we'll have to adjust some unit tests.

The official PHPUnit documentation states:

> Always use $this->expectException(NeverReturningMethodException::class) when testing code that calls a mocked method with never return type.