### PR TITLE
MediaPool: remove duplicate metadata action when editing content snippet (46546)

### DIFF
--- a/components/ILIAS/MediaPool/classes/class.ilMediaPoolPageGUI.php
+++ b/components/ILIAS/MediaPool/classes/class.ilMediaPoolPageGUI.php
@@ -347,19 +347,6 @@ class ilMediaPoolPageGUI extends ilPageObjectGUI
     {
         $tabs = [];
 
-        $mdgui = new ilObjectMetaDataGUI(
-            $this->meta_data_rep_obj,
-            $this->meta_data_type,
-            $this->meta_data_sub_obj_id
-        );
-        $mdtab = $mdgui->getTab();
-        if ($mdtab) {
-            $tabs[] = $this->ui->factory()->link()->standard(
-                $this->lng->txt('meta_data'),
-                $mdtab
-            );
-        }
-
         $tabs[] =
             $this->ui->factory()->link()->standard(
                 $this->lng->txt('cont_usage'),


### PR DESCRIPTION
This PR fixes [46546](https://mantis.ilias.de/view.php?id=46546) by removing the metadata action from `ilMediaPoolPageGUI::getAdditionalPageActions`.

