### PR TITLE
[Fix] 0046870 UI: aria-label cannot be on div element

### DIFF
--- a/components/ILIAS/Search/templates/default/tpl.main_menu_search.html
+++ b/components/ILIAS/Search/templates/default/tpl.main_menu_search.html
@@ -7,8 +7,8 @@
 	<!-- BEGIN ov_head -->
 	<div id="ilMMSearchMenu">
 		<p><a id="search_link" target="_top" href="{HREF_SEARCH_LINK}">{TXT_SEARCH_LINK}</a></p>
-		<div id="mm_search_menu_options" aria-label="{LABEL_SEARCH_OPTIONS}">
-			<fieldset>
+		<div id="mm_search_menu_options">
+			<fieldset aria-label="{LABEL_SEARCH_OPTIONS}">
 				<legend>{LABEL_SEARCH_OPTIONS}</legend>
 				<!-- BEGIN position --><input type="radio" name="root_id" value="{ROOT_ID}" checked="checked" id="ilmmsg"/> <label for="ilmmsg"> {TXT_GLOBALLY}</label><br/><!-- END position -->
 				<!-- BEGIN position_rep -->


### PR DESCRIPTION
The “aria-label” attribute must not be specified on any “div” element
https://mantis.ilias.de/view.php?id=46870