### PR TITLE
[Feature] UI/Init: Remove "Cannot find this block" error handling

### DIFF
--- a/components/ILIAS/Init/classes/class.ilErrorHandling.php
+++ b/components/ILIAS/Init/classes/class.ilErrorHandling.php
@@ -150,38 +150,13 @@ class ilErrorHandling
         global $log;
 
         $session_failure = ilSession::get('failure');
-        if ($session_failure && !str_starts_with($message, 'Cannot find this block')) {
+        if ($session_failure) {
             $m = 'Fatal Error: Called raise error two times.<br>' .
                 'First error: ' . $session_failure . '<br>' .
                 'Last Error:' . $message;
             $log->write($m);
             ilSession::clear('failure');
             die($m);
-        }
-
-        if (str_starts_with($message, 'Cannot find this block')) {
-            if ($this->isDevmodeActive()) {
-                echo '<b>DEVMODE</b><br><br>';
-                echo '<b>Template Block not found.</b><br>';
-                echo 'You used a template block in your code that is not available.<br>';
-                echo 'Native Messge: <b>' . $message . '</b><br>';
-                echo 'Backtrace:<br>';
-                foreach ($backtrace as $b) {
-                    if ($b['function'] === 'setCurrentBlock' &&
-                        basename($b['file']) !== 'class.ilTemplate.php') {
-                        echo '<b>';
-                    }
-                    echo 'File: ' . $b['file'] . ', ';
-                    echo 'Line: ' . $b['line'] . ', ';
-                    echo $b['function'] . '()<br>';
-                    if ($b['function'] === 'setCurrentBlock' &&
-                        basename($b['file']) !== 'class.ilTemplate.php') {
-                        echo '</b>';
-                    }
-                }
-                exit;
-            }
-            return;
         }
 
         if ($log instanceof ilLogger) {

--- a/components/ILIAS/UI/tests/Renderer/ilIndependentTemplate.php
+++ b/components/ILIAS/UI/tests/Renderer/ilIndependentTemplate.php
@@ -72,12 +72,9 @@ class ilIndependantTemplate extends ilTemplate
         $this->real_filename = $filename;
 
         if (!($fh = @fopen($filename, 'rb'))) {
-            $this->err[] = (new PEAR())->raiseError(
-                $this->errorMessage(self::IT_TPL_NOT_FOUND) .
-                ': "' . $filename . '"',
-                self::IT_TPL_NOT_FOUND
+            throw new ilTemplateException(
+                $this->errorMessage(self::IT_TPL_NOT_FOUND) . ': "' . $filename . '"'
             );
-            return "";
         }
 
         $fsize = filesize($filename);


### PR DESCRIPTION
This PR removes legacy `PEAR` dependencies and outdated error handling from the template engine.

# Commits

## 1. Remove last `PEAR` usage from template tests
- Removes the final `PEAR` usage from `components/ILIAS/UI/tests/Renderer/ilIndependentTemplate.php`
- This code could not have worked anyway, as we no longer depend on `PEAR`

## 2. Remove special "Cannot find this block" error handling
- Removes legacy error handling in `ilErrorHandling` for template engine errors
- This special handling dates back to when the template engine used the `PEAR` error handler
- All template engine code (except one case, see 1.) already uses proper `ilTemplateException` instead
- The remaining special error handling is no longer necessary