### PR TITLE
Mantis 46988: Adds fix for ilBookingManagerAppEventListener

### DIFF
--- a/Modules/BookingManager/classes/class.ilBookingManagerAppEventListener.php
+++ b/Modules/BookingManager/classes/class.ilBookingManagerAppEventListener.php
@@ -33,20 +33,19 @@ class ilBookingManagerAppEventListener
         array $a_parameter
     ): void {
         global $DIC;
-        $internal_domain_service = $DIC->bookingManager()->internal()->domain();
 
         switch ($a_component) {
             case "Services/User":
                 switch ($a_event) {
                     case "deleteUser":
-                        $internal_domain_service->userEvent()->handleDeletion((int) $a_parameter["usr_id"]);
+                        $DIC->bookingManager()->internal()->domain()->userEvent()->handleDeletion((int) $a_parameter["usr_id"]);
                         break;
                 }
                 break;
             case "Services/Object":
                 switch ($a_event) {
                     case "toTrash":
-                        $internal_domain_service->objectEvent()->handleDeletion([$a_parameter["ref_id"]]);
+                        $DIC->bookingManager()->internal()->domain()->objectEvent()->handleDeletion([$a_parameter["ref_id"]]);
                         break;
                 }
                 break;


### PR DESCRIPTION
This PR is releated to Mantis https://mantis.ilias.de/view.php?id=46988

This fixes a runtime error in ilBookingManagerAppEventListener that caused CronJobs to fail due to an undefined constant when triggered outside normal web contexts.This change reverts the previous use of a central $internal_domain_service and restores direct calls to $DIC->bookingManager()->internal()->domain().

Best Regards,
@thojou 
