### PR TITLE
[Fix] 0047063 UI: Rating – aria-label on input instead of label

### DIFF
--- a/components/ILIAS/UI/src/templates/default/Input/tpl.rating.html
+++ b/components/ILIAS/UI/src/templates/default/Input/tpl.rating.html
@@ -13,14 +13,14 @@
 			<!-- END average -->
 
 			<!-- BEGIN scaleoption -->
-			<input aria-describedby="{DESCRIPTION_ID}" type="radio" id="{OPT_ID}" name="{NAME}" value="{OPT_VALUE}" class="il-input-rating-scaleoption" {DISABLED}{SELECTED}/>
-			<label class="glyphicon-star il-input-rating-star" for="{OPT_ID}" aria-label="{ARIALABEL}"></label>
+			<input aria-describedby="{DESCRIPTION_ID}" aria-label="{ARIALABEL}" type="radio" id="{OPT_ID}" name="{NAME}" value="{OPT_VALUE}" class="il-input-rating-scaleoption" {DISABLED}{SELECTED}/>
+			<label class="glyphicon-star il-input-rating-star" for="{OPT_ID}"></label>
 			<!-- END scaleoption -->
 		</div>
 
 		<!-- BEGIN scaleoption_neutral -->
 		<div class="il-input-rating__none">
-			<label for="{NEUTRAL_ID}" aria-label="{NEUTRAL_LABEL}">{NEUTRAL_LABEL}</label>
+			<label for="{NEUTRAL_ID}">{NEUTRAL_LABEL}</label>
 			<input aria-describedby="{NEUTRAL_DESCRIPTION_ID}" type="radio" id="{NEUTRAL_ID}" name="{NEUTRAL_NAME}" value="0" {DISABLED}{NEUTRAL_SELECTED}/>
 		</div>
 		<!-- END scaleoption_neutral -->

--- a/components/ILIAS/UI/src/templates/default/Input/tpl.rating.html
+++ b/components/ILIAS/UI/src/templates/default/Input/tpl.rating.html
@@ -13,8 +13,8 @@
 			<!-- END average -->
 
 			<!-- BEGIN scaleoption -->
-			<input aria-describedby="{DESCRIPTION_ID}" aria-label="{ARIALABEL}" type="radio" id="{OPT_ID}" name="{NAME}" value="{OPT_VALUE}" class="il-input-rating-scaleoption" {DISABLED}{SELECTED}/>
-			<label class="glyphicon-star il-input-rating-star" for="{OPT_ID}"></label>
+			<input aria-describedby="{DESCRIPTION_ID}" type="radio" id="{OPT_ID}" name="{NAME}" value="{OPT_VALUE}" class="il-input-rating-scaleoption" {DISABLED}{SELECTED}/>
+			<label class="glyphicon-star il-input-rating-star" for="{OPT_ID}"><span class="sr-only">{ARIALABEL}</span></label>
 			<!-- END scaleoption -->
 		</div>
 

--- a/components/ILIAS/UI/tests/Component/Input/Field/RatingInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/RatingInputTest.php
@@ -69,23 +69,23 @@ class RatingInputTest extends ILIAS_UI_TestBase
                 <legend class="il-input-rating__text" id="id_1_desc"></legend>
                 <div class="il-input-rating__stars" role="radiogroup">
                     <div class="il-input-rating__options">
-                        <input aria-describedby="id_1_desc" type="radio" id="id_1-5" name="name_0" value="5" class="il-input-rating-scaleoption" />
-                        <label class="glyphicon-star il-input-rating-star" for="id_1-5" aria-label="5stars"></label>
+                        <input aria-describedby="id_1_desc" aria-label="5stars" type="radio" id="id_1-5" name="name_0" value="5" class="il-input-rating-scaleoption" />
+                        <label class="glyphicon-star il-input-rating-star" for="id_1-5"></label>
 
-                        <input aria-describedby="id_1_desc" type="radio" id="id_1-4" name="name_0" value="4" class="il-input-rating-scaleoption" />
-                        <label class="glyphicon-star il-input-rating-star" for="id_1-4" aria-label="4stars"></label>
+                        <input aria-describedby="id_1_desc" aria-label="4stars" type="radio" id="id_1-4" name="name_0" value="4" class="il-input-rating-scaleoption" />
+                        <label class="glyphicon-star il-input-rating-star" for="id_1-4"></label>
 
-                        <input aria-describedby="id_1_desc" type="radio" id="id_1-3" name="name_0" value="3" class="il-input-rating-scaleoption" />
-                        <label class="glyphicon-star il-input-rating-star" for="id_1-3" aria-label="3stars"></label>
+                        <input aria-describedby="id_1_desc" aria-label="3stars" type="radio" id="id_1-3" name="name_0" value="3" class="il-input-rating-scaleoption" />
+                        <label class="glyphicon-star il-input-rating-star" for="id_1-3"></label>
 
-                        <input aria-describedby="id_1_desc" type="radio" id="id_1-2" name="name_0" value="2" class="il-input-rating-scaleoption" />
-                        <label class="glyphicon-star il-input-rating-star" for="id_1-2" aria-label="2stars"></label>
+                        <input aria-describedby="id_1_desc" aria-label="2stars" type="radio" id="id_1-2" name="name_0" value="2" class="il-input-rating-scaleoption" />
+                        <label class="glyphicon-star il-input-rating-star" for="id_1-2"></label>
 
-                        <input aria-describedby="id_1_desc" type="radio" id="id_1-1" name="name_0" value="1" class="il-input-rating-scaleoption" />
-                        <label class="glyphicon-star il-input-rating-star" for="id_1-1" aria-label="1stars"></label>
+                        <input aria-describedby="id_1_desc" aria-label="1stars" type="radio" id="id_1-1" name="name_0" value="1" class="il-input-rating-scaleoption" />
+                        <label class="glyphicon-star il-input-rating-star" for="id_1-1"></label>
                     </div>
                     <div class="il-input-rating__none">
-                        <label for="id_1-0" aria-label="reset_stars">reset_stars</label>
+                        <label for="id_1-0">reset_stars</label>
                         <input aria-describedby="id_1_desc" type="radio" id="id_1-0" name="name_0" value="0" checked="checked"/>
                     </div>
                 </div>
@@ -121,24 +121,24 @@ class RatingInputTest extends ILIAS_UI_TestBase
                                 <div class="il-input-rating__average_value" style="width:60%;"></div>
                             </div>
 
-                            <input aria-describedby="id_1_desc" type="radio" id="id_1-5" name="name_0" value="5" class="il-input-rating-scaleoption" disabled="disabled"/>
-                            <label class="glyphicon-star il-input-rating-star" for="id_1-5" aria-label="5stars"></label>
+                            <input aria-describedby="id_1_desc" aria-label="5stars" type="radio" id="id_1-5" name="name_0" value="5" class="il-input-rating-scaleoption" disabled="disabled"/>
+                            <label class="glyphicon-star il-input-rating-star" for="id_1-5"></label>
 
-                            <input aria-describedby="id_1_desc" type="radio" id="id_1-4" name="name_0" value="4" class="il-input-rating-scaleoption" disabled="disabled" checked="checked"/>
-                            <label class="glyphicon-star il-input-rating-star" for="id_1-4" aria-label="4stars"></label>
+                            <input aria-describedby="id_1_desc" aria-label="4stars" type="radio" id="id_1-4" name="name_0" value="4" class="il-input-rating-scaleoption" disabled="disabled" checked="checked"/>
+                            <label class="glyphicon-star il-input-rating-star" for="id_1-4"></label>
 
-                            <input aria-describedby="id_1_desc" type="radio" id="id_1-3" name="name_0" value="3" class="il-input-rating-scaleoption" disabled="disabled"/>
-                            <label class="glyphicon-star il-input-rating-star" for="id_1-3" aria-label="3stars"></label>
+                            <input aria-describedby="id_1_desc" aria-label="3stars" type="radio" id="id_1-3" name="name_0" value="3" class="il-input-rating-scaleoption" disabled="disabled"/>
+                            <label class="glyphicon-star il-input-rating-star" for="id_1-3"></label>
 
-                            <input aria-describedby="id_1_desc" type="radio" id="id_1-2" name="name_0" value="2" class="il-input-rating-scaleoption" disabled="disabled"/>
-                            <label class="glyphicon-star il-input-rating-star" for="id_1-2" aria-label="2stars"></label>
+                            <input aria-describedby="id_1_desc" aria-label="2stars" type="radio" id="id_1-2" name="name_0" value="2" class="il-input-rating-scaleoption" disabled="disabled"/>
+                            <label class="glyphicon-star il-input-rating-star" for="id_1-2"></label>
 
-                            <input aria-describedby="id_1_desc" type="radio" id="id_1-1" name="name_0" value="1" class="il-input-rating-scaleoption" disabled="disabled"/>
-                            <label class="glyphicon-star il-input-rating-star" for="id_1-1" aria-label="1stars"></label>
+                            <input aria-describedby="id_1_desc" aria-label="1stars" type="radio" id="id_1-1" name="name_0" value="1" class="il-input-rating-scaleoption" disabled="disabled"/>
+                            <label class="glyphicon-star il-input-rating-star" for="id_1-1"></label>
                         </div>
                     
                         <div class="il-input-rating__none">
-                            <label for="id_1-0" aria-label="reset_stars">reset_stars</label>
+                            <label for="id_1-0">reset_stars</label>
                             <input aria-describedby="id_1_desc" type="radio" id="id_1-0" name="name_0" value="0" />
                         </div>
                     

--- a/components/ILIAS/UI/tests/Component/Input/Field/RatingInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/RatingInputTest.php
@@ -69,20 +69,20 @@ class RatingInputTest extends ILIAS_UI_TestBase
                 <legend class="il-input-rating__text" id="id_1_desc"></legend>
                 <div class="il-input-rating__stars" role="radiogroup">
                     <div class="il-input-rating__options">
-                        <input aria-describedby="id_1_desc" aria-label="5stars" type="radio" id="id_1-5" name="name_0" value="5" class="il-input-rating-scaleoption" />
-                        <label class="glyphicon-star il-input-rating-star" for="id_1-5"></label>
+                        <input aria-describedby="id_1_desc" type="radio" id="id_1-5" name="name_0" value="5" class="il-input-rating-scaleoption" />
+                        <label class="glyphicon-star il-input-rating-star" for="id_1-5"><span class="sr-only">5stars</span></label>
 
-                        <input aria-describedby="id_1_desc" aria-label="4stars" type="radio" id="id_1-4" name="name_0" value="4" class="il-input-rating-scaleoption" />
-                        <label class="glyphicon-star il-input-rating-star" for="id_1-4"></label>
+                        <input aria-describedby="id_1_desc" type="radio" id="id_1-4" name="name_0" value="4" class="il-input-rating-scaleoption" />
+                        <label class="glyphicon-star il-input-rating-star" for="id_1-4"><span class="sr-only">4stars</span></label>
 
-                        <input aria-describedby="id_1_desc" aria-label="3stars" type="radio" id="id_1-3" name="name_0" value="3" class="il-input-rating-scaleoption" />
-                        <label class="glyphicon-star il-input-rating-star" for="id_1-3"></label>
+                        <input aria-describedby="id_1_desc" type="radio" id="id_1-3" name="name_0" value="3" class="il-input-rating-scaleoption" />
+                        <label class="glyphicon-star il-input-rating-star" for="id_1-3"><span class="sr-only">3stars</span></label>
 
-                        <input aria-describedby="id_1_desc" aria-label="2stars" type="radio" id="id_1-2" name="name_0" value="2" class="il-input-rating-scaleoption" />
-                        <label class="glyphicon-star il-input-rating-star" for="id_1-2"></label>
+                        <input aria-describedby="id_1_desc" type="radio" id="id_1-2" name="name_0" value="2" class="il-input-rating-scaleoption" />
+                        <label class="glyphicon-star il-input-rating-star" for="id_1-2"><span class="sr-only">2stars</span></label>
 
-                        <input aria-describedby="id_1_desc" aria-label="1stars" type="radio" id="id_1-1" name="name_0" value="1" class="il-input-rating-scaleoption" />
-                        <label class="glyphicon-star il-input-rating-star" for="id_1-1"></label>
+                        <input aria-describedby="id_1_desc" type="radio" id="id_1-1" name="name_0" value="1" class="il-input-rating-scaleoption" />
+                        <label class="glyphicon-star il-input-rating-star" for="id_1-1"><span class="sr-only">1stars</span></label>
                     </div>
                     <div class="il-input-rating__none">
                         <label for="id_1-0">reset_stars</label>
@@ -121,20 +121,20 @@ class RatingInputTest extends ILIAS_UI_TestBase
                                 <div class="il-input-rating__average_value" style="width:60%;"></div>
                             </div>
 
-                            <input aria-describedby="id_1_desc" aria-label="5stars" type="radio" id="id_1-5" name="name_0" value="5" class="il-input-rating-scaleoption" disabled="disabled"/>
-                            <label class="glyphicon-star il-input-rating-star" for="id_1-5"></label>
+                            <input aria-describedby="id_1_desc" type="radio" id="id_1-5" name="name_0" value="5" class="il-input-rating-scaleoption" disabled="disabled"/>
+                            <label class="glyphicon-star il-input-rating-star" for="id_1-5"><span class="sr-only">5stars</span></label>
 
-                            <input aria-describedby="id_1_desc" aria-label="4stars" type="radio" id="id_1-4" name="name_0" value="4" class="il-input-rating-scaleoption" disabled="disabled" checked="checked"/>
-                            <label class="glyphicon-star il-input-rating-star" for="id_1-4"></label>
+                            <input aria-describedby="id_1_desc" type="radio" id="id_1-4" name="name_0" value="4" class="il-input-rating-scaleoption" disabled="disabled" checked="checked"/>
+                            <label class="glyphicon-star il-input-rating-star" for="id_1-4"><span class="sr-only">4stars</span></label>
 
-                            <input aria-describedby="id_1_desc" aria-label="3stars" type="radio" id="id_1-3" name="name_0" value="3" class="il-input-rating-scaleoption" disabled="disabled"/>
-                            <label class="glyphicon-star il-input-rating-star" for="id_1-3"></label>
+                            <input aria-describedby="id_1_desc" type="radio" id="id_1-3" name="name_0" value="3" class="il-input-rating-scaleoption" disabled="disabled"/>
+                            <label class="glyphicon-star il-input-rating-star" for="id_1-3"><span class="sr-only">3stars</span></label>
 
-                            <input aria-describedby="id_1_desc" aria-label="2stars" type="radio" id="id_1-2" name="name_0" value="2" class="il-input-rating-scaleoption" disabled="disabled"/>
-                            <label class="glyphicon-star il-input-rating-star" for="id_1-2"></label>
+                            <input aria-describedby="id_1_desc" type="radio" id="id_1-2" name="name_0" value="2" class="il-input-rating-scaleoption" disabled="disabled"/>
+                            <label class="glyphicon-star il-input-rating-star" for="id_1-2"><span class="sr-only">2stars</span></label>
 
-                            <input aria-describedby="id_1_desc" aria-label="1stars" type="radio" id="id_1-1" name="name_0" value="1" class="il-input-rating-scaleoption" disabled="disabled"/>
-                            <label class="glyphicon-star il-input-rating-star" for="id_1-1"></label>
+                            <input aria-describedby="id_1_desc" type="radio" id="id_1-1" name="name_0" value="1" class="il-input-rating-scaleoption" disabled="disabled"/>
+                            <label class="glyphicon-star il-input-rating-star" for="id_1-1"><span class="sr-only">1stars</span></label>
                         </div>
                     
                         <div class="il-input-rating__none">


### PR DESCRIPTION
Error: The “aria-label” attribute must not be used on any “label” element that is associated with a labelable element.	
https://mantis.ilias.de/view.php?id=47063

Label with for= must not duplicate name via aria-label. Move
aria-label to the radio input; label remains for click target.
Apply to scale options and neutral option.

## Problem
- Validator: `<label for="..." aria-label="...">` ungültig, wenn das Label mit Formularelement verknüpft ist; Name soll aus Label-Inhalt kommen.

## Lösung
- aria-label vom label entfernt, auf das jeweilige input (radio) setzen.
- RatingInputTest anpassen.