### PR TITLE
[PROPOSAL] Change of ActiveRecord and WebAccessChecker Authorities

### DIFF
--- a/components/ILIAS/ActiveRecord/maintenance.json
+++ b/components/ILIAS/ActiveRecord/maintenance.json
@@ -1,6 +1,6 @@
 {
   "maintenance_model": "Classic",
-  "first_maintainer": "fschmid(21087)",
+  "first_maintainer": "fwolf(29018)",
   "second_maintainer": "",
   "implicit_maintainers": [],
   "coordinator": [

--- a/components/ILIAS/WebAccessChecker/maintenance.json
+++ b/components/ILIAS/WebAccessChecker/maintenance.json
@@ -1,6 +1,6 @@
 {
     "maintenance_model": "Classic",
-    "first_maintainer": "fschmid(21087)",
+    "first_maintainer": "fwolf(29018)",
     "second_maintainer": "ukohnle(21855)",
     "implicit_maintainers": [],
     "coordinator": [

--- a/docs/development/maintenance.md
+++ b/docs/development/maintenance.md
@@ -176,12 +176,12 @@ of ILIAS. The file contains the following fields:
 [//]: # (BEGIN ActiveRecord)
 
 * **ActiveRecord**
-    * Authority to Sign off on Conceptual Changes: MISSING
-    * Authority to Sign off on Code Changes: MISSING
+    * Authority to Sign off on Conceptual Changes: [fwolf](https://docu.ilias.de/go/usr/29018)
+    * Authority to Sign off on Code Changes: [fwolf](https://docu.ilias.de/go/usr/29018)
     * Authority to Curate Test Cases: MISSING
-    * Authority to (De-)Assign Authorities: MISSING
-    * Assignee for Security Reports: MISSING
-    * Assignee for Security Issues: MISSING
+    * Authority to (De-)Assign Authorities: [fwolf](https://docu.ilias.de/go/usr/29018)
+    * Assignee for Security Reports: [fwolf](https://docu.ilias.de/go/usr/29018)
+    * Assignee for Security Issues: [fwolf](https://docu.ilias.de/go/usr/29018)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END ActiveRecord)
@@ -1571,12 +1571,12 @@ of ILIAS. The file contains the following fields:
 [//]: # (BEGIN WebAccessChecker)
 
 * **Web Access Checker**
-    * Authority to Sign off on Conceptual Changes: MISSING 
+    * Authority to Sign off on Conceptual Changes: [fwolf](https://docu.ilias.de/go/usr/29018) 
     * Authority to Sign off on Code Changes: [ukohnle](https://docu.ilias.de/go/usr/21855)
     * Authority to Curate Test Cases: [AUTHOR MISSING](https://docu.ilias.de/go/pg/64423_4793)
-    * Authority to (De-)Assign Authorities: MISSING
-    * Assignee for Security Reports: MISSING
-    * Assignee for Security Issues: MISSING
+    * Authority to (De-)Assign Authorities: [fwolf](https://docu.ilias.de/go/usr/29018)
+    * Assignee for Security Reports: [fwolf](https://docu.ilias.de/go/usr/29018)
+    * Assignee for Security Issues: [fwolf](https://docu.ilias.de/go/usr/29018)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END WebAccessChecker)


### PR DESCRIPTION
This PR proposes to set ( @fwolf-ilias) as the following authorities:

**ActiveRecord**
    Authority to Sign off on Conceptual Changes
    Authority to Sign off on Code Changes
    Authority to (De-)Assign Authorities
    Assignee for Security Reports
    Assignee for Security Issues

**WebAccessChecker**
    Authority to Sign off on Conceptual Changes
    Authority to (De-)Assign Authorities
    Assignee for Security Reports
    Assignee for Security Issues