### PR TITLE
UI 47271: Standard filter popover for duration and multi selection not shown on click

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/FilterContextRenderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/FilterContextRenderer.php
@@ -190,6 +190,7 @@ class FilterContextRenderer extends Renderer
 
         $prox = new ProxyFilterField();
         $prox = $prox->withOnClick($popover->getShowSignal());
+        $prox = $this->addTriggererOnLoadCode($prox);
         $tpl->touchBlock("tabindex");
 
         $this->bindJSandApplyId($prox, $tpl);


### PR DESCRIPTION
This PR attempts to fix https://mantis.ilias.de/view.php?id=47271.

Fixes standard filter popover for duration and multi-selection not showing.

Kind regards,
@bidzanaaron 