### PR TITLE
LegalDocuments: Always provide a footer

### DIFF
--- a/components/ILIAS/DataProtection/classes/Consumer.php
+++ b/components/ILIAS/DataProtection/classes/Consumer.php
@@ -22,7 +22,6 @@ namespace ILIAS\DataProtection;
 
 use ilLink;
 use ILIAS\Data\URI;
-use ILIAS\LegalDocuments\ConsumerToolbox\UI;
 use ILIAS\LegalDocuments\ConsumerToolbox\User;
 use ilDBConstants;
 use ilDBInterface;
@@ -71,7 +70,8 @@ final class Consumer implements ConsumerInterface
                      ->hasPublicApi($public_api);
 
         if (!$is_active) {
-            return $slot->hasPublicPage($blocks->notAvailable(...), self::GOTO_NAME);
+            return $slot->hasPublicPage($blocks->notAvailable(...), self::GOTO_NAME)
+                        ->showInFooter($blocks->slot()->dummyFooter(...));
         }
 
         $user = $build_user($this->container->user());
@@ -82,7 +82,7 @@ final class Consumer implements ConsumerInterface
         $constraint = $this->container->refinery()->custom()->constraint(...);
 
         if ($global_settings->noAcceptance()->value()) {
-            $slot = $slot->showInFooter($this->showMatchingDocument($user, $blocks->ui(), $provide))
+            $slot = $slot->showInFooter($this->showMatchingDocument($user, $blocks, $provide))
                          ->hasPublicPage($agreement->showAgreement(...), self::GOTO_NAME);
         } else {
             $slot = $slot->canWithdraw($blocks->slot()->withdrawProcess($user, $global_settings, $this->userHasWithdrawn(...)))
@@ -98,18 +98,18 @@ final class Consumer implements ConsumerInterface
         return $slot;
     }
 
-    private function showMatchingDocument(User $user, UI $ui, Provide $legal_documents): Closure
+    private function showMatchingDocument(User $user, Blocks $blocks, Provide $legal_documents): Closure
     {
-        return function (Closure $footer) use ($user, $ui, $legal_documents) {
-            $in_footer = fn($v) => $footer('usr_agreement', $ui->txt('usr_agreement'), $v);
+        return function (Closure $footer) use ($user, $blocks, $legal_documents) {
+            $in_footer = fn($v) => $footer($this->id(), $blocks->ui()->txt('usr_agreement'), $v);
             if (!$user->isLoggedIn()) {
                 return $in_footer(new URI(ilLink::_getLink(null, 'usr', [], self::GOTO_NAME)));
             }
             if ($user->cannotAgree()) {
-                return $footer;
+                return $blocks->slot()->dummyFooter($footer);
             }
 
-            $render = fn(Document $document): Closure => $in_footer($ui->create()->modal()->roundtrip(
+            $render = fn(Document $document): Closure => $in_footer($blocks->ui()->create()->modal()->roundtrip(
                 $document->content()->title(),
                 [$legal_documents->document()->contentAsComponent($document->content())]
             ));

--- a/components/ILIAS/DataProtection/tests/ConsumerTest.php
+++ b/components/ILIAS/DataProtection/tests/ConsumerTest.php
@@ -63,6 +63,7 @@ class ConsumerTest extends TestCase
         $slot->expects(self::once())->method('hasHistory')->willReturn($slot);
         $slot->expects(self::once())->method('hasPublicApi')->willReturn($slot);
         $slot->expects(self::once())->method('hasPublicPage')->willReturn($slot);
+        $slot->expects(self::once())->method('showInFooter')->willReturn($slot);
 
         $instance = new Consumer($container);
 

--- a/components/ILIAS/LegalDocuments/classes/ConsumerToolbox/ConsumerSlots/ModifyFooter.php
+++ b/components/ILIAS/LegalDocuments/classes/ConsumerToolbox/ConsumerSlots/ModifyFooter.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace ILIAS\LegalDocuments\ConsumerToolbox\ConsumerSlots;
 
+use ILIAS\Data\URI;
 use ilLink;
 use ILIAS\LegalDocuments\Value\DocumentContent;
 use ILIAS\UI\Component\Component;
@@ -55,7 +56,7 @@ final class ModifyFooter
         )->except(
             fn() => new Ok(
                 !$this->goto_link || $this->user->isLoggedIn() ?
-                    $footer :
+                    $this->footer($footer, null) :
                     $this->footer($footer, ($this->goto_link)())
             )
         )->value();
@@ -88,9 +89,9 @@ final class ModifyFooter
     }
 
     /**
-     * @param URI|Modal $value
+     * @param URI|Modal|null $value
      */
-    private function footer(Closure $footer, object $value): Closure
+    private function footer(Closure $footer, ?object $value): Closure
     {
         return $footer($this->legal_documents->id(), $this->ui->txt('usr_agreement'), $value);
     }

--- a/components/ILIAS/LegalDocuments/classes/ConsumerToolbox/Slot.php
+++ b/components/ILIAS/LegalDocuments/classes/ConsumerToolbox/Slot.php
@@ -20,6 +20,8 @@ declare(strict_types=1);
 
 namespace ILIAS\LegalDocuments\ConsumerToolbox;
 
+use ILIAS\Refinery\Encode\Transformation\URL;
+use ILIAS\UI\Component\Modal\Modal;
 use ILIAS\Data\URI;
 use ilLink;
 use ILIAS\Refinery\Constraint;
@@ -74,7 +76,19 @@ class Slot
     public function modifyFooter(User $user, ?string $goto_target = null): ModifyFooter
     {
         $link = $goto_target ? static fn() => new URI(ilLink::_getLink(null, 'usr', [], $goto_target)) : null;
-        return new ModifyFooter($this->blocks->ui(), $user, $this->provide, fn($arg) => $this->container->ui()->renderer()->render($arg), $this->template(...), $link);
+        return new ModifyFooter(
+            $this->blocks->ui(),
+            $user,
+            $this->provide,
+            fn($arg) => $this->container->ui()->renderer()->render($arg),
+            $this->template(...),
+            $link
+        );
+    }
+
+    public function dummyFooter(Closure $footer): Closure
+    {
+        return $footer($this->provide->id(), $this->blocks->ui()->txt('usr_agreement'), null);
     }
 
     /**

--- a/components/ILIAS/LegalDocuments/classes/GlobalScreen/FooterProvider.php
+++ b/components/ILIAS/LegalDocuments/classes/GlobalScreen/FooterProvider.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace ILIAS\LegalDocuments\GlobalScreen;
 
+use ILIAS\Data\URI;
 use ILIAS\LegalDocuments\Conductor;
 use ILIAS\DI\Container;
 use ILIAS\GlobalScreen\Scope\MetaBar\Provider\AbstractStaticFooterProvider;
@@ -66,12 +67,19 @@ class FooterProvider extends AbstractStaticFooterProvider
         };
     }
 
-    private function item(string $id, string $title, object $obj): isItem
+    private function item(string $id, string $title, ?object $obj): isItem
     {
+        $false = fn() => false;
         $id = $this->id_factory->identifier($id);
-        $item = $obj instanceof Modal ?
-            $this->item_factory->modal($id, $title, $obj) :
-            $this->item_factory->link($id, $title)->withAction($obj);
+
+        $item = match (true) {
+            $obj === null => $this->item_factory->link($id, $title)
+                                  ->withAction(new URI(ILIAS_HTTP_PATH))
+                                  ->withAvailableCallable($false)
+                                  ->withVisibilityCallable($false),
+            $obj instanceof Modal => $this->item_factory->modal($id, $title, $obj),
+            default => $this->item_factory->link($id, $title)->withAction($obj),
+        };
 
         return $item->withParent($this->parent_id);
     }

--- a/components/ILIAS/LegalDocuments/classes/UseSlot.php
+++ b/components/ILIAS/LegalDocuments/classes/UseSlot.php
@@ -20,13 +20,13 @@ declare(strict_types=1);
 
 namespace ILIAS\LegalDocuments;
 
+use Closure;
 use ILIAS\LegalDocuments\ConsumerSlots\Agreement;
 use ILIAS\LegalDocuments\ConsumerSlots\CriterionToCondition;
 use ILIAS\LegalDocuments\ConsumerSlots\SelfRegistration;
 use ILIAS\LegalDocuments\ConsumerSlots\WithdrawProcess;
 use ILIAS\LegalDocuments\ConsumerSlots\PublicApi;
 use ILIAS\Refinery\Constraint;
-use ILIAS\UI\Component\MainControls\Footer;
 use ilObjUser;
 use ilNonEditableValueGUI;
 use ILIAS\UI\Component\Component;
@@ -40,7 +40,7 @@ interface UseSlot
     public function afterLogin(callable $after_login): self;
 
     /**
-     * @param callable(Footer): Footer $show
+     * @param callable(Closure): Closure $show
      */
     public function showInFooter(callable $show): self;
 

--- a/components/ILIAS/TermsOfService/classes/Consumer.php
+++ b/components/ILIAS/TermsOfService/classes/Consumer.php
@@ -63,7 +63,8 @@ class Consumer implements ConsumerInterface
                      ->hasPublicApi($public_api);
 
         if (!$is_active) {
-            return $slot->hasPublicPage($blocks->notAvailable(...), self::GOTO_NAME);
+            return $slot->hasPublicPage($blocks->notAvailable(...), self::GOTO_NAME)
+                        ->showInFooter($blocks->slot()->dummyFooter(...));
         }
 
         $user = $build_user($this->container->user());

--- a/components/ILIAS/TermsOfService/tests/ConsumerTest.php
+++ b/components/ILIAS/TermsOfService/tests/ConsumerTest.php
@@ -63,6 +63,7 @@ class ConsumerTest extends TestCase
         $slot->expects(self::once())->method('hasHistory')->willReturn($slot);
         $slot->expects(self::once())->method('hasPublicApi')->willReturn($slot);
         $slot->expects(self::once())->method('hasPublicPage')->willReturn($slot);
+        $slot->expects(self::once())->method('showInFooter')->willReturn($slot);
 
         $instance = new Consumer($container);
 


### PR DESCRIPTION
After Mantis Bug: https://mantis.ilias.de/view.php?id=43115 has been resolved, this PR always provides footer items for LegalDocuments and TermsOfService and uses `withAvailableCallable` and `withVisibilityCallable` to hide them instead of omitting the item completely.

This fixes the issue that the tos and ldoc footer items are not shown in the Footer Administration if the root user resets the footer items.

Additionally this fixes a wrong footer id returned from dpro: https://github.com/ILIAS-eLearning/ILIAS/commit/a8107e4710d24954c9b41ef142bb35d69566ad83#diff-6502eaaa19928d7a8bd62ed5c07a18120e2436d4b5fd66e09ced7fae4f8ce73bR104 (`usr_agreement` -> `dpro`) which caused the dpro to never be shown if it is set to `Never, only informative`.