### PR TITLE
OrgUnit: fix saving of datetime custom md fields (46458)

### DIFF
--- a/components/ILIAS/OrgUnit/classes/class.ilObjOrgUnitGUI.php
+++ b/components/ILIAS/OrgUnit/classes/class.ilObjOrgUnitGUI.php
@@ -709,8 +709,9 @@ class ilObjOrgUnitGUI extends ilContainerGUI
             $this->object->getOrgUnitTypeId()
         );
         $gui->setPropertyForm($form);
-        $form->checkInput();
         $gui->parse();
+
+        $form->checkInput();
         if ($gui->importEditFormPostValues()) {
             $gui->writeEditForm();
             $this->tpl->setOnScreenMessage('success', $this->lng->txt('settings_saved'), true);


### PR DESCRIPTION
Hi @maalers , this PR fixes a small issue in OrgUnits with filling out the custom metadata for individual units, see [46458](https://mantis.ilias.de/view.php?id=46458).

I'm not quite sure why, but calling `ilPropertyFormGUI::checkInput` before adding input fields to the form (which happens here in `ilAdvancedMDRecordGUI::parse`) leads to datetime inputs not saving properly. Moving `ilPropertyFormGUI::checkInput` a few lines down makes it work.

Cheers, Tim
