### PR TITLE
[Improvement] Legacy Form: Add setDisabled for ContainerInputs

### DIFF
--- a/components/ILIAS/Form/classes/class.ilCombinationInputGUI.php
+++ b/components/ILIAS/Form/classes/class.ilCombinationInputGUI.php
@@ -270,4 +270,13 @@ class ilCombinationInputGUI extends ilSubEnabledFormPropertyGUI implements ilTab
         $html = $this->render();
         return $html;
     }
+
+    public function setDisabled(bool $a_disabled): void
+    {
+        parent::setDisabled($a_disabled);
+        foreach ($this->items as $item) {
+            $item->setDisabled($a_disabled);
+        }
+    }
+
 }

--- a/components/ILIAS/Form/classes/class.ilRadioGroupInputGUI.php
+++ b/components/ILIAS/Form/classes/class.ilRadioGroupInputGUI.php
@@ -230,4 +230,13 @@ class ilRadioGroupInputGUI extends ilSubEnabledFormPropertyGUI implements ilTabl
     {
         return "";
     }
+
+    public function setDisabled(bool $a_disabled): void
+    {
+        parent::setDisabled($a_disabled);
+        foreach ($this->getOptions() as $option) {
+            $option->setDisabled($a_disabled);
+        }
+    }
+
 }

--- a/components/ILIAS/Form/classes/class.ilRadioOption.php
+++ b/components/ILIAS/Form/classes/class.ilRadioOption.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
  * @author Alexander Killing <killing@leifos.de>
  * @deprecated 12 This component will be removed with ILIAS 12
  */
-class ilRadioOption
+class ilRadioOption extends ilSubEnabledFormPropertyGUI
 {
     protected string $title = "";
     protected string $value = "";
@@ -70,16 +70,6 @@ class ilRadioOption
     public function getValue(): string
     {
         return $this->value;
-    }
-
-    public function setDisabled(bool $a_disabled): void
-    {
-        $this->disabled = $a_disabled;
-    }
-
-    public function getDisabled(): bool
-    {
-        return $this->disabled;
     }
 
     /**

--- a/components/ILIAS/Form/classes/class.ilSubEnabledFormPropertyGUI.php
+++ b/components/ILIAS/Form/classes/class.ilSubEnabledFormPropertyGUI.php
@@ -106,4 +106,12 @@ class ilSubEnabledFormPropertyGUI extends ilFormPropertyGUI
 
         return null;
     }
+
+    public function setDisabled(bool $a_disabled): void
+    {
+        parent::setDisabled($a_disabled);
+        foreach ($this->getSubItems() as $sub_item) {
+            $sub_item->setDisabled($a_disabled);
+        }
+    }
 }

--- a/components/ILIAS/Form/classes/class.ilTextInputGUI.php
+++ b/components/ILIAS/Form/classes/class.ilTextInputGUI.php
@@ -29,7 +29,7 @@ class ilTextInputGUI extends ilSubEnabledFormPropertyGUI implements ilTableFilte
     /**
      * @var string|array
      */
-    protected $value = null;
+    protected $value = '';
     protected ?int $maxlength = 200;
     protected int $size = 40;
     protected string $validationRegexp = "";


### PR DESCRIPTION
This PR adds setDisabled override to ContainerInputs because either Sub-Elements or Options (RadioInput) aren't disabled if the Input itself ist set to disabled