### PR TITLE
[PROPOSAL] Change of IndividualAssessment Authorities

### DIFF
--- a/components/ILIAS/IndividualAssessment/maintenance.json
+++ b/components/ILIAS/IndividualAssessment/maintenance.json
@@ -1,13 +1,13 @@
 {
     "maintenance_model": "Classic",
-    "first_maintainer": "rklees(34047)",
-    "second_maintainer": "dkloepfer(42712)",
+    "first_maintainer": "mbecker(27266)",
+    "second_maintainer": "",
     "implicit_maintainers": [],
     "coordinator": [
         ""
     ],
     "tester": "kunkel(115)",
-    "testcase_writer": "dkloepfer(42712)",
+    "testcase_writer": "mbecker(27266)",
     "path": "Modules/IndividualAssessment",
     "belong_to_component": "IndividualAssessment",
     "used_in_components": []

--- a/docs/development/maintenance.md
+++ b/docs/development/maintenance.md
@@ -778,12 +778,12 @@ of ILIAS. The file contains the following fields:
 [//]: # (BEGIN IndividualAssessment)
 
 * **IndividualAssessment**
-    * Authority to Sign off on Conceptual Changes: [MISSING]
-    * Authority to Sign off on Code Changes: [MISSING]
-    * Authority to Curate Test Cases: [MISSING]
-    * Authority to (De-)Assign Authorities: [MISSING]
-    * Assignee for Security Reports: [MISSING]
-    * Assignee for Security Issues: [MISSING]
+    * Authority to Sign off on Conceptual Changes: [mbecker](https://docu.ilias.de/go/usr/27266)
+    * Authority to Sign off on Code Changes: [mbecker](https://docu.ilias.de/go/usr/27266)
+    * Authority to Curate Test Cases: [mbecker](https://docu.ilias.de/go/usr/27266)
+    * Authority to (De-)Assign Authorities: [mbecker](https://docu.ilias.de/go/usr/27266)
+    * Assignee for Security Reports: [mbecker](https://docu.ilias.de/go/usr/27266)
+    * Assignee for Security Issues: [mbecker](https://docu.ilias.de/go/usr/27266)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END IndividualAssessment)


### PR DESCRIPTION
This PR proposes to set me (@mbecker-databay) as the following IndividualAssessment authorities:

- Authority to Sign off on Conceptual Changes
- Authority to Sign off on Code Changes
- Authority to (De-)Assign Authorities
- Assignee for Security Reports
- Assignee for Security Issues

@jcopado has let me know today that it was decided to not further pursue the application of SURLABS for the authorities of the component, so I bring this PR now to your attention. 