### PR TITLE
Remove `curl_close` from codebase (PHP 8.5)

### DIFF
--- a/components/ILIAS/CmiXapi/classes/XapiProxy/XapiProxyRequest.php
+++ b/components/ILIAS/CmiXapi/classes/XapiProxy/XapiProxyRequest.php
@@ -307,7 +307,7 @@ class XapiProxyRequest
         $rawBody = curl_exec($ch);
         $statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         $curlError = curl_error($ch);
-        curl_close($ch);
+        $ch = null;
 
         if ($curlError) {
             $this->xapiproxy->log()->error("cURL error for $url: $curlError");

--- a/components/ILIAS/CmiXapi/classes/XapiReport/class.ilCmiXapiAbstractRequest.php
+++ b/components/ILIAS/CmiXapi/classes/XapiReport/class.ilCmiXapiAbstractRequest.php
@@ -65,7 +65,7 @@ abstract class ilCmiXapiAbstractRequest
         $body = curl_exec($ch);
         $error = curl_error($ch);
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-        curl_close($ch);
+        $ch = null;
 
         // Fehlerbehandlung
         if ($error) {

--- a/components/ILIAS/CmiXapi/classes/XapiResults/class.ilXapiStatementEvaluation.php
+++ b/components/ILIAS/CmiXapi/classes/XapiResults/class.ilXapiStatementEvaluation.php
@@ -401,8 +401,6 @@ class ilXapiStatementEvaluation
                 $this->log->error('checkResponse failed: ' . $e->getMessage());
             }
         }
-
-        curl_close($ch);
+        $ch = null;
     }
-
 }

--- a/components/ILIAS/CmiXapi/classes/class.ilCmiXapiLaunchGUI.php
+++ b/components/ILIAS/CmiXapi/classes/class.ilCmiXapiLaunchGUI.php
@@ -367,7 +367,7 @@ class ilCmiXapiLaunchGUI
                 $this->log()->error("CMI5preLaunch HTTP error $status: $body");
             }
             curl_multi_remove_handle($mh, $ch);
-            curl_close($ch);
+            $ch = null;
         }
 
         curl_multi_close($mh);

--- a/components/ILIAS/CmiXapi/classes/class.ilCmiXapiStatementsDeleteRequest.php
+++ b/components/ILIAS/CmiXapi/classes/class.ilCmiXapiStatementsDeleteRequest.php
@@ -239,7 +239,7 @@ class ilCmiXapiStatementsDeleteRequest
             $body = curl_exec($ch);
             $error = curl_error($ch);
             $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-            curl_close($ch);
+            $ch = null;
 
             if ($error) {
                 throw new Exception("cURL error: $error");
@@ -476,8 +476,7 @@ class ilCmiXapiStatementsDeleteRequest
         $responseBody = curl_exec($ch);
         $statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         $error = curl_error($ch);
-
-        curl_close($ch);
+        $ch = null;
 
         return [
             'status' => $statusCode,
@@ -549,7 +548,7 @@ class ilCmiXapiStatementsDeleteRequest
             ];
 
             curl_multi_remove_handle($mh, $ch);
-            curl_close($ch);
+            $ch = null;
         }
 
         curl_multi_close($mh);

--- a/components/ILIAS/CmiXapi/classes/class.ilCmiXapiStatementsGUI.php
+++ b/components/ILIAS/CmiXapi/classes/class.ilCmiXapiStatementsGUI.php
@@ -266,7 +266,7 @@ class ilCmiXapiStatementsGUI
         $body = curl_exec($ch);
         $error = curl_error($ch);
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-        curl_close($ch);
+        $ch = null;
 
         // Fehlerbehandlung
         if ($error) {

--- a/components/ILIAS/CmiXapi/classes/class.ilObjCmiXapi.php
+++ b/components/ILIAS/CmiXapi/classes/class.ilObjCmiXapi.php
@@ -146,7 +146,7 @@ class ilObjCmiXapi extends ilObject2
     protected bool $no_substatements = false;
 
     protected int $deleteData = 0;
-    
+
     protected bool $enrichData = false;
 
     protected ?ilCmiXapiUser $currentCmixUser = null;
@@ -1745,7 +1745,7 @@ class ilObjCmiXapi extends ilObject2
         $body = curl_exec($ch);
         $error = curl_error($ch);
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-        curl_close($ch);
+        $ch = null;
 
         if ($error) {
             $this->log()->error("cURL error: " . $error);

--- a/components/ILIAS/Filesystem/tests/Util/Convert/ImageConversionTest.php
+++ b/components/ILIAS/Filesystem/tests/Util/Convert/ImageConversionTest.php
@@ -458,7 +458,7 @@ class ImageConversionTest extends TestCase
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($curl, CURLOPT_USERAGENT, 'PHPUnit/1.0');
         $string = curl_exec($curl);
-        curl_close($curl);
+        $curl = null;
 
         $img = Streams::ofString($string);
         $this->assertInstanceOf(FileStream::class, $img);

--- a/components/ILIAS/MediaObjects/classes/class.ilExternalMediaAnalyzer.php
+++ b/components/ILIAS/MediaObjects/classes/class.ilExternalMediaAnalyzer.php
@@ -189,7 +189,7 @@ class ilExternalMediaAnalyzer
         curl_setopt($curl, CURLOPT_REFERER, ILIAS_HTTP_PATH);
 
         $return = curl_exec($curl);
-        curl_close($curl);
+        $curl = null;
 
         $r = json_decode($return, true);
 
@@ -209,7 +209,7 @@ class ilExternalMediaAnalyzer
         curl_setopt($curl, CURLOPT_REFERER, ILIAS_HTTP_PATH);
 
         $return = curl_exec($curl);
-        curl_close($curl);
+        $curl = null;
 
         $r = json_decode($return, true);
 

--- a/components/ILIAS/WebServices/Curl/classes/class.ilCurlConnection.php
+++ b/components/ILIAS/WebServices/Curl/classes/class.ilCurlConnection.php
@@ -177,7 +177,6 @@ class ilCurlConnection
     final public function close(): void
     {
         if ($this->ch !== null) {
-            curl_close($this->ch);
             $this->ch = null;
         }
     }

--- a/components/ILIAS/soap/lib/nusoap.php
+++ b/components/ILIAS/soap/lib/nusoap.php
@@ -3121,7 +3121,7 @@ class soap_transport_http extends nusoap_base
                 }
                 $this->debug($err);
                 $this->setError($err);
-                curl_close($this->ch);
+                $this->ch = null;
                 return false;
             } else {
                 //echo '<pre>';
@@ -3130,7 +3130,7 @@ class soap_transport_http extends nusoap_base
             }
             // close curl
             $this->debug('No cURL error, closing cURL');
-            curl_close($this->ch);
+            $this->ch = null;
 
             // try removing skippable headers
             $savedata = $data;


### PR DESCRIPTION
This function has no effect.
Prior to PHP 8.0.0, this function was used to
close the resource.