### PR TITLE
Mantis #47166: Fix SOAP ilSoapTestAdministration Fatal error caused by wrong dependency name in class constructor (ILIAS 10)

### DIFF
--- a/components/ILIAS/soap/classes/class.ilSoapTestAdministration.php
+++ b/components/ILIAS/soap/classes/class.ilSoapTestAdministration.php
@@ -31,7 +31,7 @@ class ilSoapTestAdministration extends ilSoapAdministration
     private GeneralQuestionPropertiesRepository $questionrepository;
     public function __construct(bool $use_nusoap = true)
     {
-        $this->questionrepository = TestDIC::dic()['general_question_properties_repository'];
+        $this->questionrepository = TestDIC::dic()['question.general_properties.repository'];
         parent::__construct($use_nusoap);
     }
     private function hasWritePermissionForTest(int $active_id): bool


### PR DESCRIPTION
This PR addresses the issue outlined in Mantis ticket [#47166](https://mantis.ilias.de/view.php?id=47166), where a SOAP request to the getTestResults or removeTestResults endpoints was returning a SOAP-ENV:Server error due to _"Identifier &quot;general_question_properties_repository&quot; is not defined."_ error.

The issue was discovered during investigations of another issue [#46556](https://mantis.ilias.de/view.php?id=46556). So testing steps should be the same.