### PR TITLE
AccessControl: disable public access flag of export files for role exports

### DIFF
--- a/components/ILIAS/AccessControl/classes/class.ilObjRoleGUI.php
+++ b/components/ILIAS/AccessControl/classes/class.ilObjRoleGUI.php
@@ -117,8 +117,7 @@ class ilObjRoleGUI extends ilObjectGUI
                 $eo = ilExportOptions::newInstance(ilExportOptions::allocateExportId());
                 $eo->addOption(ilExportOptions::KEY_ROOT, 0, $this->object->getId(), $this->obj_ref_id);
 
-                $exp = new ilExportGUI($this, new ilObjRole($this->object->getId()));
-                $exp->addFormat('xml');
+                $exp = new ilExportGUI($this, new ilObjRole($this->object->getId()), false);
                 $this->ctrl->forwardCommand($exp);
                 break;
 


### PR DESCRIPTION
LINK: https://mantis.ilias.de/view.php?id=47177

This PR removes the public access feature in the export area of role exports.