### PR TITLE
[Improvement] Tracking: Add usr_id Index to ut_lp_marks

### DIFF
--- a/components/ILIAS/Tracking/classes/Setup/class.ilTrackingSetupAgent.php
+++ b/components/ILIAS/Tracking/classes/Setup/class.ilTrackingSetupAgent.php
@@ -20,16 +20,27 @@ declare(strict_types=1);
 
 use ILIAS\Setup;
 use ILIAS\Setup\Config;
+use ILIAS\Setup\ObjectiveCollection;
 
 class ilTrackingSetupAgent extends Setup\Agent\NullAgent
 {
-    public function getUpdateObjective(Setup\Config $config = null): Setup\Objective
+    public function getUpdateObjective(Config $config = null): Setup\Objective
     {
-        return new ilDatabaseUpdateStepsExecutedObjective(new ilTrackingUpdateSteps9());
+        return new ObjectiveCollection(
+            'Database is updated for component/ILIAS/Tracking',
+            true,
+            new ilDatabaseUpdateStepsExecutedObjective(new ilTrackingUpdateSteps9()),
+            new ilDatabaseUpdateStepsExecutedObjective(new ilTrackingUpdateSteps10())
+        );
     }
 
     public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
     {
-        return new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilTrackingUpdateSteps9());
+        return new ObjectiveCollection(
+            'Database update status for component/ILIAS/Tracking',
+            true,
+            new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilTrackingUpdateSteps9()),
+            new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilTrackingUpdateSteps10())
+        );
     }
 }

--- a/components/ILIAS/Tracking/classes/Setup/class.ilTrackingUpdateSteps10.php
+++ b/components/ILIAS/Tracking/classes/Setup/class.ilTrackingUpdateSteps10.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+class ilTrackingUpdateSteps10 implements ilDatabaseUpdateSteps
+{
+    protected ilDBInterface $db;
+
+    public function prepare(ilDBInterface $db): void
+    {
+        $this->db = $db;
+    }
+
+    public function step_1(): void
+    {
+        if (!$this->db->indexExistsByFields('ut_lp_marks', ['usr_id'])) {
+            $this->db->addIndex('ut_lp_marks', ['usr_id'], 'i1');
+        }
+    }
+}


### PR DESCRIPTION
Performance Optimization: Add Single-Column Indexes for User Deletion Queries

The user deletion process (`ilObjUser::delete()`) exhibits performance issues, particularly when deleting users with extensive learning progress. Analysis of the deletion flow reveals that critical DELETE queries are executed without optimal index support.

1. **`ilObjUserTracking::_deleteUser()`** executes:
   ```sql
   DELETE FROM ut_lp_marks WHERE usr_id = ?
   ```
   The table `ut_lp_marks` has a composite `PRIMARY KEY (obj_id, usr_id)`, but no single-column index on `usr_id`. Since `usr_id` is not the leading column in the primary key, MySQL cannot efficiently use this index for queries filtering only on `usr_id`, resulting in inefficient table scans or range scans over the clustered index.

Related to https://mantis.ilias.de/view.php?id=31664