### PR TITLE
Fix: Correct type hints and imports in Activities component

### DIFF
--- a/components/ILIAS/Component/src/Activities/Activity.php
+++ b/components/ILIAS/Component/src/Activities/Activity.php
@@ -21,10 +21,10 @@ declare(strict_types=1);
 namespace ILIAS\Component\Activities;
 
 use ILIAS\Component\Dependencies\Name;
-use ILIAS\UI\Component\Input\Control\Form\FormInput;
 use ILIAS\Data\Result;
 use ILIAS\Data\Text;
 use ILIAS\Data\Description;
+use ILIAS\UI\Component\Input\Container\Form\FormInput;
 
 /**
  * An Activity is an action on the domain layer action of a component.

--- a/components/ILIAS/Component/src/Activities/ObjectActivity.php
+++ b/components/ILIAS/Component/src/Activities/ObjectActivity.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Component\Activities;
+
+use ILIAS\UI\Component\Input\Container\Form\FormInput;
+use ILIAS\UI\Component\Input\Input;
+
+/**
+ * An Activity that refers to a certain object in the system. This also is a
+ * generic interface but a subset of inputs is fixed.
+ *
+ * This does not necessarily need to refer to an ilObject, but can also be used
+ * to refer to any objects internal to a given component, such as questions,
+ * memberships or certain results.
+ */
+interface ObjectActivity extends Activity
+{
+    /**
+     * @inheritdoc
+     *
+     * For an ObjectActivity, this needs to return an input with one field named
+     * "id" that can accept a string value.
+     */
+    public function getInputDescription(): FormInput;
+
+    /**
+     * Works just like `getInputDescription` but checks if that description
+     * matches the spec.
+     *
+     * @throws \LogicException if there is no "id" field in the Input.
+     */
+    public function getCheckedInputDescription(): Input;
+
+    /**
+     * To allow consumers to build an understanding of internal object structure of
+     * a component, an ObjectActivity needs to tell a "type" of object it touches.
+     *
+     * The type should be a short alphanumeric string.
+     */
+    public function getTargetType(): string;
+}

--- a/components/ILIAS/Component/src/Activities/Repository.php
+++ b/components/ILIAS/Component/src/Activities/Repository.php
@@ -20,13 +20,15 @@ declare(strict_types=1);
 
 namespace ILIAS\Component\Activities;
 
+use ILIAS\Data\Range;
+
 interface Repository
 {
     /**
      * Get all activities where the name matches the provided regexp.
      *
      * @param string $name_matcher as preg_match can understand
-     * @return Iterator<string, Activity> where keys are the name
+     * @return \Iterator<string, Activity> where keys are the name
      */
     public function getActivitiesByName(string $name_matcher, ?ActivityType $type = null, ?Range $range = null): \Iterator;
 }

--- a/components/ILIAS/Component/src/Activities/StaticRepository.php
+++ b/components/ILIAS/Component/src/Activities/StaticRepository.php
@@ -20,6 +20,8 @@ declare(strict_types=1);
 
 namespace ILIAS\Component\Activities;
 
+use ILIAS\Data\Range;
+
 class StaticRepository implements Repository
 {
     protected array $activities = [];

--- a/components/ILIAS/Setup/src/Activities/GetStatus.php
+++ b/components/ILIAS/Setup/src/Activities/GetStatus.php
@@ -21,9 +21,9 @@ declare(strict_types=1);
 namespace ILIAS\Setup\Activities;
 
 use ILIAS\Component\Dependencies\Name;
-use ILIAS\UI\Component\Input\Control\Form\FormInput;
 use ILIAS\Data\Result;
 use ILIAS\Data\Text;
+use ILIAS\UI\Component\Input\Container\Form\FormInput;
 
 /**
  * This is a stub...
@@ -34,7 +34,7 @@ class GetStatus extends \ILIAS\Component\Activities\Query
     {
     }
 
-    public function getInputDescription(): \ILIAS\UI\Component\Input\Control\Form\FormInput
+    public function getInputDescription(): FormInput
     {
     }
 


### PR DESCRIPTION
This PR cleans up the Activities component by addressing several inconsistencies related to type hinting and imports.

The changes include:

- Updating the `FormInput` namespace to its correct location.
- Adding the previously missing `ILIAS\Data\Range` import.
- Correcting the return type annotation for the `getActivitiesByName` method.

### Motivation

This PR ensures that the Activities component can be used in other component developments without encountering errors during artifact compilation.




### Info

- Activity [proposal wiki page](https://docu.ilias.de/go/wiki/wpage_8112_1357)
- Activity [README.md](https://github.com/ILIAS-eLearning/ILIAS/blob/release_11/components/ILIAS/Component/src/Activities/README.md)