### PR TITLE
Fix Mantis #46965: Unknown column "condition"

### DIFF
--- a/components/ILIAS/Scorm2004/classes/ilSCORM13Package.php
+++ b/components/ILIAS/Scorm2004/classes/ilSCORM13Package.php
@@ -341,11 +341,10 @@ class ilSCORM13Package
                             break;
                         case 'language': $names[] = 'c_language';
                             break;
-                            //                        case 'condition': $names[] = 'c_condition';
-                            //                            break;
+                        case 'condition': $names[] = 'c_condition';
+                            break;
                         case 'operator': $names[] = 'c_operator';
                             break;
-                            //                        case 'condition': $names[] = 'c_condition';break;
                         case 'readnormalizedmeasure': $names[] = 'readnormalmeasure';
                             break;
                         case 'writenormalizedmeasure': $names[] = 'writenormalmeasure';
@@ -354,7 +353,6 @@ class ilSCORM13Package
                             break;
                         case 'primary': $names[] = 'c_primary';
                             break;
-                            //                        case 'minnormalizedmeasure': $names[] = 'minnormalmeasure';break;
                         case 'persistpreviousattempts': $names[] = 'persistprevattempts';
                             break;
                         case 'identifier': $names[] = 'c_identifier';


### PR DESCRIPTION
Mantis: https://mantis.ilias.de/view.php?id=46965

PDOException thrown with message "SQLSTATE[42S22]: Column not found: 1054 Unknown column 'condition' in 'INSERT INTO'"

PR for 10, 11 and TRUNK