### PR TITLE
[Fix] 0047058 UI: MetaBar extended example – no <style> inside div fo…

### DIFF
--- a/components/ILIAS/UI/src/examples/MainControls/MetaBar/extended_example_for_developers.php
+++ b/components/ILIAS/UI/src/examples/MainControls/MetaBar/extended_example_for_developers.php
@@ -211,8 +211,11 @@ function usuallyDoneByGlobalScreenProbablyIgnore($async_item, $f, $renderer, $ad
                              ->withAdditionalEntry($async_slate)
                              ->withAdditionalEntry($mail_slate);
 
-    $css_fix = "<style>.panel-primary .il-maincontrols-metabar{flex-direction: column;} .panel-primary .il-metabar-slates{position: relative;top: 0px;}</style>";
-    return $css_fix . $renderer->render([buildMetabarWithNotifications($f, $notification_center),$add_button,$set_button,$reset_button]);
+    $html = $renderer->render([buildMetabarWithNotifications($f, $notification_center), $add_button, $set_button, $reset_button]);
+    // Apply layout fix as inline styles (no <style> tag – not allowed as child of div in documentation context)
+    $html = preg_replace('/(<ul class="il-maincontrols-metabar"[^>]*\sstyle=")([^"]*)(")/', '$1flex-direction: column; $2$3', $html, 1);
+    $html = preg_replace('/<div class="il-metabar-slates">/', '<div class="il-metabar-slates" style="position: relative; top: 0px;">', $html);
+    return $html;
 }
 
 function buildMetabarWithNotifications($f, $notification_center)

--- a/components/ILIAS/UI/src/examples/MainControls/MetaBar/extended_example_for_developers.php
+++ b/components/ILIAS/UI/src/examples/MainControls/MetaBar/extended_example_for_developers.php
@@ -20,6 +20,8 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\examples\MainControls\MetaBar;
 
+use ILIAS\DI\Container;
+
 /**
  * ---
  * description: >
@@ -48,38 +50,72 @@ namespace ILIAS\UI\examples\MainControls\MetaBar;
  *      more interactions.
  *
  * expected output: >
- *   ILIAS shows the rendered Component.
+ *   ILIAS shows a link "See UI in fullscreen-mode". Clicking the link opens a
+ *   standard page with the MetaBar in the header. The Notification Center in the
+ *   MetaBar contains the Chat example with async functionality. The page content
+ *   provides buttons to add, reset or set chat notifications.
  * ---
  * @return string
  */
 function extended_example_for_developers(): string
 {
-    //Set up the gears as always
     global $DIC;
     $f = $DIC->ui()->factory();
     $renderer = $DIC->ui()->renderer();
-    $refinery = $DIC->refinery();
-    $request_wrapper = $DIC->http()->wrapper()->query();
 
-    //Create some bare UI Components Notification Item to be used all over the place
+    $url = $DIC->http()->request()->getUri()->__toString() . '&extended_metabar_ui=1';
+    $txt = $f->legacy()->content('<p>
+            The extended MetaBar example opens in fullscreen to showcase the
+            Notification Item async functionality in the proper page layout.
+            Use the Notification Center (bell icon) in the MetaBar and the
+            buttons below to try the async features.
+            </p>');
+
+    $page_demo = $f->link()->standard('See UI in fullscreen-mode', $url);
+
+    return $renderer->render([
+        $txt,
+        $page_demo
+    ]);
+}
+
+function buildMetabarWithNotifications($f, $notification_center)
+{
+    $help = $f->button()->bulky($f->symbol()->glyph()->help(), 'Help', '#');
+    $search = $f->button()->bulky($f->symbol()->glyph()->search(), 'Search', '#');
+    $user = $f->button()->bulky($f->symbol()->glyph()->user(), 'User', '#');
+
+
+    $metabar = $f->mainControls()->metabar()
+                 ->withAdditionalEntry('search', $search)
+                 ->withAdditionalEntry('help', $help)
+                 ->withAdditionalEntry('notification', $notification_center)
+                 ->withAdditionalEntry('user', $user);
+
+    return $metabar;
+}
+
+/**
+ * Handle async requests for the notification item. Exits if request was async.
+ */
+function handleAsyncRequestsIfAny(Container $dic): void
+{
+    $f = $dic->ui()->factory();
+    $renderer = $dic->ui()->renderer();
+    $refinery = $dic->refinery();
+    $request_wrapper = $dic->http()->wrapper()->query();
+
     $icon = $f->symbol()->icon()->standard("chtr", "chtr");
     $title = $f->link()->standard("Some Title", "#");
     $item = $f->item()->notification($title, $icon);
 
-    //We provide 4 async endpoints here
-    //Endpoint if element ist closed
     $async_close = $_SERVER['REQUEST_URI'] . '&close_item=true&async_load_replace=false&async_load_replace_content=false&async_add_aggregate=false';
-    //Attach this directly to all items to be closable (showing the Close Button)
     $closable_item = $item->withCloseAction($async_close);
-    //Endpoint if replace button is pressed
     $async_replace_url = $_SERVER['REQUEST_URI'] . '&close_item=false&async_load_replace=true&async_load_replace_content=false&async_add_aggregate=false';
-    //Endpoint if for only replacing data of the item (description, title etc.)
     $async_replace_content_load_url = $_SERVER['REQUEST_URI'] . '&close_item=false&async_load_replace=false&async_load_replace_content=true&async_add_aggregate=false';
-    //Endpoint for adding one single aggreate item
     $async_add_aggregate = $_SERVER['REQUEST_URI'] . '&close_item=false&async_load_replace=false&async_load_replace_content=false&async_add_aggregate=true';
 
     if ($request_wrapper->has('close_item') && $request_wrapper->retrieve('close_item', $refinery->kindlyTo()->string()) === "true") {
-        //Note that we passe back JS logic here for further processing here
         $js = $f->legacy()->content("")->withOnLoadCode(function ($id) use ($async_replace_content_load_url) {
             return "
                 il.DemoScopeRemaining--;
@@ -94,8 +130,6 @@ function extended_example_for_developers(): string
         $remaining = $request_wrapper->retrieve("remaining", $refinery->kindlyTo()->int());
         $added = $request_wrapper->retrieve("added", $refinery->kindlyTo()->int());
 
-        //We create the amount of aggregates send to us by get and put an according
-        //description into the newly create Notification Item
         $items = [];
         for ($i = 1; $i < $added + 1; $i++) {
             $items[] = $closable_item->withDescription("This item is number: " . $i . " of a fix set of 10 entries.");
@@ -117,58 +151,61 @@ function extended_example_for_developers(): string
 
     if ($request_wrapper->has('async_add_aggregate') && $request_wrapper->retrieve('async_add_aggregate', $refinery->kindlyTo()->string()) === "true") {
         $added = $request_wrapper->retrieve("added", $refinery->kindlyTo()->int());
-
         $new_aggregate = $closable_item->withDescription("The item has been added, Nr: " . $added);
-
         echo $renderer->renderAsync([$new_aggregate]);
         exit;
     }
+}
 
-    //Button with attached js logic to add one new Notification, note, that
-    //we also change the description of the already existing parent Notification
-    //Item holding the aggregates.
+function renderExtendedMetaBarInFullscreenMode(Container $dic): string
+{
+    $f = $dic->ui()->factory();
+    $renderer = $dic->ui()->renderer();
+
+    $async_replace_url = $_SERVER['REQUEST_URI'] . '&close_item=false&async_load_replace=true&async_load_replace_content=false&async_add_aggregate=false';
+    $async_add_aggregate = $_SERVER['REQUEST_URI'] . '&close_item=false&async_load_replace=false&async_load_replace_content=false&async_add_aggregate=true';
+
+    $icon = $f->symbol()->icon()->standard("chtr", "chtr");
+    $title = $f->link()->standard("Some Title", "#");
+    $item = $f->item()->notification($title, $icon);
+    $async_close = $_SERVER['REQUEST_URI'] . '&close_item=true&async_load_replace=false&async_load_replace_content=false&async_add_aggregate=false';
+    $closable_item = $item->withCloseAction($async_close);
+
     $add_button = $f->button()->standard("Add Chat Notification", "#")
-                    ->withAdditionalOnLoadCode(function ($id) use ($async_replace_url, $async_add_aggregate) {
-                        return "
-                            $('#$id').click(function() {
-                                il.DemoScopeItem.getCounterObjectIfAny().incrementNoveltyCount(1);
-                                il.DemoScopeAdded++;
-                                il.DemoScopeRemaining++;
-                                il.DemoScopeItem.addAsyncAggregate('$async_add_aggregate',{remaining: il.DemoScopeAdded,added: il.DemoScopeAdded});
-                                il.DemoScopeItem.replaceContentByAsyncItemContent('$async_replace_url',{remaining: il.DemoScopeRemaining,added: il.DemoScopeAdded});
-                            });";
-                    });
+        ->withAdditionalOnLoadCode(function ($id) use ($async_replace_url, $async_add_aggregate) {
+            return "
+                $('#$id').click(function() {
+                    il.DemoScopeItem.getCounterObjectIfAny().incrementNoveltyCount(1);
+                    il.DemoScopeAdded++;
+                    il.DemoScopeRemaining++;
+                    il.DemoScopeItem.addAsyncAggregate('$async_add_aggregate',{remaining: il.DemoScopeAdded,added: il.DemoScopeAdded});
+                    il.DemoScopeItem.replaceContentByAsyncItemContent('$async_replace_url',{remaining: il.DemoScopeRemaining,added: il.DemoScopeAdded});
+                });";
+        });
 
-    //Resetting all counts to 0, remove all aggregates
     $reset_button = $f->button()->standard("Reset Chat", "#")
-                      ->withAdditionalOnLoadCode(function ($id) use ($async_replace_url) {
-                          return "
-                            $('#$id').click(function() {
-                                il.DemoScopeItem.getCounterObjectIfAny().decrementNoveltyCount(il.DemoScopeRemaining);
-                                il.DemoScopeAdded = 0;
-                                il.DemoScopeRemaining = 0;
-                                il.DemoScopeItem.replaceByAsyncItem('$async_replace_url',{remaining: il.DemoScopeAdded,added: il.DemoScopeAdded});
-                            });";
-                      });
+        ->withAdditionalOnLoadCode(function ($id) use ($async_replace_url) {
+            return "
+                $('#$id').click(function() {
+                    il.DemoScopeItem.getCounterObjectIfAny().decrementNoveltyCount(il.DemoScopeRemaining);
+                    il.DemoScopeAdded = 0;
+                    il.DemoScopeRemaining = 0;
+                    il.DemoScopeItem.replaceByAsyncItem('$async_replace_url',{remaining: il.DemoScopeAdded,added: il.DemoScopeAdded});
+                });";
+        });
 
-    //Set all counts to a fixed value of ten.
     $set_button = $f->button()->standard("Set to 10 chat entries", "#")
-                    ->withAdditionalOnLoadCode(function ($id) use ($async_replace_url) {
-                        return "
-                            $('#$id').click(function() {
-                                il.DemoScopeItem.getCounterObjectIfAny().decrementNoveltyCount(il.DemoScopeRemaining);
-                                il.DemoScopeItem.getCounterObjectIfAny().incrementNoveltyCount(10);
-                                il.DemoScopeAdded = 10;
-                                il.DemoScopeRemaining = 10;
-                                il.DemoScopeItem.replaceByAsyncItem('$async_replace_url',{remaining: il.DemoScopeAdded,added: il.DemoScopeAdded});
-                            });";
-                    });
+        ->withAdditionalOnLoadCode(function ($id) use ($async_replace_url) {
+            return "
+                $('#$id').click(function() {
+                    il.DemoScopeItem.getCounterObjectIfAny().decrementNoveltyCount(il.DemoScopeRemaining);
+                    il.DemoScopeItem.getCounterObjectIfAny().incrementNoveltyCount(10);
+                    il.DemoScopeAdded = 10;
+                    il.DemoScopeRemaining = 10;
+                    il.DemoScopeItem.replaceByAsyncItem('$async_replace_url',{remaining: il.DemoScopeAdded,added: il.DemoScopeAdded});
+                });";
+        });
 
-    /**
-     * Important, this is the heart of the example. By creating our Notification Item
-     * we attach in additionalOnLoad code the logic to store access to our freshly
-     * created Notification Item.
-     */
     $async_item = $item
         ->withDescription("This is the original Version after the Page has loaded. Will be replaced completely.")
         ->withAdditionalOnLoadCode(function ($id) {
@@ -179,57 +216,71 @@ function extended_example_for_developers(): string
             ";
         });
 
-    /**
-     * Note the work from here on is usually done by the global screen. This is
-     * just done to get the example up and running and to give it a more realistic
-     * look. See ilias/components/ILIAS/GlobalScreen/Scope/Notification/README.md
-     */
-    return usuallyDoneByGlobalScreenProbablyIgnore($async_item, $f, $renderer, $add_button, $set_button, $reset_button);
-}
-
-function usuallyDoneByGlobalScreenProbablyIgnore($async_item, $f, $renderer, $add_button, $set_button, $reset_button)
-{
-    //Put the item in some slate.
     $async_slate = $f->mainControls()->slate()->notification("Chat", [$async_item]);
 
-
-    //Just some candy, to give the whole example a more realistic look.
     $mail_icon = $f->symbol()->icon()->standard("mail", "mail");
     $mail_title = $f->link()->standard("Inbox", "link_to_inbox");
     $mail_notification_item = $f->item()->notification($mail_title, $mail_icon)
-                                ->withDescription("You have 23 unread mails in your inbox")
-                                ->withProperties(["Time" => "3 days ago"]);
+        ->withDescription("You have 23 unread mails in your inbox")
+        ->withProperties(["Time" => "3 days ago"]);
     $mail_slate = $f->mainControls()->slate()->notification("Mail", [$mail_notification_item]);
 
 
-    //Note
     $notification_glyph = $f->symbol()->glyph()->notification("notification", "notification")
-                            ->withCounter($f->counter()->novelty(1));
+        ->withCounter($f->counter()->novelty(1));
 
     $notification_center = $f->mainControls()->slate()
-                             ->combined("Notification Center", $notification_glyph)
-                             ->withAdditionalEntry($async_slate)
-                             ->withAdditionalEntry($mail_slate);
+        ->combined("Notification Center", $notification_glyph)
+        ->withAdditionalEntry($async_slate)
+        ->withAdditionalEntry($mail_slate);
 
-    $html = $renderer->render([buildMetabarWithNotifications($f, $notification_center), $add_button, $set_button, $reset_button]);
-    // Apply layout fix as inline styles (no <style> tag – not allowed as child of div in documentation context)
-    $html = preg_replace('/(<ul class="il-maincontrols-metabar"[^>]*\sstyle=")([^"]*)(")/', '$1flex-direction: column; $2$3', $html, 1);
-    $html = preg_replace('/<div class="il-metabar-slates">/', '<div class="il-metabar-slates" style="position: relative; top: 0px;">', $html);
-    return $html;
+    $metabar = buildMetabarWithNotifications($f, $notification_center);
+
+    $logo = $f->image()->responsive("assets/images/logo/HeaderIcon.svg", "ILIAS");
+    $responsive_logo = $f->image()->responsive("assets/images/logo/HeaderIconResponsive.svg", "ILIAS");
+    $breadcrumbs = $f->breadcrumbs([]);
+    $mainbar = $f->mainControls()->mainBar();
+    $footer = $f->mainControls()->footer()->withAdditionalText('Footer');
+    $tc = $dic->ui()->factory()->toast()->container();
+
+    $content = [
+        $f->panel()->standard(
+            'Notification Item Async Demo',
+            $f->legacy()->content(
+                "Use the Notification Center (bell icon) in the MetaBar above, then try these buttons:<br /><br />"
+                . $renderer->render([$add_button, $set_button, $reset_button])
+            )
+        ),
+    ];
+
+    $page = $f->layout()->page()->standard(
+        $content,
+        $metabar,
+        $mainbar,
+        $breadcrumbs,
+        $logo,
+        $responsive_logo,
+        "./assets/images/logo/favicon.ico",
+        $tc,
+        $footer,
+        'UI MetaBar Extended Demo',
+        'ILIAS',
+        'MetaBar Async Demo'
+    )->withUIDemo(true);
+
+    return $renderer->render($page);
 }
 
-function buildMetabarWithNotifications($f, $notification_center)
-{
-    $help = $f->button()->bulky($f->symbol()->glyph()->help(), 'Help', '#');
-    $search = $f->button()->bulky($f->symbol()->glyph()->search(), 'Search', '#');
-    $user = $f->button()->bulky($f->symbol()->glyph()->user(), 'User', '#');
+global $DIC;
+$request_wrapper = $DIC->http()->wrapper()->query();
+$refinery = $DIC->refinery();
 
+handleAsyncRequestsIfAny($DIC);
 
-    $metabar = $f->mainControls()->metabar()
-                 ->withAdditionalEntry('search', $search)
-                 ->withAdditionalEntry('help', $help)
-                 ->withAdditionalEntry('notification', $notification_center)
-                 ->withAdditionalEntry('user', $user);
-
-    return $metabar;
+if ($request_wrapper->has('extended_metabar_ui')
+    && $request_wrapper->retrieve('extended_metabar_ui', $refinery->kindlyTo()->int()) === 1
+) {
+    \ilInitialisation::initILIAS();
+    echo renderExtendedMetaBarInFullscreenMode($DIC);
+    exit();
 }

--- a/components/ILIAS/UI/tests/Examples/ExamplesTest.php
+++ b/components/ILIAS/UI/tests/Examples/ExamplesTest.php
@@ -201,6 +201,7 @@ class ExamplesTest extends ILIAS_UI_TestBase
         return [
             ['ILIAS\UI\examples\MainControls\Footer\base', "components/ILIAS/UI/src/examples/MainControls/Footer/base.php"],
             ['ILIAS\UI\examples\MainControls\MetaBar\renderMetaBarInFullscreenMode', "components/ILIAS/UI/src/examples/MainControls/MetaBar/base_metabar.php"],
+            ['ILIAS\UI\examples\MainControls\MetaBar\renderExtendedMetaBarInFullscreenMode', "components/ILIAS/UI/src/examples/MainControls/MetaBar/extended_example_for_developers.php"],
             ['ILIAS\UI\examples\Layout\Page\Standard\getUIMainbarExampleCondensed', "components/ILIAS/UI/src/examples/Layout/Page/Standard/ui_mainbar.php"],
             ['ILIAS\UI\examples\Layout\Page\Standard\getUIMainbarExampleFull', "components/ILIAS/UI/src/examples/Layout/Page/Standard/ui_mainbar.php"],
             ['ILIAS\UI\examples\Layout\Page\Standard\ui', "components/ILIAS/UI/src/examples/Layout/Page/Standard/ui.php"],


### PR DESCRIPTION
Error Element “style” not allowed as child of element “div” in this context. (Suppressing further errors from this subtree.)	
https://mantis.ilias.de/view.php?id=47058 

The example prepended a <style> block for layout in the documentation
panel. Validator: "Element 'style' not allowed as child of element
'div' in this context." Apply the same rules as inline styles via
preg_replace on the rendered HTML (ul: flex-direction; .il-metabar-slates:
position) so no style element is output.

## Problem
- HTML-Validator: "Element 'style' not allowed as child of element 'div' in this context."
- Im System-Style-Beispiel "Extended example for developers" (MetaBar) wurde ein `<style>`-Block ausgegeben, der in der Doku in einem `<div class="well">` bzw. unter `panel-body` landete – beides div-Kontexte, in denen der Validator style nicht erlaubt.

## Lösung
- Kein `<style>`-Tag mehr im Beispiel.
- Stattdessen die gleichen Anpassungen (flex-direction für Metabar, position für Slates) per Inline-Styles in den gerenderten HTML-String einbauen (preg_replace auf ul und div.il-metabar-slates).
- Darstellung unverändert, Validator-Fehler entfällt.