### PR TITLE
[Improvement] Block: Add user_id Index to il_block_setting

### DIFF
--- a/components/ILIAS/Block/Block.php
+++ b/components/ILIAS/Block/Block.php
@@ -32,6 +32,9 @@ class Block implements Component\Component
         array | \ArrayAccess &$pull,
         array | \ArrayAccess &$internal,
     ): void {
+        $contribute[\ILIAS\Setup\Agent::class] = static fn() => new \ilBlockSetupAgent(
+            $pull[\ILIAS\Refinery\Factory::class]
+        );
         $contribute[Component\Resource\PublicAsset::class] = fn() =>
             new Component\Resource\ComponentJS($this, "ilblockcallback.js");
     }

--- a/components/ILIAS/Block/classes/Setup/class.ilBlockDBUpdateSteps.php
+++ b/components/ILIAS/Block/classes/Setup/class.ilBlockDBUpdateSteps.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+class ilBlockDBUpdateSteps implements ilDatabaseUpdateSteps
+{
+    protected ilDBInterface $db;
+
+    public function prepare(ilDBInterface $db): void
+    {
+        $this->db = $db;
+    }
+
+    public function step_1(): void
+    {
+        if (!$this->db->indexExistsByFields('il_block_setting', ['user_id'])) {
+            $this->db->addIndex('il_block_setting', ['user_id'], 'i1');
+        }
+    }
+}

--- a/components/ILIAS/Block/classes/Setup/class.ilBlockSetupAgent.php
+++ b/components/ILIAS/Block/classes/Setup/class.ilBlockSetupAgent.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\Setup;
+
+class ilBlockSetupAgent extends Setup\Agent\NullAgent
+{
+    public function getUpdateObjective(Setup\Config $config = null): Setup\Objective
+    {
+        return new ilDatabaseUpdateStepsExecutedObjective(new ilBlockDBUpdateSteps());
+    }
+
+    public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
+    {
+        return new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilBlockDBUpdateSteps());
+    }
+}


### PR DESCRIPTION
Performance Optimization: Add Single-Column Indexes for User Deletion Queries

The user deletion process (`ilObjUser::delete()`) exhibits performance issues, particularly when deleting users with extensive learning progress. Analysis of the deletion flow reveals that critical DELETE queries are executed without optimal index support.

**Dashboard settings cleanup** (in `ilBlockSetting::_deleteSettingsOfUser()`) executes:
   ```sql
   DELETE FROM il_block_setting WHERE user_id = ?
   ```
   The table `il_block_setting` has a composite `PRIMARY KEY (obj_id, user_id)`, but no single-column index on `user_id`. Since `user_id` is not the leading column in the primary key, MySQL cannot efficiently use this index for queries filtering only on `user_id`, resulting in inefficient table scans or range scans over the clustered index.

Related to https://mantis.ilias.de/view.php?id=31664