### PR TITLE
[FIX] #45695: Fix specific permission check for container link objects missing

### DIFF
--- a/components/ILIAS/Repository/classes/class.ilRepositoryExplorerGUI.php
+++ b/components/ILIAS/Repository/classes/class.ilRepositoryExplorerGUI.php
@@ -441,6 +441,10 @@ class ilRepositoryExplorerGUI extends ilTreeExplorerGUI
 
     public function isNodeClickable($a_node): bool
     {
+        if (in_array($a_node['type'], ['grpr', 'crsr', 'catr'], true)) {
+            return ilContainerReferenceAccess::_isAccessible($a_node['child']);
+        }
+
         return
             $this->access->checkAccess("read", "", (int) $a_node["child"]) ||
             $this->access->checkAccess("join", "", (int) $a_node["child"]);


### PR DESCRIPTION
Fixes https://mantis.ilias.de/view.php?id=45695

If accepted should be picked into **release_11** & **trunk**.