### PR TITLE
[Fix] 0045422: Use ButtonContextRenderer for Glyph in Filter and Mode…

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/GlyphRendererFactory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/GlyphRendererFactory.php
@@ -29,6 +29,8 @@ class GlyphRendererFactory extends Render\DefaultRendererFactory
     /**
      * components which render glyphs inside an HTML <button> element (or equivalent),
      * where only palpable content is allowed (no <a>).
+     * Any glyph rendered anywhere within these components' subtree will use the
+     * ButtonContextRenderer.
      * @see https://html.spec.whatwg.org/#palpable-content
      */
     protected const array USE_BUTTON_CONTEXT_RENDERER_FOR = [
@@ -43,13 +45,27 @@ class GlyphRendererFactory extends Render\DefaultRendererFactory
         'ShyLink',
         'MultiSelectFieldInput',
         'RadioFieldInput',
+    ];
+
+    /**
+     * Components that render glyphs inside an HTML <button> element themselves
+     * but also contain child components whose glyphs should NOT use the
+     * ButtonContextRenderer. Only glyphs that are direct children of these
+     * components (i.e. these components are the immediate parent context) will
+     * use the ButtonContextRenderer. This prevents false-positives for glyphs
+     * in nested child components.
+     */
+    protected const array USE_BUTTON_CONTEXT_RENDERER_FOR_DIRECT_CONTEXT = [
         'StandardFilterContainerInput',
         'ModeViewControl',
     ];
 
     public function getRendererInContext(Component\Component $component, array $contexts): ComponentRenderer
     {
-        if (count(array_intersect(self::USE_BUTTON_CONTEXT_RENDERER_FOR, $contexts)) > 0) {
+        if (
+            $this->isDirectContextMatch($contexts) ||
+            count(array_intersect(self::USE_BUTTON_CONTEXT_RENDERER_FOR, $contexts)) > 0
+        ) {
             return new ButtonContextRenderer(
                 $this->ui_factory,
                 $this->tpl_factory,
@@ -71,5 +87,23 @@ class GlyphRendererFactory extends Render\DefaultRendererFactory
             $this->help_text_retriever,
             $this->upload_limit_resolver
         );
+    }
+
+    /**
+     * Checks whether the immediate parent context (the component that directly
+     * renders this glyph) matches one of the DIRECT_CONTEXT components.
+     * The context array has the current component (glyph) as the last element,
+     * so the immediate parent is the second-to-last element.
+     *
+     * @param string[] $contexts
+     */
+    private function isDirectContextMatch(array $contexts): bool
+    {
+        $count = count($contexts);
+        if ($count < 2) {
+            return false;
+        }
+        $immediate_parent = $contexts[$count - 2];
+        return in_array($immediate_parent, self::USE_BUTTON_CONTEXT_RENDERER_FOR_DIRECT_CONTEXT, true);
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/GlyphRendererFactory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/GlyphRendererFactory.php
@@ -27,8 +27,8 @@ use ILIAS\UI\Implementation\Render\ComponentRenderer;
 class GlyphRendererFactory extends Render\DefaultRendererFactory
 {
     /**
-     * components which render glyphs inside an HTML <button> element, where only
-     * palpable content is allowed.
+     * components which render glyphs inside an HTML <button> element (or equivalent),
+     * where only palpable content is allowed (no <a>).
      * @see https://html.spec.whatwg.org/#palpable-content
      */
     protected const array USE_BUTTON_CONTEXT_RENDERER_FOR = [
@@ -43,6 +43,8 @@ class GlyphRendererFactory extends Render\DefaultRendererFactory
         'ShyLink',
         'MultiSelectFieldInput',
         'RadioFieldInput',
+        'StandardFilterContainerInput',
+        'ModeViewControl',
     ];
 
     public function getRendererInContext(Component\Component $component, array $contexts): ComponentRenderer

--- a/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/GlyphRendererFactory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/GlyphRendererFactory.php
@@ -57,7 +57,6 @@ class GlyphRendererFactory extends Render\DefaultRendererFactory
      */
     protected const array USE_BUTTON_CONTEXT_RENDERER_FOR_DIRECT_CONTEXT = [
         'StandardFilterContainerInput',
-        'ModeViewControl',
     ];
 
     public function getRendererInContext(Component\Component $component, array $contexts): ComponentRenderer

--- a/components/ILIAS/UI/tests/Component/Input/Container/Filter/FilterInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Filter/FilterInputTest.php
@@ -132,9 +132,9 @@ class FilterInputTest extends ILIAS_UI_TestBase
                 <label for="id_1" class="input-group-addon leftaddon">label</label>
                 <input id="id_1" type="text" class="c-field-text" />
                 <span class="input-group-addon rightaddon">
-                    <span class="glyph" aria-label="remove" role="img" id="id_2" >
+                    <a class="glyph" href="" aria-label="remove" id="id_2">
                         <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
-                    </span>
+                    </a>
                 </span>
             </div>
         </div>
@@ -157,9 +157,9 @@ class FilterInputTest extends ILIAS_UI_TestBase
                 <label for="id_1" class="input-group-addon leftaddon">label</label>
                 <input id="id_1" type="number" step="1" class="c-field-number" />
                 <span class="input-group-addon rightaddon">
-                    <span class="glyph" aria-label="remove" role="img" id="id_2">
+                    <a class="glyph" href="" aria-label="remove" id="id_2">
                         <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
-                    </span>
+                    </a>
                 </span>
             </div>
         </div>
@@ -188,7 +188,7 @@ class FilterInputTest extends ILIAS_UI_TestBase
                     <option value="three">Three</option>
                 </select>
                 <span class="input-group-addon rightaddon">
-                    <span class="glyph" aria-label="remove" role="img" id="id_2"><span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span></span>
+                    <a class="glyph" href="" aria-label="remove" id="id_2"><span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span></a>
                 </span>
             </div>
         </div>
@@ -241,9 +241,9 @@ class FilterInputTest extends ILIAS_UI_TestBase
                     <input id="id_1" type="date" class="c-field-datetime" />
                 </div>
                 <span class="input-group-addon rightaddon">
-                    <span class="glyph" aria-label="remove" role="img" id="id_2">
+                    <a class="glyph" href="" aria-label="remove" id="id_2">
                         <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
-                    </span>
+                    </a>
                 </span>
             </div>
         </div>
@@ -294,9 +294,9 @@ class FilterInputTest extends ILIAS_UI_TestBase
                 <span role="button" tabindex="0" class="form-control il-filter-field" id="id_7" data-placement="bottom"></span>
                 <div class="il-standard-popover-content" style="display:none;" id="id_5"></div>
                 <span class="input-group-addon rightaddon">
-                    <span class="glyph" aria-label="remove" role="img" id="id_8" >
+                    <a class="glyph" href="" aria-label="remove" id="id_8">
                         <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
-                    </span>
+                    </a>
                 </span>
             </div>
             {POPOVER}

--- a/components/ILIAS/UI/tests/Component/Input/Container/Filter/FilterInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Filter/FilterInputTest.php
@@ -132,9 +132,9 @@ class FilterInputTest extends ILIAS_UI_TestBase
                 <label for="id_1" class="input-group-addon leftaddon">label</label>
                 <input id="id_1" type="text" class="c-field-text" />
                 <span class="input-group-addon rightaddon">
-                    <a class="glyph" href="" aria-label="remove" id="id_2">
+                    <span class="glyph" aria-label="remove" role="img" id="id_2" >
                         <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
-                    </a>
+                    </span>
                 </span>
             </div>
         </div>
@@ -157,9 +157,9 @@ class FilterInputTest extends ILIAS_UI_TestBase
                 <label for="id_1" class="input-group-addon leftaddon">label</label>
                 <input id="id_1" type="number" step="1" class="c-field-number" />
                 <span class="input-group-addon rightaddon">
-                    <a class="glyph" href="" aria-label="remove" id="id_2">
+                    <span class="glyph" aria-label="remove" role="img" id="id_2">
                         <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
-                    </a>
+                    </span>
                 </span>
             </div>
         </div>
@@ -188,7 +188,7 @@ class FilterInputTest extends ILIAS_UI_TestBase
                     <option value="three">Three</option>
                 </select>
                 <span class="input-group-addon rightaddon">
-                    <a class="glyph" href="" aria-label="remove" id="id_2"><span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span></a>
+                    <span class="glyph" aria-label="remove" role="img" id="id_2"><span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span></span>
                 </span>
             </div>
         </div>
@@ -241,9 +241,9 @@ class FilterInputTest extends ILIAS_UI_TestBase
                     <input id="id_1" type="date" class="c-field-datetime" />
                 </div>
                 <span class="input-group-addon rightaddon">
-                    <a class="glyph" href="" aria-label="remove" id="id_2">
+                    <span class="glyph" aria-label="remove" role="img" id="id_2">
                         <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
-                    </a>
+                    </span>
                 </span>
             </div>
         </div>
@@ -294,9 +294,9 @@ class FilterInputTest extends ILIAS_UI_TestBase
                 <span role="button" tabindex="0" class="form-control il-filter-field" id="id_7" data-placement="bottom"></span>
                 <div class="il-standard-popover-content" style="display:none;" id="id_5"></div>
                 <span class="input-group-addon rightaddon">
-                    <a class="glyph" href="" aria-label="remove" id="id_8">
+                    <span class="glyph" aria-label="remove" role="img" id="id_8" >
                         <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
-                    </a>
+                    </span>
                 </span>
             </div>
             {POPOVER}

--- a/components/ILIAS/UI/tests/Component/Input/Container/Filter/StandardFilterTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Filter/StandardFilterTest.php
@@ -184,14 +184,14 @@ class StandardFilterTest extends ILIAS_UI_TestBase
                 <button type="button" aria-expanded="false" aria-controls="active_inputs_id_1 section_inputs_id_1" id="opener_id_1">
                     <span>
                         <span data-collapse-glyph-visibility="0">
-                            <a class="glyph" aria-label="collapse_content">
+                            <span class="glyph" aria-label="collapse_content" role="img">
                                 <span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span>
-                            </a>
+                            </span>
                         </span>
                         <span data-expand-glyph-visibility="1">
-                            <a class="glyph" aria-label="expand_content">
+                            <span class="glyph" aria-label="expand_content" role="img">
                                 <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span>
-                            </a>
+                            </span>
                         </span> filter
                     </span>
                 </button>
@@ -217,9 +217,9 @@ class StandardFilterTest extends ILIAS_UI_TestBase
                     <label for="id_5" class="input-group-addon leftaddon">Title</label>
                     <input id="id_5" type="text" name="filter_input_0/filter_input_1" class="c-field-text" />
                     <span class="input-group-addon rightaddon">
-                        <a class="glyph" href="" aria-label="remove" id="id_6">
+                        <span class="glyph" aria-label="remove" role="img" id="id_6">
                             <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
-                        </a>
+                        </span>
                     </span>
                 </div>
             </div>
@@ -233,9 +233,9 @@ class StandardFilterTest extends ILIAS_UI_TestBase
                         <option value="three">Three</option>
                     </select>
                     <span class="input-group-addon rightaddon">
-                        <a class="glyph" href="" aria-label="remove" id="id_8">
+                        <span class="glyph" aria-label="remove" role="img" id="id_8">
                             <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
-                        </a>
+                        </span>
                     </span>
                 </div>
             </div>
@@ -322,14 +322,14 @@ EOT;
                 <button type="button" aria-expanded="false" aria-controls="active_inputs_id_1 section_inputs_id_1" id="opener_id_1">
                     <span>
                         <span data-collapse-glyph-visibility="0">
-                            <a class="glyph" aria-label="collapse_content">
+                            <span class="glyph" aria-label="collapse_content" role="img">
                                 <span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span>
-                            </a>
+                            </span>
                         </span>
                         <span data-expand-glyph-visibility="1">
-                            <a class="glyph" aria-label="expand_content">
+                            <span class="glyph" aria-label="expand_content" role="img">
                                 <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span>
-                            </a>
+                            </span>
                         </span> filter
                     </span>
                 </button>
@@ -355,9 +355,9 @@ EOT;
                     <label for="id_5" class="input-group-addon leftaddon">Title</label>
                     <input id="id_5" type="text" name="filter_input_0/filter_input_1" class="c-field-text" />
                     <span class="input-group-addon rightaddon">
-                        <a class="glyph" href="" aria-label="remove" id="id_6">
+                        <span class="glyph" aria-label="remove" role="img" id="id_6">
                             <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
-                        </a>
+                        </span>
                     </span>
                 </div>
             </div>
@@ -371,9 +371,9 @@ EOT;
                         <option value="three">Three</option>
                     </select>
                     <span class="input-group-addon rightaddon">
-                        <a class="glyph" href="" aria-label="remove" id="id_8">
+                        <span class="glyph" aria-label="remove" role="img" id="id_8">
                             <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
-                        </a>
+                        </span>
                     </span>
                 </div>
             </div>
@@ -460,14 +460,14 @@ EOT;
                 <button type="button" aria-expanded="true" aria-controls="active_inputs_id_1 section_inputs_id_1" id="opener_id_1">
                     <span>
                         <span data-collapse-glyph-visibility="1">
-                            <a class="glyph" aria-label="collapse_content">
+                            <span class="glyph" aria-label="collapse_content" role="img">
                                 <span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span>
-                            </a>
+                            </span>
                         </span>
                         <span data-expand-glyph-visibility="0">
-                            <a class="glyph" aria-label="expand_content">
+                            <span class="glyph" aria-label="expand_content" role="img">
                                 <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span>
-                            </a>
+                            </span>
                         </span> filter
                     </span>
                 </button>
@@ -493,9 +493,9 @@ EOT;
                     <label for="id_5" class="input-group-addon leftaddon">Title</label>
                     <input id="id_5" type="text" name="filter_input_0/filter_input_1" class="c-field-text" />
                     <span class="input-group-addon rightaddon">
-                        <a class="glyph" href="" aria-label="remove" id="id_6">
+                        <span class="glyph" aria-label="remove" role="img" id="id_6">
                             <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
-                        </a>
+                        </span>
                     </span>
                 </div>
             </div>
@@ -509,9 +509,9 @@ EOT;
                         <option value="three">Three</option>
                     </select>
                     <span class="input-group-addon rightaddon">
-                        <a class="glyph" href="" aria-label="remove" id="id_8">
+                        <span class="glyph" aria-label="remove" role="img" id="id_8">
                             <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
-                        </a>
+                        </span>
                     </span>
                 </div>
             </div>
@@ -598,14 +598,14 @@ EOT;
                 <button type="button" aria-expanded="true" aria-controls="active_inputs_id_1 section_inputs_id_1" id="opener_id_1">
                     <span>
                         <span data-collapse-glyph-visibility="1">
-                            <a class="glyph" aria-label="collapse_content">
+                            <span class="glyph" aria-label="collapse_content" role="img">
                                 <span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span>
-                            </a>
+                            </span>
                         </span>
                         <span data-expand-glyph-visibility="0">
-                            <a class="glyph" aria-label="expand_content">
+                            <span class="glyph" aria-label="expand_content" role="img">
                                 <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span>
-                            </a>
+                            </span>
                         </span> filter
                     </span>
                 </button>
@@ -631,9 +631,9 @@ EOT;
                     <label for="id_5" class="input-group-addon leftaddon">Title</label>
                     <input id="id_5" type="text" name="filter_input_0/filter_input_1" class="c-field-text" />
                     <span class="input-group-addon rightaddon">
-                    <a class="glyph" href="" aria-label="remove" id="id_6">
+                    <span class="glyph" aria-label="remove" role="img" id="id_6">
                         <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
-                    </a>
+                    </span>
                     </span>
                 </div>
             </div>
@@ -647,9 +647,9 @@ EOT;
                         <option value="three">Three</option>
                     </select>
                     <span class="input-group-addon rightaddon">
-                        <a class="glyph" href="" aria-label="remove" id="id_8">
+                        <span class="glyph" aria-label="remove" role="img" id="id_8">
                             <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
-                        </a>
+                        </span>
                     </span>
                 </div>
             </div>

--- a/components/ILIAS/UI/tests/Component/Input/Container/Filter/StandardFilterTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Filter/StandardFilterTest.php
@@ -217,9 +217,9 @@ class StandardFilterTest extends ILIAS_UI_TestBase
                     <label for="id_5" class="input-group-addon leftaddon">Title</label>
                     <input id="id_5" type="text" name="filter_input_0/filter_input_1" class="c-field-text" />
                     <span class="input-group-addon rightaddon">
-                        <span class="glyph" aria-label="remove" role="img" id="id_6">
+                        <a class="glyph" href="" aria-label="remove" id="id_6">
                             <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
-                        </span>
+                        </a>
                     </span>
                 </div>
             </div>
@@ -233,9 +233,9 @@ class StandardFilterTest extends ILIAS_UI_TestBase
                         <option value="three">Three</option>
                     </select>
                     <span class="input-group-addon rightaddon">
-                        <span class="glyph" aria-label="remove" role="img" id="id_8">
+                        <a class="glyph" href="" aria-label="remove" id="id_8">
                             <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
-                        </span>
+                        </a>
                     </span>
                 </div>
             </div>
@@ -355,9 +355,9 @@ EOT;
                     <label for="id_5" class="input-group-addon leftaddon">Title</label>
                     <input id="id_5" type="text" name="filter_input_0/filter_input_1" class="c-field-text" />
                     <span class="input-group-addon rightaddon">
-                        <span class="glyph" aria-label="remove" role="img" id="id_6">
+                        <a class="glyph" href="" aria-label="remove" id="id_6">
                             <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
-                        </span>
+                        </a>
                     </span>
                 </div>
             </div>
@@ -371,9 +371,9 @@ EOT;
                         <option value="three">Three</option>
                     </select>
                     <span class="input-group-addon rightaddon">
-                        <span class="glyph" aria-label="remove" role="img" id="id_8">
+                        <a class="glyph" href="" aria-label="remove" id="id_8">
                             <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
-                        </span>
+                        </a>
                     </span>
                 </div>
             </div>
@@ -493,9 +493,9 @@ EOT;
                     <label for="id_5" class="input-group-addon leftaddon">Title</label>
                     <input id="id_5" type="text" name="filter_input_0/filter_input_1" class="c-field-text" />
                     <span class="input-group-addon rightaddon">
-                        <span class="glyph" aria-label="remove" role="img" id="id_6">
+                        <a class="glyph" href="" aria-label="remove" id="id_6">
                             <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
-                        </span>
+                        </a>
                     </span>
                 </div>
             </div>
@@ -509,9 +509,9 @@ EOT;
                         <option value="three">Three</option>
                     </select>
                     <span class="input-group-addon rightaddon">
-                        <span class="glyph" aria-label="remove" role="img" id="id_8">
+                        <a class="glyph" href="" aria-label="remove" id="id_8">
                             <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
-                        </span>
+                        </a>
                     </span>
                 </div>
             </div>
@@ -631,9 +631,9 @@ EOT;
                     <label for="id_5" class="input-group-addon leftaddon">Title</label>
                     <input id="id_5" type="text" name="filter_input_0/filter_input_1" class="c-field-text" />
                     <span class="input-group-addon rightaddon">
-                    <span class="glyph" aria-label="remove" role="img" id="id_6">
+                    <a class="glyph" href="" aria-label="remove" id="id_6">
                         <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
-                    </span>
+                    </a>
                     </span>
                 </div>
             </div>
@@ -647,9 +647,9 @@ EOT;
                         <option value="three">Three</option>
                     </select>
                     <span class="input-group-addon rightaddon">
-                        <span class="glyph" aria-label="remove" role="img" id="id_8">
+                        <a class="glyph" href="" aria-label="remove" id="id_8">
                             <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
-                        </span>
+                        </a>
                     </span>
                 </div>
             </div>


### PR DESCRIPTION
Error: The element “a” must not appear as a descendant of the “button” element.
https://mantis.ilias.de/view.php?id=45422


Glyphs with action were rendered as <a> and ended up inside <button>,
which is invalid. Extend USE_BUTTON_CONTEXT_RENDERER_FOR with
StandardFilterContainerInput and ModeViewControl so glyphs render
as <span> in these contexts.

## Problem
- Validator: `<a>` als Nachfahre von `<button>` ungültig (z. B. Filter, Dashboard ViewControlMode).

## Lösung
- GlyphRendererFactory: StandardFilterContainerInput und ModeViewControl zu USE_BUTTON_CONTEXT_RENDERER_FOR hinzufügen → Glyphe als span in diesen Kontexten.