### PR TITLE
[Fix] 0047057 UI: Select field must not have more than one selected option

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
@@ -488,17 +488,16 @@ class Renderer extends AbstractComponentRenderer
         $this->applyName($component, $tpl);
 
         $value = $component->getValue();
+        $value_is_empty = $value === null || $value === '';
         //disable first option if required.
         $tpl->setCurrentBlock("options");
-        if (!$value) {
-            $tpl->setVariable("SELECTED", 'selected="selected"');
-        }
-        if ($component->isRequired() && !$value) {
+        $tpl->setVariable("SELECTED", $value_is_empty ? 'selected="selected"' : '');
+        if ($component->isRequired() && $value_is_empty) {
             $tpl->setVariable("DISABLED_OPTION", "disabled");
             $tpl->setVariable("HIDDEN", "hidden");
         }
 
-        if (!($value && $component->isRequired())) {
+        if ($value_is_empty || !$component->isRequired()) {
             $tpl->setVariable("VALUE", null);
             $tpl->setVariable("VALUE_STR", $component->isRequired() ? $this->txt('ui_select_dropdown_label') : '-');
             $tpl->parseCurrentBlock();
@@ -506,9 +505,7 @@ class Renderer extends AbstractComponentRenderer
 
         foreach ($component->getOptions() as $option_key => $option_value) {
             $tpl->setCurrentBlock("options");
-            if ($value == $option_key) {
-                $tpl->setVariable("SELECTED", 'selected="selected"');
-            }
+            $tpl->setVariable("SELECTED", ($value !== null && $value !== '' && $value == $option_key) ? 'selected="selected"' : '');
             $tpl->setVariable("VALUE", $option_key);
             $tpl->setVariable("VALUE_STR", $option_value);
             $tpl->parseCurrentBlock();

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
@@ -491,8 +491,10 @@ class Renderer extends AbstractComponentRenderer
         $value_is_empty = $value === null || $value === '';
         //disable first option if required.
         $tpl->setCurrentBlock("options");
-        $tpl->setVariable("SELECTED", $value_is_empty ? 'selected="selected"' : '');
-        if ($component->isRequired() && $value_is_empty) {
+        if ($value_is_empty) {
+            $tpl->setVariable("SELECTED", 'selected="selected"');
+        }
+        if ($value_is_empty && $component->isRequired()) {
             $tpl->setVariable("DISABLED_OPTION", "disabled");
             $tpl->setVariable("HIDDEN", "hidden");
         }
@@ -505,7 +507,9 @@ class Renderer extends AbstractComponentRenderer
 
         foreach ($component->getOptions() as $option_key => $option_value) {
             $tpl->setCurrentBlock("options");
-            $tpl->setVariable("SELECTED", ($value !== null && $value !== '' && $value == $option_key) ? 'selected="selected"' : '');
+            if (!$value_is_empty && $value == $option_key) {
+                $tpl->setVariable("SELECTED", 'selected="selected"');
+            }
             $tpl->setVariable("VALUE", $option_key);
             $tpl->setVariable("VALUE_STR", $option_value);
             $tpl->parseCurrentBlock();


### PR DESCRIPTION
When the select value was 0 (e.g. DataTable action dropdown), both the
placeholder option and the option with value "0" got selected="selected"
because PHP treats 0 as falsy. Use explicit empty check (value === null
|| value === '') for placeholder selection and clear SELECTED for
non-matching options so only one option is ever selected.

## Problem
- HTML-Validator: "The 'select' element cannot have more than one selected 'option' descendant unless the 'multiple' attribute is specified."
- Trat z. B. bei DataTable-Aktions-Dropdown mit Wert 0 ("some action") auf: Platzhalter "Bitte auswählen" und Option value="0" hatten beide selected.

## Lösung
- Leerer Wert explizit prüfen: `$value_is_empty = ($value === null || $value === '')` statt `!$value`.
- Platzhalter nur bei echt leerem Wert als selected markieren.
- In der Options-Schleife SELECTED nur für die passende Option setzen, sonst leer.

Error: The “select” element cannot have more than one selected “option” descendant unless the “multiple” attribute is specified.	
https://mantis.ilias.de/view.php?id=47057
