### PR TITLE
Remove `xml_parser_free` from codebase (PHP 8.5 issue)

### DIFF
--- a/components/ILIAS/Component/classes/class.ilComponentDefinitionReader.php
+++ b/components/ILIAS/Component/classes/class.ilComponentDefinitionReader.php
@@ -72,24 +72,17 @@ class ilComponentDefinitionReader
 
     protected function parseComponentXML(string $type, string $component, string $xml): void
     {
-        $xml_parser = null;
-        try {
-            $xml_parser = xml_parser_create("UTF-8");
-            xml_parser_set_option($xml_parser, XML_OPTION_CASE_FOLDING, false);
-            xml_set_element_handler($xml_parser, $this->beginTag(...), $this->endTag(...));
-            if (!xml_parse($xml_parser, $xml)) {
-                $code = xml_get_error_code($xml_parser);
-                $line = xml_get_current_line_number($xml_parser);
-                $col = xml_get_current_column_number($xml_parser);
-                $msg = xml_error_string($code);
-                throw new \InvalidArgumentException(
-                    "Error $code component xml of $type/$component, on line $line in column $col: $msg"
-                );
-            }
-        } finally {
-            if ($xml_parser) {
-                xml_parser_free($xml_parser);
-            }
+        $xml_parser = xml_parser_create("UTF-8");
+        xml_parser_set_option($xml_parser, XML_OPTION_CASE_FOLDING, false);
+        xml_set_element_handler($xml_parser, $this->beginTag(...), $this->endTag(...));
+        if (!xml_parse($xml_parser, $xml)) {
+            $code = xml_get_error_code($xml_parser);
+            $line = xml_get_current_line_number($xml_parser);
+            $col = xml_get_current_column_number($xml_parser);
+            $msg = xml_error_string($code);
+            throw new \InvalidArgumentException(
+                "Error $code component xml of $type/$component, on line $line in column $col: $msg"
+            );
         }
     }
 

--- a/components/ILIAS/TestQuestionPool/classes/QTI/class.ilQTIParser.php
+++ b/components/ILIAS/TestQuestionPool/classes/QTI/class.ilQTIParser.php
@@ -1803,7 +1803,6 @@ class ilQTIParser extends ilSaxParser
     {
         $parser = xml_parser_create();
         $is_resource = is_resource($parser);
-        xml_parser_free($parser);
 
         return $is_resource ? [] : new SplObjectStorage();
     }

--- a/components/ILIAS/Xml/classes/class.ilSaxParser.php
+++ b/components/ILIAS/Xml/classes/class.ilSaxParser.php
@@ -108,7 +108,6 @@ abstract class ilSaxParser
                 );
                 break;
         }
-        $this->freeParser($xml_parser);
     }
 
     /**
@@ -190,18 +189,6 @@ abstract class ilSaxParser
             throw new ilSaxParserException($message);
         }
     }
-
-    /**
-     * @param resource $a_xml_parser
-     * @throws ilSaxParserException
-     */
-    private function freeParser($a_xml_parser): void
-    {
-        if (!xml_parser_free($a_xml_parser)) {
-            $this->handleError("Error freeing xml parser handle");
-        }
-    }
-
 
     protected function setThrowException(bool $throw_exception): void
     {

--- a/components/ILIAS/soap/lib/nusoap.php
+++ b/components/ILIAS/soap/lib/nusoap.php
@@ -1211,8 +1211,6 @@ class nusoap_xmlschema extends nusoap_base
                 $this->debug("XML payload:\n" . $xml);
                 $this->setError($errstr);
             }
-
-            xml_parser_free($this->parser);
         } else {
             $this->debug('no xml passed to parseString()!!');
             $this->setError('no xml passed to parseString()!!');
@@ -4853,8 +4851,6 @@ class wsdl extends nusoap_base
             $this->setError($errstr);
             return false;
         }
-        // free the parser
-        xml_parser_free($this->parser);
         $this->debug('Parsing WSDL done');
         // catch wsdl parse errors
         if ($this->getError()) {
@@ -6640,7 +6636,6 @@ class nusoap_parser extends nusoap_base
                     }
                 }
             }
-            xml_parser_free($this->parser);
         } else {
             $this->debug('xml was empty, didn\'t parse!');
             $this->setError('xml was empty, didn\'t parse!');


### PR DESCRIPTION
This function has no effect.
Prior to PHP 8.0.0, this function was used to
close the resource.