### PR TITLE
plugin path to docu for ILIAS 10

### DIFF
--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -565,7 +565,7 @@ After upgrading the code from ILIAS 9 to ILIAS 10 due to structural changes, you
 and `/data` folder to its new destination. Both are now located in the newly created `public` folder.
 
 ```shell
-sudo -uwww-data mkdir -p public/Customizing/global/plugins
+sudo -u www-data mkdir -p public/Customizing/global/plugins
 mv data public/
 mv Customizing/global/plugins/* public/Customizing/global/plugins/
 ```


### PR DESCRIPTION
Frankly speaking: I am not fully sure if this is really correct. But I can only make plugins work on a local 10 installation when they are in the old directory structure. Otherwise I receive an error message: "Could not scan for classes inside "./public/Customizing/global/plugins" which does not appear to be a file nor a folder".
Additionally it looks like the root path of the plugins is located in "./public/Customizing/global/plugins/": https://github.com/ILIAS-eLearning/ILIAS/blob/027fc7b771bfbae4073e6eb6913ff7835c076780/components/ILIAS/Component/classes/Setup/class.ilComponentBuildPluginInfoObjective.php#L23

I'll assign you @chfsx as authority for Component and @fwolf-ilias for rechecking for the docu. Please shed some light on this.
Thanks a lot!

Best regards!