### PR TITLE
WebServices: Replace `socket_set_timeout` with `stream_set_timeout` (PHP 8.5)

### DIFF
--- a/components/ILIAS/soap/lib/nusoap.php
+++ b/components/ILIAS/soap/lib/nusoap.php
@@ -2372,7 +2372,7 @@ class soap_transport_http extends nusoap_base
 
             // set response timeout
             $this->debug('set response timeout to ' . $response_timeout);
-            socket_set_timeout($this->fp, $response_timeout);
+            stream_set_timeout($this->fp, $response_timeout);
 
             $this->debug('socket connected');
             return true;


### PR DESCRIPTION
In PHP 8.5, the alias function [socket_set_timeout](https://www.php.net/manual/en/function.stream-set-timeout.php) is deprecated, and calling it emits a deprecation notice.