### PR TITLE
[Fix] 0047164 Init: Double lang_key because regex is wrong

### DIFF
--- a/components/ILIAS/Init/classes/Provider/StartUpMetaBarProvider.php
+++ b/components/ILIAS/Init/classes/Provider/StartUpMetaBarProvider.php
@@ -146,6 +146,6 @@ class StartUpMetaBarProvider extends AbstractStaticMetaBarProvider
     {
         $base = substr($uri->__toString(), strrpos($uri->__toString(), '/') + 1);
 
-        return rtrim(preg_replace('/([&?])lang=[a-z]{2}([&$])/', '$1', $base), '?&');
+        return rtrim(preg_replace('/([&?])lang=[a-z]{2}(&|$)/', '$1', $base), '?&');
     }
 }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=47164