### PR TITLE
Mantis #46993: Filter time limit expired users from mail recipient autocomplete results

### DIFF
--- a/components/ILIAS/Contact/classes/class.ilMailSearchGUI.php
+++ b/components/ILIAS/Contact/classes/class.ilMailSearchGUI.php
@@ -36,6 +36,7 @@ class ilMailSearchGUI
     private readonly ilFormatMail $umail;
     private readonly GlobalHttpState $http;
     private readonly Refinery $refinery;
+    private ilSearchSettings $search_settings;
 
     /**
      * @param ilWorkspaceAccessHandler|null|ilPortfolioAccessHandler $wsp_access_handler
@@ -52,6 +53,7 @@ class ilMailSearchGUI
         $this->object_data_cache = $DIC['ilObjDataCache'];
         $this->http = $DIC->http();
         $this->refinery = $DIC->refinery();
+        $this->search_settings = ilSearchSettings::getInstance();
 
         $this->ctrl->saveParameter($this, 'mobj_id');
         $this->ctrl->saveParameter($this, 'ref');
@@ -286,7 +288,9 @@ class ilMailSearchGUI
             $query_parser->parse();
 
             $user_search = ilObjectSearchFactory::_getUserSearchInstance($query_parser);
-            $user_search->enableActiveCheck(true);
+            $user_search->enableActiveCheck(!$this->search_settings->isInactiveUserVisible());
+            $user_search->enableTimeLimitedCheck(!$this->search_settings->isLimitedUserVisible());
+
             $user_search->setFields(['login']);
             $result_obj = $user_search->performSearch();
             $contacts_search_result->mergeEntries($result_obj);
@@ -382,7 +386,8 @@ class ilMailSearchGUI
         $query_parser->parse();
 
         $user_search = ilObjectSearchFactory::_getUserSearchInstance($query_parser);
-        $user_search->enableActiveCheck(true);
+        $user_search->enableActiveCheck(!$this->search_settings->isInactiveUserVisible());
+        $user_search->enableTimeLimitedCheck(!$this->search_settings->isLimitedUserVisible());
         $user_search->setFields(['login']);
         $result_obj = $user_search->performSearch();
         $all_results->mergeEntries($result_obj);

--- a/components/ILIAS/Mail/classes/class.ilMailAutoCompleteUserProvider.php
+++ b/components/ILIAS/Mail/classes/class.ilMailAutoCompleteUserProvider.php
@@ -23,6 +23,14 @@ declare(strict_types=1);
  */
 class ilMailAutoCompleteUserProvider extends ilMailAutoCompleteRecipientProvider
 {
+    private ilSearchSettings $search_settings;
+
+    public function __construct(string $quoted_term, string $term)
+    {
+        parent::__construct($quoted_term, $term);
+        $this->search_settings = ilSearchSettings::getInstance();
+    }
+
     /**
      * @return array{login: string, firstname: string, lastname:string}
      */
@@ -110,7 +118,18 @@ class ilMailAutoCompleteUserProvider extends ilMailAutoCompleteRecipientProvider
     {
         $outer_conditions = [];
         $outer_conditions[] = 'usr_data.usr_id != ' . $this->db->quote(ANONYMOUS_USER_ID, 'integer');
-        $outer_conditions[] = 'usr_data.active != ' . $this->db->quote(0, 'integer');
+        if (!$this->search_settings->isInactiveUserVisible()) {
+            $outer_conditions[] = 'usr_data.active != ' . $this->db->quote(0, 'integer');
+        }
+
+        if (!$this->search_settings->isLimitedUserVisible()) {
+            $outer_conditions[] = sprintf(
+                '(usr_data.time_limit_unlimited = %s OR (time_limit_from < %s AND time_limit_until > %s))',
+                $this->db->quote(1, ilDBConstants::T_INTEGER),
+                $this->db->quote(time(), ilDBConstants::T_INTEGER),
+                $this->db->quote(time(), ilDBConstants::T_INTEGER)
+            );
+        }
 
         $field_conditions = [];
         foreach ($this->getFields() as $field) {


### PR DESCRIPTION
Fixes https://mantis.ilias.de/view.php?id=46993.

Requires https://github.com/ILIAS-eLearning/ILIAS/pull/11044

If accepted should be picked into **release_11** & **trunk**.