### PR TITLE
[Fix] 0046697 UI: Menu/Sub example – close paragraph with </p> not <p/>

### DIFF
--- a/components/ILIAS/UI/src/examples/Menu/Sub/sub.php
+++ b/components/ILIAS/UI/src/examples/Menu/Sub/sub.php
@@ -33,7 +33,7 @@ function sub()
 {
     $comment =
     '<p> The sub-menu is actually not meant to be rendered standalone. '
-    . 'However, it will generate a ul-tree with buttons for nodes. See Drilldown for a Example using Sub Menus<p/>';
+    . 'However, it will generate a ul-tree with buttons for nodes. See Drilldown for a Example using Sub Menus</p>';
 
     return $comment;
 }


### PR DESCRIPTION
 Error Self-closing syntax (“/>”) used on a non-void HTML element. Ignoring the slash and treating as a start tag.	
https://mantis.ilias.de/view.php?id=46697

Self-closing <p/> is invalid in HTML (p is not a void element).
Validator: "Self-closing syntax used on a non-void HTML element."
Use proper closing tag </p>.

## Problem
- HTML-Validator: "Self-closing syntax ('/>') used on a non-void HTML element. Ignoring the slash and treating as a start tag."
- Im Menu/Sub-Beispiel wurde der Absatz mit `<p/>` statt `</p>` geschlossen.

## Lösung
- `<p/>` durch `</p>` ersetzen.
- Nur diese eine Zeile im Beispiel-Text betroffen.