### PR TITLE
Order migration steps by last_update since migrations on large installations can take a long time

### DIFF
--- a/components/ILIAS/MediaObjects/classes/Setup/class.ilMobMigration.php
+++ b/components/ILIAS/MediaObjects/classes/Setup/class.ilMobMigration.php
@@ -52,7 +52,7 @@ class ilMobMigration implements Migration
     public function step(Environment $environment): void
     {
         $r = $this->helper->getDatabase()->query(
-            "SELECT * FROM object_data od LEFT JOIN mob_data md ON (od.obj_id = md.id) WHERE od.type='mob' AND (rid='' OR rid IS NULL) LIMIT 1;"
+            "SELECT * FROM object_data od LEFT JOIN mob_data md ON (od.obj_id = md.id) WHERE od.type='mob' AND (rid='' OR rid IS NULL) ORDER BY od.last_update DESC LIMIT 1;"
         );
 
         $d = $this->helper->getDatabase()->fetchObject($r);


### PR DESCRIPTION
With ~150,000 media object migrations on NFS, the migration can take several days. This change processes the most recently updated objects first, allowing older objects to be migrated later.