### PR TITLE
Session: add default return values to _lookupAppointment if an appointment does not exist

### DIFF
--- a/components/ILIAS/Session/classes/class.ilSessionAppointment.php
+++ b/components/ILIAS/Session/classes/class.ilSessionAppointment.php
@@ -72,7 +72,11 @@ class ilSessionAppointment implements ilDatePeriod
 
             return $info;
         }
-        return [];
+        return [
+            'fullday' => 0,
+            'start' => 0,
+            'end' => 0,
+        ];
     }
 
     /**


### PR DESCRIPTION
LINK: https://mantis.ilias.de/view.php?id=47080