### PR TITLE
Database: Update supported & recommended MariaDB & MySQL versions

### DIFF
--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -64,7 +64,7 @@ current configuration of the [ILIAS test server](https://test11.ilias.de), which
 | Package      | Version                                                | Reference System |
 |--------------|--------------------------------------------------------|------------------|
 | Distribution | current version of Debian GNU Linux, Ubuntu or RHEL    | Ubuntu 22.04 LTS |
-| Database     | MySQL >8.0.21 or MariaDB 10.5 - 10.11                  | MariaDB 10.6.18  |
+| Database     | MySQL 8.4 - 9.7 or MariaDB 11.4 - 12.3                 | MariaDB 11.8     |
 | PHP          | 8.3, 8.4                                               | 8.4              |
 | Webserver    | nginx: 1.12.x – 1.18.x, Apache: ≥ 2.4.x                | Apache 2.4.52    |
 | JDK          | Open JDK Runtime 11, 17 or 21 LTS                      | OpenJDK 17       |
@@ -681,6 +681,7 @@ We strongly recommend using MariaDB instead of MySQL due to performance, licensi
 
 | ILIAS Version | MySQL Version       | MariaDB Version        |
 |---------------|---------------------|------------------------|
+| 12.0 - 12.x   | 8.4.x               | 11.4, 11.8, 12.3       |
 | 11.0 - 11.x   | 8.0.x               | 10.4, 10.5, 10.6       |
 | 10.0 - 10.x   | 8.0.x               | 10.4, 10.5, 10.6       |
 | 9.0 - 9.x     | 8.0.x               | 10.3, 10.4, 10.5, 10.6 |


### PR DESCRIPTION
This PR updates the supported & recommended DBMS for ILIAS 12 in the `install.md`.