### PR TITLE
T&A 46424: Moves tst_skill_triggerings_num_req_answers_not_reached_warn message from test info to qeustion/competence assignment tab

### DIFF
--- a/components/ILIAS/Test/classes/Toolbars/class.ilTestInfoScreenToolbarGUI.php
+++ b/components/ILIAS/Test/classes/Toolbars/class.ilTestInfoScreenToolbarGUI.php
@@ -19,7 +19,6 @@
 declare(strict_types=1);
 
 use ILIAS\Test\Settings\MainSettings\SettingsMainGUI;
-
 use ILIAS\UI\Factory as UIFactory;
 use ILIAS\UI\Renderer as UIRenderer;
 
@@ -212,27 +211,6 @@ class ilTestInfoScreenToolbarGUI extends ilToolbarGUI
         return md5($_COOKIE[session_name()] . time());
     }
 
-    private function hasFixedQuestionSetSkillAssignsLowerThanBarrier(): bool
-    {
-        if (!$this->test_obj->isFixedTest()) {
-            return false;
-        }
-
-        $assignmentList = new ilAssQuestionSkillAssignmentList($this->db);
-        $assignmentList->setParentObjId($this->test_obj->getId());
-        $assignmentList->loadFromDb();
-
-        return $assignmentList->hasSkillsAssignedLowerThanBarrier();
-    }
-
-    private function getSkillAssignBarrierInfo(): string
-    {
-        return sprintf(
-            $this->lng->txt('tst_skill_triggerings_num_req_answers_not_reached_warn'),
-            $this->getTestOBJ()->getGlobalSettings()->getSkillTriggeringNumberOfAnswers()
-        );
-    }
-
     public function build(): void
     {
         $this->ensureInitialisedSessionLockString();
@@ -284,10 +262,6 @@ class ilTestInfoScreenToolbarGUI extends ilToolbarGUI
                 $msgBox = $this->ui_factory->messageBox()->failure($message)->withButtons([$button]);
 
                 $this->populateMessage($this->ui_renderer->render($msgBox));
-            } elseif ($this->getTestOBJ()->isSkillServiceToBeConsidered()) {
-                if ($this->hasFixedQuestionSetSkillAssignsLowerThanBarrier()) {
-                    $this->addInfoMessage($this->getSkillAssignBarrierInfo());
-                }
             }
         }
     }

--- a/components/ILIAS/Test/classes/class.ilTestSkillAdministrationGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestSkillAdministrationGUI.php
@@ -99,7 +99,8 @@ class ilTestSkillAdministrationGUI
                     $this->refinery,
                     $this->http,
                     $this->toolbar,
-                    $this->tabs
+                    $this->tabs,
+                    $this->test_obj
                 );
                 $gui->setAssignmentEditingEnabled($this->isAssignmentEditingRequired());
                 $gui->setQuestionContainerId($questionContainerId);

--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php
@@ -79,7 +79,8 @@ class ilAssQuestionSkillAssignmentsGUI
         private readonly Refinery $refinery,
         private readonly HTTP $http,
         private readonly ilToolbarGUI $toolbar,
-        private readonly ilTabsGUI $tabs
+        private readonly ilTabsGUI $tabs,
+        private readonly ?ilObjTest $test_object = null
     ) {
         $this->data_factory = new DataFactory();
     }
@@ -516,6 +517,38 @@ class ilAssQuestionSkillAssignmentsGUI
                 SkillAssignmentViewControlMode::tryFrom($mode) ?? SkillAssignmentViewControlMode::ALL
             )
         ));
+
+        if (
+            $this->test_object instanceof ilObjTest
+            && $this->test_object->isSkillServiceToBeConsidered()
+            && $this->hasFixedQuestionSetSkillAssignsLowerThanBarrier()
+        ) {
+            $this->tpl->setOnScreenMessage('info', $this->getSkillAssignBarrierInfo());
+        }
+    }
+
+    private function hasFixedQuestionSetSkillAssignsLowerThanBarrier(): bool
+    {
+        if (!$this->test_object?->isFixedTest()) {
+            return false;
+        }
+
+        $assignmentList = new ilAssQuestionSkillAssignmentList($this->db);
+        $assignmentList->setParentObjId($this->test_object->getId());
+        $assignmentList->loadFromDb();
+
+        return $assignmentList->hasSkillsAssignedLowerThanBarrier();
+    }
+
+    private function getSkillAssignBarrierInfo(): string
+    {
+        return !$this->test_object instanceof ilObjTest
+            ? ''
+            : sprintf(
+                $this->lng->txt('tst_skill_triggerings_num_req_answers_not_reached_warn'),
+                $this->test_object->getGlobalSettings()->getSkillTriggeringNumberOfAnswers()
+            );
+
     }
 
     private function editSkillQuestionAssignmentCmd(): void

--- a/components/ILIAS/TestQuestionPool/tests/ilAssQuestionSkillAssignmentsGUITest.php
+++ b/components/ILIAS/TestQuestionPool/tests/ilAssQuestionSkillAssignmentsGUITest.php
@@ -55,7 +55,8 @@ class ilAssQuestionSkillAssignmentsGUITest extends assBaseTestCase
             $this->createMock(Refinery::class),
             $this->createMock(HTTP::class),
             $this->createMock(ilToolbarGUI::class),
-            $this->createMock(ilTabsGUI::class)
+            $this->createMock(ilTabsGUI::class),
+            $this->createMock(ilObjTest::class)
         );
     }
 


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=46424

Aims to move tst_skill_triggerings_num_req_answers_not_reached_warn message from test info to qeustion/competence assignment tab.
@thojou 