### PR TITLE
[LSO][FIX] Learning Sequence import from older ILIAS versions without position attribute

### DIFF
--- a/components/ILIAS/Export/xml/SchemaValidation/ilias_lso_9_0.xsd
+++ b/components/ILIAS/Export/xml/SchemaValidation/ilias_lso_9_0.xsd
@@ -39,7 +39,7 @@
     </xs:sequence>
     <xs:attribute name="obj_id" type="xs:string" use="required"/>
     <xs:attribute name="ref_id" type="xs:string" use="required"/>
-    <xs:attribute name="position" type="xs:string" use="required"/>
+    <xs:attribute name="position" type="xs:string" use="optional"/>
   </xs:complexType>
 
   <xs:complexType name="Condition">

--- a/components/ILIAS/LearningSequence/classes/Export/class.ilLearningSequenceXMLParser.php
+++ b/components/ILIAS/LearningSequence/classes/Export/class.ilLearningSequenceXMLParser.php
@@ -104,7 +104,9 @@ class ilLearningSequenceXMLParser extends ilSaxParser
             case Writer::TAG_LSITEM:
                 $this->counter = (int) $attributes["ref_id"];
                 $this->ls_item_data[$this->counter]["ref_id"] = $attributes["ref_id"];
-                $this->ls_item_data[$this->counter]["position"] = $attributes["position"];
+                if (isset($attributes["position"])) {
+                    $this->ls_item_data[$this->counter]["position"] = $attributes["position"];
+                }
                 break;
 
             case Writer::TAG_CONDITION:

--- a/components/ILIAS/LearningSequence/classes/class.ilLearningSequenceImporter.php
+++ b/components/ILIAS/LearningSequence/classes/class.ilLearningSequenceImporter.php
@@ -121,7 +121,9 @@ class ilLearningSequenceImporter extends ilXmlImporter
                     $item_data["condition_value"]
                 );
                 $item = $item->withPostCondition($post_condition);
-                $item = $item->withOrderNumber((int) $item_data["position"]);
+                if (isset($item_data["position"])) {
+                    $item = $item->withOrderNumber((int) $item_data["position"]);
+                }
                 $updated[] = $item;
             }
         }


### PR DESCRIPTION

XSD Schema Update: Changed the position attribute of the LSItem element from required to optional in ilias_lso_9_0.xsd. This ensures that XML files from older versions pass the schema validation.

• Robust XML Parsing: Updated ilLearningSequenceXMLParser to check for the existence of the position attribute before attempting to store it in the internal data array.
• Safe Importing: Modified ilLearningSequenceImporter to only apply the item order number if the position data is actually available in the imported set. If missing, the default sorting of the system is used.