### PR TITLE
[Fix] 0047066 UI: Standard filter – add aria-labelledby to region divs

### DIFF
--- a/components/ILIAS/UI/src/templates/default/Input/tpl.standard_filter.html
+++ b/components/ILIAS/UI/src/templates/default/Input/tpl.standard_filter.html
@@ -13,9 +13,9 @@
         <div class="il-filter-bar-toggle"> {TOGGLE} </div>
     </div>
     <!-- BEGIN active_inputs_section -->
-    <div class="il-filter-inputs-active clearfix" id="active_inputs_{ID_FILTER_ACTIVE}" aria-labelledby="opener_{ID_FILTER_ACTIVE}" data-active-inputs-expanded="{ACTIVE_INPUTS_EXPANDED}"><!-- BEGIN active_inputs --> <span id="{ID_INPUT_ACTIVE}"> </span> <!-- END active_inputs --></div>
+    <div class="il-filter-inputs-active clearfix" id="active_inputs_{ID_FILTER_ACTIVE}" role="region" aria-labelledby="opener_{ID_FILTER_ACTIVE}" data-active-inputs-expanded="{ACTIVE_INPUTS_EXPANDED}"><!-- BEGIN active_inputs --> <span id="{ID_INPUT_ACTIVE}"> </span> <!-- END active_inputs --></div>
     <!-- END active_inputs_section -->
-    <div class="il-filter-input-section row" id="section_inputs_{ID_FILTER}" aria-labelledby="opener_{ID_FILTER}" data-section-inputs-expanded="{SECTION_INPUTS_EXPANDED}">
+    <div class="il-filter-input-section row" id="section_inputs_{ID_FILTER}" role="region" aria-labelledby="opener_{ID_FILTER}" data-section-inputs-expanded="{SECTION_INPUTS_EXPANDED}">
         {INPUTS}
         <div class="il-filter-controls"> {APPLY} {RESET} </div>
     </div>

--- a/components/ILIAS/UI/tests/Component/Input/Container/Filter/StandardFilterTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Filter/StandardFilterTest.php
@@ -206,12 +206,12 @@ class StandardFilterTest extends ILIAS_UI_TestBase
                 </div>
             </div>
         </div>
-        <div class="il-filter-inputs-active clearfix" id="active_inputs_id_1" aria-labelledby="opener_id_1" data-active-inputs-expanded="1">
+        <div class="il-filter-inputs-active clearfix" id="active_inputs_id_1" role="region" aria-labelledby="opener_id_1" data-active-inputs-expanded="1">
             <span id="1"></span>
             <span id="2"></span>
             <span id="3"></span>
         </div>
-        <div class="il-filter-input-section row" id="section_inputs_id_1" aria-labelledby="opener_id_1" data-section-inputs-expanded="0">
+        <div class="il-filter-input-section row" id="section_inputs_id_1" role="region" aria-labelledby="opener_id_1" data-section-inputs-expanded="0">
             <div class="col-md-6 col-lg-4 il-popover-container">
                 <div class="input-group">
                     <label for="id_5" class="input-group-addon leftaddon">Title</label>
@@ -344,12 +344,12 @@ EOT;
                 </div>
             </div>
         </div>
-        <div class="il-filter-inputs-active clearfix" id="active_inputs_id_1" aria-labelledby="opener_id_1" data-active-inputs-expanded="1">
+        <div class="il-filter-inputs-active clearfix" id="active_inputs_id_1" role="region" aria-labelledby="opener_id_1" data-active-inputs-expanded="1">
             <span id="1"></span>
             <span id="2"></span>
             <span id="3"></span>
         </div>
-        <div class="il-filter-input-section row" id="section_inputs_id_1" aria-labelledby="opener_id_1" data-section-inputs-expanded="0">
+        <div class="il-filter-input-section row" id="section_inputs_id_1" role="region" aria-labelledby="opener_id_1" data-section-inputs-expanded="0">
             <div class="col-md-6 col-lg-4 il-popover-container">
                 <div class="input-group">
                     <label for="id_5" class="input-group-addon leftaddon">Title</label>
@@ -482,12 +482,12 @@ EOT;
                 </div>
             </div>
         </div>
-        <div class="il-filter-inputs-active clearfix" id="active_inputs_id_1" aria-labelledby="opener_id_1" data-active-inputs-expanded="0">
+        <div class="il-filter-inputs-active clearfix" id="active_inputs_id_1" role="region" aria-labelledby="opener_id_1" data-active-inputs-expanded="0">
             <span id="1"></span>
             <span id="2"></span>
             <span id="3"></span>
         </div>
-        <div class="il-filter-input-section row" id="section_inputs_id_1" aria-labelledby="opener_id_1" data-section-inputs-expanded="1">
+        <div class="il-filter-input-section row" id="section_inputs_id_1" role="region" aria-labelledby="opener_id_1" data-section-inputs-expanded="1">
             <div class="col-md-6 col-lg-4 il-popover-container">
                 <div class="input-group">
                     <label for="id_5" class="input-group-addon leftaddon">Title</label>
@@ -620,12 +620,12 @@ EOT;
                 </div>
             </div>
         </div>
-        <div class="il-filter-inputs-active clearfix" id="active_inputs_id_1" aria-labelledby="opener_id_1" data-active-inputs-expanded="0">
+        <div class="il-filter-inputs-active clearfix" id="active_inputs_id_1" role="region" aria-labelledby="opener_id_1" data-active-inputs-expanded="0">
             <span id="1"></span>
             <span id="2"></span>
             <span id="3"></span>
         </div>
-        <div class="il-filter-input-section row" id="section_inputs_id_1" aria-labelledby="opener_id_1" data-section-inputs-expanded="1">
+        <div class="il-filter-input-section row" id="section_inputs_id_1" role="region" aria-labelledby="opener_id_1" data-section-inputs-expanded="1">
             <div class="col-md-6 col-lg-4 il-popover-container">
                 <div class="input-group">
                     <label for="id_5" class="input-group-addon leftaddon">Title</label>


### PR DESCRIPTION
 Error 6881 5 The “aria-labelledby” attribute must not be specified on any “div” element unless the element has a “role” value other than “caption”, “code”, “deletion”, “emphasis”, “generic”, “insertion”, “paragraph”, “presentation”, “strong”, “subscript”, or “superscript”.
https://mantis.ilias.de/view.php?id=47066

Regions (role="region") for active inputs and section inputs must
reference their label. Set aria-labelledby="opener_{ID_FILTER}"
(resp. opener_{ID_FILTER_ACTIVE}) so screen readers associate the
expandable sections with the filter opener button.

## Problem
- Accessibility: Die Bereiche mit role="region" (aktive Filter, Filter-Eingaben) hatten keine Zuordnung zum beschriftenden Element (Opener-Button).

## Lösung
- In tpl.standard_filter.ht