### PR TITLE
[FIX] #47056 UI: Removes hyphens css property from mainbar tiles

### DIFF
--- a/templates/default/070-components/UI-framework/MainControls/_ui-component_mainbar.scss
+++ b/templates/default/070-components/UI-framework/MainControls/_ui-component_mainbar.scss
@@ -80,10 +80,10 @@ $il-slate-bulky-link-padding: $il-slate-bulky-padding-vertical $il-padding-base-
 		.bulky-label {
 			@include t-line-cap.il-multi-line-cap-mixin(2);
 			word-break: break-word;
-			-ms-hyphens: auto;
-			-moz-hyphens: auto;
-			-webkit-hyphens: auto;
-			hyphens: auto;
+			-ms-hyphens: manual;
+			-moz-hyphens: manual;
+			-webkit-hyphens: manual;
+			hyphens: manual;
 		}
 	}
 }

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -6197,10 +6197,10 @@ a[aria-disabled].il-link.link-bulky:hover {
   /* edge, chrome, safari go here... */
   /* may come with next firefox 68, https://caniuse.com/#search=clamp */
   word-break: break-word;
-  -ms-hyphens: auto;
-  -moz-hyphens: auto;
-  -webkit-hyphens: auto;
-  hyphens: auto;
+  -ms-hyphens: manual;
+  -moz-hyphens: manual;
+  -webkit-hyphens: manual;
+  hyphens: manual;
 }
 .il-mainbar-triggers .btn-bulky .bulky-label,
 .il-mainbar-triggers .il-link.link-bulky .bulky-label,


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=47056

Aims to remvoe hyphens css property from page layout.
@oliversamoila  @thojou 