### PR TITLE
[FIX] compatibility between ilObject and Metadata-call

### DIFF
--- a/components/ILIAS/ILIASObject/classes/class.ilObject.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObject.php
@@ -709,7 +709,7 @@ class ilObject
             $this->lom_services->derive()->fromBasicProperties(
                 $this->getTitle(),
                 $this->getLongDescription(),
-                $ilUser->getPref('language')
+                $ilUser->getPref('language') ?? ''
             )->forObject($this->getId(), 0, $this->getType());
 
             $this->doCreateMetaData();


### PR DESCRIPTION
`fromBasicProperties` needs a string for language, `getPref` may return null. 