### PR TITLE
[FIX] #47263 LTI: Table pagination and filter fixes

### DIFF
--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerAdministrationGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerAdministrationGUI.php
@@ -162,7 +162,7 @@ class ilLTIConsumerAdministrationGUI
         $providerList->setKeywordFilter($filter_params['keywords'] ?? '');
         $providerList->setHasOutcomeFilter(($filter_params['outcome'] ?? '') === '' ? null : $filter_params['outcome'] === 'yes');
         $providerList->setIsExternalFilter(($filter_params['internal'] ?? '') === '' ? null : $filter_params['internal'] !== 'yes');
-        $providerList->setIsProviderKeyCustomizableFilter(($filter_params['with_key'] ?? '') === '' ? null : $filter_params['with_key'] === 'yes');
+        $providerList->setIsProviderKeyCustomizableFilter(($filter_params['with_key'] ?? '') === '' ? null : !($filter_params['with_key'] === 'yes'));
         $providerList->setCategoryFilter($filter_params['category'] ?? '');
 
         $providerList->load();
@@ -444,7 +444,7 @@ class ilLTIConsumerAdministrationGUI
         $providerList->setKeywordFilter($filter_params['keywords'] ?? '');
         $providerList->setHasOutcomeFilter(($filter_params['outcome'] ?? '') === '' ? null : $filter_params['outcome'] === 'yes');
         $providerList->setIsExternalFilter(($filter_params['internal'] ?? '') === '' ? null : $filter_params['internal'] !== 'yes');
-        $providerList->setIsProviderKeyCustomizableFilter(($filter_params['with_key'] ?? '') === '' ? null : $filter_params['with_key'] === 'yes');
+        $providerList->setIsProviderKeyCustomizableFilter(($filter_params['with_key'] ?? '') === '' ? null : !($filter_params['with_key'] === 'yes'));
         $providerList->setCategoryFilter($filter_params['category'] ?? '');
 
         $providerList->load();

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeSynchronizationTableGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeSynchronizationTableGUI.php
@@ -122,7 +122,7 @@ class ilLTIConsumerGradeSynchronizationTableGUI implements DataRetrieval
     public function getHTML(): string
     {
         $table = $this->ui_factory->table()
-            ->data("", $this->getColumns(), $this)
+            ->data($this, "", $this->getColumns())
             ->withOrder(new Order("lti_timestamp", Order::DESC))
             ->withRequest($this->request);
 

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeSynchronizationTableGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeSynchronizationTableGUI.php
@@ -66,7 +66,7 @@ class ilLTIConsumerGradeSynchronizationTableGUI implements DataRetrieval
         mixed $filter_data,
         mixed $additional_parameters
     ): Generator {
-        $records = $this->applyOrdering($this->records, $order);
+        $records = $this->applyOrdering($this->records, $order, $range);
         foreach ($records as $record) {
             $record['lti_timestamp'] = new DateTimeImmutable($record['lti_timestamp']);
             $record['score_given'] = $record['score_given'] . ' / ' . $record['score_maximum'];
@@ -91,7 +91,7 @@ class ilLTIConsumerGradeSynchronizationTableGUI implements DataRetrieval
         $this->records = $records;
     }
 
-    protected function applyOrdering(array $records, Order $order): array
+    protected function applyOrdering(array $records, Order $order, ?Range $range = null): array
     {
         [$order_field, $order_direction] = $order->join(
             [],
@@ -116,6 +116,10 @@ class ilLTIConsumerGradeSynchronizationTableGUI implements DataRetrieval
             $records = array_reverse($records);
         }
 
+        if ($range !== null) {
+            $records = array_slice($records, $range->getStart(), $range->getLength());
+        }
+
         return $records;
     }
 
@@ -124,6 +128,7 @@ class ilLTIConsumerGradeSynchronizationTableGUI implements DataRetrieval
         $table = $this->ui_factory->table()
             ->data($this, "", $this->getColumns())
             ->withOrder(new Order("lti_timestamp", Order::DESC))
+            ->withRange(new Range(0, 20))
             ->withRequest($this->request);
 
         return $this->ui_renderer->render($table);

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerProviderSelectionFormTableGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerProviderSelectionFormTableGUI.php
@@ -57,7 +57,7 @@ class ilLTIConsumerProviderSelectionFormTableGUI extends ilPropertyFormGUI
         $providerList->setKeywordFilter($filter_params['keywords'] ?? '');
         $providerList->setHasOutcomeFilter(($filter_params['outcome'] ?? '') === '' ? null : $filter_params['outcome'] === 'yes');
         $providerList->setIsExternalFilter(($filter_params['internal'] ?? '') === '' ? null : $filter_params['internal'] !== 'yes');
-        $providerList->setIsProviderKeyCustomizableFilter(($filter_params['with_key'] ?? '') === '' ? null : $filter_params['with_key'] === 'yes');
+        $providerList->setIsProviderKeyCustomizableFilter(($filter_params['with_key'] ?? '') === '' ? null : !($filter_params['with_key'] === 'yes'));
         $providerList->setCategoryFilter($filter_params['category'] ?? '');
 
         $providerList->load();

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerProviderTableGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerProviderTableGUI.php
@@ -104,7 +104,7 @@ class ilLTIConsumerProviderTableGUI implements DataRetrieval
         mixed $filter_data,
         mixed $additional_parameters
     ): Generator {
-        $records = $this->applyOrdering($this->records, $order);
+        $records = $this->applyOrdering($this->records, $order, $range);
         foreach ($records as $record) {
             $record["icon"] = $record["icon"] ?? "lti";
             $record["icon"] = $this->ui_factory->symbol()->icon()->standard($record["icon"], $record["icon"], IconAlias::SMALL);
@@ -144,7 +144,7 @@ class ilLTIConsumerProviderTableGUI implements DataRetrieval
         $this->records = $data;
     }
 
-    protected function applyOrdering(array $records, Order $order): array
+    protected function applyOrdering(array $records, Order $order, ?Range $range = null): array
     {
         [$order_field, $order_direction] = $order->join(
             [],
@@ -161,6 +161,10 @@ class ilLTIConsumerProviderTableGUI implements DataRetrieval
             $records = array_reverse($records);
         }
 
+        if ($range !== null) {
+            $records = array_slice($records, $range->getStart(), $range->getLength());
+        }
+
         return $records;
     }
 
@@ -172,6 +176,7 @@ class ilLTIConsumerProviderTableGUI implements DataRetrieval
         $table = $this->ui_factory->table()
             ->data($this, $this->lng->txt('tbl_provider_header'), $this->getColumns())
             ->withOrder(new Order('title', Order::ASC))
+            ->withRange(new Range(0, 20))
             ->withRequest($this->request);
 
         if ($hasWriteAccess) {

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerProviderTableGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerProviderTableGUI.php
@@ -170,7 +170,7 @@ class ilLTIConsumerProviderTableGUI implements DataRetrieval
     public function getHTML(bool $hasWriteAccess = false): string
     {
         $table = $this->ui_factory->table()
-            ->data($this->lng->txt('tbl_provider_header'), $this->getColumns(), $this)
+            ->data($this, $this->lng->txt('tbl_provider_header'), $this->getColumns())
             ->withOrder(new Order('title', Order::ASC))
             ->withRequest($this->request);
 

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerProviderUsageTableGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerProviderUsageTableGUI.php
@@ -67,7 +67,7 @@ class ilLTIConsumerProviderUsageTableGUI implements DataRetrieval
         /** @var Services $static_url */
         $static_url = $DIC["static_url"];
 
-        $records = $this->applyOrdering($this->records, $order);
+        $records = $this->applyOrdering($this->records, $order, $range);
         foreach ($records as $record) {
             $record['icon'] = $record['icon'] ?? "lti";
             $record['icon'] = $this->ui_factory->symbol()->icon()->standard($record['icon'], $record['icon'], Icon::SMALL);
@@ -99,7 +99,7 @@ class ilLTIConsumerProviderUsageTableGUI implements DataRetrieval
         $this->records = $data;
     }
 
-    protected function applyOrdering(array $records, Order $order): array
+    protected function applyOrdering(array $records, Order $order, ?Range $range = null): array
     {
         [$order_field, $order_direction] = $order->join(
             [],
@@ -116,6 +116,10 @@ class ilLTIConsumerProviderUsageTableGUI implements DataRetrieval
             $records = array_reverse($records);
         }
 
+        if ($range !== null) {
+            $records = array_slice($records, $range->getStart(), $range->getLength());
+        }
+
         return $records;
     }
 
@@ -124,6 +128,7 @@ class ilLTIConsumerProviderUsageTableGUI implements DataRetrieval
         $table = $this->ui_factory->table()
             ->data($this, $this->lng->txt('tbl_provider_usage_header'), $this->getColumns())
             ->withOrder(new Order('title', Order::ASC))
+            ->withRange(new Range(0, 20))
             ->withRequest($this->request);
 
         return $this->ui_renderer->render($table);

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerProviderUsageTableGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerProviderUsageTableGUI.php
@@ -122,7 +122,7 @@ class ilLTIConsumerProviderUsageTableGUI implements DataRetrieval
     public function getHTML(): string
     {
         $table = $this->ui_factory->table()
-            ->data($this->lng->txt('tbl_provider_usage_header'), $this->getColumns(), $this)
+            ->data($this, $this->lng->txt('tbl_provider_usage_header'), $this->getColumns())
             ->withOrder(new Order('title', Order::ASC))
             ->withRequest($this->request);
 

--- a/components/ILIAS/LTIProvider/classes/Consumer/class.ilObjectConsumerTableGUI.php
+++ b/components/ILIAS/LTIProvider/classes/Consumer/class.ilObjectConsumerTableGUI.php
@@ -176,7 +176,7 @@ class ilObjectConsumerTableGUI implements DataRetrieval
         mixed $filter_data,
         mixed $additional_parameters
     ): Generator {
-        $records = $this->applyOrdering($this->records, $order);
+        $records = $this->applyOrdering($this->records, $order, $range);
         foreach ($records as $record) {
             $record["active"] = $this->ui_factory->symbol()->icon()->custom(
                 $record["active"] ?
@@ -221,6 +221,7 @@ class ilObjectConsumerTableGUI implements DataRetrieval
         $table = $this->ui_factory->table()
             ->data($this, $this->lng->txt('lti_object_consumer'), $this->getColumns())
             ->withOrder(new Order('title', Order::ASC))
+            ->withRange(new Range(0, 20))
             ->withActions($this->getActions())
             ->withRequest($this->request);
 
@@ -237,7 +238,7 @@ class ilObjectConsumerTableGUI implements DataRetrieval
         $this->editable = $a_editable;
     }
 
-    protected function applyOrdering(array $records, Order $order): array
+    protected function applyOrdering(array $records, Order $order, ?Range $range = null): array
     {
         [$order_field, $order_direction] = $order->join(
             [],
@@ -252,6 +253,10 @@ class ilObjectConsumerTableGUI implements DataRetrieval
 
         if ($order_direction === Order::DESC) {
             $records = array_reverse($records);
+        }
+
+        if ($range !== null) {
+            $records = array_slice($records, $range->getStart(), $range->getLength());
         }
 
         return $records;

--- a/components/ILIAS/LTIProvider/classes/Consumer/class.ilObjectConsumerTableGUI.php
+++ b/components/ILIAS/LTIProvider/classes/Consumer/class.ilObjectConsumerTableGUI.php
@@ -219,7 +219,7 @@ class ilObjectConsumerTableGUI implements DataRetrieval
     public function getHtml(): string
     {
         $table = $this->ui_factory->table()
-            ->data($this->lng->txt('lti_object_consumer'), $this->getColumns(), $this)
+            ->data($this, $this->lng->txt('lti_object_consumer'), $this->getColumns())
             ->withOrder(new Order('title', Order::ASC))
             ->withActions($this->getActions())
             ->withRequest($this->request);

--- a/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilLTIProviderReleasedObjectsTableGUI.php
+++ b/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilLTIProviderReleasedObjectsTableGUI.php
@@ -148,7 +148,7 @@ class ilLTIProviderReleasedObjectsTableGUI implements DataRetrieval
     public function getHtml(): string
     {
         $table = $this->ui_factory->table()
-            ->data($this->lng->txt('lti_released_objects'), $this->getColumns(), $this)
+            ->data($this, $this->lng->txt('lti_released_objects'), $this->getColumns())
             ->withOrder(new Order('title', Order::ASC))
             ->withRequest($this->request);
 

--- a/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilLTIProviderReleasedObjectsTableGUI.php
+++ b/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilLTIProviderReleasedObjectsTableGUI.php
@@ -118,7 +118,7 @@ class ilLTIProviderReleasedObjectsTableGUI implements DataRetrieval
         /** @var Services $static_url */
         $static_url = $DIC["static_url"];
 
-        $records = $this->applyOrdering($this->records, $order);
+        $records = $this->applyOrdering($this->records, $order, $range);
         foreach ($records as $record) {
             $link = (string) $static_url->builder()->build(
                 $record['type'],
@@ -150,6 +150,7 @@ class ilLTIProviderReleasedObjectsTableGUI implements DataRetrieval
         $table = $this->ui_factory->table()
             ->data($this, $this->lng->txt('lti_released_objects'), $this->getColumns())
             ->withOrder(new Order('title', Order::ASC))
+            ->withRange(new Range(0, 20))
             ->withRequest($this->request);
 
         return $this->ui_renderer->render($table);
@@ -160,7 +161,7 @@ class ilLTIProviderReleasedObjectsTableGUI implements DataRetrieval
         return $this->id;
     }
 
-    protected function applyOrdering(array $records, Order $order): array
+    protected function applyOrdering(array $records, Order $order, ?Range $range = null): array
     {
         [$order_field, $order_direction] = $order->join(
             [],
@@ -175,6 +176,10 @@ class ilLTIProviderReleasedObjectsTableGUI implements DataRetrieval
 
         if ($order_direction === Order::DESC) {
             $records = array_reverse($records);
+        }
+
+        if ($range !== null) {
+            $records = array_slice($records, $range->getStart(), $range->getLength());
         }
 
         return $records;


### PR DESCRIPTION
This pagination fix in LTI tables:
- Add pagination support with withRange()
- Fix inverted with_key filter (filter and display now use consistent negation)