### PR TITLE
UI: move escaping in charts from consumers to renderer (46966)

### DIFF
--- a/components/ILIAS/Poll/classes/BlockGUI/Results/class.ilPollResultsRenderer.php
+++ b/components/ILIAS/Poll/classes/BlockGUI/Results/class.ilPollResultsRenderer.php
@@ -89,7 +89,7 @@ class ilPollResultsRenderer
         $tooltips = [];
         $color_index = 0;
         foreach ($results->getOrderedAnswerIds() as $id) {
-            $label = $this->htmlSpecialCharsAsEntities($results->getAnswerText($id));
+            $label = nl2br($results->getAnswerText($id));
             $total_votes = $results->getAnswerTotal($id);
             $tooltip = $total_votes . ' (' . round($results->getAnswerPercentage($id)) . '%)';
             $bar_config = new BarConfig();
@@ -135,7 +135,7 @@ class ilPollResultsRenderer
         $dataset = $this->data_factory->dataset([$votes_label => $c_dimension]);
 
         foreach ($results->getOrderedAnswerIds() as $id) {
-            $label = $this->htmlSpecialCharsAsEntities($results->getAnswerText($id));
+            $label = nl2br($results->getAnswerText($id));
             $total_votes = $results->getAnswerTotal($id);
             $tooltip = $total_votes . ' (' . round($results->getAnswerPercentage($id)) . '%)';
             $dataset = $dataset->withPoint($label, [$votes_label => $total_votes])
@@ -150,10 +150,5 @@ class ilPollResultsRenderer
                                                   ->withLegendVisible(false)
                                                   ->withBarConfigs([$votes_label => $bar_config]);
         $tpl->setVariable('CHART', $this->ui_renderer->render($chart));
-    }
-
-    protected function htmlSpecialCharsAsEntities(string $string): string
-    {
-        return $this->refinery->encode()->htmlSpecialCharsAsEntities()->transform(nl2br($string));
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Chart/Bar/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Chart/Bar/Renderer.php
@@ -113,7 +113,7 @@ class Renderer extends AbstractComponentRenderer
 
     protected function renderBasics(Bar\Bar $component, Template $tpl): void
     {
-        $tpl->setVariable("TITLE", $component->getTitle());
+        $tpl->setVariable("TITLE", $this->convertSpecialCharacters($component->getTitle()));
         $height = "";
         if ($component instanceof Bar\Horizontal) {
             $height = $this->determineHeightForHorizontal($component);
@@ -166,10 +166,11 @@ class Renderer extends AbstractComponentRenderer
 
         foreach ($points_per_dimension as $dimension_name => $item_points) {
             $entries = [];
-            foreach ($item_points as $messeaurement_item_label => $point) {
-                if (isset($tooltips_per_dimension[$dimension_name][$messeaurement_item_label])) {
+            foreach ($item_points as $measurement_item_label => $point) {
+                // use numeric value as default
+                if (isset($tooltips_per_dimension[$dimension_name][$measurement_item_label])) {
                     // use custom tooltips if defined
-                    $entries[] = $messeaurement_item_label . ": " . $tooltips_per_dimension[$dimension_name][$messeaurement_item_label];
+                    $entry = $measurement_item_label . ": " . $tooltips_per_dimension[$dimension_name][$measurement_item_label];
                 } elseif (is_array($point)) {
                     // handle range values
                     $range = "";
@@ -177,19 +178,20 @@ class Renderer extends AbstractComponentRenderer
                         $range .= $p . " - ";
                     }
                     $range = rtrim($range, " -");
-                    $entries[] = $messeaurement_item_label . ": " . $range;
+                    $entry = $measurement_item_label . ": " . $range;
                 } elseif (is_null($point)) {
                     // handle null values
-                    $entries[] = $messeaurement_item_label . ": -";
+                    $entry = $measurement_item_label . ": -";
                 } elseif (!empty($value_labels) && is_int($point) && !empty($value_labels[$point - $lowest])) {
                     // use custom value labels if defined
-                    $entries[] = $messeaurement_item_label . ": " . $value_labels[$point - $lowest];
+                    $entry = $measurement_item_label . ": " . $value_labels[$point - $lowest];
                 } else {
                     // use numeric value for all other cases
-                    $entries[] = $messeaurement_item_label . ": " . $point;
+                    $entry = $measurement_item_label . ": " . $point;
                 }
+                $entries[] = $this->convertSpecialCharacters($entry);
             }
-            $list_items[$dimension_name] = $ui_fac->listing()->unordered($entries);
+            $list_items[$this->convertSpecialCharacters($dimension_name)] = $ui_fac->listing()->unordered($entries);
         }
 
         $list = $ui_fac->listing()->descriptive($list_items);

--- a/components/ILIAS/UI/tests/Component/Chart/Bar/ChartBarTest.php
+++ b/components/ILIAS/UI/tests/Component/Chart/Bar/ChartBarTest.php
@@ -18,9 +18,6 @@
 
 declare(strict_types=1);
 
-require_once(__DIR__ . "/../../../../../../../vendor/composer/vendor/autoload.php");
-require_once(__DIR__ . "/../../../Base.php");
-
 use ILIAS\UI\Component as C;
 use ILIAS\UI\Implementation as I;
 
@@ -390,6 +387,100 @@ EOT;
             <ul>
                 <li>Item 1: -2 - -1</li>
                 <li>Item 2: 0 - 0.5</li>
+            </ul>
+        </dd>
+    </dl>
+</div>
+EOT;
+
+        $this->assertHTMLEquals("<div>" . $expected_html . "</div>", "<div>" . $html . "</div>");
+    }
+
+    public static function provideRiskyData(): array
+    {
+        return [
+            "ampersand" => ["this&that", "this&amp;that"],
+            "single quote" => ["it's a kind of magic", "it&#039;s a kind of magic"],
+            "double quote" => ['Dwayne "The Rock" Johnson', 'Dwayne &quot;The Rock&quot; Johnson'],
+            "tags" => ['<script>alert("XSS")</script>', '&lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt;'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideRiskyData
+     */
+    public function testRenderConvertSpecialCharactersInDatasetLabel(
+        string $risky_datum,
+        string $expected_in_html
+    ): void {
+        $r = $this->getDefaultRenderer();
+        $f = $this->getFactory();
+        $df = $this->getDataFactory();
+
+        $c_dimension = $df->dimension()->cardinal();
+
+        $dataset = $df->dataset([$risky_datum => $c_dimension]);
+        $dataset = $dataset->withPoint("Item", [$risky_datum => 123]);
+
+        $vertical = $f->vertical(
+            "bar123",
+            $dataset
+        );
+
+        $html = $r->render($vertical);
+
+        $expected_html = <<<EOT
+<div class="il-chart-bar-vertical">
+    <canvas id="id_1" height="150px" aria-label="bar123" role="img"></canvas>
+</div>
+<div class="sr-only">
+    <dl>
+        <dt>$expected_in_html</dt>
+        <dd>
+            <ul>
+                <li>Item: 123</li>
+            </ul>
+        </dd>
+    </dl>
+</div>
+EOT;
+
+        $this->assertHTMLEquals("<div>" . $expected_html . "</div>", "<div>" . $html . "</div>");
+    }
+
+    /**
+     * @dataProvider provideRiskyData
+     */
+    public function testRenderConvertSpecialCharactersInItemLabel(
+        string $risky_datum,
+        string $expected_in_html
+    ): void {
+        $r = $this->getDefaultRenderer();
+        $f = $this->getFactory();
+        $df = $this->getDataFactory();
+
+        $c_dimension = $df->dimension()->cardinal();
+
+        $dataset = $df->dataset(["Dataset" => $c_dimension]);
+        $dataset = $dataset->withPoint($risky_datum, ["Dataset" => 123]);
+
+        $vertical = $f->vertical(
+            "bar123",
+            $dataset
+        );
+
+        $html = $r->render($vertical);
+
+        $expected_html = <<<EOT
+<div class="il-chart-bar-vertical">
+    <canvas id="id_1" height="150px" aria-label="bar123" role="img"></canvas>
+</div>
+<div class="sr-only">
+    <dl>
+        <dt>Dataset</dt>
+        <dd>
+            <ul>
+                <li>$expected_in_html: 123</li>
             </ul>
         </dd>
     </dl>


### PR DESCRIPTION
This PR fixes [46966](https://mantis.ilias.de/view.php?id=46966) by escaping the content of KS charts directly before rendering it, instead of leaving it to consumers to escape the data themselves. This is necessary, because the same data is used for two different purposes, with two different requirements for escaping: once to a screen-reader-only listing rendered as HTML, and once passed as JSON to chart.js.

Let me know if you want anything done differently!  