### PR TITLE
[FIX] LDAP: Support failover during authentication process (10.x)

### DIFF
--- a/components/ILIAS/LDAP/classes/class.ilAuthProviderLDAP.php
+++ b/components/ILIAS/LDAP/classes/class.ilAuthProviderLDAP.php
@@ -149,6 +149,7 @@ class ilAuthProviderLDAP extends ilAuthProvider implements ilAuthProviderAccount
     protected function initServer(int $a_server_id): void
     {
         $this->server = new ilLDAPServer($a_server_id);
+        $this->server->doConnectionCheck(true);
     }
 
     /**

--- a/components/ILIAS/LDAP/classes/class.ilLDAPServer.php
+++ b/components/ILIAS/LDAP/classes/class.ilLDAPServer.php
@@ -81,6 +81,7 @@ class ilLDAPServer
     private ilDBInterface $db;
     private ilLanguage $lng;
     private ilErrorHandling $ilErr;
+    private ilLogger $logger;
 
     public function __construct(int $a_server_id = 0)
     {
@@ -88,6 +89,7 @@ class ilLDAPServer
 
         $this->db = $DIC->database();
         $this->lng = $DIC->language();
+        $this->logger = $DIC->logger()->auth();
         $this->ilErr = $DIC['ilErr'];
 
         $this->server_id = $a_server_id;
@@ -525,22 +527,49 @@ class ilLDAPServer
      * @access public
      *
      */
-    public function doConnectionCheck(): bool
+    public function doConnectionCheck(bool $prevent_persisted_rotation = false): bool
     {
-        foreach (array_merge(array(0 => $this->url), $this->fallback_urls) as $url) {
+        $connection_failures = [];
+        foreach (array_merge([0 => $this->url], $this->fallback_urls) as $url) {
             try {
-                ilLoggerFactory::getLogger('auth')->debug('Using url: ' . $url);
+                $this->logger->debug('Attempting LDAP connection to: {url}', ['url' => $url]);
+
                 // Need to do a full bind, since openldap return valid connection links for invalid hosts
                 $query = new ilLDAPQuery($this, $url);
                 $query->bind(ilLDAPQuery::LDAP_BIND_TEST);
                 $this->url = $url;
+
+                if ($connection_failures !== []) {
+                    $this->logger->info(
+                        'Successfully connected to LDAP server: {url} after {failures} failed attempts',
+                        [
+                            'url' => $url,
+                            'failures' => count($connection_failures)
+                        ]
+                    );
+                }
+
                 return true;
             } catch (ilLDAPQueryException $exc) {
-                $this->rotateFallbacks();
-                ilLoggerFactory::getLogger('auth')->error('Cannot connect to LDAP server: ' . $url . ' ' . $exc->getCode() . ' ' . $exc->getMessage());
+                $connection_failures[] = $url;
+
+                $this->logger->error('LDAP connection failed for server: {url} - {message}', [
+                    'url' => $url,
+                    'message' => $exc->getMessage(),
+                    'exception' => $exc
+                ]);
+
+                if (!$prevent_persisted_rotation) {
+                    $this->rotateFallbacks();
+                }
             }
         }
-        ilLoggerFactory::getLogger('auth')->warning('No valid LDAP server found');
+
+        $this->logger->warning('No valid LDAP server found. Tried {count} server(s)', [
+            'count' => count($connection_failures),
+            'urls' => implode(', ', $connection_failures)
+        ]);
+
         return false;
     }
 

--- a/components/ILIAS/LDAP/tests/ilLDAPServerTest.php
+++ b/components/ILIAS/LDAP/tests/ilLDAPServerTest.php
@@ -27,12 +27,15 @@ use PHPUnit\Framework\TestCase;
  */
 class ilLDAPServerTest extends TestCase
 {
-    private Container $dic;
+    private ?Container $dic = null;
 
     protected function setUp(): void
     {
-        $this->dic = new Container();
-        $GLOBALS['DIC'] = $this->dic;
+        global $DIC;
+
+        $this->dic = is_object($DIC) ? clone $DIC : $DIC;
+
+        $DIC = new Container();
 
         $this->setGlobalVariable('lng', $this->getLanguageMock());
         $this->setGlobalVariable(
@@ -48,7 +51,25 @@ class ilLDAPServerTest extends TestCase
             'ilErr',
             $this->getMockBuilder(ilErrorHandling::class)->getMock()
         );
+
+        $logger = $this->getMockBuilder(ilLogger::class)->disableOriginalConstructor()->getMockForAbstractClass();
+        $logger_factory = $this->getMockBuilder(ilLoggerFactory::class)->disableOriginalConstructor()->getMock();
+        $logger_factory->method('getComponentLogger')->willReturn($logger);
+        $this->setGlobalVariable(
+            ilLoggerFactory::class,
+            $logger_factory
+        );
+
         parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        global $DIC;
+
+        $DIC = $this->dic;
+
+        parent::tearDown();
     }
 
     /**
@@ -62,9 +83,7 @@ class ilLDAPServerTest extends TestCase
         $GLOBALS[$name] = $value;
 
         unset($DIC[$name]);
-        $DIC[$name] = static function ($c) use ($name) {
-            return $GLOBALS[$name];
-        };
+        $DIC[$name] = static fn(Container $c) => $GLOBALS[$name];
     }
 
     /**

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -10862,7 +10862,7 @@ ldap#:#ldap_server_name#:#Name der LDAP-Konfiguration
 ldap#:#ldap_server_name_info#:#Bitte wählen Sie einen Namen für diese Server-Konfiguration!
 ldap#:#ldap_server_security_settings#:#Sicherheitseinstellungen
 ldap#:#ldap_server_short#:#Server URL:
-ldap#:#ldap_server_url_info#:#Die komplette URL für die Verbindung zum LDAP-Server. Z.B. "ldap://ldaps.ilias.de:636".
+ldap#:#ldap_server_url_info#:#Bitte tragen Sie die komplette URL für die Verbindung zum LDAP-Server ein, z.B. "ldap://ldaps.ilias.de:636". Mehrere URLs können kommagetrennt für Failover-Unterstützung angegeben werden. Bei Verbindungsfehlern rotiert ILIAS automatisch durch die verfügbaren Server. Hinweis: Während der Authentifizierung erfolgt die URL-Rotation nur im Arbeitsspeicher (nicht persistiert). In anderen Kontexten (z.B. Synchronisierungsaufgaben) wird eine erfolgreiche Rotation in der Datenbank gespeichert.
 ldap#:#ldap_server_version_info#:#Protokollversion des LDAP-Server (in den meisten Fällen "LDAPv3").
 ldap#:#ldap_servers#:#LDAP Server
 ldap#:#ldap_settings#:#Server-Einstellungen

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -10863,7 +10863,7 @@ ldap#:#ldap_server_name#:#Name of LDAP Configuration
 ldap#:#ldap_server_name_info#:#Please choose a name for this LDAP server configuration.
 ldap#:#ldap_server_security_settings#:#Security Settings
 ldap#:#ldap_server_short#:#Server URL:
-ldap#:#ldap_server_url_info#:#A fully qualified URL for specifying the protocol, url and port to connect to. E.g "ldaps://ldap.ilias.de:636".
+ldap#:#ldap_server_url_info#:#Please enter a fully qualified URL for specifying the protocol, url and port to connect to, e.g "ldaps://ldap.ilias.de:636". Multiple URLs can be comma-separated for failover support. In case of connection failures, ILIAS will automatically rotate through the available servers. Note: During authentication, URL rotation is performed in-memory only (not persisted). In other contexts (e.g., synchronization tasks), each failed connection will rotate the URL order and persist it to the database, helping future requests avoid recently-failed servers.
 ldap#:#ldap_server_version_info#:#LDAP version to use, usually 3.
 ldap#:#ldap_servers#:#LDAP Server
 ldap#:#ldap_settings#:#Server Settings


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=20651

Sister PR of #11182 , but without refactorings.