### PR TITLE
[Fix] 0047060 UI: Audio/Video elements must not have empty id attribute

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Player/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Player/Renderer.php
@@ -45,7 +45,9 @@ class Renderer extends AbstractComponentRenderer
     {
         $tpl = $this->getTemplate("tpl.audio.html", true, true);
 
-        $id = $this->bindJavaScript($component);
+        // Always provide a non-empty id attribute. If there is no JS binding,
+        // fall back to a plain, unique id.
+        $id = $this->bindJavaScript($component) ?? $this->createId();
 
         if ($component->getTranscription() != "") {
             $factory = $this->getUIFactory();
@@ -96,7 +98,8 @@ class Renderer extends AbstractComponentRenderer
 
         $tpl = $this->getTemplate("tpl.video_vimeo.html", true, true);
 
-        $id = $this->bindJavaScript($component);
+        // Ensure the iframe always has a valid, non-empty id attribute.
+        $id = $this->bindJavaScript($component) ?? $this->createId();
 
         $tpl->setVariable("ID", $id);
         $tpl->setVariable("SOURCE", $component->getSource());
@@ -111,7 +114,8 @@ class Renderer extends AbstractComponentRenderer
 
         $tpl = $this->getTemplate("tpl.video_youtube.html", true, true);
 
-        $id = $this->bindJavaScript($component);
+        // Ensure the iframe always has a valid, non-empty id attribute.
+        $id = $this->bindJavaScript($component) ?? $this->createId();
 
         $tpl->setVariable("ID", $id);
         $tpl->setVariable("SOURCE", $component->getSource());
@@ -126,7 +130,8 @@ class Renderer extends AbstractComponentRenderer
 
         $tpl = $this->getTemplate("tpl.video.html", true, true);
 
-        $id = $this->bindJavaScript($component);
+        // Ensure the <video> element always has a valid, non-empty id attribute.
+        $id = $this->bindJavaScript($component) ?? $this->createId();
 
         foreach ($component->getSubtitleFiles() as $lang_key => $file) {
             $tpl->setCurrentBlock("track");

--- a/components/ILIAS/UI/src/Implementation/Component/Player/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Player/Renderer.php
@@ -45,8 +45,6 @@ class Renderer extends AbstractComponentRenderer
     {
         $tpl = $this->getTemplate("tpl.audio.html", true, true);
 
-        // Always provide a non-empty id attribute. If there is no JS binding,
-        // fall back to a plain, unique id.
         $id = $this->bindJavaScript($component) ?? $this->createId();
 
         if ($component->getTranscription() != "") {
@@ -98,7 +96,6 @@ class Renderer extends AbstractComponentRenderer
 
         $tpl = $this->getTemplate("tpl.video_vimeo.html", true, true);
 
-        // Ensure the iframe always has a valid, non-empty id attribute.
         $id = $this->bindJavaScript($component) ?? $this->createId();
 
         $tpl->setVariable("ID", $id);
@@ -114,7 +111,6 @@ class Renderer extends AbstractComponentRenderer
 
         $tpl = $this->getTemplate("tpl.video_youtube.html", true, true);
 
-        // Ensure the iframe always has a valid, non-empty id attribute.
         $id = $this->bindJavaScript($component) ?? $this->createId();
 
         $tpl->setVariable("ID", $id);
@@ -130,7 +126,6 @@ class Renderer extends AbstractComponentRenderer
 
         $tpl = $this->getTemplate("tpl.video.html", true, true);
 
-        // Ensure the <video> element always has a valid, non-empty id attribute.
         $id = $this->bindJavaScript($component) ?? $this->createId();
 
         foreach ($component->getSubtitleFiles() as $lang_key => $file) {

--- a/components/ILIAS/UI/tests/Component/Item/ItemTest.php
+++ b/components/ILIAS/UI/tests/Component/Item/ItemTest.php
@@ -642,7 +642,7 @@ EOT;
 <div class="il-item il-std-item ">
     <h4 class="il-item-title">title</h4>
     <div class="il-item-audio"><div class="il-audio-container">
-    <audio controls="controls" class="il-audio-player" id="" src="src" preload="metadata"></audio>
+    <audio controls="controls" class="il-audio-player" id="id_1" src="src" preload="metadata"></audio>
 </div></div>
 </div>
 EOT;

--- a/components/ILIAS/UI/tests/Component/Player/PlayerAudioTest.php
+++ b/components/ILIAS/UI/tests/Component/Player/PlayerAudioTest.php
@@ -100,7 +100,7 @@ class PlayerAudioTest extends ILIAS_UI_TestBase
 
         $expected = <<<EOT
 <div class="il-audio-container">
-    <audio controls="controls" class="il-audio-player" id="" src="/foo" preload="metadata"></audio>
+    <audio controls="controls" class="il-audio-player" id="id_1" src="/foo" preload="metadata"></audio>
 </div>
 EOT;
         $this->assertHTMLEquals(

--- a/components/ILIAS/UI/tests/Component/Player/PlayerVideoTest.php
+++ b/components/ILIAS/UI/tests/Component/Player/PlayerVideoTest.php
@@ -108,7 +108,7 @@ class PlayerVideoTest extends ILIAS_UI_TestBase
         $html = $r->render($video);
         $expected = <<<EOT
 <div class="il-video-container">
-    <video controls="controls" class="il-video-player" id="" src="/foo" preload="metadata" >
+    <video controls="controls" class="il-video-player" id="id_1" src="/foo" preload="metadata" >
     </video>
 </div>
 EOT;
@@ -128,7 +128,7 @@ EOT;
         $html = $r->render($video);
         $expected = <<<EOT
 <div class="il-video-container">
-    <video controls="controls" class="il-video-player" id="" src="/foo" preload="metadata" poster="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" style="background-image:url('bar.jpg')">
+    <video controls="controls" class="il-video-player" id="id_1" src="/foo" preload="metadata" poster="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" style="background-image:url('bar.jpg')">
     </video>
 </div>
 EOT;
@@ -148,7 +148,7 @@ EOT;
         $html = $r->render($video);
         $expected = <<<EOT
 <div class="il-video-container">
-    <video controls="controls" class="il-video-player" id="" src="/foo" preload="metadata" >
+    <video controls="controls" class="il-video-player" id="id_1" src="/foo" preload="metadata" >
         <track kind="subtitles" src="subtitles.vtt" srclang="en" />
     </video>
 </div>
@@ -170,7 +170,7 @@ EOT;
 
         $expected = <<<EOT
 <div class="il-video-container">
-    <iframe id="" src="https://www.youtube.com/embed/YSN2osYbshQ" allow="fullscreen; autoplay; picture-in-picture;" referrerpolicy="strict-origin-when-cross-origin"></iframe>
+    <iframe id="id_1" src="https://www.youtube.com/embed/YSN2osYbshQ" allow="fullscreen; autoplay; picture-in-picture;" referrerpolicy="strict-origin-when-cross-origin"></iframe>
 </div>
 EOT;
         $this->assertHTMLEquals(
@@ -190,7 +190,7 @@ EOT;
 
         $expected = <<<EOT
 <div class="il-video-container">
-    <iframe id="" src="https://player.vimeo.com/video/669475821" allow="fullscreen; autoplay; picture-in-picture;" referrerpolicy="strict-origin-when-cross-origin"></iframe>
+    <iframe id="id_1" src="https://player.vimeo.com/video/669475821" allow="fullscreen; autoplay; picture-in-picture;" referrerpolicy="strict-origin-when-cross-origin"></iframe>
 </div>
 EOT;
         $this->assertHTMLEquals(


### PR DESCRIPTION
Error: Bad value “” for attribute “id” on element “audio”: An ID must not be the empty string.
https://mantis.ilias.de/view.php?id=47060

Fix: Audio/Video elements must not have empty id attribute

When no JavaScript binding is needed, use createId() so the id is
never empty. Validator: empty id="" is invalid.

## Problem
- HTML-Validator: `<video>` und `<audio>` mit leerem `id=""` sind ungültig.

## Lösung
- In Player/Renderer: id = bindJavaScript(component) ?? createId(); id ist nie leer.
- Tests: Erwartung auf generierte ID statt id="" anpassen.