### PR TITLE
[Survey] fix: Survey update lenguage variable

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -16756,7 +16756,7 @@ survey#:#survey_360_sure_appraisee_close#:#Wollen Sie wirklich die Umfrage für 
 survey#:#survey_360_sure_appraisee_close_admin#:#Wollen Sie wirklich die Umfrage für die folgenden Feedback-Nehmer schließen?
 survey#:#survey_360_sure_delete_appraises#:#Wollen Sie wirklich die folgenden Feedback-Nehmer entfernen?
 survey#:#survey_360_sure_delete_raters#:#Wollen Sie wirklich die folgenden Feedback-Geber für %s entfernen?
-survey#:#survey_access_codes#:#Authentifizierung mit Zugangsschlüsseln
+survey#:#survey_access_codes#:#Authentifizierung mit Zugangsschlüssel
 survey#:#survey_access_codes_info#:#Im Reiter „Info“ muss ein Zugangsschlüssel eingegeben werden, um Zugang zur Umfrage zu erhalten. Diese Zugangsschlüssel werden erzeugt im Reiter „Befragte » Zugangsschlüssel“.
 survey#:#survey_activate_skill_service#:#Kompetenz-Service aktivieren
 survey#:#survey_activate_skill_service_info#:#Es wird ein weiterer Reiter „Kompetenzen“ eingeblendet. Hier werden zunächst den Fragen Kompetenzen zugeordnet, danach werden den Schwellenwerte für die Erreichung bestimmter Kompetenzstufen gesetzt.


### PR DESCRIPTION
Updates the survey language variable to singular form.  

The variable `survey_access_codes` is changed to: "Zugangsschlüssel" / "Access Code"

---

This ensures the text matches the actual functionality and maintains linguistic consistency.
This is related to this ticket: https://mantis.ilias.de/view.php?id=42409