### PR TITLE
[FIX] #46588 UI: `Input\Container\Filter\FilterInput` JavaScript binding

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Duration.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Duration.php
@@ -298,29 +298,31 @@ class Duration extends Group implements C\Input\Field\Duration
      */
     public function getUpdateOnLoadCode(): Closure
     {
-        return fn($id) => "var combinedDuration = function() {
-				var options = [];
-				$('#$id').find('input').each(function() {
-				    const value = $(this).val();
-				    if (value == '') {
-				        options.push('');
-				        return;
-				    }
-				    const date = new Date(value);
-				    var readable_value = '';
-				    if (value.includes('T')) {
-				        readable_value = date.toLocaleString([], { dateStyle: 'short', timeStyle: 'short' });
-				    } else {
-				    	readable_value = date.toLocaleDateString();
-				    }
-					options.push(readable_value);
-				});
-				return options.join(' - ');
-			}
-			$('#$id').on('input', function(event) {
-				il.UI.input.onFieldUpdate(event, '$id', combinedDuration());
-			});
-			il.UI.input.onFieldUpdate(event, '$id', combinedDuration());";
+        return static fn($id) => <<<JS
+          (function () {
+            function formatDateTimeValue(value) {
+              const date = new Date(value);
+              if (value.includes('T')) {
+                return date.toLocaleString([], { dateStyle: 'short', timeStyle: 'short' });
+              }
+              return date.toLocaleDateString();
+            }
+            function reduceDateTimeInputs(inputs) {
+              return Array
+                  .from(dateTimeInputs)
+                  .map((input) => (input.value) ? formatDateTimeValue(input.value) : '')
+                  .join(' - ');
+            }
+            const durationField = document.getElementById('$id');
+            const dateTimeInputs = durationField.querySelectorAll('.c-field-datetime');
+            dateTimeInputs.forEach((input) => {
+              input.addEventListener('input', (event) => {
+                il.UI.input.onFieldUpdate(event, '$id', reduceDateTimeInputs(dateTimeInputs));
+              });
+            });
+            il.UI.input.onFieldUpdate(undefined, '$id', reduceDateTimeInputs(dateTimeInputs));
+          })();
+JS;
     }
 
     public function withLabels(string $start_label, string $end_label): C\Input\Field\Duration

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Duration.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Duration.php
@@ -301,7 +301,19 @@ class Duration extends Group implements C\Input\Field\Duration
         return fn($id) => "var combinedDuration = function() {
 				var options = [];
 				$('#$id').find('input').each(function() {
-					options.push($(this).val());
+				    const value = $(this).val();
+				    if (value == '') {
+				        options.push('');
+				        return;
+				    }
+				    const date = new Date(value);
+				    var readable_value = '';
+				    if (value.includes('T')) {
+				        readable_value = date.toLocaleString([], { dateStyle: 'short', timeStyle: 'short' });
+				    } else {
+				    	readable_value = date.toLocaleDateString();
+				    }
+					options.push(readable_value);
 				});
 				return options.join(' - ');
 			}

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/FilterContextRenderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/FilterContextRenderer.php
@@ -148,6 +148,14 @@ class FilterContextRenderer extends Renderer
 							return false; // stop event propagation
 					});");
 
+        $tpl->setVariable("UI_COMPONENT_NAME", $this->getComponentCanonicalNameAttribute($component));
+        $tpl->setVariable("INPUT_NAME", $component->getName());
+
+        if ($component->getOnLoadCode() !== null) {
+            $binding_id = $this->bindJavaScript($component) ?? $this->createId();
+            $tpl->setVariable("BINDING_ID", $binding_id);
+        }
+
         $tpl->setCurrentBlock("addon_left");
         $tpl->setVariable("LABEL", $component->getLabel());
         if ($id_pointing_to_input) {
@@ -184,9 +192,6 @@ class FilterContextRenderer extends Renderer
         $tpl = $this->getTemplate("tpl.filter_field.html", true, true);
 
         $popover = $f->popover()->standard($f->legacy($input_html))->withVerticalPosition();
-        if ($component->getOnLoadCode() !== null) {
-            $popover = $popover->withAdditionalOnLoadCode($component->getOnLoadCode());
-        }
         $tpl->setVariable("POPOVER", $default_renderer->render($popover));
 
         $prox = new ProxyFilterField();
@@ -211,7 +216,6 @@ class FilterContextRenderer extends Renderer
         $input_html .= $default_renderer->render($input);
 
         $tpl = $this->getTemplate("tpl.duration.html", true, true);
-        $id = $this->bindJSandApplyId($component, $tpl);
         $tpl->setVariable('DURATION', $input_html);
 
         return $this->wrapInFormContext($component, $component->getLabel(), $tpl->get());

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/FilterContextRenderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/FilterContextRenderer.php
@@ -158,7 +158,7 @@ class FilterContextRenderer extends Renderer
         $tpl->parseCurrentBlock();
         $tpl->setCurrentBlock("filter_field");
         if ($component->isComplex()) {
-            $tpl->setVariable("FILTER_FIELD", $this->renderProxyField($input_html, $default_renderer));
+            $tpl->setVariable("FILTER_FIELD", $this->renderProxyField($component, $input_html, $default_renderer));
         } else {
             $tpl->setVariable("FILTER_FIELD", $input_html);
         }
@@ -176,6 +176,7 @@ class FilterContextRenderer extends Renderer
     }
 
     protected function renderProxyField(
+        FormInput $component,
         string $input_html,
         RendererInterface $default_renderer
     ): string {
@@ -183,6 +184,9 @@ class FilterContextRenderer extends Renderer
         $tpl = $this->getTemplate("tpl.filter_field.html", true, true);
 
         $popover = $f->popover()->standard($f->legacy($input_html))->withVerticalPosition();
+        if ($component->getOnLoadCode() !== null) {
+            $popover = $popover->withAdditionalOnLoadCode($component->getOnLoadCode());
+        }
         $tpl->setVariable("POPOVER", $default_renderer->render($popover));
 
         $prox = new ProxyFilterField();

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/MultiSelect.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/MultiSelect.php
@@ -96,21 +96,25 @@ class MultiSelect extends FormInput implements C\Input\Field\MultiSelect
      */
     public function getUpdateOnLoadCode(): Closure
     {
-        return fn($id) => "(function() {
-            var checkedBoxes = function() {
-				var options = [];
-				$('#$id').find('li').each(function() {
-				    if ($(this).find('input').prop('checked')) {
-					    options.push($(this).find('span').text());
-                    }
-				});
-				return options.join(', ');
-			}
-			$('#$id').on('input', function(event) {
-				il.UI.input.onFieldUpdate(event, '$id', checkedBoxes());
-			});
-			il.UI.input.onFieldUpdate(event, '$id', checkedBoxes());
-        })();";
+        return static fn($id) => <<<JS
+          (function () {
+            function reduceMultiSelectCheckboxInputs(inputs) {
+              return Array
+                .from(inputs)
+                .filter((input) => input.checked)
+                .map((input) => input.parentElement.querySelector('.c-field-multiselect__label-text')?.textContent ?? '')
+                .join(', ');
+            }
+            const multiSelectField = document.getElementById('$id');
+            const multiSelectCheckboxInputs = multiSelectField.querySelectorAll('.c-field-multiselect input[type="checkbox"]');
+            multiSelectCheckboxInputs.forEach((input) => {
+              input.addEventListener('input', (event) => {
+                il.UI.input.onFieldUpdate(event, '$id', reduceMultiSelectCheckboxInputs(multiSelectCheckboxInputs));
+              });
+            });
+            il.UI.input.onFieldUpdate(undefined, '$id', reduceMultiSelectCheckboxInputs(multiSelectCheckboxInputs));
+          })();
+JS;
     }
 
     /**

--- a/components/ILIAS/UI/src/examples/Input/Container/Filter/Standard/with_additional_on_load_code.php
+++ b/components/ILIAS/UI/src/examples/Input/Container/Filter/Standard/with_additional_on_load_code.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Input\Container\Filter\Standard;
+
+/**
+ * ---
+ * description: >
+ *   Example showing a Filter Container and Filter Inputs with additional JavaScript on-load-code
+ *   attached to them.
+ *
+ * expected output: >
+ *   ILIAS shows the rendered Filter Component with several Filter Inputs. When opening the browser
+ *   console, for each of the Filter Input, as well as the Filter Container, a log entry that refers
+ *   to their ID will be visible.
+ * ---
+ */
+function with_additional_on_load_code(): string
+{
+    global $DIC;
+
+    $factory = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    $pseudo_load_code = static fn($name) => static fn($id) => "console.log('Loaded $name with ID: ' + '$id');";
+
+    $pseudo_options = [
+        'A' => 'Option A',
+        'B' => 'Option B',
+        'C' => 'Option C',
+    ];
+
+    $filter_inputs = [
+        $factory->input()->field()->multiSelect('multi-select', $pseudo_options)->withAdditionalOnLoadCode($pseudo_load_code('multi-select')),
+        $factory->input()->field()->select('single-select', $pseudo_options)->withAdditionalOnLoadCode($pseudo_load_code('single-select')),
+        $factory->input()->field()->duration('duration')->withAdditionalOnLoadCode($pseudo_load_code('duration')),
+        $factory->input()->field()->dateTime('datetime')->withAdditionalOnLoadCode($pseudo_load_code('datetime')),
+        $factory->input()->field()->numeric('numeric')->withAdditionalOnLoadCode($pseudo_load_code('numeric')),
+        $factory->input()->field()->text('text')->withAdditionalOnLoadCode($pseudo_load_code('text')),
+    ];
+
+    $filter = $factory->input()->container()->filter()->standard(
+        '#',
+        '#',
+        '#',
+        '#',
+        '#',
+        '#',
+        $filter_inputs,
+        array_map(static fn() => true, $filter_inputs),
+        true,
+        true,
+    )->withAdditionalOnLoadCode($pseudo_load_code('filter'));
+
+    return $renderer->render($filter);
+}

--- a/components/ILIAS/UI/src/templates/default/Input/tpl.context_filter.html
+++ b/components/ILIAS/UI/src/templates/default/Input/tpl.context_filter.html
@@ -1,5 +1,5 @@
 <div class="col-md-6 col-lg-4 il-popover-container">
-    <div class="input-group">
+    <div data-il-ui-component="{UI_COMPONENT_NAME}" data-il-ui-input-name="{INPUT_NAME}"<!-- BEGIN binding --> id="{BINDING_ID}"<!-- END binding --> class="input-group">
         <!-- BEGIN addon_left -->
         <label <!-- BEGIN for -->for="{ID}" <!-- END for --> class="input-group-addon leftaddon">{LABEL}</label>
         <!-- END addon_left -->

--- a/components/ILIAS/UI/tests/Base.php
+++ b/components/ILIAS/UI/tests/Base.php
@@ -480,6 +480,11 @@ trait BaseUITestTrait
         return trim(str_replace(["\n", "\r"], "", $html));
     }
 
+    /**
+     * @deprecated please try not to use this method anymore. It relies on DOMDocument, which DOES NOT
+     *             support HTML5 and will trigger warnings for such elements and COULD add self-closing
+     *             tags ( <... />) automatically, which produces false-positives.
+     */
     public function assertHTMLEquals(string $expected_html_as_string, string $html_as_string): void
     {
         $html = new DOMDocument();

--- a/components/ILIAS/UI/tests/Component/Input/Container/Filter/FilterInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Filter/FilterInputTest.php
@@ -123,7 +123,7 @@ class FilterInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
         <div class="col-md-6 col-lg-4 il-popover-container">
-            <div class="input-group">
+            <div data-il-ui-component="text-field-input" data-il-ui-input-name="" class="input-group">
                 <label for="id_1" class="input-group-addon leftaddon">label</label>
                 <input id="id_1" type="text" class="c-field-text" />
                 <span class="input-group-addon rightaddon">
@@ -147,8 +147,7 @@ class FilterInputTest extends ILIAS_UI_TestBase
         $html = $this->brutallyTrimHTML($fr->render($numeric));
 
         $expected = $this->brutallyTrimHTML('
-        <div class="col-md-6 col-lg-4 il-popover-container">
-            <div class="input-group">
+        <div class="col-md-6 col-lg-4 il-popover-container"><div data-il-ui-component="numeric-field-input" data-il-ui-input-name="" class="input-group">
                 <label for="id_1" class="input-group-addon leftaddon">label</label>
                 <input id="id_1" type="number" class="c-field-number" />
                 <span class="input-group-addon rightaddon">
@@ -173,8 +172,7 @@ class FilterInputTest extends ILIAS_UI_TestBase
         $html = $this->brutallyTrimHTML($fr->render($select));
 
         $expected = $this->brutallyTrimHTML('
-        <div class="col-md-6 col-lg-4 il-popover-container">
-            <div class="input-group">
+        <div class="col-md-6 col-lg-4 il-popover-container"><div data-il-ui-component="select-field-input" data-il-ui-input-name="" class="input-group">
                 <label for="id_1" class="input-group-addon leftaddon">label</label>
                 <select id="id_1">
                     <option selected="selected" value="">-</option>
@@ -202,8 +200,7 @@ class FilterInputTest extends ILIAS_UI_TestBase
         $html = $this->brutallyTrimHTML($fr->render($multi));
 
         $expected = $this->brutallyTrimHTML('
-        <div class="col-md-6 col-lg-4 il-popover-container">
-            <div class="input-group">
+        <div class="col-md-6 col-lg-4 il-popover-container"><div data-il-ui-component="multi-select-field-input" data-il-ui-input-name="" class="input-group">
                 <label class="input-group-addon leftaddon">label</label>
                 <span role="button" tabindex="0" class="form-control il-filter-field" id="id_3" data-placement="bottom"></span>
                 <div class="il-standard-popover-content" style="display:none;" id="id_1"></div>
@@ -213,7 +210,6 @@ class FilterInputTest extends ILIAS_UI_TestBase
                     </a>
                 </span>
             </div>
-            {POPOVER}
         </div>
         ');
         $this->assertHTMLEquals($expected, $html);
@@ -229,8 +225,7 @@ class FilterInputTest extends ILIAS_UI_TestBase
         $html = $this->brutallyTrimHTML($fr->render($datetime));
 
         $expected = $this->brutallyTrimHTML('
-        <div class="col-md-6 col-lg-4 il-popover-container">
-            <div class="input-group">
+        <div class="col-md-6 col-lg-4 il-popover-container"><div data-il-ui-component="date-time-field-input" data-il-ui-input-name="" class="input-group">
                 <label for="id_1" class="input-group-addon leftaddon">label</label>
                 <div class="c-input-group">
                     <input id="id_1" type="date" class="c-field-datetime" />
@@ -283,18 +278,16 @@ class FilterInputTest extends ILIAS_UI_TestBase
 
 
         $expected = $this->brutallyTrimHTML('
-        <div class="col-md-6 col-lg-4 il-popover-container">
-            <div class="input-group">
+        <div class="col-md-6 col-lg-4 il-popover-container"><div data-il-ui-component="duration-field-input" data-il-ui-input-name="" class="input-group">
                 <label class="input-group-addon leftaddon">label</label>
-                <span role="button" tabindex="0" class="form-control il-filter-field" id="id_7" data-placement="bottom"></span>
-                <div class="il-standard-popover-content" style="display:none;" id="id_5"></div>
+                <span role="button" tabindex="0" class="form-control il-filter-field" id="id_6" data-placement="bottom"></span>
+                <div class="il-standard-popover-content" style="display:none;" id="id_4"></div>
                 <span class="input-group-addon rightaddon">
-                    <a class="glyph" href="" aria-label="remove" id="id_8">
+                    <a class="glyph" href="" aria-label="remove" id="id_7">
                         <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
                     </a>
                 </span>
             </div>
-            {POPOVER}
         </div>
         ');
         $this->assertHTMLEquals($expected, $html);

--- a/components/ILIAS/UI/tests/Component/Input/Container/Filter/StandardFilterTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Filter/StandardFilterTest.php
@@ -204,54 +204,54 @@ class StandardFilterTest extends ILIAS_UI_TestBase
         </div>
         <div class="il-filter-input-section row" id="section_inputs_id_1" role="region" aria-labelledby="opener_id_1" data-section-inputs-expanded="0">
             <div class="col-md-6 col-lg-4 il-popover-container">
-                <div class="input-group">
+                <div data-il-ui-component="text-field-input" data-il-ui-input-name="filter_input_0/filter_input_1" id="id_6" class="input-group">
                     <label for="id_5" class="input-group-addon leftaddon">Title</label>
                     <input id="id_5" type="text" name="filter_input_0/filter_input_1" class="c-field-text" />
                     <span class="input-group-addon rightaddon">
-                        <a class="glyph" href="" aria-label="remove" id="id_6">
+                        <a class="glyph" href="" aria-label="remove" id="id_7">
                             <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
                         </a>
                     </span>
                 </div>
             </div>
             <div class="col-md-6 col-lg-4 il-popover-container">
-                <div class="input-group">
-                    <label for="id_7" class="input-group-addon leftaddon">Selection</label>
-                    <select id="id_7" name="filter_input_0/filter_input_2">
+                <div data-il-ui-component="select-field-input" data-il-ui-input-name="filter_input_0/filter_input_2" id="id_9" class="input-group">
+                    <label for="id_8" class="input-group-addon leftaddon">Selection</label>
+                    <select id="id_8" name="filter_input_0/filter_input_2">
                         <option selected="selected" value="">-</option>
                         <option value="one">One</option>
                         <option value="two">Two</option>
                         <option value="three">Three</option>
                     </select>
                     <span class="input-group-addon rightaddon">
-                        <a class="glyph" href="" aria-label="remove" id="id_8">
+                        <a class="glyph" href="" aria-label="remove" id="id_10">
                             <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
                         </a>
                     </span>
                 </div>
             </div>
             <div class="col-md-6 col-lg-4 il-popover-container">
-                <div class="input-group">
+                <div data-il-ui-component="multi-select-field-input" data-il-ui-input-name="filter_input_0/filter_input_3" id="id_11" class="input-group">
                     <label class="input-group-addon leftaddon">Multi Selection</label>
-                    <span role="button" tabindex="0" class="form-control il-filter-field" id="id_11" data-placement="bottom"></span>
-                    <div class="il-standard-popover-content" style="display:none;" id="id_9"></div>
+                    <span role="button" tabindex="0" class="form-control il-filter-field" id="id_14" data-placement="bottom"></span>
+                    <div class="il-standard-popover-content" style="display:none;" id="id_12"></div>
                     <span class="input-group-addon rightaddon">
-                        <a class="glyph" href="" aria-label="remove" id="id_12">
+                        <a class="glyph" href="" aria-label="remove" id="id_15">
                             <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
                         </a>
                     </span>
                 </div>
             </div>
             <div class="col-md-6 col-lg-4 il-popover-container">
-                <div class="input-group">
-                    <button class="btn btn-bulky" id="id_18">
+                <div data-il-ui-component="" data-il-ui-input-name="" class="input-group">
+                    <button class="btn btn-bulky" id="id_21">
                         <span class="glyph" aria-label="add" role="img">
                             <span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>
                         </span>
                         <span class="bulky-label"></span>
                     </button>
                 </div>
-                <div class="il-standard-popover-content" style="display:none;" id="id_16"></div>
+                <div class="il-standard-popover-content" style="display:none;" id="id_19"></div>
             </div>
             <div class="il-filter-controls">
                 <button class="btn btn-bulky" data-action="" id="id_2">
@@ -275,7 +275,7 @@ class StandardFilterTest extends ILIAS_UI_TestBase
 </div>
 EOT;
 
-        $this->assertHTMLEquals($this->brutallyTrimHTML($expected), $this->brutallyTrimHTML($html));
+        $this->assertEquals($this->brutallyTrimHTML($expected), $this->brutallyTrimHTML($html));
     }
 
     public function testRenderDeactivatedCollapsed(): void
@@ -342,54 +342,54 @@ EOT;
         </div>
         <div class="il-filter-input-section row" id="section_inputs_id_1" role="region" aria-labelledby="opener_id_1" data-section-inputs-expanded="0">
             <div class="col-md-6 col-lg-4 il-popover-container">
-                <div class="input-group">
+                <div data-il-ui-component="text-field-input" data-il-ui-input-name="filter_input_0/filter_input_1" id="id_6" class="input-group">
                     <label for="id_5" class="input-group-addon leftaddon">Title</label>
                     <input id="id_5" type="text" name="filter_input_0/filter_input_1" class="c-field-text" />
                     <span class="input-group-addon rightaddon">
-                        <a class="glyph" href="" aria-label="remove" id="id_6">
+                        <a class="glyph" href="" aria-label="remove" id="id_7">
                             <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
                         </a>
                     </span>
                 </div>
             </div>
             <div class="col-md-6 col-lg-4 il-popover-container">
-                <div class="input-group">
-                    <label for="id_7" class="input-group-addon leftaddon">Selection</label>
-                    <select id="id_7" name="filter_input_0/filter_input_2">
+                <div data-il-ui-component="select-field-input" data-il-ui-input-name="filter_input_0/filter_input_2" id="id_9" class="input-group">
+                    <label for="id_8" class="input-group-addon leftaddon">Selection</label>
+                    <select id="id_8" name="filter_input_0/filter_input_2">
                         <option selected="selected" value="">-</option>
                         <option value="one">One</option>
                         <option value="two">Two</option>
                         <option value="three">Three</option>
                     </select>
                     <span class="input-group-addon rightaddon">
-                        <a class="glyph" href="" aria-label="remove" id="id_8">
+                        <a class="glyph" href="" aria-label="remove" id="id_10">
                             <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
                         </a>
                     </span>
                 </div>
             </div>
             <div class="col-md-6 col-lg-4 il-popover-container">
-                <div class="input-group">
+                <div data-il-ui-component="multi-select-field-input" data-il-ui-input-name="filter_input_0/filter_input_3" id="id_11" class="input-group">
                     <label class="input-group-addon leftaddon">Multi Selection</label>
-                    <span role="button" tabindex="0" class="form-control il-filter-field" id="id_11" data-placement="bottom"></span>
-                    <div class="il-standard-popover-content" style="display:none;" id="id_9"></div>
+                    <span role="button" tabindex="0" class="form-control il-filter-field" id="id_14" data-placement="bottom"></span>
+                    <div class="il-standard-popover-content" style="display:none;" id="id_12"></div>
                     <span class="input-group-addon rightaddon">
-                        <a class="glyph" href="" aria-label="remove" id="id_12">
+                        <a class="glyph" href="" aria-label="remove" id="id_15">
                             <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
                         </a>
                     </span>
                 </div>
             </div>
             <div class="col-md-6 col-lg-4 il-popover-container">
-                <div class="input-group">
-                    <button class="btn btn-bulky" id="id_18">
+                <div data-il-ui-component="" data-il-ui-input-name="" class="input-group">
+                    <button class="btn btn-bulky" id="id_21">
                         <span class="glyph" aria-label="add" role="img">
                             <span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>
                         </span>
                         <span class="bulky-label"></span>
                     </button>
                 </div>
-                <div class="il-standard-popover-content" style="display:none;" id="id_16"></div>
+                <div class="il-standard-popover-content" style="display:none;" id="id_19"></div>
             </div>
             <div class="il-filter-controls">
                 <button class="btn btn-bulky" data-action="" id="id_2">
@@ -413,7 +413,7 @@ EOT;
 </div>
 EOT;
 
-        $this->assertHTMLEquals($this->brutallyTrimHTML($expected), $this->brutallyTrimHTML($html));
+        $this->assertEquals($this->brutallyTrimHTML($expected), $this->brutallyTrimHTML($html));
     }
 
     public function testRenderActivatedExpanded(): void
@@ -480,54 +480,54 @@ EOT;
         </div>
         <div class="il-filter-input-section row" id="section_inputs_id_1" role="region" aria-labelledby="opener_id_1" data-section-inputs-expanded="1">
             <div class="col-md-6 col-lg-4 il-popover-container">
-                <div class="input-group">
+                <div data-il-ui-component="text-field-input" data-il-ui-input-name="filter_input_0/filter_input_1" id="id_6" class="input-group">
                     <label for="id_5" class="input-group-addon leftaddon">Title</label>
                     <input id="id_5" type="text" name="filter_input_0/filter_input_1" class="c-field-text" />
                     <span class="input-group-addon rightaddon">
-                        <a class="glyph" href="" aria-label="remove" id="id_6">
+                        <a class="glyph" href="" aria-label="remove" id="id_7">
                             <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
                         </a>
                     </span>
                 </div>
             </div>
             <div class="col-md-6 col-lg-4 il-popover-container">
-                <div class="input-group">
-                    <label for="id_7" class="input-group-addon leftaddon">Selection</label>
-                    <select id="id_7" name="filter_input_0/filter_input_2">
+                <div data-il-ui-component="select-field-input" data-il-ui-input-name="filter_input_0/filter_input_2" id="id_9" class="input-group">
+                    <label for="id_8" class="input-group-addon leftaddon">Selection</label>
+                    <select id="id_8" name="filter_input_0/filter_input_2">
                         <option selected="selected" value="">-</option>
                         <option value="one">One</option>
                         <option value="two">Two</option>
                         <option value="three">Three</option>
                     </select>
                     <span class="input-group-addon rightaddon">
-                        <a class="glyph" href="" aria-label="remove" id="id_8">
+                        <a class="glyph" href="" aria-label="remove" id="id_10">
                             <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
                         </a>
                     </span>
                 </div>
             </div>
             <div class="col-md-6 col-lg-4 il-popover-container">
-                <div class="input-group">
+                <div data-il-ui-component="multi-select-field-input" data-il-ui-input-name="filter_input_0/filter_input_3" id="id_11" class="input-group">
                     <label class="input-group-addon leftaddon">Multi Selection</label>
-                    <span role="button" tabindex="0" class="form-control il-filter-field" id="id_11" data-placement="bottom"></span>
-                    <div class="il-standard-popover-content" style="display:none;" id="id_9"></div>
+                    <span role="button" tabindex="0" class="form-control il-filter-field" id="id_14" data-placement="bottom"></span>
+                    <div class="il-standard-popover-content" style="display:none;" id="id_12"></div>
                     <span class="input-group-addon rightaddon">
-                        <a class="glyph" href="" aria-label="remove" id="id_12">
+                        <a class="glyph" href="" aria-label="remove" id="id_15">
                             <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
                         </a>
                     </span>
                 </div>
             </div>
             <div class="col-md-6 col-lg-4 il-popover-container">
-                <div class="input-group">
-                    <button class="btn btn-bulky" id="id_18">
+                <div data-il-ui-component="" data-il-ui-input-name="" class="input-group">
+                    <button class="btn btn-bulky" id="id_21">
                         <span class="glyph" aria-label="add" role="img">
                             <span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>
                         </span>
                         <span class="bulky-label"></span>
                     </button>
                 </div>
-                <div class="il-standard-popover-content" style="display:none;" id="id_16"></div>
+                <div class="il-standard-popover-content" style="display:none;" id="id_19"></div>
             </div>
             <div class="il-filter-controls">
                 <button class="btn btn-bulky" data-action="" id="id_2">
@@ -551,7 +551,7 @@ EOT;
 </div>
 EOT;
 
-        $this->assertHTMLEquals($this->brutallyTrimHTML($expected), $this->brutallyTrimHTML($html));
+        $this->assertEquals($this->brutallyTrimHTML($expected), $this->brutallyTrimHTML($html));
     }
 
     public function testRenderDeactivatedExpanded(): void
@@ -618,54 +618,54 @@ EOT;
         </div>
         <div class="il-filter-input-section row" id="section_inputs_id_1" role="region" aria-labelledby="opener_id_1" data-section-inputs-expanded="1">
             <div class="col-md-6 col-lg-4 il-popover-container">
-                <div class="input-group">
+                <div data-il-ui-component="text-field-input" data-il-ui-input-name="filter_input_0/filter_input_1" id="id_6" class="input-group">
                     <label for="id_5" class="input-group-addon leftaddon">Title</label>
                     <input id="id_5" type="text" name="filter_input_0/filter_input_1" class="c-field-text" />
                     <span class="input-group-addon rightaddon">
-                        <a class="glyph" href="" aria-label="remove" id="id_6">
+                        <a class="glyph" href="" aria-label="remove" id="id_7">
                             <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
                         </a>
                     </span>
                 </div>
             </div>
             <div class="col-md-6 col-lg-4 il-popover-container">
-                <div class="input-group">
-                    <label for="id_7" class="input-group-addon leftaddon">Selection</label>
-                    <select id="id_7" name="filter_input_0/filter_input_2">
+                <div data-il-ui-component="select-field-input" data-il-ui-input-name="filter_input_0/filter_input_2" id="id_9" class="input-group">
+                    <label for="id_8" class="input-group-addon leftaddon">Selection</label>
+                    <select id="id_8" name="filter_input_0/filter_input_2">
                         <option selected="selected" value="">-</option>
                         <option value="one">One</option>
                         <option value="two">Two</option>
                         <option value="three">Three</option>
                     </select>
                     <span class="input-group-addon rightaddon">
-                        <a class="glyph" href="" aria-label="remove" id="id_8">
+                        <a class="glyph" href="" aria-label="remove" id="id_10">
                             <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
                         </a>
                     </span>
                 </div>
             </div>
             <div class="col-md-6 col-lg-4 il-popover-container">
-                <div class="input-group">
+                <div data-il-ui-component="multi-select-field-input" data-il-ui-input-name="filter_input_0/filter_input_3" id="id_11" class="input-group">
                     <label class="input-group-addon leftaddon">Multi Selection</label>
-                    <span role="button" tabindex="0" class="form-control il-filter-field" id="id_11" data-placement="bottom"></span>
-                    <div class="il-standard-popover-content" style="display:none;" id="id_9"></div>
+                    <span role="button" tabindex="0" class="form-control il-filter-field" id="id_14" data-placement="bottom"></span>
+                    <div class="il-standard-popover-content" style="display:none;" id="id_12"></div>
                     <span class="input-group-addon rightaddon">
-                        <a class="glyph" href="" aria-label="remove" id="id_12">
+                        <a class="glyph" href="" aria-label="remove" id="id_15">
                             <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
                         </a>
                     </span>
                 </div>
             </div>
             <div class="col-md-6 col-lg-4 il-popover-container">
-                <div class="input-group">
-                    <button class="btn btn-bulky" id="id_18">
+                <div data-il-ui-component="" data-il-ui-input-name="" class="input-group">
+                    <button class="btn btn-bulky" id="id_21">
                         <span class="glyph" aria-label="add" role="img">
                             <span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>
                         </span>
                         <span class="bulky-label"></span>
                     </button>
                 </div>
-                <div class="il-standard-popover-content" style="display:none;" id="id_16"></div>
+                <div class="il-standard-popover-content" style="display:none;" id="id_19"></div>
             </div>
             <div class="il-filter-controls">
                 <button class="btn btn-bulky" data-action="" id="id_2">
@@ -689,7 +689,7 @@ EOT;
 </div>
 EOT;
 
-        $this->assertHTMLEquals($this->brutallyTrimHTML($expected), $this->brutallyTrimHTML($html));
+        $this->assertEquals($this->brutallyTrimHTML($expected), $this->brutallyTrimHTML($html));
     }
 
     public function testDedicatedNames(): void


### PR DESCRIPTION
Hi all,

During the review of #10780 I have tried to find the root cause of this issue. What @schmitz-ilias proposed was merely a bandaid for the fact that filter inputs were left behind in some refactoring of the form context and its JavaScript binding. I therefore streamlined this so the necessary HTML attributes for the JavaScript binding to work are now registered similar as to the form inputs.

In addition, I had to rewrite the "update-on-load-code" of the duration and multi-select fields, because jQuery had some odd behaviour regarding its event-listening of elements, which I now replaced with vanilla JS.

@oliversamoila I kindly ask you to verify this behaviour on a test installation.

Kind regards,
@thibsy (as UI coordinator)