### PR TITLE
fix: access to ILIAS learning module inside a course across LTI

### DIFF
--- a/components/ILIAS/LearningModule/Presentation/class.ilLMPresentationGUI.php
+++ b/components/ILIAS/LearningModule/Presentation/class.ilLMPresentationGUI.php
@@ -1015,12 +1015,7 @@ class ilLMPresentationGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInt
         }
 
         if (!$this->offlineMode()) {
-            // LTI
-            if ($ltiview->isActive()) {
-                // Do nothing, its complicated...
-            } else {
-                $ilLocator->addRepositoryItems();
-            }
+            $ilLocator->addRepositoryItems();
         } else {
             $ilLocator->setOffline(true);
         }


### PR DESCRIPTION
When a Learning Module is opened through LTI, the ilLocator stack does not register the module in the navigation path. As a result, ILIAS resolves the request to the LTI context container instead of the target Learning Module, causing a redirect to the course.

This change ensures that the Learning Module reference is properly added to the locator stack during LTI launches, matching the behavior of a direct (non-LTI) access. This restores correct navigation resolution and prevents unintended redirects to the parent container.