### PR TITLE
[Fix] 0047065 UI: Lightbox carousel nav – use data-target and type="b…

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Modal/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Modal/Renderer.php
@@ -262,11 +262,9 @@ class Renderer extends AbstractComponentRenderer
             $first = false;
         }
         if (count($pages) > 1) {
-            $tpl->setCurrentBlock('controls');
-            $tpl->setVariable('ID_CAROUSEL3', $id_carousel);
+            $tpl->touchBlock('controls');
             $tpl->parseCurrentBlock();
         }
-        $tpl->setVariable('ID_CAROUSEL4', $id_carousel);
         return $tpl->get();
     }
 

--- a/components/ILIAS/UI/src/templates/default/Modal/tpl.lightbox.html
+++ b/components/ILIAS/UI/src/templates/default/Modal/tpl.lightbox.html
@@ -31,11 +31,11 @@
 					</div>
 
 					<!-- BEGIN controls -->
-					<button class="left carousel-control btn-link" href="#{ID_CAROUSEL3}" role="button" type="button" data-slide="prev">
+					<button class="left carousel-control btn-link" data-target="#{ID_CAROUSEL3}" type="button" type="button" data-slide="prev">
 						<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
 						<span class="sr-only">Previous</span>
 					</button>
-					<button class="right carousel-control btn-link" href="#{ID_CAROUSEL3}" role="button" type="button" data-slide="next">
+					<button class="right carousel-control btn-link" data-target="#{ID_CAROUSEL3}" type="button" type="button" data-slide="next">
 						<span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
 						<span class="sr-only">Next</span>
 					</button>

--- a/components/ILIAS/UI/src/templates/default/Modal/tpl.lightbox.html
+++ b/components/ILIAS/UI/src/templates/default/Modal/tpl.lightbox.html
@@ -31,11 +31,11 @@
 					</div>
 
 					<!-- BEGIN controls -->
-					<button class="left carousel-control btn-link" data-target="#{ID_CAROUSEL3}" type="button" type="button" data-slide="prev">
+					<button class="left carousel-control btn-link" type="button" data-slide="prev">
 						<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
 						<span class="sr-only">Previous</span>
 					</button>
-					<button class="right carousel-control btn-link" data-target="#{ID_CAROUSEL3}" type="button" type="button" data-slide="next">
+					<button class="right carousel-control btn-link" type="button" data-slide="next">
 						<span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
 						<span class="sr-only">Next</span>
 					</button>

--- a/components/ILIAS/UI/tests/Component/Modal/LightboxTest.php
+++ b/components/ILIAS/UI/tests/Component/Modal/LightboxTest.php
@@ -183,11 +183,11 @@ EOT;
 						</div>
 					</div>
 
-					<button class="left carousel-control btn-link" data-target="#id_1_carousel" type="button" type="button" data-slide="prev">
+					<button class="left carousel-control btn-link" type="button" data-slide="prev">
 						<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
 						<span class="sr-only">Previous</span>
 					</button>
-					<button class="right carousel-control btn-link" data-target="#id_1_carousel" type="button" type="button" data-slide="next">
+					<button class="right carousel-control btn-link" type="button" data-slide="next">
 						<span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
 						<span class="sr-only">Next</span>
 					</button>

--- a/components/ILIAS/UI/tests/Component/Modal/LightboxTest.php
+++ b/components/ILIAS/UI/tests/Component/Modal/LightboxTest.php
@@ -183,11 +183,11 @@ EOT;
 						</div>
 					</div>
 
-					<button class="left carousel-control btn-link" href="#id_1_carousel" role="button" type="button" data-slide="prev">
+					<button class="left carousel-control btn-link" data-target="#id_1_carousel" type="button" type="button" data-slide="prev">
 						<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
 						<span class="sr-only">Previous</span>
 					</button>
-					<button class="right carousel-control btn-link" href="#id_1_carousel" role="button" type="button" data-slide="next">
+					<button class="right carousel-control btn-link" data-target="#id_1_carousel" type="button" type="button" data-slide="next">
 						<span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
 						<span class="sr-only">Next</span>
 					</button>


### PR DESCRIPTION
 Error: Attribute “href” not allowed on element “button” at this point
https://mantis.ilias.de/view.php?id=47065

href on <button> is invalid. Replace with data-target for carousel
target; add type="button" and remove redundant role="button".
Update LightboxTest.

- Validator: href auf <button> im Lightbox-Carousel ungültig.

## Lösung
- tpl.lightbox.html: href durch data-target; type="button" setzen; role="button" entfernen.
- LightboxTest anpassen.