### PR TITLE
Fix 44987: Dynamic rendering of MathJax 3 fails

### DIFF
--- a/components/ILIAS/Accordion/resources/accordion.js
+++ b/components/ILIAS/Accordion/resources/accordion.js
@@ -1,4 +1,18 @@
-/* */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ******************************************************************** */
 
 il.Accordion = {
 
@@ -474,10 +488,7 @@ il.Accordion = {
 	rerenderContent: function(acc_el) {
 
 		// rerender mathjax
-		if (typeof MathJax != "undefined" && typeof MathJax.Hub != "undefined") {
-			MathJax.Hub.Queue(["Reprocess",MathJax.Hub, acc_el[0]]);
-		}
-		// see http://docs.mathjax.org/en/latest/typeset.html
+		il.Util.renderMathJax([acc_el[0]], true);
 
 		// rerender google maps
 		if (typeof ilMapRerender != "undefined") {

--- a/components/ILIAS/COPage/templates/default/tpl.question_export.html
+++ b/components/ILIAS/COPage/templates/default/tpl.question_export.html
@@ -19,9 +19,8 @@
 		jQuery('div#container{VAL_ID}').autoRender(questions[{VAL_ID}]);
 		{HANDLE_IMAGES}
 
-		if (typeof MathJax != "undefined" && typeof MathJax.Hub != "undefined") {
-			MathJax.Hub.Queue(["Typeset",MathJax.Hub, "container{VAL_ID}"]);
-		}
+		const el = document.getElementById("container{VAL_ID}");
+		il.Util.renderMathJax([el]);
 	}
 </script>
 <!-- END singlechoice -->
@@ -54,9 +53,8 @@ function renderILQuestion{VAL_ID}(){
 
 	question.init();
 
-	if (typeof MathJax != "undefined" && typeof MathJax.Hub != "undefined") {
-		MathJax.Hub.Queue(["Typeset", MathJax.Hub, "container{VAL_ID}"]);
-	}
+	const el = document.getElementById("container{VAL_ID}");
+	il.Util.renderMathJax([el]);
 };
 </script>
 <!-- END multiplechoice -->
@@ -107,9 +105,8 @@ function renderILQuestion{VAL_ID}(){
 
 		{HANDLE_IMAGES}
 
-		if (typeof MathJax != "undefined") {
-			MathJax.Hub.Queue(["Typeset", MathJax.Hub, "container{VAL_ID}"]);
-		}
+		const el = document.getElementById("container{VAL_ID}");
+		il.Util.renderMathJax([el]);
 
 	})(questions[{VAL_ID}]);
 };
@@ -134,10 +131,9 @@ function renderILQuestion{VAL_ID}() {
 	ilias.questions.shuffle(questions[{VAL_ID}]);
 	jQuery('div#container{VAL_ID}').autoRender(questions[{VAL_ID}]);
 	{HANDLE_IMAGES}
-	if (typeof MathJax != "undefined") {
-		MathJax.Hub.Queue(["Typeset", MathJax.Hub, "container{VAL_ID}"]);
-	}
-    il.test.orderingvertical.init(document.querySelector('#container{VAL_ID}'));
+	const el = document.getElementById("#container{VAL_ID}");
+	il.Util.renderMathJax([el]);
+  	il.test.orderingvertical.init(document.querySelector('#container{VAL_ID}'));
 }
 </script>
 <!-- END orderingquestion -->
@@ -287,10 +283,9 @@ function renderILQuestion{VAL_ID}()
 
 		$(document).ready(
             function () {
-                if (typeof MathJax != "undefined" && typeof MathJax.Hub != "undefined") {
-                    MathJax.Hub.Queue(["Typeset", MathJax.Hub, "container{VAL_ID}"]);
-                }
-                il.test.matching.init(document.querySelector('#ilMatchingQuestionContainer_{VAL_ID}'), questionData.matching_mode);
+              const el = document.getElementById("container{VAL_ID}");
+              il.Util.renderMathJax([el]);
+              il.test.matching.init(document.querySelector('#ilMatchingQuestionContainer_{VAL_ID}'), questionData.matching_mode);
             }
 		);
 

--- a/components/ILIAS/JavaScript/resources/Basic.js
+++ b/components/ILIAS/JavaScript/resources/Basic.js
@@ -254,15 +254,62 @@ il.Util = {
   },
 
   /**
+   * Render Mathjax
+   * @param {array} elements Array of DOM elements
+   * @see https://docs.mathjax.org/en/latest/web/typeset.html#typesetting-math-in-a-web-page
+   */
+  renderMathJax(elements, reprocess = false) {
+    if (typeof MathJax !== 'undefined') {
+      if (typeof MathJax.Hub !== 'undefined') {
+        // MathJax 2
+        if (reprocess) {
+          MathJax.Hub.Queue(['Reprocess', MathJax.Hub, elements]);
+        } else {
+          MathJax.Hub.Queue(['Typeset', MathJax.Hub, elements]);
+        }
+      } else {
+        // MathJax 3
+        const interval_id = setInterval((resolve, reject) => {
+          if (typeof MathJax.startup.promise !== 'undefined') {
+            clearInterval(interval_id);
+            MathJax.startup.promise = MathJax.startup.promise
+              .then(() => {
+                if (reprocess) {
+                  MathJax.typesetClear(elements);
+                }
+                MathJax.typesetPromise()
+                  .catch((err) => console.log(`MathJax typesetting failed: ${err.message}`));
+              });
+          }
+        });
+      }
+    }
+  },
+
+  /**
 	 * print current window, thanks to anoack for the mathjax fix (see bug #)
 	 */
   print() {
     if (typeof (window.print) !== 'undefined') {
-      if (typeof MathJax !== 'undefined' && typeof MathJax.Hub !== 'undefined') {
-        MathJax.Hub.Queue(
-          ['Delay', MathJax.Callback, 700],
-          window.print,
-        );
+      if (typeof MathJax !== 'undefined') {
+        if (typeof MathJax.Hub !== 'undefined') {
+          // MathJax 2
+          MathJax.Hub.Queue(
+            ['Delay', MathJax.Callback, 700],
+            window.print,
+          );
+        } else {
+          // MathJax 3
+          const interval_id = setInterval((resolve, reject) => {
+            if (typeof MathJax.startup.promise !== 'undefined') {
+              clearInterval(interval_id);
+              MathJax.startup.promise = MathJax.startup.promise
+                .then(() => MathJax.typesetPromise()
+                  .then(window.print)
+                  .catch((err) => console.log(`MathJax typesetting failed: ${err.message}`)));
+            }
+          });
+        }
       } else {
         window.print();
       }

--- a/components/ILIAS/TestQuestionPool/resources/js/dist/question_handling.js
+++ b/components/ILIAS/TestQuestionPool/resources/js/dist/question_handling.js
@@ -296,9 +296,7 @@ ilias.questions.assTextQuestion = function(a_id) {
 	const el = document.getElementById("feedback" + a_id);
 	if (el) {
 		el.style.display = '';
-		if (typeof MathJax != "undefined") {
-			MathJax.Hub.Queue(["Typeset",MathJax.Hub, el]);
-		}
+		il.Util.renderMathJax([el]);
 	}
 	answers[a_id].passed = true;
 	ilias.questions.scormHandler(a_id,"neutral",jQuery('#textarea'+a_id).val());
@@ -679,6 +677,9 @@ ilias.questions.initClozeTest = function(a_id) {
 	var parsed=jQuery("div#"+a_id).get(0).innerHTML.replace(/\[gap[\s\S\d]*?\](.*?)\[\/gap\]/g,
         () => {return _initClozeTestCallBack();});
 	jQuery("div#"+a_id).html(parsed);
+
+	const el = document.getElementById("div#"+a_id);
+	il.Util.renderMathJax([el]);
 };
 
 ilias.questions.initLongMenu = function(a_id) {
@@ -957,9 +958,7 @@ ilias.questions.showFeedback = function(a_id) {
 	const el = document.getElementById('feedback' + a_id);
 	if (el) {
 		el.style.display = '';
-		if (typeof MathJax != "undefined" && typeof MathJax.Hub != "undefined") {
-			MathJax.Hub.Queue(["Typeset",MathJax.Hub, el]);
-		}
+		il.Util.renderMathJax([el]);
 	}
 
 	// update question overviews


### PR DESCRIPTION
See https://mantis.ilias.de/view.php?id=44987

Both MathJax 2 and 3 are supported. The rendering calls are centralized in Basic.js where the MathJax rendering is already called for the print view of a page. This is fixed for MathJax 3, too.

This is a merge of https://github.com/ILIAS-eLearning/ILIAS/pull/9487 which has been approved for ILIAS 9