### PR TITLE
[Survey] fix: Validate url param

### DIFF
--- a/components/ILIAS/Survey/Editing/class.ilSurveyQuestionTableGUI.php
+++ b/components/ILIAS/Survey/Editing/class.ilSurveyQuestionTableGUI.php
@@ -305,7 +305,7 @@ class ilSurveyQuestionTableGUI extends ilTable2GUI
 
             $actions = [];
 
-            if ($a_set["url"]) {
+            if ($a_set["url"] ?? false) {
                 $actions[] = $ui_factory->link()->standard(
                     $lng->txt("edit"),
                     $a_set["url"]
@@ -342,7 +342,7 @@ class ilSurveyQuestionTableGUI extends ilTable2GUI
             $this->tpl->parseCurrentBlock();
 
             // #11186
-            if ($a_set["url"]) {
+            if ($a_set["url"] ?? false) {
                 $this->tpl->setCurrentBlock("title_edit");
                 $this->tpl->setVariable("TITLE", $a_set["title"]);
                 $this->tpl->setVariable("URL_TITLE", $a_set["url"]);


### PR DESCRIPTION
We implemented these changes in ILIAS 11 based on @chfsx, as they could not be implemented in ILIAS 9 due to the closing of non-security changes.

Thanks for the proposal — I have incorporated the changes into ILIAS 11.

PR link: https://github.com/ILIAS-eLearning/ILIAS/pull/10899