### PR TITLE
[Fix] 004951 UI: Required asterisk – sr-only text + aria-hidden

### DIFF
--- a/components/ILIAS/Test/tests/Scoring/Settings/ScoreSettingsTest.php
+++ b/components/ILIAS/Test/tests/Scoring/Settings/ScoreSettingsTest.php
@@ -291,7 +291,7 @@ class ScoreSettingsTest extends ilTestBaseTestCase
 
         $i1_1_4_1 = $this->getFormWrappedHtml(
             'date-time-field-input',
-            'tst_reporting_date<span class="asterisk" aria-label="required_field">*</span>',
+            'tst_reporting_date<span class="sr-only">required_field</span><span class="asterisk" aria-hidden="true">*</span>',
             '<div class="c-input-group">
                 <input id="id_6" type="datetime-local" class="c-field-datetime" />
             </div>',
@@ -303,7 +303,7 @@ class ScoreSettingsTest extends ilTestBaseTestCase
 
         $i1_1_4 = $this->getFormWrappedHtml(
             'group-field-input',
-            '<input type="radio" id="id_5" value="3" /><span>tst_results_access_date</span><span class="asterisk" aria-label="required_field">*</span>',
+            '<input type="radio" id="id_5" value="3" /><span>tst_results_access_date</span><span class="sr-only">required_field</span><span class="asterisk" aria-hidden="true">*</span>',
             $i1_1_4_1,
             'tst_results_access_date_desc',
             'id_5',
@@ -313,7 +313,7 @@ class ScoreSettingsTest extends ilTestBaseTestCase
 
         $i1_1 = $this->getFormWrappedHtml(
             'switchable-group-field-input',
-            'tst_results_access_setting<span class="asterisk" aria-label="required_field">*</span>',
+            'tst_results_access_setting<span class="sr-only">required_field</span><span class="asterisk" aria-hidden="true">*</span>',
             $i1_1_1 . $i1_1_2 . $i1_1_3 . $i1_1_4,
             null,
             null,
@@ -441,7 +441,7 @@ class ScoreSettingsTest extends ilTestBaseTestCase
 
         $fields = $this->getFormWrappedHtml(
             'radio-field-input',
-            'tst_highscore_mode<span class="asterisk" aria-label="required_field">*</span>',
+            'tst_highscore_mode<span class="sr-only">required_field</span><span class="asterisk" aria-hidden="true">*</span>',
             '<div class="c-field-radio">
                 <div class="c-field-radio__item">
                     <input type="radio" id="id_2_1_opt" value="1" /><label for="id_2_1_opt">tst_highscore_own_table</label><div class="c-input__help-byline">tst_highscore_own_table_description</div>
@@ -460,7 +460,7 @@ class ScoreSettingsTest extends ilTestBaseTestCase
         );
         $fields .= $this->getFormWrappedHtml(
             'numeric-field-input',
-            'tst_highscore_top_num<span class="asterisk" aria-label="required_field">*</span>',
+            'tst_highscore_top_num<span class="sr-only">required_field</span><span class="asterisk" aria-hidden="true">*</span>',
             '<input id="id_3" type="number" step="1" value="10" class="c-field-number" />',
             'tst_highscore_top_num_description',
             'id_3',

--- a/components/ILIAS/UI/src/templates/default/Input/tpl.context_form.html
+++ b/components/ILIAS/UI/src/templates/default/Input/tpl.context_form.html
@@ -1,6 +1,6 @@
 <fieldset class="c-input" data-il-ui-component="{UI_COMPONENT_NAME}" data-il-ui-input-name="{INPUT_NAME}"<!-- BEGIN disabled --> disabled="disabled"<!-- END disabled --><!-- BEGIN described --> aria-describedby="{ERROR_ID}"<!-- END described --><!-- BEGIN binding --> id="{BINDING_ID}"<!-- END binding --><!-- BEGIN tabindex --> tabindex="0"<!-- END tabindex -->>
 
-	<label <!-- BEGIN for --> for="{ID}"<!-- END for -->>{LABEL}<!-- BEGIN required --><span class="asterisk" aria-label="{REQUIRED_ARIA}">*</span><!-- END required --></label>
+	<label <!-- BEGIN for --> for="{ID}"<!-- END for -->>{LABEL}<!-- BEGIN required --><span class="sr-only">{REQUIRED_ARIA}</span><span class="asterisk" aria-hidden="true">*</span><!-- END required --></label>
 
 	<div class="c-input__field">
 		{INPUT}

--- a/components/ILIAS/UI/tests/Component/Input/Container/Form/StandardFormTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Form/StandardFormTest.php
@@ -366,7 +366,7 @@ class StandardFormTest extends ILIAS_UI_TestBase
 
         $field_html = $this->getFormWrappedHtml(
             'text-field-input',
-            'label<span class="asterisk" aria-label="required_field">*</span>',
+            'label<span class="sr-only">required_field</span><span class="asterisk" aria-hidden="true">*</span>',
             '<input id="id_1" type="text" name="form/input_0" class="c-field-text" />',
             'byline',
             'id_1',

--- a/components/ILIAS/UI/tests/Component/Input/Field/CommonFieldRendering.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/CommonFieldRendering.php
@@ -60,7 +60,7 @@ trait CommonFieldRendering
 
     protected function testWithRequired(FormInput $component): void
     {
-        $expected = '<span class="asterisk" aria-label="required_field">*</span></label>';
+        $expected = '<span class="sr-only">required_field</span><span class="asterisk" aria-hidden="true">*</span></label>';
         $this->assertStringContainsString($expected, $this->render($component->withRequired(true)));
     }
 

--- a/components/ILIAS/UI/tests/Component/Input/Field/MarkdownTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/MarkdownTest.php
@@ -357,7 +357,7 @@ class MarkdownTest extends ILIAS_UI_TestBase
         $expected = $this->brutallyTrimHTML(
             "
             <fieldset class=\"c-input\" data-il-ui-component=\"markdown-field-input\" data-il-ui-input-name=\"name_0\" id=\"id_8\" tabindex=\"0\">
-                <label>$label<span class=\"asterisk\" aria-label=\"required_field\">*</span></label>
+                <label>$label<span class=\"sr-only\">required_field</span><span class=\"asterisk\" aria-hidden=\"true\">*</span></label>
                 <div class=\"c-input__field\">
 
                         <div class=\"c-field-markdown\">

--- a/components/ILIAS/UI/tests/Component/Input/Field/TreeMultiSelectTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/TreeMultiSelectTest.php
@@ -223,7 +223,7 @@ HTML;
         $renderer = $this->getDefaultRenderer();
 
         $expected_html = <<<HTML
-<label for="id_2"><span class="asterisk" aria-label="required_field">*</span></label>
+<label for="id_2"><span class="sr-only">required_field</span><span class="asterisk" aria-hidden="true">*</span></label>
 HTML;
 
         $actual_html = $renderer->render($component);

--- a/components/ILIAS/UI/tests/Component/Input/Field/TreeSelectTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/TreeSelectTest.php
@@ -223,7 +223,7 @@ HTML;
         $renderer = $this->getDefaultRenderer();
 
         $expected_html = <<<HTML
-<label for="id_2"><span class="asterisk" aria-label="required_field">*</span></label>
+<label for="id_2"><span class="sr-only">required_field</span><span class="asterisk" aria-hidden="true">*</span></label>
 HTML;
 
         $actual_html = $renderer->render($component);


### PR DESCRIPTION
Error: The “aria-label” attribute must not be specified on any “span” element unless the element has a “role” value other than “caption”, “code”, “deletion”, “emphasis”, “generic”, “insertion”, “paragraph”, “presentation”, “strong”, “subscript”, or “superscript”.
https://mantis.ilias.de/view.php?id=46951

aria-label on generic span is discouraged. Use <span class="sr-only">{REQUIRED_ARIA}</span>
for screen readers and <span class="asterisk" aria-hidden="true">*</span> for the visual
star. Update field and form tests accordingly.

## Problem
- Validator/A11y: `<span class="asterisk" aria-label="...">*</span>` – aria-label auf span ohne passende role ungültig/ungenau.

## Lösung
- Bedeutung "erforderlich" über sr-only-Text; Stern mit aria-hidden="true".
- Tests in Input/Field und Form anpassen.