### PR TITLE
[Feature] Init/ErrorHandler: Introduce `ShouldNotAutoReport` interface

### DIFF
--- a/components/ILIAS/Init/README.md
+++ b/components/ILIAS/Init/README.md
@@ -1,0 +1,10 @@
+# Init
+
+This folder contains types and concepts for the ILIAS `Init` component.
+
+The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”,
+“SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be
+interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+**Table of Contents**
+* [Error Handling](src/ErrorHandling/README.md)

--- a/components/ILIAS/Init/classes/class.ilErrorHandling.php
+++ b/components/ILIAS/Init/classes/class.ilErrorHandling.php
@@ -230,6 +230,7 @@ class ilErrorHandling
         return new CallbackHandler(function ($exception, Inspector $inspector, Run $run) {
             global $DIC;
 
+            $should_report = !($exception instanceof \ILIAS\Init\ErrorHandling\Exception\ShouldNotAutoReport);
             $logger = ilLoggingErrorSettings::getInstance();
 
             $message = 'Sorry, an error occured.';
@@ -238,7 +239,7 @@ class ilErrorHandling
                 $message = $DIC->language()->txt('error_sry_error');
             }
 
-            if (!empty($logger->folder())) {
+            if ($should_report && !empty($logger->folder())) {
                 $session_id = substr(session_id(), 0, 5);
                 $r = new \Random\Randomizer();
                 $err_num = $r->getInt(1, 9999);
@@ -362,6 +363,11 @@ class ilErrorHandling
              * @var ilLogger $ilLog
              */
             global $ilLog;
+
+            $should_report = !($exception instanceof \ILIAS\Init\ErrorHandling\Exception\ShouldNotAutoReport);
+            if (!$should_report) {
+                return;
+            }
 
             if (is_object($ilLog)) {
                 $message = $exception->getMessage() . ' in ' . $exception->getFile() . ':' . $exception->getLine();

--- a/components/ILIAS/Init/src/ErrorHandling/Exception/ShouldNotAutoReport.php
+++ b/components/ILIAS/Init/src/ErrorHandling/Exception/ShouldNotAutoReport.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Init\ErrorHandling\Exception;
+
+/**
+ * Marker interface for exceptions that must not be automatically
+ * reported (e.g., not written to error log files or application logs, not
+ * sent as e-mail or to other components/systems).
+ *
+ * Use this for expected or high-volume exceptions (e.g., routing failures,
+ * invalid request parameters) where reporting would cause unnecessary I/O
+ * or log noise. The user may still see an error page; only reporting is skipped.
+ *
+ * Only exception classes (subclasses of Exception or Error) should implement
+ * this interface, since only throwables can reach the error handler.
+ */
+interface ShouldNotAutoReport
+{
+}

--- a/components/ILIAS/Init/src/ErrorHandling/README.md
+++ b/components/ILIAS/Init/src/ErrorHandling/README.md
@@ -1,0 +1,87 @@
+# Error Handling
+
+This folder contains types and concepts for ILIAS error and exception handling.
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+**Table of Contents**
+* [ShouldNotAutoReport marker interface](#shouldnotautoreport-marker-interface)
+  * [Purpose](#purpose)
+  * [Behaviour in ilErrorHandling](#behaviour-in-ilerrorhandling)
+  * [Usage example](#usage-example)
+
+## ShouldNotAutoReport marker interface
+
+### Purpose
+
+`ILIAS\Init\ErrorHandling\Exception\ShouldNotAutoReport` is a **marker interface** for
+exception classes that MUST NOT be reported by ILIAS' global error handling.
+
+"Reporting" here means:
+
+* Writing a dedicated log file (e.g., via `ilLoggingErrorFileStorage`) when the
+  exception is handled by the default Whoops handler,
+* Writing the exception to the application log (e.g. `$ilLog->error(...)`),
+* Sending the exception message to the PHP system logger (`error_log()`),
+* (Outlook) Sending exceptions to third-party log or error-tracking services
+  (e.g., Sentry).
+
+Exceptions that implement `ShouldNotAutoReport` still reach the error handler and the
+user may still see an error page (e.g., redirect to `error.php`). Only the
+reporting step is skipped: no log file is created and no log entries are
+written for that exception.
+
+Use this for **expected** or **high-volume** exceptions where reporting would
+cause unnecessary I/O, log noise, or cost, for example:
+
+* Client errors that are common under load (e.g., bots, orphaned search indexes),
+* Validation or business-rule exceptions that are already communicated to the
+  user and do not require administrator attention,
+* Avoiding cost or quota consumption when exceptions are forwarded to
+  third-party log or error-tracking services (e.g., Sentry) that charge per
+  event.
+
+### Behaviour in ilErrorHandling
+
+When Whoops handles an uncaught exception:
+
+1. **Default handler (production):** If the exception implements `ShouldNotAutoReport`,
+   `ilErrorHandling` does NOT write a log file and does NOT show a "logfile has
+   been created" message. The user sees a generic error message.
+
+2. **Logging handler:** If the exception implements `ShouldNotAutoReport`, the logging
+   handler does NOT write to the application log or to the system logger. It
+   returns without reporting.
+
+Exceptions that do not implement `ShouldNotAutoReport` are reported as before (log
+file when configured, application log, and `error_log()`).
+
+### Usage example
+
+Implement the interface on your exception class so that instances are not
+reported when they bubble up to the global handler:
+
+```php
+<?php
+
+namespace MyComponent\Exception;
+
+use Exception;
+use ILIAS\Init\ErrorHandling\Exception\ShouldNotAutoReport;
+
+class InvalidRequestException extends Exception implements ShouldNotAutoReport
+{
+    public function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+}
+```
+
+If this exception is thrown and not caught, the user will still see an error
+page, but no log file will be created and no log entries will be written. This
+is useful for expected client errors (e.g., invalid or tampered request
+parameters) that you do not want to treat as incidents requiring administrator
+attention or disk I/O.

--- a/components/ILIAS/Init/src/ErrorHandling/ROADMAP.md
+++ b/components/ILIAS/Init/src/ErrorHandling/ROADMAP.md
@@ -9,7 +9,8 @@
 When an uncaught exception is handled by `ilErrorHandling`'s default
 (production) handler, the handler:
 
-1. Optionally writes a log file and builds a message that references it,
+1. Optionally writes a/to log file(s) and builds a message that references it, or
+   uses a generic message for `ShouldNotAutoReport` exceptions,
 2. Sets the message in the UI template component or session,
 3. **Redirects the user to `error.php`** (via
    `$DIC->ctrl()->redirectToURL('error.php')` or


### PR DESCRIPTION
This PR introduces a way to mark exceptions so that they are **not reported** by ILIAS' global error handling, and adds documentation for the Error Handling roadmap.

**Marker interface**

- New interface: `ILIAS\Init\ErrorHandling\Exception\ShouldNotAutoReport` in `components/ILIAS/Init/src/ErrorHandling/Exception/ShouldNotAutoReport.php`.
- Exceptions implementing this interface are **not reported**: no log file is written, and nothing is written to the application log or PHP's `error_log()` when they are handled by Whoops' default and logging handlers.
- The user still sees an error page (by being redirected to `error.php`); only the reporting step is skipped.
- Use this for expected or high-volume exceptions (e.g. routing/dispatching failures, invalid request parameters) to avoid log noise and unnecessary I/O, or **to avoid cost or quota consumption** when exceptions are forwarded to third-party log or error-tracking services in the future (I am thinking of third party components implementing a "Sentry Exception Handler" or similar for ILIAS).

**ilErrorHandling**

- `defaultHandler()` (for production env.): if the exception implements the new interface, no log file is written, and the user sees a generic error message instead of a "logfile has been created" message.
- `loggingHandler()`: if the exception implements the marker interface, it returns without writing to the app log or system logger.

**Documentation**

- **README.md** in `Init/src/ErrorHandling/`: describes the new marker interface, when to use it, how `ilErrorHandling` uses it, and a short usage example.
- **ROADMAP.md**: short-term goal to **get rid of redirects to `error.php`** from the default exception handler and respond in-place with the error page (one response per error instead of redirect and second request, this is related to #11110).
### Motivation

- Lets components opt out of reporting for specific exception types without touching global handler configuration.
- Reduces I/O and log volume for expected or client-side failures (e.g. bots, broken links).
- Avoid cost or quota consumption when exceptions are forwarded to third-party log or error-tracking services in the future. Some of my colleagues at Databay already use such services ("Sentry") in plugins (CC @amichelsdatabay).