### PR TITLE
[Improvement] Init: Introduce ErrorResponder (first usage: handle `ilCtrl` routing errors as HTTP 404)

### DIFF
--- a/components/ILIAS/Init/classes/ErrorHandling/Http/ErrorPageResponder.php
+++ b/components/ILIAS/Init/classes/ErrorHandling/Http/ErrorPageResponder.php
@@ -35,9 +35,9 @@ use ILIAS\GlobalScreen\Services as GlobalScreenServices;
  *
  * Use this when the DI container and all ILIAS services are available.
  * The consumer MUST wrap the main logic in a try-catch and call
- * {@see handleError()} in the catch block for expected errors (e.g. routing
+ * {@see respond()} in the catch block for expected errors (e.g. routing
  * failures). For unexpected errors during bootstrap, use
- * {@see \ILIAS\Init\ErrorHandling\PlainTextFallbackResponder} instead.
+ * {@see \ILIAS\Init\ErrorHandling\Http\PlainTextFallbackResponder} instead.
  *
  * The error message is rendered via MessageBox::failure(). If a back target
  * (Data\Link) is provided, it is embedded into the MessageBox via withButtons().
@@ -52,7 +52,7 @@ class ErrorPageResponder
     ) {
     }
 
-    public function handleError(
+    public function respond(
         string $error_message,
         int $status_code,
         ?Link $back_target = null

--- a/components/ILIAS/Init/classes/ErrorHandling/Http/ErrorPageResponder.php
+++ b/components/ILIAS/Init/classes/ErrorHandling/Http/ErrorPageResponder.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Init\ErrorHandling\Http;
+
+use ilUtil;
+use ilLanguage;
+use ILIAS\Data\Link;
+use ilGlobalTemplate;
+use ILIAS\DI\UIServices;
+use ILIAS\HTTP\Response\ResponseHeader;
+use ILIAS\HTTP\Services as HTTPServices;
+use ILIAS\GlobalScreen\Services as GlobalScreenServices;
+
+/**
+ * Responder that renders a full ILIAS error page (UI-Framework MessageBox)
+ * and sends it with the appropriate HTTP status code.
+ *
+ * Use this when the DI container and all ILIAS services are available.
+ * The consumer MUST wrap the main logic in a try-catch and call
+ * {@see handleError()} in the catch block for expected errors (e.g. routing
+ * failures). For unexpected errors during bootstrap, use
+ * {@see \ILIAS\Init\ErrorHandling\PlainTextFallbackResponder} instead.
+ *
+ * The error message is rendered via MessageBox::failure(). If a back target
+ * (Data\Link) is provided, it is embedded into the MessageBox via withButtons().
+ */
+class ErrorPageResponder
+{
+    public function __construct(
+        private readonly GlobalScreenServices $global_screen,
+        private readonly ilLanguage $language,
+        private readonly UIServices $ui,
+        private readonly HTTPServices $http
+    ) {
+    }
+
+    public function handleError(
+        string $error_message,
+        int $status_code,
+        ?Link $back_target = null
+    ): void {
+        $this->global_screen->tool()->context()->claim()->external();
+        $this->language->loadLanguageModule('error');
+
+        $message_box = $this->ui->factory()->messageBox()->failure($error_message);
+
+        if ($back_target !== null) {
+            $ui_button = $this->ui->factory()->button()->standard(
+                $back_target->getLabel(),
+                ilUtil::secureUrl((string) $back_target->getURL())
+            );
+            $message_box = $message_box->withButtons([$ui_button]);
+        }
+
+        $local_tpl = new ilGlobalTemplate('tpl.error.html', true, true);
+        $local_tpl->setCurrentBlock('msg_box');
+        $local_tpl->setVariable(
+            'MESSAGE_BOX',
+            $this->ui->renderer()->render($message_box)
+        );
+        $local_tpl->parseCurrentBlock();
+
+        $this->http->saveResponse(
+            $this->http
+                ->response()
+                ->withStatus($status_code)
+                ->withHeader(ResponseHeader::CONTENT_TYPE, 'text/html')
+        );
+
+        $this->ui->mainTemplate()->setContent($local_tpl->get());
+        $this->ui->mainTemplate()->printToStdout();
+
+        $this->http->close();
+    }
+}

--- a/components/ILIAS/Init/classes/ErrorHandling/Http/PlainTextFallbackResponder.php
+++ b/components/ILIAS/Init/classes/ErrorHandling/Http/PlainTextFallbackResponder.php
@@ -18,7 +18,7 @@
 
 declare(strict_types=1);
 
-namespace ILIAS\Init\ErrorHandling;
+namespace ILIAS\Init\ErrorHandling\Http;
 
 use PDOException;
 use Throwable;

--- a/components/ILIAS/Init/classes/ErrorHandling/PlainTextFallbackResponder.php
+++ b/components/ILIAS/Init/classes/ErrorHandling/PlainTextFallbackResponder.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Init\ErrorHandling;
+
+use PDOException;
+use Throwable;
+use DateTimeZone;
+use DateTimeImmutable;
+use ILIAS\HTTP\StatusCode;
+
+/**
+ * Responder that sends a minimal plain-text error response without relying on
+ * any ILIAS service (no DIC, no UI framework, no templates).
+ *
+ * Use this as a last-resort fallback when the DI container or other
+ * infrastructure is not available — for instance in the catch block of
+ * error.php when the bootstrap itself has failed.
+ *
+ * The consumer MUST wrap the bootstrap / main logic in a try-catch and call
+ * {@see respond()} in the catch block. In DEVMODE the exception is re-thrown
+ * so that Whoops / the developer can inspect the full stack trace.
+ *
+ * This responder always works: it uses only PHP built-ins (headers, echo,
+ * error_log, exit). Prefer {@see \ILIAS\Init\ErrorHandling\Http\ErrorPageResponder}
+ * when the DIC is available, as it renders a proper ILIAS page with the
+ * UI framework.
+ */
+class PlainTextFallbackResponder
+{
+    /**
+     * Send a minimal plain-text error response and terminate the process.
+     *
+     * The status code defaults to 500 (Internal Server Error). The caller may pass
+     * a different code when the failure context is known.
+     *
+     * @param int $status_code HTTP status code (default: 500).
+     * @throws Throwable in DEVMODE
+     */
+    public function respond(Throwable $e, int $status_code = StatusCode::HTTP_INTERNAL_SERVER_ERROR): never
+    {
+        if (defined('DEVMODE') && DEVMODE) {
+            throw $e;
+        }
+
+        if (!headers_sent()) {
+            http_response_code($status_code);
+            header('Content-Type: text/plain; charset=UTF-8');
+        }
+
+        $incident_id = session_id() . '_' . (new \Random\Randomizer())->getInt(1, 9999);
+        $timestamp = (new DateTimeImmutable())
+            ->setTimezone(new DateTimeZone('UTC'))
+            ->format('Y-m-d\TH:i:s\Z');
+
+        echo "Internal Server Error\n";
+        echo "Incident: $incident_id\n";
+        echo "Timestamp: $timestamp\n";
+
+        if ($e instanceof PDOException) {
+            echo "Message: A database error occurred. Please contact the system administrator with the incident id.\n";
+        } else {
+            echo "Message: {$e->getMessage()}\n";
+        }
+
+        error_log(sprintf(
+            "[%s] INCIDENT %s — Uncaught %s: %s in %s:%d\nStack trace:\n%s\n",
+            $timestamp,
+            $incident_id,
+            get_class($e),
+            $e->getMessage(),
+            $e->getFile(),
+            $e->getLine(),
+            $e->getTraceAsString()
+        ));
+
+        exit(1);
+    }
+}

--- a/components/ILIAS/Init/classes/ErrorHandling/README.md
+++ b/components/ILIAS/Init/classes/ErrorHandling/README.md
@@ -1,0 +1,33 @@
+# Error Responders
+
+This package provides responders for rendering HTTP error pages in ILIAS.
+
+## When to use which responder
+
+- **ErrorPageResponder** (`Http\ErrorPageResponder`): Use when the DI container and all ILIAS services (UI, language, HTTP, etc.) are available. Renders a full ILIAS page with a UI-Framework MessageBox and optional back button. Use for expected errors (e.g. routing failures, access denied) that should be shown as a proper HTML page.
+
+- **PlainTextFallbackResponder**: Use when the DI container or other infrastructure is *not* available — for instance in the catch block of `error.php` when the bootstrap itself has failed. Sends a minimal plain-text response with `Content-Type: text/plain; charset=UTF-8` and logs the exception via `error_log`. This responder always works because it uses only PHP built-ins. The HTTP status code defaults to 500; pass a different code (e.g. 502) when the failure context is known.
+
+## Consumer responsibility
+
+**The consumer MUST implement a try-catch block.** Both responders must be invoked explicitly:
+
+1. Wrap the main logic (bootstrap, routing, etc.) in a `try` block.
+2. In the `catch` block, call either `ErrorPageResponder::handleError()` (if DIC is available) or `PlainTextFallbackResponder::respond()` (if DIC is not available).
+
+Example:
+
+```php
+try {
+    entry_point('ILIAS Legacy Initialisation Adapter');
+    global $DIC;
+    new ErrorPageResponder(
+        $DIC->globalScreen(),
+        $DIC->language(),
+        $DIC->ui(),
+        $DIC->http()
+    )->handleError($message, 500, $back_target);
+} catch (Throwable $e) {
+    new PlainTextFallbackResponder()->respond($e);
+}
+```

--- a/components/ILIAS/Init/classes/ErrorHandling/README.md
+++ b/components/ILIAS/Init/classes/ErrorHandling/README.md
@@ -6,14 +6,14 @@ This package provides responders for rendering HTTP error pages in ILIAS.
 
 - **ErrorPageResponder** (`Http\ErrorPageResponder`): Use when the DI container and all ILIAS services (UI, language, HTTP, etc.) are available. Renders a full ILIAS page with a UI-Framework MessageBox and optional back button. Use for expected errors (e.g. routing failures, access denied) that should be shown as a proper HTML page.
 
-- **PlainTextFallbackResponder**: Use when the DI container or other infrastructure is *not* available — for instance in the catch block of `error.php` when the bootstrap itself has failed. Sends a minimal plain-text response with `Content-Type: text/plain; charset=UTF-8` and logs the exception via `error_log`. This responder always works because it uses only PHP built-ins. The HTTP status code defaults to 500; pass a different code (e.g. 502) when the failure context is known.
+- **PlainTextFallbackResponder** (`Http\PlainTextFallbackResponder`): Use when the DI container or other infrastructure is *not* available — for instance in the catch block of `error.php` when the bootstrap itself has failed. Sends a minimal plain-text response with `Content-Type: text/plain; charset=UTF-8` and logs the exception via `error_log`. This responder always works because it uses only PHP built-ins. The HTTP status code defaults to 500; pass a different code (e.g. 502) when the failure context is known.
 
 ## Consumer responsibility
 
 **The consumer MUST implement a try-catch block.** Both responders must be invoked explicitly:
 
 1. Wrap the main logic (bootstrap, routing, etc.) in a `try` block.
-2. In the `catch` block, call either `ErrorPageResponder::handleError()` (if DIC is available) or `PlainTextFallbackResponder::respond()` (if DIC is not available).
+2. In the `catch` block, call either `ErrorPageResponder::respond()` (if DIC is available) or `PlainTextFallbackResponder::respond()` (if DIC is not available).
 
 Example:
 
@@ -26,7 +26,7 @@ try {
         $DIC->language(),
         $DIC->ui(),
         $DIC->http()
-    )->handleError($message, 500, $back_target);
+    )->respond($message, 500, $back_target);
 } catch (Throwable $e) {
     new PlainTextFallbackResponder()->respond($e);
 }

--- a/components/ILIAS/Init/resources/error.php
+++ b/components/ILIAS/Init/resources/error.php
@@ -20,73 +20,44 @@ declare(strict_types=1);
 
 namespace ILIAS\Init;
 
+use Throwable;
+use ILIAS\HTTP\StatusCode;
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Init\ErrorHandling\Http\ErrorPageResponder;
+use ILIAS\Init\ErrorHandling\PlainTextFallbackResponder;
+
 try {
     require_once '../vendor/composer/vendor/autoload.php';
 
     require_once __DIR__ . '/../artifacts/bootstrap_default.php';
     entry_point('ILIAS Legacy Initialisation Adapter');
 
-    $DIC->globalScreen()->tool()->context()->claim()->external();
-
-    $lng->loadLanguageModule('error');
-    $txt = $lng->txt('error_back_to_repository');
-
-    $local_tpl = new \ilGlobalTemplate('tpl.error.html', true, true);
-    $local_tpl->setCurrentBlock('ErrorLink');
-    $local_tpl->setVariable('TXT_LINK', $txt);
-    $local_tpl->setVariable('LINK', \ilUtil::secureUrl(ILIAS_HTTP_PATH . '/ilias.php?baseClass=ilRepositoryGUI'));
-    $local_tpl->parseCurrentBlock();
+    /** @var \ILIAS\DI\Container $DIC */
+    global $DIC;
 
     \ilSession::clear('referer');
     \ilSession::clear('message');
 
-    $DIC->http()->saveResponse(
-        $DIC->http()
-            ->response()
-            ->withStatus(500)
-            ->withHeader(\ILIAS\HTTP\Response\ResponseHeader::CONTENT_TYPE, 'text/html')
+    $DIC->language()->loadLanguageModule('error');
+
+    $message = \ilSession::get('failure') ?? $DIC->language()->txt('http_500_internal_server_error');
+
+    $df = new DataFactory();
+    $back_target = $df->link(
+        $DIC->language()->txt('error_back_to_repository'),
+        $df->uri(ILIAS_HTTP_PATH . '/ilias.php?baseClass=ilRepositoryGUI')
     );
 
-    $tpl->setContent($local_tpl->get());
-    $tpl->printToStdout();
-
-    $DIC->http()->close();
-} catch (\Throwable $e) {
-    if (\defined('DEVMODE') && DEVMODE) {
-        throw $e;
-    }
-
-    /*
-     * Since we are already in the `error.php` and an unexpected error occurred, we should not rely on the $DIC or any
-     * other components here and use "Vanilla PHP" instead to handle the error.
-     */
-    if (!headers_sent()) {
-        http_response_code(500);
-        header('Content-Type: text/plain; charset=UTF-8');
-    }
-
-    $incident_id = session_id() . '_' . (new \Random\Randomizer())->getInt(1, 9999);
-    $timestamp = (new \DateTimeImmutable())->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d\TH:i:s\Z');
-
-    echo "Internal Server Error\n";
-    echo "Incident: $incident_id\n";
-    echo "Timestamp: $timestamp\n";
-    if ($e instanceof \PDOException) {
-        echo "Message: A database error occurred. Please contact the system administrator with the incident id.\n";
-    } else {
-        echo "Message: {$e->getMessage()}\n";
-    }
-
-    error_log(\sprintf(
-        "[%s] INCIDENT %s — Uncaught %s: %s in %s:%d\nStack trace:\n%s\n",
-        $timestamp,
-        $incident_id,
-        \get_class($e),
-        $e->getMessage(),
-        $e->getFile(),
-        $e->getLine(),
-        $e->getTraceAsString()
-    ));
-
-    exit(1);
+    new ErrorPageResponder(
+        $DIC->globalScreen(),
+        $DIC->language(),
+        $DIC->ui(),
+        $DIC->http()
+    )->handleError(
+        $message,
+        StatusCode::HTTP_INTERNAL_SERVER_ERROR,
+        $back_target
+    );
+} catch (Throwable $e) {
+    new PlainTextFallbackResponder()->respond($e);
 }

--- a/components/ILIAS/Init/resources/error.php
+++ b/components/ILIAS/Init/resources/error.php
@@ -24,7 +24,7 @@ use Throwable;
 use ILIAS\HTTP\StatusCode;
 use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Init\ErrorHandling\Http\ErrorPageResponder;
-use ILIAS\Init\ErrorHandling\PlainTextFallbackResponder;
+use ILIAS\Init\ErrorHandling\Http\PlainTextFallbackResponder;
 
 try {
     require_once '../vendor/composer/vendor/autoload.php';
@@ -53,7 +53,7 @@ try {
         $DIC->language(),
         $DIC->ui(),
         $DIC->http()
-    )->handleError(
+    )->respond(
         $message,
         StatusCode::HTTP_INTERNAL_SERVER_ERROR,
         $back_target

--- a/components/ILIAS/Init/resources/ilias.php
+++ b/components/ILIAS/Init/resources/ilias.php
@@ -55,7 +55,7 @@ try {
         $DIC->language(),
         $DIC->ui(),
         $DIC->http()
-    )->handleError(
+    )->respond(
         $DIC->language()->txt('http_404_not_found'),
         StatusCode::HTTP_NOT_FOUND,
         $back_target

--- a/components/ILIAS/Init/resources/ilias.php
+++ b/components/ILIAS/Init/resources/ilias.php
@@ -18,6 +18,10 @@
 
 declare(strict_types=1);
 
+use ILIAS\HTTP\StatusCode;
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Init\ErrorHandling\Http\ErrorPageResponder;
+
 if (!file_exists('../ilias.ini.php')) {
     die('The ILIAS setup is not completed. Please run the setup routine.');
 }
@@ -26,7 +30,7 @@ require_once '../vendor/composer/vendor/autoload.php';
 require_once __DIR__ . '/../artifacts/bootstrap_default.php';
 entry_point('ILIAS Legacy Initialisation Adapter');
 
-/** @var $DIC \ILIAS\DI\Container */
+/** @var \ILIAS\DI\Container $DIC */
 global $DIC;
 
 try {
@@ -36,14 +40,26 @@ try {
         throw $e;
     }
 
-    if (!str_contains($e->getMessage(), 'not given a baseclass') &&
-        !str_contains($e->getMessage(), 'not a baseclass')) {
-        throw new RuntimeException(sprintf('ilCtrl could not dispatch request: %s', $e->getMessage()), 0, $e);
-    }
-
     $DIC->logger()->root()->error($e->getMessage());
     $DIC->logger()->root()->error($e->getTraceAsString());
-    $DIC->ctrl()->redirectToURL(ilUtil::_getHttpPath());
+
+    $DIC->language()->loadLanguageModule('error');
+    $df = new DataFactory();
+    $back_target = $df->link(
+        $DIC->language()->txt('error_back_to_repository'),
+        $df->uri(ILIAS_HTTP_PATH . '/ilias.php?baseClass=ilRepositoryGUI')
+    );
+
+    new ErrorPageResponder(
+        $DIC->globalScreen(),
+        $DIC->language(),
+        $DIC->ui(),
+        $DIC->http()
+    )->handleError(
+        $DIC->language()->txt('http_404_not_found'),
+        StatusCode::HTTP_NOT_FOUND,
+        $back_target
+    );
 }
 
 $DIC['ilBench']->save();

--- a/components/ILIAS/UICore/classes/Path/class.ilCtrlExistingPath.php
+++ b/components/ILIAS/UICore/classes/Path/class.ilCtrlExistingPath.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\UICore\Exceptions\ilCtrlPathException;
+
 /**
  * Class ilCtrlExistingPath
  *
@@ -56,7 +58,7 @@ class ilCtrlExistingPath extends ilCtrlAbstractPath
             $child_class = $this->structure->getClassNameByCid($child_cid);
             $allowed_children = $this->structure->getChildrenByCid($parent_cid) ?? [];
             if (null === $child_class || !in_array($child_class, $allowed_children, true)) {
-                throw new RuntimeException('ilCtrl: invalid ' . ilCtrlInterface::PARAM_CID_PATH . ' parameter requested.');
+                throw new ilCtrlPathException('ilCtrl: invalid ' . ilCtrlInterface::PARAM_CID_PATH . ' parameter requested.');
             }
         }
     }

--- a/components/ILIAS/UICore/exceptions/ilCtrlPathException.php
+++ b/components/ILIAS/UICore/exceptions/ilCtrlPathException.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UICore\Exceptions;
+
+use ilCtrlException;
+
+/**
+ * Thrown when ilCtrl encounters an invalid or unresolvable CID path during
+ * request dispatching
+ */
+class ilCtrlPathException extends ilCtrlException
+{
+}

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -9231,6 +9231,8 @@ ecs#:#ecs_wiki_export_enabled#:#Freigeben
 ecs#:#ecs_wiki_export_obj_settings#:#Einstellungen für Wikifreigaben
 error#:#error_back_to_repository#:#Zurück zum Magazin
 error#:#error_sry_error#:#Es ist leider ein Fehler aufgetreten.
+error#:#http_404_not_found#:#Die angeforderte Seite wurde nicht gefunden.
+error#:#http_500_internal_server_error#:#Es ist ein interner Serverfehler aufgetreten.
 etal#:#appointments#:#Sitzungen
 etal#:#cal_type_tals#:#Gespräche
 etal#:#change_date_of_series#:#Gesprächsserie anpassen

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -9205,6 +9205,8 @@ ecs#:#ecs_wiki_export_enabled#:#Release this Wiki
 ecs#:#ecs_wiki_export_obj_settings#:#Wiki Release Settings
 error#:#error_back_to_repository#:#Back to Repository
 error#:#error_sry_error#:#Sorry, an error occurred.
+error#:#http_404_not_found#:#The requested page could not be found.
+error#:#http_500_internal_server_error#:#An internal server error occurred.
 etal#:#appointments#:#Appointments
 etal#:#cal_type_tals#:#Talks
 etal#:#change_date_of_series#:#Change date of talk series

--- a/templates/default/tpl.error.html
+++ b/templates/default/tpl.error.html
@@ -1,6 +1,3 @@
-<!-- BEGIN ErrorLink -->
-<!-- additional link e.g. by WebAccessChecker -->
-<p>
-	<a class="btn btn-default" href="{LINK}">{TXT_LINK}</a>
-</p>
-<!-- END ErrorLink -->
+<!-- BEGIN msg_box -->
+{MESSAGE_BOX}
+<!-- END msg_box -->


### PR DESCRIPTION
## Summary

- Introduces a centralised `ErrorController` (`ILIAS\Init\ErrorController`) that renders error pages with proper HTTP status codes using the UI-Framework MessageBox, replacing duplicated error-rendering logic across `ilias.php` and `error.php`.
- Catches `ilCtrlException` and any `Throwable` with "ilCtrl" in the message during request dispatching and responds with HTTP 404 instead of redirecting (which previously caused cascading requests and separate log files).
- Refactors `error.php` to delegate page rendering to the `ErrorController` (HTTP 500), keeping only the error.php-specific session cleanup in place.
- Adds language variables `http_404_not_found` and `http_500_internal_server_error` (DE/EN).

## Motivation

`ilCtrl`-related exceptions are semantical routing/dispatching problems. Previously, these caused redirects to `error.php` or the ILIAS base URL in production, generating cascading requests and individual log files — unhelpful for administrators and monitoring. Requests causing these issues are often related to any kind of bots/client automation (AI, Search Engines, Hack Attempts). The additional I/O (the dedicated log file, if enabled, and the subsequent HTTP request) can also lead to performance issues on platforms with high traffic/many concurrent users.

This change returns a clean HTTP 404 response directly, which is the correct semantic for "this route could not be resolved".

The changes also address the issue described in: https://mantis.ilias.de/view.php?id=45455