### PR TITLE
[FIX] #44560 UI: Removes display none when auto save message fades out

### DIFF
--- a/components/ILIAS/Test/resources/ilTestPlayerQuestionEditControl.js
+++ b/components/ILIAS/Test/resources/ilTestPlayerQuestionEditControl.js
@@ -376,9 +376,11 @@ il.TestPlayerQuestionEditControl = new function() {
      * @param jqXHR
      */
     function detectBackgroundChangesFailure(jqXHR) {
-        $('#autosavemessage').text(jqXHR.responseText)
-            .fadeIn(500, function(){
-                $('#autosavemessage').fadeOut(5000)
+        $('#autosavemessage').removeClass('sr-only').text(jqXHR.responseText)
+            .fadeTo(500, 1, function(){
+                $(this).fadeTo(5000, 0, function(){
+                    $(this).removeAttr('style').addClass('sr-only');
+                });
             });
     }
 
@@ -708,9 +710,11 @@ il.TestPlayerQuestionEditControl = new function() {
      */
     function autoSaveSuccess(responseText) {
         if (typeof responseText !== 'undefined' && responseText != '-IGNORE-') {
-            $('#autosavemessage').text(responseText)
-                .fadeIn(500, function(){
-                    $('#autosavemessage').fadeOut(5000)
+            $('#autosavemessage').removeClass('sr-only').text(responseText)
+                .fadeTo(500, 1, function(){
+                    $(this).fadeTo(5000, 0, function(){
+                        $(this).removeAttr('style').addClass('sr-only');
+                    });
             });
         }
     }
@@ -725,9 +729,11 @@ il.TestPlayerQuestionEditControl = new function() {
         responseText = jqXHR.responseText ;
       }
 
-      $('#autosavemessage').text(responseText)
-        .fadeIn(500, function(){
-            $('#autosavemessage').fadeOut(5000);
+      $('#autosavemessage').removeClass('sr-only').text(responseText)
+        .fadeTo(500, 1, function(){
+            $(this).fadeTo(5000, 0, function(){
+                $(this).removeAttr('style').addClass('sr-only');
+            });
       });
       autoSavedData = '';
     }

--- a/components/ILIAS/Test/templates/default/tpl.il_as_tst_output.html
+++ b/components/ILIAS/Test/templates/default/tpl.il_as_tst_output.html
@@ -97,4 +97,4 @@
 	<!-- BEGIN nav_while_edit_modal -->{NAV_WHILE_EDIT_MODAL}<!-- END nav_while_edit_modal -->
 	</div>
 </div>
-<div id="autosavemessage" class="tstAutosaveMsg alert alert-info"></div>
+<div id="autosavemessage" role="status" aria-live="polite" class="tstAutosaveMsg alert alert-info"></div>


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=44560

Aims to remove display none when auto save message fades out.
@oliversamoila  @thojou 