### PR TITLE
Fix layout of mail page component [2/2]

### DIFF
--- a/components/ILIAS/UI/resources/ui-examples/css/mail_examples.css
+++ b/components/ILIAS/UI/resources/ui-examples/css/mail_examples.css
@@ -1,122 +1,122 @@
 .table {
-  background-color: #f0f0f0;
-  width: 100%;
+    background-color: #f0f0f0;
+    width: 100%;
 }
 
 .header {
-  background-color: white;
-  border-bottom: 2px solid #f0f0f0;
+    background-color: white;
+    border-bottom: 2px solid #f0f0f0;
 }
 
 .footer {
-  background-color: white;
+    background-color: white;
 }
 
 .image-data {
-  width: 90px;
+    width: 60px;
 }
 
 td.spacing {
-  padding: 20px 0;
+    padding: 20px 0;
 }
 
 .logo {
-  width: 45px;
-  height: 45px;
-  outline-style: none;
-  text-decoration: none;
-  border: none;
-  margin: 0;
+    width: 45px;
+    height: 45px;
+    outline-style: none;
+    text-decoration: none;
+    border: none;
+    margin: 0;
 }
 
 .installation-text {
-  vertical-align: middle;
+    vertical-align: middle;
 }
 .installation-text span {
-  border-collapse: collapse;
-  color: #161616;
-  font-family: "Open Sans", Arial, Helvetica, sans-serif;
-  font-size: 16px;
-  line-height: 22px;
+    border-collapse: collapse;
+    color: #161616;
+    font-family: "Open Sans", Arial, Helvetica, sans-serif;
+    font-size: 16px;
+    line-height: 22px;
 }
 
 .content .spacing {
-  padding: 80px 0;
+    padding: 60px 0;
 }
 
 .content td td {
-  background-color: white;
-}
-
-.text-color {
-  color: #4c6586;
+    background-color: white;
 }
 
 .footer .font-definition {
-  color: #161616;
+    color: #161616;
 }
 
 .font-definition {
-  font-family: "Open Sans", Arial, Helvetica, sans-serif;
-  font-size: 16px;
-  line-height: 22px;
-  padding: 30px;
+    font-family: "Open Sans", Arial, Helvetica, sans-serif;
+    padding: 30px;
+}
+.font-definitionp {
+    line-height: 22px;
+    font-size: 16px;
 }
 
 body {
-  height: 100% !important;
-  margin: 0;
-  padding: 0;
-  width: 100% !important;
-  mso-margin-top-alt: 0px;
-  mso-margin-bottom-alt: 0px;
-  mso-padding-alt: 0px 0px 0px 0px;
-  overflow-y: scroll;
-  -webkit-text-size-adjust: none;
-  -ms-text-size-adjust: none;
+    height: 100% !important;
+    margin: 0;
+    padding: 0;
+    width: 100% !important;
+    color: #161616;
+    mso-margin-top-alt: 0px;
+    mso-margin-bottom-alt: 0px;
+    mso-padding-alt: 0px 0px 0px 0px;
+    overflow-y: scroll;
+    -webkit-text-size-adjust: none;
+    -ms-text-size-adjust: none;
 }
 
 .center {
-  margin-left: auto;
-  margin-right: auto;
+    margin-left: auto;
+    margin-right: auto;
 }
 
-.w-750 {
-  width: 750px;
+.w-mail {
+    width: 80%;
 }
 
-.link-color {
-  color: #4c6586;
+a {
+    color: #4c6586;
 }
 
 table {
-  mso-table-lspace: 0pt;
-  mso-table-rspace: 0pt;
+    mso-table-lspace: 0pt;
+    mso-table-rspace: 0pt;
 }
 
 table, table th, table td {
-  border-collapse: collapse;
+    border-collapse: collapse;
 }
 
 a, img, a img {
-  border: 0;
-  outline: none;
-  text-decoration: none;
+    border: 0;
+    outline: none;
+    text-decoration: none;
 }
 
 img {
-  -ms-interpolation-mode: bicubic;
+    -ms-interpolation-mode: bicubic;
 }
 
 body, table, td, th, p, a, li {
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
+    -ms-text-size-adjust: 100%;
+    -webkit-text-size-adjust: 100%;
 }
 
 @media only screen and (max-width: 760px) {
-  .w-750 {
-    width: 100%;
-  }
+    .w-mail {
+        width: 90%;
+    }
+    .content .spacing {
+        padding: 40px 0;
+    }
 }
-
-/*# sourceMappingURL=mail.css.map */

--- a/components/ILIAS/UI/src/templates/default/Layout/tpl.mailpage.html
+++ b/components/ILIAS/UI/src/templates/default/Layout/tpl.mailpage.html
@@ -1,10 +1,16 @@
+<!--
+ATTENTION!
+This file belongs to the new ‘UI/Layout/Page/Mail’ component.
+This will be used to generate emails starting with ILIAS 12 and currently does NOT affect the layout of emails.
+-->
+
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 
 <html xmlns="http://www.w3.org/1999/xhtml">
 
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-	<meta name="viewport" content="width=device-width"/>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+    <meta name="viewport" content="width=device-width"/>
     <style>
         {CSS_CONTENT}
     </style>
@@ -15,55 +21,51 @@
 <!--full mail-template-->
 <table class="table">
 
-	<!--header-row-->
-	<tr class="header">
-		<td class="spacing">
-			<table class="w-750 center">
-				<tr class="rowheight"></tr>
-				<tr>
-					<td class="image-data">
-						<img class="logo" src="{LOGO_SRC}" alt="Logo">
-					</td>
-					<td class="installation-text">
+    <!--header-row-->
+    <tr class="header">
+        <td class="spacing">
+            <table class="w-mail center">
+                <tr>
+                    <td class="image-data">
+                        <img class="logo" src="{LOGO_SRC}" alt="">
+                    </td>
+                    <td class="installation-text">
 						<span>
 							<strong>{INSTALLATION_TITLE}</strong>
 						</span>
-					</td>
-				</tr>
-				<tr class="rowheight"></tr>
-			</table>
-		</td>
-	</tr>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
 
-	<!--content-row-->
-	<tr class="content">
-		<td class="spacing">
-			<table class="w-750 center">
-				<tr class="headerheight"></tr>
-				<tr>
-					<td class="font-definition">
-						{CONTENT}
-					</td>
-				</tr>
-				<tr class="headerheight"></tr>
-			</table>
-		</td>
-	</tr>
+    <!--content-row-->
+    <tr class="content">
+        <td class="spacing">
+            <table class="w-mail center">
+                <tr>
+                    <td class="font-definition">
+                        {CONTENT}
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
 
-	<!--footer-row-->
-	<tr class="footer">
-		<td class="spacing">
-			<table class="w-750 center">
-				<tr>
-					<td class="font-definition">
-						<span>{INSTALLATION_TITLE}</span>
-						<br>
-						{FOOTER_URL}
-					</td>
-				</tr>
-			</table>
-		</td>
-	</tr>
+    <!--footer-row-->
+    <tr class="footer">
+        <td class="spacing">
+            <table class="w-mail center">
+                <tr>
+                    <td class="font-definition">
+                        <span>{INSTALLATION_TITLE}</span>
+                        <br>
+                        {FOOTER_URL}
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
 </table>
 
 </body>


### PR DESCRIPTION
This PR removes unused HTML tags and CSS classes from the mail-page UI component.
A comment in `tpl.mailpage.html` ensures that the creation process for skins is understandable.

For the UI documentation, the CSS in `mail_examples.css` was copied from `mail.css` (see PR 1/2).

This PR belongs to:
https://github.com/ILIAS-eLearning/ILIAS/pull/11026

If approved, please pick this to [trunk](https://github.com/ILIAS-eLearning/ILIAS/tree/trunk).