### PR TITLE
[Fix] 0046870 UI: Maincontrols preserve role menu when engaging/disengaging

### DIFF
--- a/components/ILIAS/UI/resources/js/MainControls/dist/mainbar.js
+++ b/components/ILIAS/UI/resources/js/MainControls/dist/mainbar.js
@@ -802,7 +802,10 @@ var persistence = function() {
 
                 element.attr('aria-hidden', false);
                 //https://www.w3.org/TR/wai-aria-practices-1.1/examples/accordion/accordion.html
-                element.attr('role', 'region');
+                var currentRole = element.attr('role');
+                if (!currentRole || currentRole === 'region') {
+                    element.attr('role', 'region');
+                }
                 if(isInView && !thrown) {
                     element.trigger('in_view'); //this is most important for async loading of slates,
                                                 //it triggers the GlobalScreen-Service.
@@ -815,8 +818,11 @@ var persistence = function() {
             additional_disengage: function(){
                 var entry_id = dom_ref_to_element[this.html_id];
                 thrown_for[entry_id] = false;
-                this.getElement().attr('aria-hidden', true);
-                this.getElement().removeAttr('role', 'region');
+                var element = this.getElement();
+                element.attr('aria-hidden', true);
+                if (element.attr('role') === 'region') {
+                    element.removeAttr('role');
+                }
             }
         }),
         remover: Object.assign({}, dom_element, {

--- a/components/ILIAS/UI/resources/js/MainControls/src/mainbar.renderer.js
+++ b/components/ILIAS/UI/resources/js/MainControls/src/mainbar.renderer.js
@@ -95,7 +95,10 @@
 
                 element.attr('aria-hidden', false);
                 //https://www.w3.org/TR/wai-aria-practices-1.1/examples/accordion/accordion.html
-                element.attr('role', 'region');
+                var currentRole = element.attr('role');
+                if (!currentRole || currentRole === 'region') {
+                    element.attr('role', 'region');
+                }
                 if(isInView && !thrown) {
                     element.trigger('in_view'); //this is most important for async loading of slates,
                                                 //it triggers the GlobalScreen-Service.
@@ -108,8 +111,11 @@
             additional_disengage: function(){
                 var entry_id = dom_ref_to_element[this.html_id];
                 thrown_for[entry_id] = false;
-                this.getElement().attr('aria-hidden', true);
-                this.getElement().removeAttr('role', 'region');
+                var element = this.getElement();
+                element.attr('aria-hidden', true);
+                if (element.attr('role') === 'region') {
+                    element.removeAttr('role');
+                }
             }
         }),
         remover: Object.assign({}, dom_element, {


### PR DESCRIPTION
Preserve role="menu" on slates when engaging/disengaging

Prevent JavaScript from overwriting role="menu" with role="region" 
when slates are engaged. Only set role="region" if no role is 
already present, and only remove it if it was set to "region".
https://mantis.ilias.de/view.php?id=46870
