### PR TITLE
[FIX] 046534: Failed test: Vorschau anzeigen über Reiter Info

### DIFF
--- a/components/ILIAS/UI/src/templates/default/Modal/tpl.lightbox.html
+++ b/components/ILIAS/UI/src/templates/default/Modal/tpl.lightbox.html
@@ -31,11 +31,11 @@
 					</div>
 
 					<!-- BEGIN controls -->
-					<button class="left carousel-control btn-link" href="#{ID_CAROUSEL3}" role="button" data-slide="prev">
+					<button class="left carousel-control btn-link" href="#{ID_CAROUSEL3}" role="button" type="button" data-slide="prev">
 						<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
 						<span class="sr-only">Previous</span>
 					</button>
-					<button class="right carousel-control btn-link" href="#{ID_CAROUSEL3}" role="button" data-slide="next">
+					<button class="right carousel-control btn-link" href="#{ID_CAROUSEL3}" role="button" type="button" data-slide="next">
 						<span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
 						<span class="sr-only">Next</span>
 					</button>

--- a/components/ILIAS/UI/tests/Component/Modal/LightboxTest.php
+++ b/components/ILIAS/UI/tests/Component/Modal/LightboxTest.php
@@ -183,11 +183,11 @@ EOT;
 						</div>
 					</div>
 
-					<button class="left carousel-control btn-link" href="#id_1_carousel" role="button" data-slide="prev">
+					<button class="left carousel-control btn-link" href="#id_1_carousel" role="button" type="button" data-slide="prev">
 						<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
 						<span class="sr-only">Previous</span>
 					</button>
-					<button class="right carousel-control btn-link" href="#id_1_carousel" role="button" data-slide="next">
+					<button class="right carousel-control btn-link" href="#id_1_carousel" role="button" type="button" data-slide="next">
 						<span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
 						<span class="sr-only">Next</span>
 					</button>


### PR DESCRIPTION
The left/right buttons in a lighbox modal trigger surrounding forms (e.g. the InfoPage is a form, for whatever reason...). this fixes https://mantis.ilias.de/view.php?id=46534