### PR TITLE
UI: a few tweaks to fix roundtrip modals as prompt content

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Modal/RoundTrip.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Modal/RoundTrip.php
@@ -267,7 +267,7 @@ class RoundTrip extends Modal implements M\RoundTrip
      */
     public function getPromptButtons(): array
     {
-        return $this->buttons;
+        return $this->action_buttons;
     }
 
     /**
@@ -275,6 +275,6 @@ class RoundTrip extends Modal implements M\RoundTrip
      */
     public function getPromptTitle(): string
     {
-        return $this->type;
+        return $this->title;
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Prompt/State/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Prompt/State/Renderer.php
@@ -58,11 +58,19 @@ class Renderer extends AbstractComponentRenderer
             return $tpl->get();
         }
 
-        $tpl->setVariable('CONTENT', $default_renderer->render($content_component));
+        $content = $content_component;
+        if ($content_component instanceof \ILIAS\UI\Component\Modal\RoundTrip) {
+            $content = $content_component->getContent();
+        }
+
+        $tpl->setVariable('CONTENT', $default_renderer->render($content));
         $tpl->setVariable('TITLE', $component->getTitle());
 
         $buttons = $component->getButtons();
-        if ($content_component instanceof \ILIAS\UI\Component\Input\Container\Form\Form) {
+        if (
+            $content_component instanceof \ILIAS\UI\Component\Input\Container\Form\Form &&
+            !($content_component instanceof \ILIAS\UI\Component\Modal\RoundTrip)
+        ) {
             $submit_button = $this->getUIFactory()->button()->standard(
                 $content_component->getSubmitLabel() ?? $this->txt("save"),
                 $content_component->getSubmitSignal()


### PR DESCRIPTION
This PR makes roundtrip modals work as the content of prompts. Most of the needed infrastructure is already there from the original implementation of prompts, there are just a few tweaks needed, mostly in rendering.

I'm using prompts in the implementation of [‘Publish as OER‘ Button for Objects](https://docu.ilias.de/go/wiki/wpage_8586_1357), and with these tweaks everything works great. Prompts are a really handy tool for implementing multi-step workflows asynchronously.

Let me know if you want anything done differently.

Cheers, Tim 