### PR TITLE
T&A 47188: Fixes html output in question answer statistics for sc, mc, kprim, vertical and horizontal ordering questions

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.assErrorTextGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assErrorTextGUI.php
@@ -514,7 +514,9 @@ class assErrorTextGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
 
             if (!isset($answers[$error_text_hashed])) {
                 $answers[$error_text_hashed] = [
-                    'answer' => $error_text, 'frequency' => 0
+                    'answer' => $error_text,
+                    'frequency' => 0,
+                    'sanitized' => true
                 ];
             }
 

--- a/components/ILIAS/TestQuestionPool/classes/class.assKprimChoiceGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assKprimChoiceGUI.php
@@ -860,15 +860,14 @@ class assKprimChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringAd
 
     public function getAnswersFrequency($relevantAnswers, $questionIndex): array
     {
-        $agg = $this->aggregateAnswers($relevantAnswers, $this->object->getAnswers());
-
         $answers = [];
 
-        foreach ($agg as $ans) {
+        foreach ($this->aggregateAnswers($relevantAnswers, $this->object->getAnswers()) as $ans) {
             $answers[] = [
                 'answer' => $ans['answertext'],
                 'frequency_true' => $ans['count_true'],
-                'frequency_false' => $ans['count_false']
+                'frequency_false' => $ans['count_false'],
+                'sanitized' => true
             ];
         }
 

--- a/components/ILIAS/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
@@ -988,14 +988,13 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
 
     public function getAnswersFrequency($relevantAnswers, $questionIndex): array
     {
-        $agg = $this->aggregateAnswers($relevantAnswers, $this->object->getAnswers());
-
         $answers = [];
 
-        foreach ($agg as $ans) {
+        foreach ($this->aggregateAnswers($relevantAnswers, $this->object->getAnswers()) as $ans) {
             $answers[] = [
                 'answer' => $ans['answertext'],
-                'frequency' => $ans['count_checked']
+                'frequency' => $ans['count_checked'],
+                'sanitized' => true
             ];
         }
 

--- a/components/ILIAS/TestQuestionPool/classes/class.assOrderingHorizontalGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assOrderingHorizontalGUI.php
@@ -390,7 +390,9 @@ class assOrderingHorizontalGUI extends assQuestionGUI implements ilGuiQuestionSc
                 );
 
                 $answers[$md5] = [
-                    'answer' => $answer, 'frequency' => 0
+                    'answer' => $answer,
+                    'frequency' => 0,
+                    'sanitized' => true
                 ];
             }
 

--- a/components/ILIAS/TestQuestionPool/classes/class.assOrderingQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assOrderingQuestionGUI.php
@@ -666,37 +666,16 @@ class assOrderingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
 
     protected function getAnswerStatisticOrderingVariantHtml(ilAssOrderingElementList $list): string
     {
-        $html = '<ul>';
+        $list = array_map(
+            fn(ilAssOrderingElement $elem): string => htmlspecialchars(
+                $this->getAnswerStatisticOrderingElementHtml($elem) ?? '',
+                ENT_QUOTES | ENT_SUBSTITUTE,
+                'utf-8'
+            ),
+            $list->getElements()
+        );
 
-        $lastIndent = 0;
-        $firstElem = true;
-
-        foreach ($list as $elem) {
-            if ($elem->getIndentation() > $lastIndent) {
-                $html .= '<ul><li>';
-            } elseif ($elem->getIndentation() < $lastIndent) {
-                $html .= '</li></ul><li>';
-            } elseif (!$firstElem) {
-                $html .= '</li><li>';
-            } else {
-                $html .= '<li>';
-            }
-
-            $html .= $this->getAnswerStatisticOrderingElementHtml($elem);
-
-            $firstElem = false;
-            $lastIndent = $elem->getIndentation();
-        }
-
-        $html .= '</li>';
-
-        for ($i = $lastIndent; $i > 0; $i--) {
-            $html .= '</ul></li>';
-        }
-
-        $html .= '</ul>';
-
-        return $html;
+        return $this->ui->renderer()->render($this->ui->factory()->listing()->unordered($list));
     }
 
     public function getAnswersFrequency($relevantAnswers, $questionIndex): array
@@ -731,7 +710,9 @@ class assOrderingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
                 );
 
                 $answers[$hash] = [
-                    'answer' => $variantHtml, 'frequency' => 0
+                    'answer' => $variantHtml,
+                    'frequency' => 0,
+                    'sanitized' => true
                 ];
             }
 

--- a/components/ILIAS/TestQuestionPool/classes/class.assQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assQuestionGUI.php
@@ -18,6 +18,7 @@
 
 declare(strict_types=1);
 
+use ILIAS\DI\UIServices;
 use ILIAS\TestQuestionPool\QuestionPoolDIC;
 use ILIAS\TestQuestionPool\RequestDataCollector;
 use ILIAS\TestQuestionPool\ilTestLegacyFormsHelper;
@@ -98,7 +99,7 @@ abstract class assQuestionGUI
         'uploaddefintions'
     ];
 
-    private $ui;
+    protected UIServices $ui;
     private ilObjectDataCache $ilObjDataCache;
     private ilHelpGUI $ilHelp;
     private ilAccessHandler $access;

--- a/components/ILIAS/TestQuestionPool/classes/class.assSingleChoiceGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assSingleChoiceGUI.php
@@ -816,14 +816,13 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
 
     public function getAnswersFrequency($relevantAnswers, $questionIndex): array
     {
-        $agg = $this->aggregateAnswers($relevantAnswers, $this->object->getAnswers());
-
         $answers = [];
 
-        foreach ($agg as $ans) {
+        foreach ($this->aggregateAnswers($relevantAnswers, $this->object->getAnswers()) as $ans) {
             $answers[] = [
                 'answer' => $ans['answertext'],
-                'frequency' => $ans['count_checked']
+                'frequency' => $ans['count_checked'],
+                'sanitized' => true
             ];
         }
 

--- a/components/ILIAS/TestQuestionPool/classes/tables/class.ilAnswerFrequencyStatisticTableGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/tables/class.ilAnswerFrequencyStatisticTableGUI.php
@@ -111,7 +111,9 @@ class ilAnswerFrequencyStatisticTableGUI extends ilTable2GUI
 
     public function fillRow(array $a_set): void
     {
-        $a_set['answer'] = ilLegacyFormElementsUtil::prepareFormOutput((string) $a_set['answer']);
+        if (!isset($a_set['sanitized']) || !$a_set['sanitized']) {
+            $a_set['answer'] = ilLegacyFormElementsUtil::prepareFormOutput((string) $a_set['answer']);
+        }
 
         $this->tpl->setCurrentBlock('answer');
         $this->tpl->setVariable('ANSWER', $a_set['answer']);

--- a/components/ILIAS/TestQuestionPool/classes/tables/class.ilKprimChoiceAnswerFreqStatTableGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/tables/class.ilKprimChoiceAnswerFreqStatTableGUI.php
@@ -58,8 +58,12 @@ class ilKprimChoiceAnswerFreqStatTableGUI extends ilAnswerFrequencyStatisticTabl
 
     public function fillRow(array $a_set): void
     {
+        if (!isset($a_set['sanitized']) || !$a_set['sanitized']) {
+            $a_set['answer'] = htmlspecialchars($a_set['answer'], ENT_QUOTES | ENT_SUBSTITUTE, 'utf-8');
+        }
+
         $this->tpl->setCurrentBlock('answer');
-        $this->tpl->setVariable('ANSWER', ilLegacyFormElementsUtil::prepareFormOutput($a_set['answer']));
+        $this->tpl->setVariable('ANSWER', $a_set['answer']);
         $this->tpl->parseCurrentBlock();
 
         $this->tpl->setCurrentBlock('frequency');


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=47188

Aims to fix html output in question answer statistics for sc, mc, kprim, vertical and horizontal ordering questions.
@thojou 