### PR TITLE
Fix43788 removed aria haspopup on the control element

### DIFF
--- a/components/ILIAS/UI/src/templates/default/Input/tpl.viewcontrol_sortation.html
+++ b/components/ILIAS/UI/src/templates/default/Input/tpl.viewcontrol_sortation.html
@@ -1,5 +1,5 @@
 <div class="dropdown il-viewcontrol il-viewcontrol-sortation l-bar__element<!-- BEGIN disabled --> disabled<!-- END disabled -->"<!-- BEGIN id --> id="{ID}" <!-- END id -->>
-    <button class="btn btn-ctrl dropdown-toggle" type="button" data-toggle="dropdown"<!-- BEGIN aria_label --> aria-label="{ARIA_LABEL}"<!-- END aria_label --> aria-haspopup="true" aria-expanded="false" aria-controls="{ID_MENU}"><span class="glyphicon-sort"></span></button>
+    <button class="btn btn-ctrl dropdown-toggle" type="button" data-toggle="dropdown"<!-- BEGIN aria_label --> aria-label="{ARIA_LABEL}"<!-- END aria_label -->  aria-expanded="false" aria-controls="{ID_MENU}"><span class="glyphicon-sort"></span></button>
     
     <ul id="{ID_MENU}" class="dropdown-menu">
         <!-- BEGIN option -->

--- a/components/ILIAS/UI/src/templates/default/ViewControl/tpl.sortation.html
+++ b/components/ILIAS/UI/src/templates/default/ViewControl/tpl.sortation.html
@@ -1,5 +1,5 @@
 <div class="dropdown il-viewcontrol il-viewcontrol-sortation l-bar__element" id="{ID}">
-    <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown"<!-- BEGIN aria_label --> aria-label="{ARIA_LABEL}"<!-- END aria_label --> aria-haspopup="true" aria-expanded="false" aria-controls="{ID_MENU}"><span class="label">{LABEL}</span><span class="caret"></span></button>
+    <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown"<!-- BEGIN aria_label --> aria-label="{ARIA_LABEL}"<!-- END aria_label -->  aria-expanded="false" aria-controls="{ID_MENU}"><span class="label">{LABEL}</span><span class="caret"></span></button>
 
     <ul id="{ID_MENU}" class="dropdown-menu">
         <!-- BEGIN option -->

--- a/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlSortationTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlSortationTest.php
@@ -93,7 +93,7 @@ class ViewControlSortationTest extends ViewControlTestBase
 
         $expected = $this->brutallyTrimHTML('
 <div class="dropdown il-viewcontrol il-viewcontrol-sortation l-bar__element" id="id_3">
-    <button class="btn btn-ctrl dropdown-toggle" type="button" data-toggle="dropdown" aria-label="label_sortation" aria-haspopup="true" aria-expanded="false" aria-controls="id_3_ctrl"><span class="glyphicon-sort"></span></button>
+    <button class="btn btn-ctrl dropdown-toggle" type="button" data-toggle="dropdown" aria-label="label_sortation" aria-expanded="false" aria-controls="id_3_ctrl"><span class="glyphicon-sort"></span></button>
     <ul id="id_3_ctrl" class="dropdown-menu">
         <li><button class="btn btn-link" id="id_1">A</button></li>
         <li><button class="btn btn-link" id="id_2">B</button></li>
@@ -128,7 +128,7 @@ class ViewControlSortationTest extends ViewControlTestBase
 
         $expected = $this->brutallyTrimHTML('
 <div class="dropdown il-viewcontrol il-viewcontrol-sortation l-bar__element" id="id_3">
-    <button class="btn btn-ctrl dropdown-toggle" type="button" data-toggle="dropdown" aria-label="label_sortation" aria-haspopup="true" aria-expanded="false" aria-controls="id_3_ctrl"><span class="glyphicon-sort"></span></button>
+    <button class="btn btn-ctrl dropdown-toggle" type="button" data-toggle="dropdown" aria-label="label_sortation" aria-expanded="false" aria-controls="id_3_ctrl"><span class="glyphicon-sort"></span></button>
     <ul id="id_3_ctrl" class="dropdown-menu">
         <li><button class="btn btn-link" id="id_1">A</button></li>
         <li><button class="btn btn-link" id="id_2">B</button></li>

--- a/components/ILIAS/UI/tests/Component/Panel/PanelSecondaryLegacyTest.php
+++ b/components/ILIAS/UI/tests/Component/Panel/PanelSecondaryLegacyTest.php
@@ -233,7 +233,7 @@ EOT;
         <div class="panel-title"><h2>Title</h2></div>
         <div class="panel-viewcontrols l-bar__space-keeper">
             <div class="dropdown il-viewcontrol il-viewcontrol-sortation l-bar__element" id="id_1">
-                <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="sortation" aria-haspopup="true" aria-expanded="false" aria-controls="id_1_ctrl">
+                <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="sortation" aria-expanded="false" aria-controls="id_1_ctrl">
                     <span class="label">vc_sort B</span>
                     <span class="caret"></span>
                 </button>

--- a/components/ILIAS/UI/tests/Component/Panel/PanelSecondaryLegacyTest.php
+++ b/components/ILIAS/UI/tests/Component/Panel/PanelSecondaryLegacyTest.php
@@ -194,7 +194,7 @@ class PanelSecondaryLegacyTest extends ILIAS_UI_TestBase
     <div class="panel-heading ilHeader">
         <div class="panel-title"><h2>Title</h2></div>
         <div class="panel-controls">
-    		<div class="dropdown" id="id_3"><button class="btn btn-default dropdown-toggle" type="button" aria-label="actions" aria-haspopup="true" aria-expanded="false" aria-controls="id_3_menu" ><span class="caret"></span></button>
+    		<div class="dropdown" id="id_3"><button class="btn btn-default dropdown-toggle" type="button" aria-label="actions" aria-expanded="false" aria-controls="id_3_menu" ><span class="caret"></span></button>
     			<ul id="id_3_menu" class="dropdown-menu">
     				<li><button class="btn btn-link" data-action="https://www.ilias.de" id="id_1">ILIAS</button></li>
     				<li><button class="btn btn-link" data-action="https://www.github.com" id="id_2">Github</button></li>

--- a/components/ILIAS/UI/tests/Component/Panel/PanelSecondaryLegacyTest.php
+++ b/components/ILIAS/UI/tests/Component/Panel/PanelSecondaryLegacyTest.php
@@ -194,7 +194,7 @@ class PanelSecondaryLegacyTest extends ILIAS_UI_TestBase
     <div class="panel-heading ilHeader">
         <div class="panel-title"><h2>Title</h2></div>
         <div class="panel-controls">
-    		<div class="dropdown" id="id_3"><button class="btn btn-default dropdown-toggle" type="button" aria-label="actions" aria-expanded="false" aria-controls="id_3_menu" ><span class="caret"></span></button>
+    		<div class="dropdown" id="id_3"><button class="btn btn-default dropdown-toggle" type="button" aria-label="actions" aria-haspopup="true" aria-expanded="false" aria-controls="id_3_menu" ><span class="caret"></span></button>
     			<ul id="id_3_menu" class="dropdown-menu">
     				<li><button class="btn btn-link" data-action="https://www.ilias.de" id="id_1">ILIAS</button></li>
     				<li><button class="btn btn-link" data-action="https://www.github.com" id="id_2">Github</button></li>

--- a/components/ILIAS/UI/tests/Component/Panel/PanelSecondaryListingTest.php
+++ b/components/ILIAS/UI/tests/Component/Panel/PanelSecondaryListingTest.php
@@ -190,7 +190,7 @@ EOT;
         <div class="panel-title"><h2>Title</h2></div>
         <div class="panel-viewcontrols  l-bar__space-keeper">
             <div class="dropdown il-viewcontrol  il-viewcontrol-sortation l-bar__element" id="id_1">
-                <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="sortation" aria-haspopup="true" aria-expanded="false" aria-controls="id_1_ctrl">
+                <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="sortation" aria-expanded="false" aria-controls="id_1_ctrl">
                     <span class="label">vc_sort A</span>
                     <span class="caret"></span>
                 </button>

--- a/components/ILIAS/UI/tests/Component/Panel/PanelTest.php
+++ b/components/ILIAS/UI/tests/Component/Panel/PanelTest.php
@@ -475,7 +475,7 @@ EOT;
         <div class="panel-title"><h2>Title</h2></div>
         <div class="panel-viewcontrols l-bar__space-keeper">
             <div class="dropdown il-viewcontrol il-viewcontrol-sortation l-bar__element" id="id_1">
-                <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="sortation" aria-haspopup="true" aria-expanded="false" aria-controls="id_1_ctrl">
+                <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="sortation" aria-expanded="false" aria-controls="id_1_ctrl">
                     <span class="label">vc_sort B</span>
                     <span class="caret"></span>
                 </button>

--- a/components/ILIAS/UI/tests/Component/ViewControl/SortationTest.php
+++ b/components/ILIAS/UI/tests/Component/ViewControl/SortationTest.php
@@ -84,7 +84,7 @@ class SortationTest extends ILIAS_UI_TestBase
 
         $expected = <<<EOT
 <div class="dropdown il-viewcontrol il-viewcontrol-sortation l-bar__element" id="id_1">
-    <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="sortation" aria-haspopup="true" aria-expanded="false" aria-controls="id_1_ctrl">
+    <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="sortation" aria-expanded="false" aria-controls="id_1_ctrl">
         <span class="label">vc_sort Most Recent</span>
         <span class="caret"></span>
     </button>
@@ -108,7 +108,7 @@ EOT;
 
         $expected = <<<EOT
 <div class="dropdown il-viewcontrol il-viewcontrol-sortation l-bar__element" id="id_1">
-    <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="sortation" aria-haspopup="true" aria-expanded="false" aria-controls="id_1_ctrl">
+    <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="sortation" aria-expanded="false" aria-controls="id_1_ctrl">
         <span class="label">vc_sort Most Recent</span>
         <span class="caret"></span>
     </button>
@@ -144,7 +144,7 @@ EOT;
 
         $expected = <<<EOT
 <div class="dropdown il-viewcontrol il-viewcontrol-sortation l-bar__element"$id>
-    <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="sortation" aria-haspopup="true" aria-expanded="false" aria-controls="{$id_ctrl}">
+    <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="sortation" aria-expanded="false" aria-controls="{$id_ctrl}">
         <span class="label">vc_sort Best</span>
         <span class="caret"></span>
     </button>


### PR DESCRIPTION


aria-haspopup on the control element “Sort test results” is unfavorable
it is noted for the area of the button for sorting test results that the aria-haspopup attribute on the control element is unfavorable, since according to the specification it may only be used for certain types (or roles) of inserted elements (menu, listbox, tree, grid or dialog). It should therefore be removed, as users may otherwise expect a different type of operation.

https://mantis.ilias.de/view.php?id=43788
