### PR TITLE
Fix LTI auth_mode inconsistency between user creation and UI

### DIFF
--- a/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilAuthProviderLTI.php
+++ b/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilAuthProviderLTI.php
@@ -101,14 +101,14 @@ class ilAuthProviderLTI extends \ilAuthProvider implements \ilAuthProviderInterf
     {
         global $ilDB;
 
-        // move to connector
+        // Use ext_consumer_id to align with user creation logic
         $query = /** @lang text */
-            'SELECT distinct(consumer_pk) consumer_pk from lti2_consumer';
+            'SELECT DISTINCT(ext_consumer_id) ext_consumer_id FROM lti2_consumer WHERE ext_consumer_id IS NOT NULL';
         $res = $ilDB->query($query);
 
         $sids = array();
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            $sids[] = $row->consumer_pk;
+            $sids[] = $row->ext_consumer_id;
         }
         return $sids;
     }
@@ -120,9 +120,16 @@ class ilAuthProviderLTI extends \ilAuthProvider implements \ilAuthProviderInterf
      */
     public static function lookupConsumer(int $a_sid): string
     {
-        $connector = new ilLTIDataConnector();
-        $consumer = ilLTIPlatform::fromRecordId($a_sid, $connector);
-        return $consumer->getTitle();
+        global $ilDB;
+
+        // Look up provider title directly from lti_ext_consumer table
+        $query = 'SELECT title FROM lti_ext_consumer WHERE id = %s';
+        $res = $ilDB->queryF($query, ['integer'], [$a_sid]);
+
+        if ($row = $ilDB->fetchObject($res)) {
+            return $row->title;
+        }
+        return 'Unknown Provider';
     }
 
     /**


### PR DESCRIPTION
**Summary**
Fixes LTI auth_mode design inconsistency where user creation and UI use different database fields, causing orphaned
auth_modes and incorrect provider labels.

Mantis: https://mantis.ilias.de/view.php?id=47138

**Problem**
The codebase has inconsistent interpretation of what auth_mode represents:

User creation: uses ext_consumer_id (global provider)
UI dropdown: uses consumer_pk (course-level connection ID)
When admins delete a global LTI provider, course connections are removed (creating gaps in consumer_pk sequence), but remaining connections still assign auth_modes based on ext_consumer_id. This causes:

Users with auth_modes not in dropdown
Incorrect provider labels (shows wrong provider name)
Saving affected users corrupts their auth_mode → breaks LTI login
Solution
Make the code consistent by using ext_consumer_id throughout:

getAuthModes(): Query ext_consumer_id instead of consumer_pk
lookupConsumer(): Look up provider in lti_ext_consumer table directly
This aligns auth_mode with its semantic meaning: "which provider authenticates this user" (analogous to auth_mode=ldap),
not "which course-connection was used".

**Changes**
getAuthModes(): Changed query to use ext_consumer_id
lookupConsumer(): Look up directly in lti_ext_consumer table instead of through ilLTIPlatform::fromRecordId()
Testing
Tested with reproduction scenario from mantis ticket. Users created via LTI now have auth_modes that correctly appear in
dropdown, even after provider deletion.

**Backward Compatibility**
Safe for existing users: user creation always used ext_consumer_id, so all existing users already have correct auth_mode
values. Only users previously corrupted by manual edits are affected (already broken).