### PR TITLE
[Improvement] Scorm: Add user_id Index to sahs_user

### DIFF
--- a/components/ILIAS/Scorm2004/classes/Setup/class.ilScorm2004DatabaseUpdateSteps.php
+++ b/components/ILIAS/Scorm2004/classes/Setup/class.ilScorm2004DatabaseUpdateSteps.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 class ilScorm2004DatabaseUpdateSteps implements ilDatabaseUpdateSteps
 {
@@ -37,4 +37,10 @@ class ilScorm2004DatabaseUpdateSteps implements ilDatabaseUpdateSteps
         $this->db->modifyTableColumn("cp_dependency", "resourceid", array("type" => "text", "length" => 200, "notnull" => false, 'default' => null));
     }
 
+    public function step_3(): void
+    {
+        if (!$this->db->indexExistsByFields('sahs_user', ['user_id'])) {
+            $this->db->addIndex('sahs_user', ['user_id'], 'i1');
+        }
+    }
 }


### PR DESCRIPTION
Performance Optimization: Add Single-Column Indexes for User Deletion Queries

The user deletion process (`ilObjUser::delete()`) exhibits performance issues, particularly when deleting users with extensive learning progress. Analysis of the deletion flow reveals that critical DELETE queries are executed without optimal index support.

**SCORM tracking cleanup** (in `ilObjSCORMLearningModule::_removeTrackingDataForUser()` and `ilSCORM2004DeleteData`) executes:
   ```sql
   DELETE FROM sahs_user WHERE user_id = ?
   ```
    The table `sahs_user` has a composite `PRIMARY KEY (obj_id, user_id)`, but no single-column index on `user_id`. Since `user_id` is not the leading column in the primary key, MySQL cannot efficiently use this index for queries filtering only on `user_id`, resulting in inefficient table scans or range scans over the clustered index.

Related to https://mantis.ilias.de/view.php?id=31664