### PR TITLE
[FIX] #46871 UI: Fixes error when trying to view ui in fullscreen mode in documentation

### DIFF
--- a/components/ILIAS/UI/src/examples/Layout/Page/Standard/ui.php
+++ b/components/ILIAS/UI/src/examples/Layout/Page/Standard/ui.php
@@ -516,14 +516,14 @@ function getDemoEntryTools(\ILIAS\UI\Factory $f): array
     $slate = $f->maincontrols()->slate()->legacy(
         'Initially hidden',
         $symbol,
-        $f->legacy(loremIpsum())
+        $f->legacy()->content(loremIpsum())
     );
     $tools['tool3'] = $slate;
 
     $slate = $f->maincontrols()->slate()->legacy(
         'Closable Tool',
         $symbol,
-        $f->legacy(loremIpsum())
+        $f->legacy()->content(loremIpsum())
     );
     $tools['tool4'] = $slate;
 


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=46871

Aims to fix an error when trying to view ui in fullscreen mode in documentation.
@oliversamoila  @thojou 