### PR TITLE
[Fix] #004698 UI: Add href attribute to missing a-tags

### DIFF
--- a/components/ILIAS/Init/templates/default/tpl.startup_screen.html
+++ b/components/ILIAS/Init/templates/default/tpl.startup_screen.html
@@ -9,7 +9,7 @@
 	<!-- BEGIN warning -->
 	<img class="ilFailureMessage" alt="{ALT_IMAGE}" title="{ALT_IMAGE}" src="{SRC_IMAGE}" />
 	<div class="ilFailureMessage">
-		<div class="ilAccHeadingHidden"><a id="il_message_focus" name="il_message_focus">{MESSAGE_HEADING}</a></div>
+		<div class="ilAccHeadingHidden"><span id="il_message_focus" name="il_message_focus">{MESSAGE_HEADING}</span></div>
 		{TXT_MSG_LOGIN_FAILED}
 	</div>
 	<!-- END warning -->

--- a/components/ILIAS/Init/templates/default/tpl.startup_screen.html
+++ b/components/ILIAS/Init/templates/default/tpl.startup_screen.html
@@ -9,7 +9,7 @@
 	<!-- BEGIN warning -->
 	<img class="ilFailureMessage" alt="{ALT_IMAGE}" title="{ALT_IMAGE}" src="{SRC_IMAGE}" />
 	<div class="ilFailureMessage">
-		<div class="ilAccHeadingHidden"><span id="il_message_focus" name="il_message_focus">{MESSAGE_HEADING}</span></div>
+		<div class="ilAccHeadingHidden"><span id="il_message_focus">{MESSAGE_HEADING}</span></div>
 		{TXT_MSG_LOGIN_FAILED}
 	</div>
 	<!-- END warning -->

--- a/components/ILIAS/UIComponent/Tabs/templates/default/tpl.sub_tabs.html
+++ b/components/ILIAS/UIComponent/Tabs/templates/default/tpl.sub_tabs.html
@@ -1,4 +1,4 @@
-<h2 class="ilAccHeadingHidden"><a id="sub_tabs_after_tabs">{TXT_SUBTABS}</a></h2>
+<h2 class="ilAccHeadingHidden"><span id="sub_tabs_after_tabs">{TXT_SUBTABS}</span></h2>
 <ul id="ilSubTab" class="ilSubTab nav hidden-print">
 	<!-- BEGIN subtab -->
 	<li id="{ID}" class="{SUB_TAB_TYPE}">{SUB_LINK}<!-- BEGIN sel_text --> <span class="ilAccHidden">({TXT_SELECTED})</span><!-- END sel_text --></li>

--- a/components/ILIAS/UIComponent/Tabs/templates/default/tpl.tabs.html
+++ b/components/ILIAS/UIComponent/Tabs/templates/default/tpl.tabs.html
@@ -17,4 +17,4 @@
 		</ul>
 	</li>
 </ul>
-<!-- BEGIN after_tabs --><span class="ilAccHidden"><a id="after_tabs">{TXT_SUBTABS}</a></span><!-- END after_tabs -->
+<!-- BEGIN after_tabs --><span class="ilAccHidden"><span id="after_tabs">{TXT_SUBTABS}</span></span><!-- END after_tabs -->

--- a/templates/default/tpl.adm_content.html
+++ b/templates/default/tpl.adm_content.html
@@ -39,7 +39,7 @@
 {TABS}
 <!-- BEGIN tabs_outer_start --><div class="ilTabsContentOuter"><div class="clearfix"></div><!-- END tabs_outer_start -->
 {SUB_TABS}
-<div class="il_after_tabs_spacing"><a id="after_sub_tabs" name="after_sub_tabs"></a></div>
+<div class="il_after_tabs_spacing"><a id="after_sub_tabs" href="#" name="after_sub_tabs"></a></div>
 <!-- BEGIN tabs_inner_start --><!-- END tabs_inner_start -->
 <!-- BEGIN mess --><div class="ilAdminRow">{MESSAGE}</div><!-- END mess -->
 <!-- BEGIN page_form_start -->

--- a/templates/default/tpl.adm_content.html
+++ b/templates/default/tpl.adm_content.html
@@ -39,7 +39,7 @@
 {TABS}
 <!-- BEGIN tabs_outer_start --><div class="ilTabsContentOuter"><div class="clearfix"></div><!-- END tabs_outer_start -->
 {SUB_TABS}
-<div class="il_after_tabs_spacing"><a id="after_sub_tabs" href="#" name="after_sub_tabs"></a></div>
+<div class="il_after_tabs_spacing"><span id="after_sub_tabs" name="after_sub_tabs"></span></div>
 <!-- BEGIN tabs_inner_start --><!-- END tabs_inner_start -->
 <!-- BEGIN mess --><div class="ilAdminRow">{MESSAGE}</div><!-- END mess -->
 <!-- BEGIN page_form_start -->

--- a/templates/default/tpl.adm_content.html
+++ b/templates/default/tpl.adm_content.html
@@ -39,7 +39,7 @@
 {TABS}
 <!-- BEGIN tabs_outer_start --><div class="ilTabsContentOuter"><div class="clearfix"></div><!-- END tabs_outer_start -->
 {SUB_TABS}
-<div class="il_after_tabs_spacing"><span id="after_sub_tabs" name="after_sub_tabs"></span></div>
+<div class="il_after_tabs_spacing"><span id="after_sub_tabs"></span></div>
 <!-- BEGIN tabs_inner_start --><!-- END tabs_inner_start -->
 <!-- BEGIN mess --><div class="ilAdminRow">{MESSAGE}</div><!-- END mess -->
 <!-- BEGIN page_form_start -->

--- a/templates/default/tpl.adm_content.html
+++ b/templates/default/tpl.adm_content.html
@@ -39,7 +39,7 @@
 {TABS}
 <!-- BEGIN tabs_outer_start --><div class="ilTabsContentOuter"><div class="clearfix"></div><!-- END tabs_outer_start -->
 {SUB_TABS}
-<div class="il_after_tabs_spacing"><span id="after_sub_tabs"></span></div>
+<div class="il_after_tabs_spacing"></div>
 <!-- BEGIN tabs_inner_start --><!-- END tabs_inner_start -->
 <!-- BEGIN mess --><div class="ilAdminRow">{MESSAGE}</div><!-- END mess -->
 <!-- BEGIN page_form_start -->

--- a/templates/default/tpl.page_content.html
+++ b/templates/default/tpl.page_content.html
@@ -37,7 +37,7 @@
 				{TABS}
 				<!-- BEGIN tabs_outer_start --><div class="ilTabsContentOuter"><div class="clearfix"></div><!-- END tabs_outer_start -->
 				{SUB_TABS}
-				<div class="il_after_tabs_spacing"><a id="after_sub_tabs" href="#" name="after_sub_tabs"></a></div>
+				<div class="il_after_tabs_spacing"><span id="after_sub_tabs" name="after_sub_tabs"></span></div>
 				<!-- BEGIN tabs_inner_start --><!-- END tabs_inner_start -->
 				<!-- BEGIN mess --><div class="ilAdminRow">{MESSAGE}</div><!-- END mess -->
 				<!-- BEGIN toolbar_buttons --><div class="ilToolbarContainer">{BUTTONS}</div><!-- END toolbar_buttons -->

--- a/templates/default/tpl.page_content.html
+++ b/templates/default/tpl.page_content.html
@@ -37,7 +37,7 @@
 				{TABS}
 				<!-- BEGIN tabs_outer_start --><div class="ilTabsContentOuter"><div class="clearfix"></div><!-- END tabs_outer_start -->
 				{SUB_TABS}
-				<div class="il_after_tabs_spacing"><span id="after_sub_tabs" name="after_sub_tabs"></span></div>
+				<div class="il_after_tabs_spacing"><span id="after_sub_tabs"></span></div>
 				<!-- BEGIN tabs_inner_start --><!-- END tabs_inner_start -->
 				<!-- BEGIN mess --><div class="ilAdminRow">{MESSAGE}</div><!-- END mess -->
 				<!-- BEGIN toolbar_buttons --><div class="ilToolbarContainer">{BUTTONS}</div><!-- END toolbar_buttons -->

--- a/templates/default/tpl.page_content.html
+++ b/templates/default/tpl.page_content.html
@@ -37,7 +37,7 @@
 				{TABS}
 				<!-- BEGIN tabs_outer_start --><div class="ilTabsContentOuter"><div class="clearfix"></div><!-- END tabs_outer_start -->
 				{SUB_TABS}
-				<div class="il_after_tabs_spacing"><span id="after_sub_tabs"></span></div>
+				<div class="il_after_tabs_spacing"></div>
 				<!-- BEGIN tabs_inner_start --><!-- END tabs_inner_start -->
 				<!-- BEGIN mess --><div class="ilAdminRow">{MESSAGE}</div><!-- END mess -->
 				<!-- BEGIN toolbar_buttons --><div class="ilToolbarContainer">{BUTTONS}</div><!-- END toolbar_buttons -->

--- a/templates/default/tpl.page_content.html
+++ b/templates/default/tpl.page_content.html
@@ -37,7 +37,7 @@
 				{TABS}
 				<!-- BEGIN tabs_outer_start --><div class="ilTabsContentOuter"><div class="clearfix"></div><!-- END tabs_outer_start -->
 				{SUB_TABS}
-				<div class="il_after_tabs_spacing"><a id="after_sub_tabs" name="after_sub_tabs"></a></div>
+				<div class="il_after_tabs_spacing"><a id="after_sub_tabs" href="#" name="after_sub_tabs"></a></div>
 				<!-- BEGIN tabs_inner_start --><!-- END tabs_inner_start -->
 				<!-- BEGIN mess --><div class="ilAdminRow">{MESSAGE}</div><!-- END mess -->
 				<!-- BEGIN toolbar_buttons --><div class="ilToolbarContainer">{BUTTONS}</div><!-- END toolbar_buttons -->


### PR DESCRIPTION
Add missing href attributes to anchor tags to fix HTML validation errors.
https://mantis.ilias.de/view.php?id=46698