### PR TITLE
[Improvement] Mail: Adapter for Mustache Engine

### DIFF
--- a/components/ILIAS/DI/src/Container.php
+++ b/components/ILIAS/DI/src/Container.php
@@ -450,7 +450,7 @@ class Container extends \Pimple\Container
 
     public function mail(): \ILIAS\Mail\Service\MailService
     {
-        return new \ILIAS\Mail\Service\MailService($this);
+        return $this[\ILIAS\Mail\Service\MailService::class];
     }
 
     public function certificate(): \ILIAS\Certificate\Service\CertificateService

--- a/components/ILIAS/Init/classes/class.ilInitialisation.php
+++ b/components/ILIAS/Init/classes/class.ilInitialisation.php
@@ -35,6 +35,7 @@ use ILIAS\FileDelivery\Init;
 use ILIAS\LegalDocuments\Conductor;
 use ILIAS\ILIASObject\Properties\AdditionalProperties\Icon\Factory as CustomIconFactory;
 use ILIAS\User\PublicInterface as UserPublicInterface;
+use ILIAS\Mail\Service\MailService;
 
 // needed for slow queries, etc.
 if (!isset($GLOBALS['ilGlobalStartTime']) || !$GLOBALS['ilGlobalStartTime']) {
@@ -766,8 +767,7 @@ class ilInitialisation
 
     protected static function initMail(Container $c): void
     {
-        $mail_service = new \ILIAS\Mail\Service\MailService($c);
-        $mail_service->populate();
+        MailService::init($c);
     }
 
     protected static function initAccessibilityControlConcept(\ILIAS\DI\Container $c): void

--- a/components/ILIAS/Init/classes/class.ilInitialisation.php
+++ b/components/ILIAS/Init/classes/class.ilInitialisation.php
@@ -764,6 +764,12 @@ class ilInitialisation
         $c['legalDocuments'] = static fn(Container $c) => new Conductor($c);
     }
 
+    protected static function initMail(Container $c): void
+    {
+        $mail_service = new \ILIAS\Mail\Service\MailService($c);
+        $mail_service->populate();
+    }
+
     protected static function initAccessibilityControlConcept(\ILIAS\DI\Container $c): void
     {
         $c['acc.criteria.type.factory'] = function (\ILIAS\DI\Container $c) {
@@ -1312,6 +1318,7 @@ class ilInitialisation
         self::initAvatar($GLOBALS['DIC']);
         self::initCustomObjectIcons($GLOBALS['DIC']);
         self::initLegalDocuments($GLOBALS['DIC']);
+        self::initMail($GLOBALS['DIC']);
         self::initAccessibilityControlConcept($GLOBALS['DIC']);
         self::initLearningObjectMetadata($GLOBALS['DIC']);
 

--- a/components/ILIAS/Mail/classes/Mime/Sender/class.ilMailMimeSenderFactory.php
+++ b/components/ILIAS/Mail/classes/Mime/Sender/class.ilMailMimeSenderFactory.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Mail\TemplateEngine\TemplateEngineFactoryInterface;
+
 class ilMailMimeSenderFactory
 {
     /** @var array<int, ilMailMimeSender> */
@@ -26,7 +28,7 @@ class ilMailMimeSenderFactory
 
     public function __construct(
         protected ilSetting $settings,
-        protected ilMustacheFactory $mustache_factory,
+        protected TemplateEngineFactoryInterface $template_engine_factory,
         ?int $anonymous_usr_id = null
     ) {
         if ($anonymous_usr_id === null && defined('ANONYMOUS_USER_ID')) {
@@ -68,11 +70,11 @@ class ilMailMimeSenderFactory
 
     public function user(int $usr_id): ilMailMimeSenderUser
     {
-        return new ilMailMimeSenderUserById($this->settings, $usr_id, $this->mustache_factory);
+        return new ilMailMimeSenderUserById($this->settings, $usr_id, $this->template_engine_factory);
     }
 
     public function userByEmailAddress(string $email_address): ilMailMimeSenderUser
     {
-        return new ilMailMimeSenderUserByEmailAddress($this->settings, $email_address, $this->mustache_factory);
+        return new ilMailMimeSenderUserByEmailAddress($this->settings, $email_address, $this->template_engine_factory);
     }
 }

--- a/components/ILIAS/Mail/classes/Mime/Sender/class.ilMailMimeSenderUser.php
+++ b/components/ILIAS/Mail/classes/Mime/Sender/class.ilMailMimeSenderUser.php
@@ -18,12 +18,14 @@
 
 declare(strict_types=1);
 
+use ILIAS\Mail\TemplateEngine\TemplateEngineFactoryInterface;
+
 abstract class ilMailMimeSenderUser implements ilMailMimeSender
 {
     public function __construct(
         protected ilSetting $settings,
         protected ilObjUser $user,
-        protected ilMustacheFactory $mustache_factory
+        protected TemplateEngineFactoryInterface $template_engine_factory
     ) {
     }
 
@@ -82,7 +84,7 @@ abstract class ilMailMimeSenderUser implements ilMailMimeSender
         ];
 
         $template = $from;
-        $interpolated = $this->mustache_factory->getBasicEngine()->render($template, $placeholders);
+        $interpolated = $this->template_engine_factory->getBasicEngine()->render($template, $placeholders);
 
         if ($template !== $interpolated) {
             return $interpolated;

--- a/components/ILIAS/Mail/classes/Mime/Sender/class.ilMailMimeSenderUserById.php
+++ b/components/ILIAS/Mail/classes/Mime/Sender/class.ilMailMimeSenderUserById.php
@@ -18,18 +18,20 @@
 
 declare(strict_types=1);
 
+use ILIAS\Mail\TemplateEngine\TemplateEngineFactoryInterface;
+
 class ilMailMimeSenderUserById extends ilMailMimeSenderUser
 {
     /** @var array<int, ilObjUser> */
     protected static array $user_instances = [];
 
-    public function __construct(ilSetting $settings, int $usr_id, ilMustacheFactory $mustache_factory)
+    public function __construct(ilSetting $settings, int $usr_id, TemplateEngineFactoryInterface $template_engine_factory)
     {
         if (!array_key_exists($usr_id, self::$user_instances)) {
             self::$user_instances[$usr_id] = new ilObjUser($usr_id);
         }
 
-        parent::__construct($settings, self::$user_instances[$usr_id], $mustache_factory);
+        parent::__construct($settings, self::$user_instances[$usr_id], $template_engine_factory);
     }
 
     public static function addUserToCache(int $usr_id, ilObjUser $user): void

--- a/components/ILIAS/Mail/classes/Mustache/class.ilMailTemplateContextAdapter.php
+++ b/components/ILIAS/Mail/classes/Mustache/class.ilMailTemplateContextAdapter.php
@@ -18,14 +18,16 @@
 
 declare(strict_types=1);
 
+use ILIAS\Mail\TemplateEngine\TemplateEngineInterface;
+
 /**
- * This class forms an interface between the existing ILIAS mail contexts and the requirements of Mustache.
+ * This class forms an interface between the existing ILIAS mail contexts and the requirements of the template engine.
  * In the old system, it was possible to gradually replace individual placeholders via the contexts.
- * This is now done by Mustache and requires a single source. If a placeholder does not exist in this source,
+ * This is now done by the template engine and requires a single source. If a placeholder does not exist in this source,
  * then it will be replaced with NULL. Mustache takes two steps to find the placeholder.
  * On the one hand the check whether it would be theoretically possible and the actual query for the value
  * if the check is successful. This is done in this class using the two magic methods.
- * With the introduction of this interface, the ILIAS mail contexts do not have to be changed for Mustache.
+ * With the introduction of this interface, the ILIAS mail contexts do not have to be changed for the template engine.
  */
 class ilMailTemplateContextAdapter
 {
@@ -33,7 +35,7 @@ class ilMailTemplateContextAdapter
         /** @var ilMailTemplateContext[] $contexts */
         protected array $contexts,
         protected array $context_parameter,
-        protected readonly Mustache_Engine $mustache_engine,
+        protected readonly TemplateEngineInterface $template_engine,
         protected ?ilObjUser $recipient = null
     ) {
     }
@@ -67,7 +69,7 @@ class ilMailTemplateContextAdapter
         foreach ($this->contexts as $context) {
             $ret = $context->resolvePlaceholder($name, $this->context_parameter, $this->recipient);
             if (in_array($name, $context->getNestedPlaceholders(), true)) {
-                $ret = $this->mustache_engine->render($ret, $this);
+                $ret = $this->template_engine->render($ret, $this);
             }
             if ($ret !== '') {
                 return $ret;

--- a/components/ILIAS/Mail/classes/Service/MailService.php
+++ b/components/ILIAS/Mail/classes/Service/MailService.php
@@ -21,57 +21,115 @@ declare(strict_types=1);
 namespace ILIAS\Mail\Service;
 
 use ILIAS\DI\Container;
-use ILIAS\Mail\Autoresponder\AutoresponderServiceImpl;
-use ILIAS\Mail\Autoresponder\AutoresponderService;
-use ILIAS\Mail\TemplateEngine\TemplateEngineFactoryInterface;
 use ilMailTemplateService;
-use ILIAS\Data\Factory as DataFactory;
-use ILIAS\Mail\Autoresponder\AutoresponderDatabaseRepository;
+use ilMailMimeSenderFactory;
 use ilMailTemplateRepository;
+use ilMailMimeTransportFactory;
 use ilMailTemplateServiceInterface;
+use ILIAS\Data\Factory as DataFactory;
+use ilMailTemplatePlaceholderResolver;
+use ilMailTemplatePlaceholderToEmptyResolver;
+use ILIAS\Mail\Autoresponder\AutoresponderService;
+use ILIAS\Mail\Autoresponder\AutoresponderServiceImpl;
+use ILIAS\Mail\Autoresponder\AutoresponderDatabaseRepository;
+use ILIAS\Mail\TemplateEngine\TemplateEngineFactoryInterface;
 use ILIAS\Mail\TemplateEngine\Mustache\MustacheTemplateEngineFactory;
 
 class MailService
 {
     public function __construct(protected Container $dic)
     {
-        $this->dic[self::class] = $this;
     }
 
-    public function populate(): void
+    public static function init(Container $container): void
     {
-        if (!isset($this->dic[ilMailTemplateServiceInterface::class])) {
-            $this->dic[ilMailTemplateServiceInterface::class] = static function (Container $c): ilMailTemplateServiceInterface {
-                return new ilMailTemplateService(
-                    new ilMailTemplateRepository($c->database()),
-                    $c->mail()->templateEngineFactory()
-                );
-            };
-        }
+        $container[self::class] = static function (Container $c): self {
+            return new self($c);
+        };
 
-        if (!isset($this->dic[TemplateEngineFactoryInterface::class])) {
-            $this->dic[TemplateEngineFactoryInterface::class] = static function (Container $c): TemplateEngineFactoryInterface {
-                return $c->mail()->templateEngineFactory();
-            };
-        }
+        $container[ilMailTemplateServiceInterface::class] = static function (Container $c): ilMailTemplateServiceInterface {
+            return new ilMailTemplateService(
+                new ilMailTemplateRepository($c->database()),
+                $c->mail()->templateEngineFactory()
+            );
+        };
+
+        $container[TemplateEngineFactoryInterface::class] = static function (Container $c): TemplateEngineFactoryInterface {
+            return $c->mail()->templateEngineFactory();
+        };
+
+        $container[MimeMailService::class] = static function (Container $c): MimeMailService {
+            return new MimeMailService($c);
+        };
+
+        $container['mail.mime.transport.factory'] = static function (Container $c): ilMailMimeTransportFactory {
+            return new ilMailMimeTransportFactory($c->settings(), $c->event());
+        };
+
+        $container['mail.mime.sender.factory'] = static function (Container $c): ilMailMimeSenderFactory {
+            return new ilMailMimeSenderFactory(
+                $c->settings(),
+                $c->mail()->templateEngineFactory()
+            );
+        };
+
+        $container['mail.texttemplates.service'] = static function (Container $c): ilMailTemplateService {
+            return new ilMailTemplateService(
+                new ilMailTemplateRepository($c->database()),
+                $c->mail()->templateEngineFactory()
+            );
+        };
+
+        $container['mail.template.placeholder.resolver'] = static function (Container $c): ilMailTemplatePlaceholderResolver {
+            return new ilMailTemplatePlaceholderResolver(
+                $c->mail()->templateEngineFactory()->getBasicEngine()
+            );
+        };
+
+        $container[AutoresponderService::class] = static function (Container $c): AutoresponderService {
+            return new AutoresponderServiceImpl(
+                (int) $c->settings()->get(
+                    'mail_auto_responder_idle_time',
+                    (string) AutoresponderService::AUTO_RESPONDER_DEFAULT_IDLE_TIME
+                ),
+                false,
+                new AutoresponderDatabaseRepository($c->database()),
+                (new DataFactory())->clock()->utc()
+            );
+        };
+
+        $container[ilMailTemplatePlaceholderResolver::class] = static function (Container $c): ilMailTemplatePlaceholderResolver {
+            return new ilMailTemplatePlaceholderResolver(
+                $c->mail()->templateEngineFactory()->getBasicEngine()
+            );
+        };
+
+        $container[ilMailTemplatePlaceholderToEmptyResolver::class] = static function (Container $c): ilMailTemplatePlaceholderToEmptyResolver {
+            return new ilMailTemplatePlaceholderToEmptyResolver();
+        };
+
+        $container['mail.template_engine.factory'] = static function (Container $c): MustacheTemplateEngineFactory {
+            return new MustacheTemplateEngineFactory();
+        };
+
+        $container['mail.signature.service'] = static function (Container $c): MailSignatureService {
+            return new MailSignatureService(
+                $c->mail()->templateEngineFactory(),
+                $c->clientIni(),
+                $c->language(),
+                $c->settings()
+            );
+        };
     }
 
     public function mime(): MimeMailService
     {
-        return new MimeMailService($this->dic);
+        return $this->dic[MimeMailService::class];
     }
 
     public function autoresponder(): AutoresponderService
     {
-        return new AutoresponderServiceImpl(
-            (int) $this->dic->settings()->get(
-                'mail_auto_responder_idle_time',
-                (string) AutoresponderService::AUTO_RESPONDER_DEFAULT_IDLE_TIME
-            ),
-            false,
-            new AutoresponderDatabaseRepository($this->dic->database()),
-            (new DataFactory())->clock()->utc()
-        );
+        return $this->dic[AutoresponderService::class];
     }
 
     public function textTemplates(): ilMailTemplateServiceInterface
@@ -79,36 +137,23 @@ class MailService
         return $this->dic[ilMailTemplateServiceInterface::class];
     }
 
-    public function placeholderResolver(): \ilMailTemplatePlaceholderResolver
+    public function placeholderResolver(): ilMailTemplatePlaceholderResolver
     {
-        return new \ilMailTemplatePlaceholderResolver(
-            $this->templateEngineFactory()->getBasicEngine()
-        );
+        return $this->dic[ilMailTemplatePlaceholderResolver::class];
     }
 
-    public function placeholderToEmptyResolver(): \ilMailTemplatePlaceholderToEmptyResolver
+    public function placeholderToEmptyResolver(): ilMailTemplatePlaceholderToEmptyResolver
     {
-        return new \ilMailTemplatePlaceholderToEmptyResolver();
+        return $this->dic[ilMailTemplatePlaceholderToEmptyResolver::class];
     }
 
     public function templateEngineFactory(): TemplateEngineFactoryInterface
     {
-        if (!isset($this->dic['mail.template_engine.factory'])) {
-            $this->dic['mail.template_engine.factory'] = static function (Container $c): MustacheTemplateEngineFactory {
-                return new MustacheTemplateEngineFactory();
-            };
-        }
-
         return $this->dic['mail.template_engine.factory'];
     }
 
     public function signature(): MailSignatureService
     {
-        return new MailSignatureService(
-            $this->templateEngineFactory(),
-            $this->dic->clientIni(),
-            $this->dic->language(),
-            $this->dic->settings()
-        );
+        return $this->dic['mail.signature.service'];
     }
 }

--- a/components/ILIAS/Mail/classes/Service/MailService.php
+++ b/components/ILIAS/Mail/classes/Service/MailService.php
@@ -35,12 +35,23 @@ class MailService
 {
     public function __construct(protected Container $dic)
     {
+        $this->dic[self::class] = $this;
+    }
+
+    public function populate(): void
+    {
         if (!isset($this->dic[ilMailTemplateServiceInterface::class])) {
             $this->dic[ilMailTemplateServiceInterface::class] = static function (Container $c): ilMailTemplateServiceInterface {
                 return new ilMailTemplateService(
                     new ilMailTemplateRepository($c->database()),
                     $c->mail()->templateEngineFactory()
                 );
+            };
+        }
+
+        if (!isset($this->dic[TemplateEngineFactoryInterface::class])) {
+            $this->dic[TemplateEngineFactoryInterface::class] = static function (Container $c): TemplateEngineFactoryInterface {
+                return $c->mail()->templateEngineFactory();
             };
         }
     }

--- a/components/ILIAS/Mail/classes/Service/MailService.php
+++ b/components/ILIAS/Mail/classes/Service/MailService.php
@@ -23,11 +23,13 @@ namespace ILIAS\Mail\Service;
 use ILIAS\DI\Container;
 use ILIAS\Mail\Autoresponder\AutoresponderServiceImpl;
 use ILIAS\Mail\Autoresponder\AutoresponderService;
+use ILIAS\Mail\TemplateEngine\TemplateEngineFactoryInterface;
 use ilMailTemplateService;
 use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Mail\Autoresponder\AutoresponderDatabaseRepository;
 use ilMailTemplateRepository;
 use ilMailTemplateServiceInterface;
+use ILIAS\Mail\TemplateEngine\Mustache\MustacheTemplateEngineFactory;
 
 class MailService
 {
@@ -37,7 +39,7 @@ class MailService
             $this->dic[ilMailTemplateServiceInterface::class] = static function (Container $c): ilMailTemplateServiceInterface {
                 return new ilMailTemplateService(
                     new ilMailTemplateRepository($c->database()),
-                    $c->mail()->mustacheFactory()
+                    $c->mail()->templateEngineFactory()
                 );
             };
         }
@@ -69,7 +71,7 @@ class MailService
     public function placeholderResolver(): \ilMailTemplatePlaceholderResolver
     {
         return new \ilMailTemplatePlaceholderResolver(
-            $this->mustacheFactory()->getBasicEngine()
+            $this->templateEngineFactory()->getBasicEngine()
         );
     }
 
@@ -78,15 +80,21 @@ class MailService
         return new \ilMailTemplatePlaceholderToEmptyResolver();
     }
 
-    public function mustacheFactory(): \ilMustacheFactory
+    public function templateEngineFactory(): TemplateEngineFactoryInterface
     {
-        return new \ilMustacheFactory();
+        if (!isset($this->dic['mail.template_engine.factory'])) {
+            $this->dic['mail.template_engine.factory'] = static function (Container $c): MustacheTemplateEngineFactory {
+                return new MustacheTemplateEngineFactory();
+            };
+        }
+
+        return $this->dic['mail.template_engine.factory'];
     }
 
     public function signature(): MailSignatureService
     {
         return new MailSignatureService(
-            $this->mustacheFactory(),
+            $this->templateEngineFactory(),
             $this->dic->clientIni(),
             $this->dic->language(),
             $this->dic->settings()

--- a/components/ILIAS/Mail/classes/Service/MimeMailService.php
+++ b/components/ILIAS/Mail/classes/Service/MimeMailService.php
@@ -38,7 +38,7 @@ class MimeMailService
             $this->dic['mail.mime.sender.factory'] = static function (Container $c): ilMailMimeSenderFactory {
                 return new ilMailMimeSenderFactory(
                     $c->settings(),
-                    $c->mail()->mustacheFactory()
+                    $c->mail()->templateEngineFactory()
                 );
             };
         }
@@ -47,21 +47,15 @@ class MimeMailService
             $this->dic['mail.texttemplates.service'] = static function (Container $c): \ilMailTemplateService {
                 return new \ilMailTemplateService(
                     new \ilMailTemplateRepository($c->database()),
-                    $this->dic['mail.mustache.factory']
+                    $c->mail()->templateEngineFactory()
                 );
-            };
-        }
-
-        if (!isset($this->dic['mail.mustache.factory'])) {
-            $this->dic["mail.mustache.factory"] = static function (Container $c): \ilMustacheFactory {
-                return new \ilMustacheFactory();
             };
         }
 
         if (!isset($this->dic['mail.template.placeholder.resolver'])) {
             $this->dic["mail.template.placeholder.resolver"] = static function (Container $c): \ilMailTemplatePlaceholderResolver {
                 return new \ilMailTemplatePlaceholderResolver(
-                    $c["mail.mustache.factory"]->getBasicEngine()
+                    $c->mail()->templateEngineFactory()->getBasicEngine()
                 );
             };
         }

--- a/components/ILIAS/Mail/classes/Service/MimeMailService.php
+++ b/components/ILIAS/Mail/classes/Service/MimeMailService.php
@@ -28,37 +28,6 @@ class MimeMailService
 {
     public function __construct(protected Container $dic)
     {
-        if (!isset($this->dic['mail.mime.transport.factory'])) {
-            $this->dic['mail.mime.transport.factory'] = static function (Container $c): ilMailMimeTransportFactory {
-                return new ilMailMimeTransportFactory($c->settings(), $c->event());
-            };
-        }
-
-        if (!isset($this->dic['mail.mime.sender.factory'])) {
-            $this->dic['mail.mime.sender.factory'] = static function (Container $c): ilMailMimeSenderFactory {
-                return new ilMailMimeSenderFactory(
-                    $c->settings(),
-                    $c->mail()->templateEngineFactory()
-                );
-            };
-        }
-
-        if (!isset($this->dic['mail.texttemplates.service'])) {
-            $this->dic['mail.texttemplates.service'] = static function (Container $c): \ilMailTemplateService {
-                return new \ilMailTemplateService(
-                    new \ilMailTemplateRepository($c->database()),
-                    $c->mail()->templateEngineFactory()
-                );
-            };
-        }
-
-        if (!isset($this->dic['mail.template.placeholder.resolver'])) {
-            $this->dic["mail.template.placeholder.resolver"] = static function (Container $c): \ilMailTemplatePlaceholderResolver {
-                return new \ilMailTemplatePlaceholderResolver(
-                    $c->mail()->templateEngineFactory()->getBasicEngine()
-                );
-            };
-        }
     }
 
     public function transportFactory(): ilMailMimeTransportFactory

--- a/components/ILIAS/Mail/classes/Signature/MailSignatureService.php
+++ b/components/ILIAS/Mail/classes/Signature/MailSignatureService.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
 namespace ILIAS\Mail\Service;
 
 use ilIniFile;
-use ilMustacheFactory;
+use ILIAS\Mail\TemplateEngine\TemplateEngineFactoryInterface;
 use ILIAS\Mail\Signature\Signature;
 use ILIAS\Mail\Signature\MailInstallationSignature;
 use ILIAS\Mail\Signature\MailUserSignature;
@@ -37,7 +37,7 @@ use ILIAS\Mail\Placeholder\MailSignatureUserFullnamePlaceholder;
 class MailSignatureService
 {
     public function __construct(
-        private readonly ilMustacheFactory $mustache_factory,
+        private readonly TemplateEngineFactoryInterface $template_engine_factory,
         private readonly ilIniFile $client_ini_file,
         private readonly ilLanguage $lng,
         private readonly ilSetting $settings
@@ -64,7 +64,7 @@ class MailSignatureService
     {
         $placeholders = $placeholder->handle($signature);
 
-        return "\n\n\n" . $this->mustache_factory->getBasicEngine()->render($signature->getSignature(), $placeholders);
+        return "\n\n\n" . $this->template_engine_factory->getBasicEngine()->render($signature->getSignature(), $placeholders);
     }
 
     public function getPlaceholder(int $user_id = 0): Placeholder

--- a/components/ILIAS/Mail/classes/class.ilAccountMail.php
+++ b/components/ILIAS/Mail/classes/class.ilAccountMail.php
@@ -193,12 +193,12 @@ class ilAccountMail
     {
         global $DIC;
         $settings = $DIC->settings();
-        $mustache_factory = $DIC->mail()->mustacheFactory();
+        $template_engine_factory = $DIC->mail()->templateEngineFactory();
 
         $replacements = [];
 
         // determine salutation
-        $replacements['MAIL_SALUTATION'] = $mustache_factory->getBasicEngine()->render(
+        $replacements['MAIL_SALUTATION'] = $template_engine_factory->getBasicEngine()->render(
             match ($a_user->getGender()) {
                 'f' => trim($a_amail->getSalutationFemale()),
                 'm' => trim($a_amail->getSalutationMale()),
@@ -252,6 +252,6 @@ class ilAccountMail
             }
         }
 
-        return $mustache_factory->getBasicEngine()->render($a_string, $replacements);
+        return $template_engine_factory->getBasicEngine()->render($a_string, $replacements);
     }
 }

--- a/components/ILIAS/Mail/classes/class.ilMailTemplatePlaceholderResolver.php
+++ b/components/ILIAS/Mail/classes/class.ilMailTemplatePlaceholderResolver.php
@@ -18,9 +18,11 @@
 
 declare(strict_types=1);
 
+use ILIAS\Mail\TemplateEngine\TemplateEngineInterface;
+
 class ilMailTemplatePlaceholderResolver
 {
-    public function __construct(protected Mustache_Engine $mustache_engine)
+    public function __construct(protected TemplateEngineInterface $template_engine)
     {
     }
 
@@ -33,12 +35,12 @@ class ilMailTemplatePlaceholderResolver
         ?ilObjUser $user = null,
         array $context_parameters = []
     ): string {
-        return $this->mustache_engine->render(
+        return $this->template_engine->render(
             $message,
             new ilMailTemplateContextAdapter(
                 [$context],
                 $context_parameters,
-                $this->mustache_engine,
+                $this->template_engine,
                 $user
             )
         );

--- a/components/ILIAS/Mail/classes/class.ilMailTemplateService.php
+++ b/components/ILIAS/Mail/classes/class.ilMailTemplateService.php
@@ -18,6 +18,7 @@
 
 declare(strict_types=1);
 
+use ILIAS\Mail\TemplateEngine\TemplateEngineFactoryInterface;
 use ILIAS\Mail\Templates\TemplateSubjectSyntaxException;
 use ILIAS\Mail\Templates\TemplateMessageSyntaxException;
 
@@ -25,7 +26,7 @@ class ilMailTemplateService implements ilMailTemplateServiceInterface
 {
     public function __construct(
         protected ilMailTemplateRepository $repository,
-        protected ilMustacheFactory $mustache_factory
+        protected TemplateEngineFactoryInterface $template_engine_factory
     ) {
     }
 
@@ -37,13 +38,13 @@ class ilMailTemplateService implements ilMailTemplateServiceInterface
         string $language
     ): ilMailTemplate {
         try {
-            $this->mustache_factory->getBasicEngine()->render($subject, []);
+            $this->template_engine_factory->getBasicEngine()->render($subject, []);
         } catch (Exception) {
             throw new TemplateSubjectSyntaxException('Invalid mail template for subject');
         }
 
         try {
-            $this->mustache_factory->getBasicEngine()->render($message, []);
+            $this->template_engine_factory->getBasicEngine()->render($message, []);
         } catch (Exception) {
             throw new TemplateMessageSyntaxException('Invalid mail template for message');
         }
@@ -69,13 +70,13 @@ class ilMailTemplateService implements ilMailTemplateServiceInterface
         string $language
     ): void {
         try {
-            $this->mustache_factory->getBasicEngine()->render($subject, []);
+            $this->template_engine_factory->getBasicEngine()->render($subject, []);
         } catch (Exception) {
             throw new TemplateSubjectSyntaxException('Invalid mail template for subject');
         }
 
         try {
-            $this->mustache_factory->getBasicEngine()->render($message, []);
+            $this->template_engine_factory->getBasicEngine()->render($message, []);
         } catch (Exception) {
             throw new TemplateMessageSyntaxException('Invalid mail template for message');
         }

--- a/components/ILIAS/Mail/classes/class.ilObjMailGUI.php
+++ b/components/ILIAS/Mail/classes/class.ilObjMailGUI.php
@@ -23,6 +23,7 @@ use ILIAS\Mail\Signature\MailUserSignature;
 use ILIAS\Mail\Signature\Signature;
 use ILIAS\Mail\Signature\MailInstallationSignature;
 use ILIAS\Mail\Service\MailSignatureService;
+use ILIAS\Mail\TemplateEngine\TemplateEngineFactoryInterface;
 
 /**
  * @ilCtrl_Calls ilObjMailGUI: ilPermissionGUI
@@ -34,7 +35,7 @@ class ilObjMailGUI extends ilObjectGUI
     private const string PASSWORD_PLACE_HOLDER = '***********************';
 
     private readonly ilTabsGUI $tabs;
-    private readonly ilMustacheFactory $mustache_factory;
+    private readonly TemplateEngineFactoryInterface $template_engine_factory;
     private readonly MailSignatureService $mail_signature_service;
 
     public function __construct($a_data, int $a_id, bool $a_call_by_reference)
@@ -44,7 +45,7 @@ class ilObjMailGUI extends ilObjectGUI
         parent::__construct($a_data, $a_id, $a_call_by_reference, false);
 
         $this->tabs = $DIC->tabs();
-        $this->mustache_factory = $DIC->mail()->mustacheFactory();
+        $this->template_engine_factory = $DIC->mail()->templateEngineFactory();
         $this->mail_signature_service = $DIC->mail()->signature();
 
         $this->lng->loadLanguageModule('mail');
@@ -660,7 +661,7 @@ class ilObjMailGUI extends ilObjectGUI
         // If all forms in ILIAS use the UI/KS forms (here and in Services/Mail), we should move this to a proper constraint/trafo
         $is_valid_template_syntax = $this->refinery->custom()->constraint(function ($value): bool {
             try {
-                $this->mustache_factory->getBasicEngine()->render((string) $value, []);
+                $this->template_engine_factory->getBasicEngine()->render((string) $value, []);
                 return true;
             } catch (Exception) {
                 return false;

--- a/components/ILIAS/Mail/src/TemplateEngine/Mustache/MustacheTemplateEngine.php
+++ b/components/ILIAS/Mail/src/TemplateEngine/Mustache/MustacheTemplateEngine.php
@@ -18,10 +18,24 @@
 
 declare(strict_types=1);
 
-class ilMustacheFactory
+namespace ILIAS\Mail\TemplateEngine\Mustache;
+
+use ILIAS\Mail\TemplateEngine\TemplateEngineInterface;
+use Mustache_Engine;
+
+/**
+ * Mustache implementation of the template engine interface.
+ * Wraps Mustache_Engine to decouple Mail component from the concrete library.
+ */
+class MustacheTemplateEngine implements TemplateEngineInterface
 {
-    public function getBasicEngine(): Mustache_Engine
+    public function __construct(
+        private readonly Mustache_Engine $engine
+    ) {
+    }
+
+    public function render(string $template, array|object $context): string
     {
-        return new Mustache_Engine();
+        return $this->engine->render($template, $context);
     }
 }

--- a/components/ILIAS/Mail/src/TemplateEngine/Mustache/MustacheTemplateEngineFactory.php
+++ b/components/ILIAS/Mail/src/TemplateEngine/Mustache/MustacheTemplateEngineFactory.php
@@ -18,20 +18,16 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+namespace ILIAS\Mail\TemplateEngine\Mustache;
 
-class ilMustacheFactoryTest extends TestCase
+use ILIAS\Mail\TemplateEngine\TemplateEngineFactoryInterface;
+use ILIAS\Mail\TemplateEngine\TemplateEngineInterface;
+use Mustache_Engine;
+
+class MustacheTemplateEngineFactory implements TemplateEngineFactoryInterface
 {
-    public function testCreatInstance(): void
+    public function getBasicEngine(): TemplateEngineInterface
     {
-        $f = new ilMustacheFactory();
-        $this->assertInstanceOf(ilMustacheFactory::class, $f);
-    }
-
-    public function testCreateBasicEngine(): void
-    {
-        $f = new ilMustacheFactory();
-        $engine = $f->getBasicEngine();
-        $this->assertInstanceOf(Mustache_Engine::class, $engine);
+        return new MustacheTemplateEngine(new Mustache_Engine());
     }
 }

--- a/components/ILIAS/Mail/src/TemplateEngine/TemplateEngineFactoryInterface.php
+++ b/components/ILIAS/Mail/src/TemplateEngine/TemplateEngineFactoryInterface.php
@@ -18,15 +18,17 @@
 
 declare(strict_types=1);
 
-use ILIAS\Mail\TemplateEngine\TemplateEngineFactoryInterface;
+namespace ILIAS\Mail\TemplateEngine;
 
-class ilMailMimeSenderUserByEmailAddress extends ilMailMimeSenderUser
+/**
+ * Factory interface for creating template engine instances.
+ * Enables dependency inversion: consumers depend on this interface,
+ * not on a concrete implementation like Mustache.
+ */
+interface TemplateEngineFactoryInterface
 {
-    public function __construct(ilSetting $settings, string $email_address, TemplateEngineFactoryInterface $template_engine_factory)
-    {
-        $user = new ilObjUser();
-        $user->setEmail($email_address);
-
-        parent::__construct($settings, $user, $template_engine_factory);
-    }
+    /**
+     * Returns a template engine instance for basic rendering operations.
+     */
+    public function getBasicEngine(): TemplateEngineInterface;
 }

--- a/components/ILIAS/Mail/src/TemplateEngine/TemplateEngineInterface.php
+++ b/components/ILIAS/Mail/src/TemplateEngine/TemplateEngineInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Mail\TemplateEngine;
+
+/**
+ * Interface for template engine functionality used in Mail and related components.
+ * Abstracts the concrete template engine implementation (e.g. Mustache) to enable
+ * dependency inversion and easier testing.
+ */
+interface TemplateEngineInterface
+{
+    /**
+     * Renders a template string with the given context.
+     *
+     * @param string $template The template string (e.g. Mustache syntax)
+     * @param array<string, mixed>|object $context The context data for placeholder replacement
+     */
+    public function render(string $template, array|object $context): string;
+}

--- a/components/ILIAS/Mail/tests/TemplateEngine/MustacheTemplateEngineFactoryTest.php
+++ b/components/ILIAS/Mail/tests/TemplateEngine/MustacheTemplateEngineFactoryTest.php
@@ -31,18 +31,10 @@ class MustacheTemplateEngineFactoryTest extends TestCase
         $this->assertInstanceOf(TemplateEngineFactoryInterface::class, $f);
     }
 
-    public function testGetBasicEngineReturnsTemplateEngine(): void
+    public function testBasicEngineCanBeRetrieved(): void
     {
         $f = new MustacheTemplateEngineFactory();
         $engine = $f->getBasicEngine();
         $this->assertInstanceOf(TemplateEngineInterface::class, $engine);
-    }
-
-    public function testEngineRendersMustacheTemplates(): void
-    {
-        $f = new MustacheTemplateEngineFactory();
-        $engine = $f->getBasicEngine();
-        $result = $engine->render('Hello {{name}}!', ['name' => 'World']);
-        $this->assertSame('Hello World!', $result);
     }
 }

--- a/components/ILIAS/Mail/tests/TemplateEngine/MustacheTemplateEngineFactoryTest.php
+++ b/components/ILIAS/Mail/tests/TemplateEngine/MustacheTemplateEngineFactoryTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\Mail\TemplateEngine\Mustache\MustacheTemplateEngineFactory;
+use ILIAS\Mail\TemplateEngine\TemplateEngineFactoryInterface;
+use ILIAS\Mail\TemplateEngine\TemplateEngineInterface;
+use PHPUnit\Framework\TestCase;
+
+class MustacheTemplateEngineFactoryTest extends TestCase
+{
+    public function testFactoryImplementsInterface(): void
+    {
+        $f = new MustacheTemplateEngineFactory();
+        $this->assertInstanceOf(TemplateEngineFactoryInterface::class, $f);
+    }
+
+    public function testGetBasicEngineReturnsTemplateEngine(): void
+    {
+        $f = new MustacheTemplateEngineFactory();
+        $engine = $f->getBasicEngine();
+        $this->assertInstanceOf(TemplateEngineInterface::class, $engine);
+    }
+
+    public function testEngineRendersMustacheTemplates(): void
+    {
+        $f = new MustacheTemplateEngineFactory();
+        $engine = $f->getBasicEngine();
+        $result = $engine->render('Hello {{name}}!', ['name' => 'World']);
+        $this->assertSame('Hello World!', $result);
+    }
+}

--- a/components/ILIAS/Mail/tests/ilMailBaseTestCase.php
+++ b/components/ILIAS/Mail/tests/ilMailBaseTestCase.php
@@ -50,6 +50,9 @@ abstract class ilMailBaseTestCase extends TestCase
         $DIC = new Container();
         $DIC['legalDocuments'] = fn() => $this->getMockBuilder(Conductor::class)->disableOriginalConstructor()->getMock();
 
+        $mail_service = new \ILIAS\Mail\Service\MailService($DIC);
+        $mail_service->populate();
+
         parent::setUp();
     }
 

--- a/components/ILIAS/Mail/tests/ilMailBaseTestCase.php
+++ b/components/ILIAS/Mail/tests/ilMailBaseTestCase.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 use ILIAS\DI\Container;
 use PHPUnit\Framework\TestCase;
 use ILIAS\LegalDocuments\Conductor;
+use ILIAS\Mail\Service\MailService;
 
 abstract class ilMailBaseTestCase extends TestCase
 {
@@ -50,8 +51,7 @@ abstract class ilMailBaseTestCase extends TestCase
         $DIC = new Container();
         $DIC['legalDocuments'] = fn() => $this->getMockBuilder(Conductor::class)->disableOriginalConstructor()->getMock();
 
-        $mail_service = new \ILIAS\Mail\Service\MailService($DIC);
-        $mail_service->populate();
+        MailService::init($DIC);
 
         parent::setUp();
     }

--- a/components/ILIAS/Mail/tests/ilMailMimeTest.php
+++ b/components/ILIAS/Mail/tests/ilMailMimeTest.php
@@ -157,7 +157,7 @@ class ilMailMimeTest extends ilMailBaseTestCase
             'set',
             'get',
         ])->getMock();
-        $template_engine_factory = $this->getMockBuilder(TemplateEngineFactoryInterface::class)->getMock();
+        $template_engine_factory = $this->createMock(TemplateEngineFactoryInterface::class);
 
         $factory = new ilMailMimeSenderFactory($settings, $template_engine_factory);
         $this->assertInstanceOf(ilMailMimeSenderSystem::class, $factory->getSenderByUsrId(ANONYMOUS_USER_ID));
@@ -169,7 +169,7 @@ class ilMailMimeTest extends ilMailBaseTestCase
             'set',
             'get',
         ])->getMock();
-        $template_engine_factory = $this->getMockBuilder(TemplateEngineFactoryInterface::class)->getMock();
+        $template_engine_factory = $this->createMock(TemplateEngineFactoryInterface::class);
 
         $factory = new ilMailMimeSenderFactory($settings, $template_engine_factory);
         $this->assertInstanceOf(ilMailMimeSenderSystem::class, $factory->system());
@@ -192,7 +192,7 @@ class ilMailMimeTest extends ilMailBaseTestCase
             'set',
             'get',
         ])->getMock();
-        $template_engine_factory = $this->getMockBuilder(TemplateEngineFactoryInterface::class)->getMock();
+        $template_engine_factory = $this->createMock(TemplateEngineFactoryInterface::class);
 
         $factory = new ilMailMimeSenderFactory($settings, $template_engine_factory);
         $this->assertInstanceOf(ilMailMimeSenderUser::class, $factory->getSenderByUsrId(self::USER_ID));
@@ -204,7 +204,7 @@ class ilMailMimeTest extends ilMailBaseTestCase
             'set',
             'get',
         ])->getMock();
-        $template_engine_factory = $this->getMockBuilder(TemplateEngineFactoryInterface::class)->getMock();
+        $template_engine_factory = $this->createMock(TemplateEngineFactoryInterface::class);
 
         $factory = new ilMailMimeSenderFactory($settings, $template_engine_factory);
         $this->assertInstanceOf(ilMailMimeSenderUser::class, $factory->user(self::USER_ID));

--- a/components/ILIAS/Mail/tests/ilMailMimeTest.php
+++ b/components/ILIAS/Mail/tests/ilMailMimeTest.php
@@ -19,6 +19,7 @@
 declare(strict_types=1);
 
 use ILIAS\Refinery\Factory;
+use ILIAS\Mail\TemplateEngine\TemplateEngineFactoryInterface;
 
 class ilMailMimeTest extends ilMailBaseTestCase
 {
@@ -156,9 +157,9 @@ class ilMailMimeTest extends ilMailBaseTestCase
             'set',
             'get',
         ])->getMock();
-        $mustache_factory = $this->getMockBuilder(ilMustacheFactory::class)->getMock();
+        $template_engine_factory = $this->getMockBuilder(TemplateEngineFactoryInterface::class)->getMock();
 
-        $factory = new ilMailMimeSenderFactory($settings, $mustache_factory);
+        $factory = new ilMailMimeSenderFactory($settings, $template_engine_factory);
         $this->assertInstanceOf(ilMailMimeSenderSystem::class, $factory->getSenderByUsrId(ANONYMOUS_USER_ID));
     }
 
@@ -168,9 +169,9 @@ class ilMailMimeTest extends ilMailBaseTestCase
             'set',
             'get',
         ])->getMock();
-        $mustache_factory = $this->getMockBuilder(ilMustacheFactory::class)->getMock();
+        $template_engine_factory = $this->getMockBuilder(TemplateEngineFactoryInterface::class)->getMock();
 
-        $factory = new ilMailMimeSenderFactory($settings, $mustache_factory);
+        $factory = new ilMailMimeSenderFactory($settings, $template_engine_factory);
         $this->assertInstanceOf(ilMailMimeSenderSystem::class, $factory->system());
     }
 
@@ -191,9 +192,9 @@ class ilMailMimeTest extends ilMailBaseTestCase
             'set',
             'get',
         ])->getMock();
-        $mustache_factory = $this->getMockBuilder(ilMustacheFactory::class)->getMock();
+        $template_engine_factory = $this->getMockBuilder(TemplateEngineFactoryInterface::class)->getMock();
 
-        $factory = new ilMailMimeSenderFactory($settings, $mustache_factory);
+        $factory = new ilMailMimeSenderFactory($settings, $template_engine_factory);
         $this->assertInstanceOf(ilMailMimeSenderUser::class, $factory->getSenderByUsrId(self::USER_ID));
     }
 
@@ -203,9 +204,9 @@ class ilMailMimeTest extends ilMailBaseTestCase
             'set',
             'get',
         ])->getMock();
-        $mustache_factory = $this->getMockBuilder(ilMustacheFactory::class)->getMock();
+        $template_engine_factory = $this->getMockBuilder(TemplateEngineFactoryInterface::class)->getMock();
 
-        $factory = new ilMailMimeSenderFactory($settings, $mustache_factory);
+        $factory = new ilMailMimeSenderFactory($settings, $template_engine_factory);
         $this->assertInstanceOf(ilMailMimeSenderUser::class, $factory->user(self::USER_ID));
     }
 }

--- a/components/ILIAS/Mail/tests/ilMailTemplateContextTest.php
+++ b/components/ILIAS/Mail/tests/ilMailTemplateContextTest.php
@@ -23,6 +23,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use OrgUnit\PublicApi\OrgUnitUserService;
 use OrgUnit\User\ilOrgUnitUser;
 use PHPUnit\Framework\Attributes\DataProvider;
+use ILIAS\Mail\TemplateEngine\Mustache\MustacheTemplateEngineFactory;
 
 class ilMailTemplateContextTest extends ilMailBaseTestCase
 {
@@ -231,8 +232,8 @@ class ilMailTemplateContextTest extends ilMailBaseTestCase
             $lng_helper
         );
 
-        $mustache = new Mustache_Engine();
-        $placeholder_resolver = new ilMailTemplatePlaceholderResolver($mustache);
+        $template_engine = (new MustacheTemplateEngineFactory())->getBasicEngine();
+        $placeholder_resolver = new ilMailTemplatePlaceholderResolver($template_engine);
 
         $message = implode('', [
             '{{MAIL_SALUTATION}}',

--- a/components/ILIAS/Mail/tests/ilMailTemplateContextTest.php
+++ b/components/ILIAS/Mail/tests/ilMailTemplateContextTest.php
@@ -232,7 +232,7 @@ class ilMailTemplateContextTest extends ilMailBaseTestCase
             $lng_helper
         );
 
-        $template_engine = (new MustacheTemplateEngineFactory())->getBasicEngine();
+        $template_engine = (new class () extends MustacheTemplateEngineFactory {})->getBasicEngine();
         $placeholder_resolver = new ilMailTemplatePlaceholderResolver($template_engine);
 
         $message = implode('', [

--- a/components/ILIAS/Mail/tests/ilMailTemplateServiceTest.php
+++ b/components/ILIAS/Mail/tests/ilMailTemplateServiceTest.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Mail\TemplateEngine\TemplateEngineFactoryInterface;
+
 class ilMailTemplateServiceTest extends ilMailBaseTestCase
 {
     public function testDefaultTemplateCanBeSetByContext(): void
@@ -45,8 +47,8 @@ class ilMailTemplateServiceTest extends ilMailBaseTestCase
 
         $repo->expects($this->once())->method('findByContextId')->with($template->getContext())->willReturn($all);
         $repo->expects($this->exactly(count($all)))->method('store');
-        $mustache_factory = $this->getMockBuilder(ilMustacheFactory::class)->getMock();
-        $service = new ilMailTemplateService($repo, $mustache_factory);
+        $template_engine_factory = $this->getMockBuilder(TemplateEngineFactoryInterface::class)->getMock();
+        $service = new ilMailTemplateService($repo, $template_engine_factory);
 
         $service->setAsContextDefault($template);
 
@@ -65,8 +67,8 @@ class ilMailTemplateServiceTest extends ilMailBaseTestCase
         $template->setContext('phpunit');
 
         $repo->expects($this->once())->method('store')->with($template);
-        $mustache_factory = $this->getMockBuilder(ilMustacheFactory::class)->getMock();
-        $service = new ilMailTemplateService($repo, $mustache_factory);
+        $template_engine_factory = $this->getMockBuilder(TemplateEngineFactoryInterface::class)->getMock();
+        $service = new ilMailTemplateService($repo, $template_engine_factory);
 
         $service->unsetAsContextDefault($template);
 

--- a/components/ILIAS/Mail/tests/ilMailTest.php
+++ b/components/ILIAS/Mail/tests/ilMailTest.php
@@ -221,7 +221,7 @@ class ilMailTest extends ilMailBaseTestCase
             4711,
             $actor,
             new ilMailTemplatePlaceholderResolver(
-                (new class extends MustacheTemplateEngineFactory {})->getBasicEngine()
+                (new class () extends MustacheTemplateEngineFactory {})->getBasicEngine()
             )
         );
 

--- a/components/ILIAS/Mail/tests/ilMailTest.php
+++ b/components/ILIAS/Mail/tests/ilMailTest.php
@@ -26,6 +26,8 @@ use ILIAS\Refinery\Transformation;
 use ILIAS\Data\Result\Ok;
 use ILIAS\Mail\Service\MailSignatureService;
 use PHPUnit\Framework\Attributes\DataProvider;
+use ILIAS\Mail\TemplateEngine\TemplateEngineFactoryInterface;
+use ILIAS\Mail\TemplateEngine\Mustache\MustacheTemplateEngineFactory;
 
 class ilMailTest extends ilMailBaseTestCase
 {
@@ -199,7 +201,7 @@ class ilMailTest extends ilMailBaseTestCase
         $mail_options = $this->getMockBuilder(ilMailOptions::class)->disableOriginalConstructor()->getMock();
         $mail_box = $this->getMockBuilder(ilMailbox::class)->disableOriginalConstructor()->getMock();
         $actor = $this->getMockBuilder(ilObjUser::class)->disableOriginalConstructor()->getMock();
-        $mustache_factory = $this->getMockBuilder(ilMustacheFactory::class)->getMock();
+        $template_engine_factory = $this->getMockBuilder(TemplateEngineFactoryInterface::class)->getMock();
 
         $mail_service = new ilMail(
             $sender_usr_id,
@@ -212,13 +214,15 @@ class ilMailTest extends ilMailBaseTestCase
             $mail_file_data,
             $mail_options,
             $mail_box,
-            new ilMailMimeSenderFactory($settings, $mustache_factory),
+            new ilMailMimeSenderFactory($settings, $template_engine_factory),
             static fn(string $login): int => $all_users_login_to_id_map[$login] ?? 0,
             $this->createMock(AutoresponderService::class),
             0,
             4711,
             $actor,
-            new ilMailTemplatePlaceholderResolver(new Mustache_Engine())
+            new ilMailTemplatePlaceholderResolver(
+                (new MustacheTemplateEngineFactory())->getBasicEngine()
+            )
         );
 
         $old_transport = ilMimeMail::getDefaultTransport();

--- a/components/ILIAS/Mail/tests/ilMailTest.php
+++ b/components/ILIAS/Mail/tests/ilMailTest.php
@@ -221,7 +221,7 @@ class ilMailTest extends ilMailBaseTestCase
             4711,
             $actor,
             new ilMailTemplatePlaceholderResolver(
-                (new MustacheTemplateEngineFactory())->getBasicEngine()
+                (new class extends MustacheTemplateEngineFactory {})->getBasicEngine()
             )
         );
 

--- a/components/ILIAS/Test/src/Logging/AdditionalInformationGenerator.php
+++ b/components/ILIAS/Test/src/Logging/AdditionalInformationGenerator.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace ILIAS\Test\Logging;
 
+use ILIAS\Mail\TemplateEngine\TemplateEngineInterface;
 use ILIAS\TestQuestionPool\Questions\GeneralQuestionPropertiesRepository;
 use ILIAS\UI\Factory as UIFactory;
 use ILIAS\UI\Component\Listing\Descriptive as DescriptiveListing;
@@ -255,7 +256,7 @@ class AdditionalInformationGenerator
     private array $tags;
 
     public function __construct(
-        private readonly \Mustache_Engine $mustache,
+        private readonly TemplateEngineInterface $template_engine,
         private readonly \ilLanguage $lng,
         private readonly UIFactory $ui_factory,
         private readonly Refinery $refinery,
@@ -415,7 +416,7 @@ class AdditionalInformationGenerator
                 ->setTimezone($environment['timezone'])
                 ->format($environment['date_format']);
         }
-        return $this->mustache->render(
+        return $this->template_engine->render(
             $this->refinery->string()->stripTags()->transform($value),
             $this->tags
         );

--- a/components/ILIAS/Test/src/TestDIC.php
+++ b/components/ILIAS/Test/src/TestDIC.php
@@ -178,7 +178,7 @@ class TestDIC extends PimpleContainer
 
         $dic['logging.information_generator'] = static fn($c): Logging\AdditionalInformationGenerator =>
              new Logging\AdditionalInformationGenerator(
-                 $DIC->mail()->templateEngineFactory()->getBasicEngine(),
+                 $DIC[\ILIAS\Mail\TemplateEngine\TemplateEngineFactoryInterface::class]->getBasicEngine(),
                  $DIC['lng'],
                  $DIC['ui.factory'],
                  $DIC['refinery'],

--- a/components/ILIAS/Test/src/TestDIC.php
+++ b/components/ILIAS/Test/src/TestDIC.php
@@ -178,7 +178,7 @@ class TestDIC extends PimpleContainer
 
         $dic['logging.information_generator'] = static fn($c): Logging\AdditionalInformationGenerator =>
              new Logging\AdditionalInformationGenerator(
-                 (new \ilMustacheFactory())->getBasicEngine(),
+                 $DIC->mail()->templateEngineFactory()->getBasicEngine(),
                  $DIC['lng'],
                  $DIC['ui.factory'],
                  $DIC['refinery'],

--- a/components/ILIAS/Test/tests/ilTestBaseTestCase.php
+++ b/components/ILIAS/Test/tests/ilTestBaseTestCase.php
@@ -109,6 +109,7 @@ class ilTestBaseTestCase extends TestCase
         $this->addGlobal_resourceStorage();
         $this->addGlobal_objectMetadata();
         $this->addGlobal_user();
+        $this->addGlobal_mail();
 
         $this->defineGlobalConstants();
 

--- a/components/ILIAS/Test/tests/ilTestBaseTestCaseTrait.php
+++ b/components/ILIAS/Test/tests/ilTestBaseTestCaseTrait.php
@@ -424,6 +424,14 @@ trait ilTestBaseTestCaseTrait
         $this->setGlobalVariable('ui.upload_limit_resolver', $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class));
     }
 
+    protected function addGlobal_mail(): void
+    {
+        $this->setGlobalVariable(
+            \ILIAS\Mail\TemplateEngine\TemplateEngineFactoryInterface::class,
+            $this->createMock(\ILIAS\Mail\TemplateEngine\TemplateEngineFactoryInterface::class)
+        );
+    }
+
     protected function getFileDelivery(): \ILIAS\FileDelivery\Services
     {
         $data_signer = new ILIAS\FileDelivery\Token\DataSigner(

--- a/components/ILIAS/User/classes/class.ilObjUserFolderGUI.php
+++ b/components/ILIAS/User/classes/class.ilObjUserFolderGUI.php
@@ -36,6 +36,7 @@ use ILIAS\Filesystem\Util\Archive\LegacyArchives;
 use ILIAS\Filesystem\Filesystem;
 use ILIAS\FileUpload\FileUpload;
 use ILIAS\ResourceStorage\Services as ResourceStorage;
+use ILIAS\Mail\TemplateEngine\TemplateEngineFactoryInterface;
 
 ;
 
@@ -78,7 +79,7 @@ class ilObjUserFolderGUI extends ilObjectGUI
     private AdminTabs $admin_tabs;
     private int $user_owner_id = 0;
     private ilDBInterface $db;
-    private \ilMustacheFactory $mail_mustache_factory;
+    private TemplateEngineFactoryInterface $mail_template_engine_factory;
     private ilLogger $log;
     private ilAppEventHandler $event;
     private Filesystem $filesystem;
@@ -102,7 +103,7 @@ class ilObjUserFolderGUI extends ilObjectGUI
         $this->filesystem = $DIC->filesystem()->storage();
         $this->upload = $DIC['upload'];
         $this->db = $DIC['ilDB'];
-        $this->mail_mustache_factory = $DIC->mail()->mustacheFactory();
+        $this->mail_template_engine_factory = $DIC->mail()->templateEngineFactory();
         $this->archives = $DIC->legacyArchives();
         $this->irss = $DIC['resource_storage'];
 
@@ -263,7 +264,7 @@ class ilObjUserFolderGUI extends ilObjectGUI
                         $this->ctrl,
                         $this->access,
                         $this->tpl,
-                        $this->mail_mustache_factory,
+                        $this->mail_template_engine_factory,
                         $this->ui_factory,
                         $this->ui_renderer,
                         $this->refinery,

--- a/components/ILIAS/User/src/Settings/NewAccountMail/class.SettingsGUI.php
+++ b/components/ILIAS/User/src/Settings/NewAccountMail/class.SettingsGUI.php
@@ -29,6 +29,7 @@ use ILIAS\Refinery\Constraint;
 use ILIAS\Refinery\Transformation;
 use Psr\Http\Message\ServerRequestInterface;
 use ILIAS\ResourceStorage\Services as ResourceStorage;
+use ILIAS\Mail\TemplateEngine\TemplateEngineFactoryInterface;
 
 /**
  * @ilCtrl_Calls ILIAS\User\Settings\NewAccountMail\SettingsGUI: ILIAS\User\Settings\NewAccountMail\UploadHandlerGUI
@@ -45,7 +46,7 @@ class SettingsGUI
         private readonly \ilCtrl $ctrl,
         private readonly \ilAccess $access,
         private readonly \ilGlobalTemplateInterface $tpl,
-        private readonly \ilMustacheFactory $mail_mustache_factory,
+        private readonly TemplateEngineFactoryInterface $mail_template_engine_factory,
         private readonly UIFactory $ui_factory,
         private readonly UIRenderer $ui_renderer,
         private readonly Refinery $refinery,
@@ -204,7 +205,7 @@ class SettingsGUI
         return $this->refinery->custom()->constraint(
             function ($v): bool {
                 try {
-                    $this->mail_mustache_factory->getBasicEngine()->render($v, []);
+                    $this->mail_template_engine_factory->getBasicEngine()->render($v, []);
                     return true;
                 } catch (\Exception) {
                     return false;


### PR DESCRIPTION
Introduces `TemplateEngineInterface` and `TemplateEngineFactoryInterface` in the Mail component, plus a Mustache-based implementation (MustacheTemplateEngine, MustacheTemplateEngineFactory). 
Mail, User, and Test now depend on these interfaces instead of Mustache_Engine or ilMustacheFactory.

Why: Direct dependencies on third-party libraries make the code harder to test, maintain, and change. An abstraction layer lets us mock the template engine in tests, swap implementations later, and keep the Mail component independent of a specific library.

ilMustacheFactory is removed. Use $DIC->mail()->templateEngineFactory() instead of mustacheFactory().