### PR TITLE
Mantis #47166: Fix SOAP ilSoapTestAdministration Fatal error caused by wrong dependency name in class constructor (ILIAS 11)

### DIFF
--- a/components/ILIAS/soap/classes/class.ilSoapTestAdministration.php
+++ b/components/ILIAS/soap/classes/class.ilSoapTestAdministration.php
@@ -31,7 +31,7 @@ class ilSoapTestAdministration extends ilSoapAdministration
     private GeneralQuestionPropertiesRepository $questionrepository;
     public function __construct(bool $use_nusoap = true)
     {
-        $this->questionrepository = TestDIC::dic()['general_question_properties_repository'];
+        $this->questionrepository = TestDIC::dic()['question.general_properties.repository'];
         parent::__construct($use_nusoap);
     }
     private function hasWritePermissionForTest(int $active_id): bool


### PR DESCRIPTION
Sister PR https://github.com/ILIAS-eLearning/ILIAS/pull/11079