### PR TITLE
[FIX] #0046339: Use ResizeObserver to handle expanding map

### DIFF
--- a/components/ILIAS/Maps/js/src/ServiceOpenLayers.js
+++ b/components/ILIAS/Maps/js/src/ServiceOpenLayers.js
@@ -120,6 +120,26 @@ export default class ServiceOpenLayers {
             }
             this.updateInputFields(id, center);
         });
+
+        // OpenLayers cannot render a map without a size. Use a ResizeObserver to update
+        // the map once the container has a real size (fixing Mantis #0046339).
+        const el = document.getElementById(id);
+
+        if (!el) return;
+
+        const resizeObserver = new ResizeObserver((entries) => {
+            for (const entry of entries) {
+                const rect = entry.contentRect;
+
+                if (rect.width && rect.height) {
+                    this.map.updateSize();
+                    resizeObserver.unobserve(el);
+                    resizeObserver.disconnect();
+                }
+            }
+        });
+
+        resizeObserver.observe(el);
     }
 
     /**

--- a/components/ILIAS/Maps/resources/ServiceOpenLayers.js
+++ b/components/ILIAS/Maps/resources/ServiceOpenLayers.js
@@ -21302,6 +21302,26 @@ class ServiceOpenLayers {
             }
             this.updateInputFields(id, center);
         });
+
+        // OpenLayers cannot render a map without a size. Use a ResizeObserver to update
+        // the map once the container has a real size (fixing Mantis #0046339).
+        const el = document.getElementById(id);
+
+        if (!el) return;
+
+        const resizeObserver = new ResizeObserver((entries) => {
+            for (const entry of entries) {
+                const rect = entry.contentRect;
+
+                if (rect.width && rect.height) {
+                    this.map.updateSize();
+                    resizeObserver.unobserve(el);
+                    resizeObserver.disconnect();
+                }
+            }
+        });
+
+        resizeObserver.observe(el);
     }
 
     /**


### PR DESCRIPTION
Since OpenLayers cannot render a map with zero size, it needs to be redrawn after the container becomes visible.