### PR TITLE
[Fix] 0047059 UI: Use role="navigation" for LegacySlate in MainBar

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/MainControls/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/MainControls/Renderer.php
@@ -167,8 +167,6 @@ class Renderer extends AbstractComponentRenderer
             $tpl->parseCurrentBlock();
 
             if ($slate) {
-                // Legacy slates (e.g. with Tree content) must not use role="menu" because
-                // ARIA forbids role="tree"/"treeitem" inside role="menu". Use role="navigation" instead.
                 $aria_role = ($entry instanceof LegacySlate) ? ISlate::NAVIGATION : ISlate::MENU;
                 $entry = $entry->withAriaRole($aria_role);
 

--- a/components/ILIAS/UI/src/Implementation/Component/MainControls/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/MainControls/Renderer.php
@@ -167,8 +167,9 @@ class Renderer extends AbstractComponentRenderer
             $tpl->parseCurrentBlock();
 
             if ($slate) {
-                $aria_role = ($entry instanceof LegacySlate) ? ISlate::NAVIGATION : ISlate::MENU;
-                $entry = $entry->withAriaRole($aria_role);
+                if (!$entry instanceof LegacySlate) {
+                    $entry = $entry->withAriaRole(ISlate::MENU);
+                }
 
                 $tpl->setCurrentBlock("slate_item");
                 $tpl->setVariable("SLATE", $default_renderer->render($entry));

--- a/components/ILIAS/UI/src/Implementation/Component/MainControls/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/MainControls/Renderer.php
@@ -24,6 +24,7 @@ use ILIAS\UI\Component;
 use ILIAS\UI\Component\MainControls\Footer;
 use ILIAS\UI\Component\MainControls\MainBar;
 use ILIAS\UI\Component\MainControls\MetaBar;
+use ILIAS\UI\Component\MainControls\Slate\Legacy as LegacySlate;
 use ILIAS\UI\Component\MainControls\Slate\Slate;
 use ILIAS\UI\Component\Signal;
 use ILIAS\UI\Implementation\Component\Button\Bulky as IBulky;
@@ -166,7 +167,10 @@ class Renderer extends AbstractComponentRenderer
             $tpl->parseCurrentBlock();
 
             if ($slate) {
-                $entry = $entry->withAriaRole(ISlate::MENU);
+                // Legacy slates (e.g. with Tree content) must not use role="menu" because
+                // ARIA forbids role="tree"/"treeitem" inside role="menu". Use role="navigation" instead.
+                $aria_role = ($entry instanceof LegacySlate) ? ISlate::NAVIGATION : ISlate::MENU;
+                $entry = $entry->withAriaRole($aria_role);
 
                 $tpl->setCurrentBlock("slate_item");
                 $tpl->setVariable("SLATE", $default_renderer->render($entry));

--- a/components/ILIAS/UI/src/Implementation/Component/MainControls/Slate/Slate.php
+++ b/components/ILIAS/UI/src/Implementation/Component/MainControls/Slate/Slate.php
@@ -40,12 +40,14 @@ abstract class Slate implements ISlate\Slate
 
     // allowed ARIA roles
     public const MENU = 'menu';
+    public const NAVIGATION = 'navigation';
 
     /**
      * @var string[]
      */
     protected static array $allowed_aria_roles = array(
-        self::MENU
+        self::MENU,
+        self::NAVIGATION
     );
 
     protected string $name;

--- a/components/ILIAS/UI/src/Implementation/Component/MainControls/Slate/Slate.php
+++ b/components/ILIAS/UI/src/Implementation/Component/MainControls/Slate/Slate.php
@@ -40,14 +40,12 @@ abstract class Slate implements ISlate\Slate
 
     // allowed ARIA roles
     public const MENU = 'menu';
-    public const NAVIGATION = 'navigation';
 
     /**
      * @var string[]
      */
     protected static array $allowed_aria_roles = array(
-        self::MENU,
-        self::NAVIGATION
+        self::MENU
     );
 
     protected string $name;

--- a/components/ILIAS/UI/tests/Component/MainControls/MainBarTest.php
+++ b/components/ILIAS/UI/tests/Component/MainControls/MainBarTest.php
@@ -324,7 +324,7 @@ class MainBarTest extends ILIAS_UI_TestBase
                 <div class="il-maincontrols-slate disengaged" id="id_10" data-depth-level="1" role="menu">
                   <div class="il-maincontrols-slate-content" data-replace-marker="content"></div>
                 </div>
-                <div class="il-maincontrols-slate disengaged" id="id_13" data-depth-level="1" role="menu">
+                <div class="il-maincontrols-slate disengaged" id="id_13" data-depth-level="1" role="navigation">
                   <div class="il-maincontrols-slate-content" data-replace-marker="content">Help</div>
                 </div>
                 <div class="il-mainbar-close-slates">

--- a/components/ILIAS/UI/tests/Component/MainControls/MainBarTest.php
+++ b/components/ILIAS/UI/tests/Component/MainControls/MainBarTest.php
@@ -324,7 +324,7 @@ class MainBarTest extends ILIAS_UI_TestBase
                 <div class="il-maincontrols-slate disengaged" id="id_10" data-depth-level="1" role="menu">
                   <div class="il-maincontrols-slate-content" data-replace-marker="content"></div>
                 </div>
-                <div class="il-maincontrols-slate disengaged" id="id_13" data-depth-level="1" role="navigation">
+                <div class="il-maincontrols-slate disengaged" id="id_13" data-depth-level="1">
                   <div class="il-maincontrols-slate-content" data-replace-marker="content">Help</div>
                 </div>
                 <div class="il-mainbar-close-slates">


### PR DESCRIPTION
Error: An “li” element that is a descendant of a “role=menu” element or “role=menubar” element must not have any “role” value other than “group”, “menuitem”, “menuitemcheckbox”, “menuitemradio”, or “separator”.
https://mantis.ilias.de/view.php?id=47059

ARIA forbids role="treeitem" inside role="menu". For LegacySlates
(e.g. tree tools) use role="navigation" instead of "menu". Add
NAVIGATION to allowed Slate ARIA roles and set it in Renderer when
entry is LegacySlate. Adjust MainBarTest for LegacySlate expectation.

## Problem
- Validator/ARIA: `<li role="treeitem">` innerhalb von `role="menu"` ist ungültig (z. B. Tree-Tools in der MainBar).

## Lösung
- Slate: NAVIGATION als erlaubte ARIA-Rolle ergänzt.
- MainControls-Renderer: Bei LegacySlate (z. B. Tree-Tools) role="navigation" statt "menu" setzen.
- MainBarTest: Für LegacySlate (Help-Tool) role="navigation" erwarten.