### PR TITLE
[Fix] #004698 UI: Add role for glyphs without href

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/ButtonContextRenderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/ButtonContextRenderer.php
@@ -38,16 +38,16 @@ class ButtonContextRenderer extends Renderer
     protected function renderLabel(Component\Component $component, Template $tpl): Template
     {
         $aria_label = $component->getLabel();
-        if($aria_label != '') {
+        if ($aria_label != '') {
             $aria_label = $this->txt($aria_label);
         }
         foreach ($component->getCounters() as $counter) {
-            if($counter->getNumber() > 0) {
+            if ($counter->getNumber() > 0) {
                 $aria_label .= $this->txt("counter_" . $counter->getType()) . " " . $counter->getNumber() . "; ";
             }
         }
 
-        if($aria_label != "") {
+        if ($aria_label != "") {
             $tpl->setVariable("LABEL", $aria_label);
         }
 

--- a/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/ButtonContextRenderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/ButtonContextRenderer.php
@@ -53,4 +53,9 @@ class ButtonContextRenderer extends Renderer
 
         return $tpl;
     }
+
+    public function renderRole(Component\Component $component, Template $tpl): Template
+    {
+        return $tpl;
+    }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/Renderer.php
@@ -67,6 +67,16 @@ class Renderer extends AbstractComponentRenderer
             $tpl->parseCurrentBlock();
         }
 
+        $has_action = $component->isActive() && ($component->getAction() !== '');
+        $is_clickable = $component->isTabbable() || ($component instanceof Component\Triggerer && count($component->getTriggeredSignals()) > 0);
+
+        if (!$has_action) {
+            $role = $is_clickable ? 'button' : 'img';
+            $tpl->setCurrentBlock("with_role");
+            $tpl->setVariable("ROLE", $role);
+            $tpl->parseCurrentBlock();
+        }
+
         $tpl = $this->renderLabel($component, $tpl);
 
         $id = $this->bindJavaScript($component);

--- a/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/Renderer.php
@@ -67,7 +67,7 @@ class Renderer extends AbstractComponentRenderer
             $tpl->parseCurrentBlock();
         }
 
-        $tpl= $this->renderRole($component, $tpl);
+        $tpl = $this->renderRole($component, $tpl);
         $tpl = $this->renderLabel($component, $tpl);
 
         $id = $this->bindJavaScript($component);

--- a/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/Renderer.php
@@ -67,16 +67,7 @@ class Renderer extends AbstractComponentRenderer
             $tpl->parseCurrentBlock();
         }
 
-        $has_action = $component->isActive() && ($component->getAction() !== '');
-        $is_clickable = $component->isTabbable() || ($component instanceof Component\Triggerer && count($component->getTriggeredSignals()) > 0);
-
-        if (!$has_action) {
-            $role = $is_clickable ? 'button' : 'img';
-            $tpl->setCurrentBlock("with_role");
-            $tpl->setVariable("ROLE", $role);
-            $tpl->parseCurrentBlock();
-        }
-
+        $tpl= $this->renderRole($component, $tpl);
         $tpl = $this->renderLabel($component, $tpl);
 
         $id = $this->bindJavaScript($component);
@@ -105,6 +96,21 @@ class Renderer extends AbstractComponentRenderer
             $tpl->setVariable("ACTION", $component->getAction());
             $tpl->parseCurrentBlock();
         }
+        return $tpl;
+    }
+
+    public function renderRole(Component\Component $component, Template $tpl): Template
+    {
+        $has_action = $component->isActive() && ($component->getAction() !== null);
+        $is_clickable = $component->isTabbable() || ($component instanceof Component\Triggerer && count($component->getTriggeredSignals()) > 0);
+
+        if (!$has_action) {
+            $role = $is_clickable ? 'button' : 'img';
+            $tpl->setCurrentBlock("with_role");
+            $tpl->setVariable("ROLE", $role);
+            $tpl->parseCurrentBlock();
+        }
+
         return $tpl;
     }
 

--- a/components/ILIAS/UI/src/templates/default/Symbol/tpl.glyph.context_btn.html
+++ b/components/ILIAS/UI/src/templates/default/Symbol/tpl.glyph.context_btn.html
@@ -1,3 +1,3 @@
-<span class="glyph<!-- BEGIN highlighted --> highlighted<!-- END highlighted --><!-- BEGIN disabled --> disabled<!-- END disabled -->" <!-- BEGIN with_aria_disabled --> aria-disabled="{ARIA_DISABLED}"<!-- END with_aria_disabled --><!-- BEGIN aria_label --> aria-label="{LABEL}"<!-- END aria_label --> role="img"<!-- BEGIN with_id --> id="{ID}"<!-- END with_id -->>
+<span class="glyph<!-- BEGIN highlighted --> highlighted<!-- END highlighted --><!-- BEGIN disabled --> disabled<!-- END disabled -->" <!-- BEGIN with_aria_disabled --> aria-disabled="{ARIA_DISABLED}"<!-- END with_aria_disabled --><!-- BEGIN aria_label --> aria-label="{LABEL}"<!-- END aria_label --><!-- BEGIN with_role --> role="{ROLE}"<!-- END with_role --><!-- BEGIN with_id --> id="{ID}"<!-- END with_id -->>
 {GLYPH}
 </span>

--- a/components/ILIAS/UI/src/templates/default/Symbol/tpl.glyph.context_btn.html
+++ b/components/ILIAS/UI/src/templates/default/Symbol/tpl.glyph.context_btn.html
@@ -1,3 +1,3 @@
-<span class="glyph<!-- BEGIN highlighted --> highlighted<!-- END highlighted --><!-- BEGIN disabled --> disabled<!-- END disabled -->" <!-- BEGIN with_aria_disabled --> aria-disabled="{ARIA_DISABLED}"<!-- END with_aria_disabled --><!-- BEGIN aria_label --> aria-label="{LABEL}"<!-- END aria_label --><!-- BEGIN with_role --> role="{ROLE}"<!-- END with_role --><!-- BEGIN with_id --> id="{ID}"<!-- END with_id -->>
+<span class="glyph<!-- BEGIN highlighted --> highlighted<!-- END highlighted --><!-- BEGIN disabled --> disabled<!-- END disabled -->" <!-- BEGIN with_aria_disabled --> aria-disabled="{ARIA_DISABLED}"<!-- END with_aria_disabled --><!-- BEGIN aria_label --> aria-label="{LABEL}"<!-- END aria_label --> role="img"<!-- BEGIN with_id --> id="{ID}"<!-- END with_id -->>
 {GLYPH}
 </span>

--- a/components/ILIAS/UI/src/templates/default/Symbol/tpl.glyph.standard.html
+++ b/components/ILIAS/UI/src/templates/default/Symbol/tpl.glyph.standard.html
@@ -1,3 +1,3 @@
-<a <!-- BEGIN tabbable -->tabindex="0" <!-- END tabbable -->class="glyph<!-- BEGIN highlighted --> highlighted<!-- END highlighted --><!-- BEGIN disabled --> disabled<!-- END disabled -->"<!-- BEGIN with_action --> href="{ACTION}"<!-- END with_action --> aria-label="{LABEL}"<!-- BEGIN with_aria_disabled --> aria-disabled="{ARIA_DISABLED}"<!-- END with_aria_disabled --><!-- BEGIN with_id --> id="{ID}"<!-- END with_id -->>
+<a<!-- BEGIN tabbable --> tabindex="0"<!-- END tabbable --> class="glyph<!-- BEGIN highlighted --> highlighted<!-- END highlighted --><!-- BEGIN disabled --> disabled<!-- END disabled -->"<!-- BEGIN with_action --> href="{ACTION}"<!-- END with_action --> aria-label="{LABEL}"<!-- BEGIN with_aria_disabled --> aria-disabled="{ARIA_DISABLED}"<!-- END with_aria_disabled --><!-- BEGIN with_role --> role="{ROLE}"<!-- END with_role --><!-- BEGIN with_id --> id="{ID}"<!-- END with_id -->>
 {GLYPH}
 </a>

--- a/components/ILIAS/UI/tests/Component/Entity/EntityTest.php
+++ b/components/ILIAS/UI/tests/Component/Entity/EntityTest.php
@@ -161,11 +161,11 @@ class EntityTest extends ILIAS_UI_TestBase
     <div class="c-entity __availability">a</div>
     <div class="c-entity __details">d</div>
     <div class="c-entity __reactions">
-        <a class="glyph" aria-label="some glyph"><span class="glyphicon il-glyphicon-laugh" aria-hidden="true"></span></a>
-        <a class="glyph" aria-label="some glyph"><span class="glyphicon il-glyphicon-laugh" aria-hidden="true"></span></a>
+        <a class="glyph" aria-label="some glyph" role="img"><span class="glyphicon il-glyphicon-laugh" aria-hidden="true"></span></a>
+        <a class="glyph" aria-label="some glyph" role="img"><span class="glyphicon il-glyphicon-laugh" aria-hidden="true"></span></a>
     </div>
     <div class="c-entity __featured-reactions">
-        <a class="glyph" aria-label="some glyph"><span class="glyphicon il-glyphicon-laugh" aria-hidden="true"></span></a>
+        <a class="glyph" aria-label="some glyph" role="img"><span class="glyphicon il-glyphicon-laugh" aria-hidden="true"></span></a>
         <button class="btn btn-tag btn-tag-relevance-veryhigh" data-action="#" id="id_10">tag</button>
     </div>
 </div>

--- a/components/ILIAS/UI/tests/Component/Symbol/Glyph/GlyphTest.php
+++ b/components/ILIAS/UI/tests/Component/Symbol/Glyph/GlyphTest.php
@@ -355,7 +355,7 @@ class GlyphTest extends ILIAS_UI_TestBase
         $css_classes = self::$canonical_css_classes[$type];
         $aria_label = self::$aria_labels[$type];
 
-        $expected = '<a class="glyph" aria-label="' . $aria_label . '"><span class="' . $css_classes . '" aria-hidden="true"></span></a>';
+        $expected = '<a class="glyph" aria-label="' . $aria_label . '" role="img"><span class="' . $css_classes . '" aria-hidden="true"></span></a>';
         $this->assertEquals($expected, $html);
     }
 
@@ -372,7 +372,7 @@ class GlyphTest extends ILIAS_UI_TestBase
         $aria_label = self::$aria_labels[$type];
 
         $expected = '
-        <a class="glyph disabled" aria-label="' . $aria_label . '" aria-disabled="true">
+        <a class="glyph disabled" aria-label="' . $aria_label . '" aria-disabled="true" role="img">
             <span class="' . $css_classes . '" aria-hidden="true"></span>
         </a>';
         $this->assertEquals($this->brutallyTrimHTML($expected), $this->brutallyTrimHTML($html));
@@ -392,7 +392,7 @@ class GlyphTest extends ILIAS_UI_TestBase
         $aria_label = self::$aria_labels[G\Glyph::MAIL];
 
         $expected = '
-            <a class="glyph" aria-label="' . $aria_label . '">
+            <a class="glyph" aria-label="' . $aria_label . '" role="img">
                     <span class="' . $css_classes . '" aria-hidden="true"></span>
                     <span class="il-counter"><span class="badge badge-notify il-counter-' . $type . '">42</span></span>
                     <span class="il-counter-spacer">42</span>
@@ -413,7 +413,7 @@ class GlyphTest extends ILIAS_UI_TestBase
 
         $css_classes = self::$canonical_css_classes[G\Glyph::MAIL];
         $aria_label = self::$aria_labels[G\Glyph::MAIL];
-        $expected = '<a class="glyph" aria-label="' . $aria_label . '">' .
+        $expected = '<a class="glyph" aria-label="' . $aria_label . '" role="img">' .
                     '<span class="' . $css_classes . '" aria-hidden="true"></span>' .
                     '<span class="il-counter"><span class="badge badge-notify il-counter-status">7</span></span>' .
                     '<span class="il-counter"><span class="badge badge-notify il-counter-novelty">42</span></span>' .
@@ -460,7 +460,7 @@ class GlyphTest extends ILIAS_UI_TestBase
         $aria_label = self::$aria_labels[$type];
 
         $id = $ids[0];
-        $expected = '<a class="glyph" aria-label="' . $aria_label . '" id="' . $id . '"><span class="' . $css_classes . '" aria-hidden="true"></span></a>';
+        $expected = '<a class="glyph" aria-label="' . $aria_label . '" role="img" id="' . $id . '"><span class="' . $css_classes . '" aria-hidden="true"></span></a>';
         $this->assertEquals($expected, $html);
     }
 }


### PR DESCRIPTION
Adds role to glyph elements with aria-label

Glyphs with aria-label require a valid role. Set role="img" 
for non-interactive glyphs and role="button" for clickable 
glyphs without href. Glyphs with href (links) don't need a role 
as <a> elements are already semantically links.

This fixes HTML validation errors for glyph elements that have aria-label but no role attribute.
https://mantis.ilias.de/view.php?id=46921