### PR TITLE
fix stacking context for dropdown menus from #0045874

### DIFF
--- a/templates/default/070-components/UI-framework/Layout/_ui-component_standardpage.scss
+++ b/templates/default/070-components/UI-framework/Layout/_ui-component_standardpage.scss
@@ -174,6 +174,7 @@ main {
 	#mainspacekeeper {
 	    flex-grow: 1; // stretches content from top to footer
     	width: 100%;
+      z-index: 1; // fixes #0045874
 	}
 }
 #il_center_col {


### PR DESCRIPTION
Fix Dropdown z-index / stacking context underlying button elements in footer. 

Adding a z-index of 1 to #mainspacekeeper sets the stacking context of all its elements higher than the footer, which is its sibling.

Fixes Mantis Bug #0045874