### PR TITLE
Expose HTTP factories in DI

### DIFF
--- a/components/ILIAS/HTTP/HTTP.php
+++ b/components/ILIAS/HTTP/HTTP.php
@@ -21,6 +21,14 @@ declare(strict_types=1);
 namespace ILIAS;
 
 use ILIAS\Component\Component;
+use ILIAS\HTTP\Cookies\CookieFactory;
+use ILIAS\HTTP\Cookies\CookieFactoryImpl;
+use ILIAS\HTTP\Cookies\CookieJarFactory;
+use ILIAS\HTTP\Cookies\CookieJarFactoryImpl;
+use ILIAS\HTTP\Request\RequestFactory;
+use ILIAS\HTTP\Request\RequestFactoryImpl;
+use ILIAS\HTTP\Response\ResponseFactory;
+use ILIAS\HTTP\Response\ResponseFactoryImpl;
 
 class HTTP implements Component
 {
@@ -34,6 +42,9 @@ class HTTP implements Component
         array | \ArrayAccess &$pull,
         array | \ArrayAccess &$internal,
     ): void {
-        // ...
+        $implement[CookieFactory::class] = static fn(): CookieFactory => new CookieFactoryImpl();
+        $implement[CookieJarFactory::class] = static fn(): CookieJarFactory => new CookieJarFactoryImpl();
+        $implement[RequestFactory::class] = static fn(): RequestFactory => new RequestFactoryImpl();
+        $implement[ResponseFactory::class] = static fn(): ResponseFactory => new ResponseFactoryImpl();
     }
 }


### PR DESCRIPTION
This change exposes the HTTP-related factories through the dependency injection system by registering them in the `$implement` map during component initialization.

_Note: This change is only in `trunk` (for now), but could be picked up in other branches if someone needs such a dependency in earlier versions._

### Motivation

This improves consistency with the DI architecture, enables easier substitution and testing, and avoids eager instantiation.

### What changed

The following factories are now registered in the DI container:

- `CookieFactory` → `CookieFactoryImpl`
- `CookieJarFactory` → `CookieJarFactoryImpl`
- `RequestFactory` → `RequestFactoryImpl`
- `ResponseFactory` → `ResponseFactoryImpl`

### Scope and impact

- No behavioral changes to existing consumers.
- No runtime logic added beyond DI registration.
- Existing code can now depend directly on the factory interfaces via DI.