### PR TITLE
[Fix] 0047064 UI: Entity listing template – close tag </ul> (was </uĺ>)

### DIFF
--- a/components/ILIAS/UI/src/templates/default/Listing/tpl.entitylisting.html
+++ b/components/ILIAS/UI/src/templates/default/Listing/tpl.entitylisting.html
@@ -4,4 +4,4 @@
 		{ENTITY}
 	</li>
 <!-- END entry -->
-</uĺ>
+</ul>


### PR DESCRIPTION
Error	8807	1	Stray end tag “uĺ”.	
 Error	8808	1	End tag “div” seen, but there were open elements.	
 Error	8521	21	Unclosed element “ul”.
https://mantis.ilias.de/view.php?id=47064


Correct typo: Unicode 'l' with acute instead of ASCII 'l' in
closing list tag. Validator: "Stray end tag uĺ".

## Problem
- Validator: Stray end tag "uĺ" (falsches Zeichen im schließenden Tag).

## Lösung
- In tpl.entitylisting.html: `</uĺ>` → `</ul>`.