### PR TITLE
Fix some issues due to fractional points in objective driven courses

### DIFF
--- a/components/ILIAS/Course/classes/Objectives/Setup/ilCourseObjectiveDBUpdateSteps.php
+++ b/components/ILIAS/Course/classes/Objectives/Setup/ilCourseObjectiveDBUpdateSteps.php
@@ -55,4 +55,18 @@ class ilCourseObjectiveDBUpdateSteps implements ilDatabaseUpdateSteps
             ]);
         }
     }
+
+    public function step_4(): void
+    {
+        if (
+            $this->db->tableExists('loc_tst_run') &&
+            $this->db->tableColumnExists('loc_tst_run', 'max_points')
+        ) {
+            $this->db->modifyTableColumn('loc_tst_run', 'max_points', [
+                    'type' => 'float',
+                    'notnull' => false,
+                    'default' => 0
+            ]);
+        }
+    }
 }

--- a/components/ILIAS/Course/classes/Objectives/class.ilCourseObjectiveQuestion.php
+++ b/components/ILIAS/Course/classes/Objectives/class.ilCourseObjectiveQuestion.php
@@ -339,7 +339,7 @@ class ilCourseObjectiveQuestion
         return $self;
     }
 
-    public function getSelfAssessmentPoints(): int
+    public function getSelfAssessmentPoints(): float
     {
         $points = 0;
         foreach ($this->getSelfAssessmentQuestions() as $question) {
@@ -348,7 +348,7 @@ class ilCourseObjectiveQuestion
         return $points;
     }
 
-    public function getFinalTestPoints(): int
+    public function getFinalTestPoints(): float
     {
         $points = 0;
         foreach ($this->getFinalTestQuestions() as $question) {
@@ -443,7 +443,7 @@ class ilCourseObjectiveQuestion
         return $this->question_id;
     }
 
-    public function getMaxPointsByObjective(): int
+    public function getMaxPointsByObjective(): float
     {
         $points = 0;
         foreach ($this->getQuestions() as $question) {
@@ -454,7 +454,7 @@ class ilCourseObjectiveQuestion
         return $points;
     }
 
-    public function getMaxPointsByTest(int $a_test_ref_id): int
+    public function getMaxPointsByTest(int $a_test_ref_id): float
     {
         $points = 0;
         $tmp_test = ilObjectFactory::getInstanceByRefId($a_test_ref_id);

--- a/components/ILIAS/Course/classes/Objectives/class.ilLOTestQuestionAdapter.php
+++ b/components/ILIAS/Course/classes/Objectives/class.ilLOTestQuestionAdapter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.

--- a/components/ILIAS/Course/classes/Objectives/class.ilLOTestQuestionAdapter.php
+++ b/components/ILIAS/Course/classes/Objectives/class.ilLOTestQuestionAdapter.php
@@ -457,7 +457,7 @@ class ilLOTestQuestionAdapter
                 $tst_run->addQuestion($qst_id);
                 $points += ilCourseObjectiveQuestion::_lookupMaximumPointsOfQuestion($qst_id);
             }
-            $tst_run->setMaxPoints((int) $points);
+            $tst_run->setMaxPoints((float) $points);
         }
     }
 
@@ -474,7 +474,7 @@ class ilLOTestQuestionAdapter
                 $tst_run->addQuestion($id);
                 $points += ilCourseObjectiveQuestion::_lookupMaximumPointsOfQuestion($id);
             }
-            $tst_run->setMaxPoints((int) $points);
+            $tst_run->setMaxPoints((float) $points);
         }
     }
 
@@ -502,7 +502,7 @@ class ilLOTestQuestionAdapter
                     $points += ilCourseObjectiveQuestion::_lookupMaximumPointsOfQuestion($qst);
                 }
             }
-            $tst_run->setMaxPoints((int) $points);
+            $tst_run->setMaxPoints((float) $points);
         }
     }
 

--- a/components/ILIAS/Course/classes/Objectives/class.ilLOTestRun.php
+++ b/components/ILIAS/Course/classes/Objectives/class.ilLOTestRun.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.

--- a/components/ILIAS/Course/classes/Objectives/class.ilLOTestRun.php
+++ b/components/ILIAS/Course/classes/Objectives/class.ilLOTestRun.php
@@ -26,7 +26,7 @@ class ilLOTestRun
     protected int $user_id = 0;
     protected int $test_id = 0;
     protected int $objective_id = 0;
-    protected int $max_points = 0;
+    protected float $max_points = 0;
     protected array $questions = array();
 
     protected ilDBInterface $db;
@@ -142,12 +142,12 @@ class ilLOTestRun
         return $this->objective_id;
     }
 
-    public function getMaxPoints(): int
+    public function getMaxPoints(): float
     {
         return $this->max_points;
     }
 
-    public function setMaxPoints(int $a_points): void
+    public function setMaxPoints(float $a_points): void
     {
         $this->max_points = $a_points;
     }
@@ -215,7 +215,7 @@ class ilLOTestRun
             $this->db->quote($this->getUserId(), 'integer') . ', ' .
             $this->db->quote($this->getTestId(), 'integer') . ', ' .
             $this->db->quote($this->getObjectiveId(), 'integer') . ', ' .
-            $this->db->quote($this->getMaxPoints(), 'integer') . ', ' .
+            $this->db->quote($this->getMaxPoints(), 'float') . ', ' .
             $this->db->quote(serialize($this->getQuestions()), 'text') . ' ' .
             ')';
         $this->db->manipulate($query);
@@ -224,7 +224,7 @@ class ilLOTestRun
     public function update(): void
     {
         $query = 'UPDATE loc_tst_run SET ' .
-            'max_points = ' . $this->db->quote($this->getMaxPoints(), 'integer') . ', ' .
+            'max_points = ' . $this->db->quote($this->getMaxPoints(), 'float') . ', ' .
             'questions = ' . $this->db->quote(serialize($this->getQuestions()), 'text') . ' ' .
             'WHERE container_id = ' . $this->db->quote($this->container_id, 'integer') . ' ' .
             'AND user_id = ' . $this->db->quote($this->getUserId(), 'integer') . ' ' .

--- a/components/ILIAS/Course/classes/Objectives/class.ilLOUtils.php
+++ b/components/ILIAS/Course/classes/Objectives/class.ilLOUtils.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=0);
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +16,8 @@ declare(strict_types=0);
  *
  *********************************************************************/
 
+declare(strict_types=0);
+
 /**
  * Settings for LO courses
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
@@ -30,8 +31,8 @@ class ilLOUtils
         int $a_cont_oid,
         int $a_test_rid,
         int $a_objective_id,
-        int $max_points,
-        int $reached,
+        float $max_points,
+        float $reached,
         int $limit_perc
     ): bool {
         $settings = ilLOSettings::getInstanceByObjId($a_cont_oid);
@@ -62,7 +63,7 @@ class ilLOUtils
         int $a_container_id,
         int $a_objective_id,
         int $a_test_ref_id,
-        int $a_max_points
+        float $a_max_points
     ): int {
         $settings = ilLOSettings::getInstanceByObjId($a_container_id);
         $assignments = ilLOTestAssignments::getInstance($a_container_id);


### PR DESCRIPTION
We still encounter some issues regarding fractional points in locs, like initially reported in mantis #39923
I found several places where points and max_points were casted from float to int and this pr offers potential fixes/ improvements.
The exact code line mentioned in 39923 was fixed before, but the basic problem reappeared throun testing of ilias 11.

Additionally some other mantis issues arount this topic are affected, these may be 
46906
43473
41414
but I didn't check all of them.

I added a database update, since the max_points per objective were stored as int in loc_tst_run

I successfully tested these fixes with diagnostic and final tests for all objectives containg questions with fractional point results  and fractional max_points

The pr contains some minor codestyle fixes around the copyright notice, too