### PR TITLE
[Fix] 0047062 UI: Canvas height attribute must be numeric (no "px")

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Chart/Bar/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Chart/Bar/Renderer.php
@@ -136,7 +136,7 @@ class Renderer extends AbstractComponentRenderer
             $height = $max_height;
         }
 
-        return $height . "px";
+        return (string) (int) $height;
     }
 
     protected function determineHeightForVertical(Bar\Bar $component): string
@@ -149,7 +149,7 @@ class Renderer extends AbstractComponentRenderer
             $height = $max_height;
         }
 
-        return $height . "px";
+        return (string) (int) $height;
     }
 
     protected function getAccessibilityList(

--- a/components/ILIAS/UI/tests/Component/Chart/Bar/ChartBarTest.php
+++ b/components/ILIAS/UI/tests/Component/Chart/Bar/ChartBarTest.php
@@ -345,7 +345,7 @@ class ChartBarTest extends ILIAS_UI_TestBase
 
         $expected_html = <<<EOT
 <div class="il-chart-bar-horizontal">
-    <canvas id="id_1" height="150px" aria-label="bar123" role="img"></canvas>
+    <canvas id="id_1" height="150" aria-label="bar123" role="img"></canvas>
 </div>
 <div class="sr-only">
     <dl>
@@ -378,7 +378,7 @@ EOT;
 
         $expected_html = <<<EOT
 <div class="il-chart-bar-vertical">
-    <canvas id="id_1" height="165px" aria-label="bar123" role="img"></canvas>
+    <canvas id="id_1" height="165" aria-label="bar123" role="img"></canvas>
 </div>
 <div class="sr-only">
     <dl>


### PR DESCRIPTION
Error: Bad value “550px” for attribute “height” on element “canvas”: Expected a digit but saw “p” instead.
https://mantis.ilias.de/view.php?id=47062

HTML canvas height accepts only a number. Strip unit in
determineHeightForHorizontal and determineHeightForVertical
(e.g. return (string)(int) $height). Update ChartBarTest.

## Problem
- HTML-Validator: `height="550px"` bei `<canvas>` ungültig; nur Zahl erlaubt.

## Lösung
- Bar-Renderer: Höhe nur noch numerisch zurückgeben (z. B. "550").
- ChartBarTest: Erwartete Höhenwerte anpassen.