### PR TITLE
SystemFolder: Fix missing "ref_id" when redirecting in `_goto`

### DIFF
--- a/components/ILIAS/Administration/classes/SystemFolder/class.ilObjSystemFolderGUI.php
+++ b/components/ILIAS/Administration/classes/SystemFolder/class.ilObjSystemFolderGUI.php
@@ -44,9 +44,11 @@ class ilObjSystemFolderGUI extends ilObject2GUI
         $this->tpl->setOnScreenMessage(GlobalTemplate::MESSAGE_TYPE_INFO, $this->lng->txt('system_folder_info'));
     }
 
-    public static function _goto(): void
+    public static function _goto(string $target): void
     {
         global $DIC;
+
+        $DIC->ctrl()->setParameterByClass(self::class, 'ref_id', (int) $target);
         $DIC->ctrl()->redirectByClass([ilAdministrationGUI::class, self::class]);
     }
 }

--- a/components/ILIAS/Administration/classes/SystemFolder/class.ilObjSystemFolderGUI.php
+++ b/components/ILIAS/Administration/classes/SystemFolder/class.ilObjSystemFolderGUI.php
@@ -44,11 +44,11 @@ class ilObjSystemFolderGUI extends ilObject2GUI
         $this->tpl->setOnScreenMessage(GlobalTemplate::MESSAGE_TYPE_INFO, $this->lng->txt('system_folder_info'));
     }
 
-    public static function _goto(string $target): void
+    public static function _goto(): void
     {
         global $DIC;
 
-        $DIC->ctrl()->setParameterByClass(self::class, 'ref_id', (int) $target);
+        $DIC->ctrl()->setParameterByClass(self::class, 'ref_id', SYSTEM_FOLDER_ID);
         $DIC->ctrl()->redirectByClass([ilAdministrationGUI::class, self::class]);
     }
 }


### PR DESCRIPTION
Slightly adapted from https://github.com/ILIAS-eLearning/ILIAS/pull/11091

As there is only one system folder, its ref_id can be fixed and not taken from the request. Otherwise it would show its page with the title from the other node.