### PR TITLE
Fix wrong heading level for sub tabs accessibility

### DIFF
--- a/components/ILIAS/UIComponent/Tabs/templates/default/tpl.sub_tabs.html
+++ b/components/ILIAS/UIComponent/Tabs/templates/default/tpl.sub_tabs.html
@@ -1,4 +1,4 @@
-<h2 class="ilAccHeadingHidden"><a id="sub_tabs_after_tabs">{TXT_SUBTABS}</a></h2>
+<h3 class="ilAccHeadingHidden"><a id="sub_tabs_after_tabs">{TXT_SUBTABS}</a></h3>
 <ul id="ilSubTab" class="ilSubTab nav hidden-print">
 	<!-- BEGIN subtab -->
 	<li id="{ID}" class="{SUB_TAB_TYPE}">{SUB_LINK}<!-- BEGIN sel_text --> <span class="ilAccHidden">({TXT_SELECTED})</span><!-- END sel_text --></li>


### PR DESCRIPTION
This PR addresses accessibility issue 0041778: False Heading hierarchy of equestrian navigation
https://mantis.ilias.de/view.php?id=41778