### PR TITLE
SystemFolder: Fix missing "ref_id" when redirecting in `_goto`

### DIFF
--- a/components/ILIAS/Administration/classes/SystemFolder/class.ilObjSystemFolderGUI.php
+++ b/components/ILIAS/Administration/classes/SystemFolder/class.ilObjSystemFolderGUI.php
@@ -44,9 +44,11 @@ class ilObjSystemFolderGUI extends ilObject2GUI
         $this->tpl->setOnScreenMessage(GlobalTemplate::MESSAGE_TYPE_INFO, $this->lng->txt('system_folder_info'));
     }
 
-    public static function _goto(): void
+    public static function _goto(string $target): void
     {
         global $DIC;
+
+        $DIC->ctrl()->setParameterByClass(self::class, 'ref_id', (int) $target);
         $DIC->ctrl()->redirectByClass([ilAdministrationGUI::class, self::class]);
     }
 }


### PR DESCRIPTION
The "ref_id" is missing in the HTTP redirect initiated in `\ilObjSystemFolderGUI::_goto` if the request looks like: **https://my.ilias.de/go/adm/9**

If approved, please pick this to `trunk`.