### PR TITLE
T&A 47192: Prevents overall score from becoming negative after point adjustments

### DIFF
--- a/components/ILIAS/Test/src/Scoring/Manual/TestScoring.php
+++ b/components/ILIAS/Test/src/Scoring/Manual/TestScoring.php
@@ -239,7 +239,7 @@ class TestScoring
                 [\ilDBConstants::T_INTEGER, \ilDBConstants::T_INTEGER],
                 [$active_id, $pass]
             );
-            $values['points'] = [\ilDBConstants::T_FLOAT, $result->fetchAssoc()['reachedpoints'] ?? 0.0];
+            $values['points'] = [\ilDBConstants::T_FLOAT, max($result->fetchAssoc()['reachedpoints'] ?? 0.0, 0.0)];
         }
 
         $this->db->update(

--- a/components/ILIAS/Test/src/Scoring/Manual/TestScoring.php
+++ b/components/ILIAS/Test/src/Scoring/Manual/TestScoring.php
@@ -47,6 +47,7 @@ class TestScoring
 {
     private bool $preserve_manual_scores = false;
     private int $question_id = 0;
+    private \ilTestEvaluationFactory $evaluation_factory;
 
     /**
      * @var array<int, \assQuestionGUI> $question_cache
@@ -59,6 +60,7 @@ class TestScoring
         private \ilDBInterface $db,
         private readonly TestResultRepository $test_result_repository
     ) {
+        $this->evaluation_factory = new \ilTestEvaluationFactory($this->db, $this->test);
     }
 
     public function setPreserveManualScores(bool $preserve_manual_scores): void
@@ -83,16 +85,12 @@ class TestScoring
 
     public function recalculateSolutions(): array
     {
-        $factory = new \ilTestEvaluationFactory($this->db, $this->test);
-        $participants = $factory->getCorrectionsEvaluationData()->getParticipants();
+        $participants = $this->evaluation_factory->getCorrectionsEvaluationData()->getParticipants();
 
         foreach ($participants as $active_id => $userdata) {
-            if (is_object($userdata) && is_array($userdata->getPasses())) {
+            if ($userdata instanceof \ilTestEvaluationUserData) {
                 $this->recalculatePasses($userdata, $active_id);
-                \ilLPStatusWrapper::_updateStatus(
-                    $this->test->getId(),
-                    $userdata->getUserID()
-                );
+                \ilLPStatusWrapper::_updateStatus($this->test->getId(), $userdata->getUserID());
             }
         }
 
@@ -118,9 +116,8 @@ class TestScoring
 
     private function recalculatePasses(\ilTestEvaluationUserData $userdata, int $active_id): void
     {
-        $passes = $userdata->getPasses();
-        foreach ($passes as $pass => $passdata) {
-            if (is_object($passdata)) {
+        foreach ($userdata->getPasses() as $pass => $passdata) {
+            if ($passdata instanceof \ilTestEvaluationPassData) {
                 $this->recalculatePass($passdata, $userdata->getUserID(), $active_id, $pass);
             }
         }
@@ -133,10 +130,9 @@ class TestScoring
         int $active_id,
         int $pass
     ): void {
-        $questions = $passdata->getAnsweredQuestions();
         $reached_points_changed = false;
-        foreach ($questions as $question_data) {
-            if (!$this->getQuestionId() || $this->getQuestionId() === $question_data['id']) {
+        foreach ($passdata->getAnsweredQuestions() as $question_data) {
+            if ($this->getQuestionId() !== 0 || $this->getQuestionId() === $question_data['id']) {
                 $reached_points_changed = $reached_points_changed || $this->recalculateQuestionScore($user_id, $active_id, $pass, $question_data);
             }
         }
@@ -149,14 +145,13 @@ class TestScoring
         int $pass,
         array $questiondata
     ): bool {
-        if ($this->preserve_manual_scores === true && $questiondata['manual'] === 1) {
+        if ($this->preserve_manual_scores && $questiondata['manual'] === 1) {
             return false;
         }
 
         $q_id = $questiondata['id'];
-        if (!isset($this->question_cache[$q_id])) {
-            $this->question_cache[$q_id] = $this->test->createQuestionGUI('', $q_id)->getObject();
-        }
+        $this->question_cache[$q_id] ??= $this->test->createQuestionGUI('', $q_id)->getObject();
+        /** @var \assQuestion $question */
         $question = $this->question_cache[$q_id];
 
         $old_points = $question->getReachedPoints($active_id, $pass);


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=47192

Aims to prevent overall score from becoming negative after point adjustments.
@thojou 