### PR TITLE
T&A 46549: Fixes issues with incorrect solution compare expressions for competences for cloze questions

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php
@@ -430,9 +430,13 @@ class ilAssQuestionSkillAssignmentsGUI
             }
 
             if ($assignment->hasEvalModeBySolution()) {
+                /** @var ?ilLogicalAnswerComparisonExpressionInputGUI $sol_cmp_expr_input */
                 $sol_cmp_expr_input = $form->getItemByPostVar('solution_compare_expressions');
 
-                if (!$this->checkSolutionCompareExpressionInput($sol_cmp_expr_input, $question_gui->getObject())) {
+                if (
+                    $sol_cmp_expr_input instanceof ilLogicalAnswerComparisonExpressionInputGUI
+                    && !$this->checkSolutionCompareExpressionInput($sol_cmp_expr_input, $question_gui->getObject())
+                ) {
                     $this->tpl->setOnScreenMessage('failure', $this->lng->txt('form_input_not_valid'));
                     $this->showSkillQuestionAssignmentPropertiesFormCmd($question_gui, $assignment, $form);
                     return;
@@ -441,7 +445,7 @@ class ilAssQuestionSkillAssignmentsGUI
                 $assignment->initSolutionComparisonExpressionList();
                 $assignment->getSolutionComparisonExpressionList()->reset();
 
-                foreach ($sol_cmp_expr_input->getValues() as $expression) {
+                foreach ($sol_cmp_expr_input?->getValues() ?? [] as $expression) {
                     $assignment->getSolutionComparisonExpressionList()->add($expression);
                 }
             } else {
@@ -722,8 +726,10 @@ class ilAssQuestionSkillAssignmentsGUI
         return $this->question_list->isInList($questionId);
     }
 
-    private function checkSolutionCompareExpressionInput($input, assQuestion $question): bool
-    {
+    private function checkSolutionCompareExpressionInput(
+        ilLogicalAnswerComparisonExpressionInputGUI $input,
+        assQuestion $question
+    ): bool {
         $errors = [];
 
         foreach ($input->getValues() as $expression) {
@@ -734,10 +740,8 @@ class ilAssQuestionSkillAssignmentsGUI
             }
         }
 
-        if (count($errors)) {
-            $alert = $this->lng->txt('ass_lac_validation_error');
-            $alert .= '<br />' . implode('<br />', $errors);
-            $input->setAlert($alert);
+        if ($errors !== []) {
+            $input->setAlert($this->lng->txt('ass_lac_validation_error') . '<br />' . implode('<br />', $errors));
             return false;
         }
 
@@ -759,8 +763,13 @@ class ilAssQuestionSkillAssignmentsGUI
         return false;
     }
 
-    private function validateSolutionCompareExpression(ilAssQuestionSolutionComparisonExpression $expression, $question): bool
-    {
+    /**
+     * @throws ilAssLacException
+     */
+    private function validateSolutionCompareExpression(
+        ilAssQuestionSolutionComparisonExpression $expression,
+        assQuestion $question
+    ): bool|string {
         try {
             $question_provider = new ilAssLacQuestionProvider();
             $question_provider->setQuestion($question);
@@ -768,11 +777,7 @@ class ilAssQuestionSkillAssignmentsGUI
                 (new ilAssLacConditionParser())->parse($expression->getExpression())
             );
         } catch (ilAssLacException $e) {
-            if ($e instanceof ilAssLacFormAlertProvider) {
-                return $e->getFormAlert($this->lng);
-            }
-
-            throw $e;
+            return $e instanceof ilAssLacFormAlertProvider ? $e->getFormAlert($this->lng) : throw $e;
         }
 
         return true;

--- a/components/ILIAS/TestQuestionPool/classes/questions/LogicalAnswerCompare/Exception/ilAssLacAnswerValueNotExist.php
+++ b/components/ILIAS/TestQuestionPool/classes/questions/LogicalAnswerCompare/Exception/ilAssLacAnswerValueNotExist.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 /**
  * Class ilAssLacQuestionNotReachable
  * @package
@@ -27,101 +29,51 @@
  */
 class ilAssLacAnswerValueNotExist extends ilAssLacException implements ilAssLacFormAlertProvider
 {
-    /**
-     * @var int
-     */
-    protected $question_index;
-
-    /**
-     * @var string
-     */
-    protected $value;
-
-    /**
-     * @var int
-     */
-    protected $answer_index;
-
-    /**
-     * @param int $question_index
-     * @param string $value
-     * @param int $answer_index
-     */
-    public function __construct($question_index, $value, $answer_index = null)
-    {
-        $this->question_index = $question_index;
-        $this->answer_index = $answer_index;
-        $this->value = $value;
-
+    public function __construct(
+        protected ?int $question_index,
+        protected string $value,
+        protected ?int $answer_index = null
+    ) {
         if ($this->getQuestionIndex() === null && $this->getAnswerIndex() === null) {
-            $msg = sprintf(
-                'The value "%s" does not exist for the current question',
-                $value
-            );
+            $msg = "The value \"{$value}\" does not exist for the current question";
         } elseif ($this->getQuestionIndex() === null) {
-            $msg = sprintf(
-                'The value "%s" does not exist for the answer with index "%s" of the current question',
-                $value,
-                $this->getAnswerIndex()
-            );
+            $msg = "The value \"{$value}\" does not exist for the answer with index \"{$this->getAnswerIndex()}\" of the current question";
         } elseif ($this->getAnswerIndex() === null) {
-            $msg = sprintf(
-                'The value "%s" does not exist for the question Q%s',
-                $value,
-                $this->getQuestionIndex()
-            );
+            $msg = "The value \"{$value}\" does not exist for the question Q{$this->getQuestionIndex()}";
         } else {
-            $msg = sprintf(
-                'The value "%s" does not exist for the question Q%s[%s]',
-                $value,
-                $this->getQuestionIndex(),
-                $this->getAnswerIndex()
-            );
+            $msg = "The value \"{$value}\" does not exist for the question Q{$this->getQuestionIndex()}[{$this->getAnswerIndex()}]";
         }
 
         parent::__construct($msg);
     }
 
-    /**
-     * @return int
-     */
-    public function getQuestionIndex(): int
+    public function getQuestionIndex(): ?int
     {
         return $this->question_index;
     }
 
-    /**
-     * @return int
-     */
     public function getAnswerIndex(): ?int
     {
         return $this->answer_index;
     }
 
-    /**
-     * @return string
-     */
     public function getValue(): string
     {
         return $this->value;
     }
 
-    /**
-     * @param ilLanguage $lng
-     * @return string
-     */
     public function getFormAlert(ilLanguage $lng): string
     {
         if ($this->getQuestionIndex() === null && $this->getAnswerIndex() === null) {
             return sprintf(
-                $lng->txt("ass_lac_answer_value_not_exists_cur_qst_one_answer"),
+                $lng->txt('ass_lac_answer_value_not_exists_cur_qst_one_answer'),
                 $this->getValue()
             );
         }
 
         if ($this->getQuestionIndex() === null) {
             return sprintf(
-                $lng->txt("ass_lac_answer_value_not_exists_cur_qst"),
+                $lng->txt('ass_lac_answer_value_not_exists_cur_qst'),
                 $this->getValue(),
                 $this->getAnswerIndex()
             );
@@ -129,14 +81,14 @@ class ilAssLacAnswerValueNotExist extends ilAssLacException implements ilAssLacF
 
         if ($this->getAnswerIndex() === null) {
             return sprintf(
-                $lng->txt("ass_lac_answer_value_not_exists_one_answer"),
+                $lng->txt('ass_lac_answer_value_not_exists_one_answer'),
                 $this->getValue(),
                 $this->getQuestionIndex()
             );
         }
 
         return sprintf(
-            $lng->txt("ass_lac_answer_value_not_exists"),
+            $lng->txt('ass_lac_answer_value_not_exists'),
             $this->getValue(),
             $this->getQuestionIndex(),
             $this->getAnswerIndex()

--- a/components/ILIAS/TestQuestionPool/classes/questions/LogicalAnswerCompare/Exception/ilAssLacFormAlertProvider.php
+++ b/components/ILIAS/TestQuestionPool/classes/questions/LogicalAnswerCompare/Exception/ilAssLacFormAlertProvider.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 /**
  * @author		Björn Heyser <bheyser@databay.de>
  * @version		$Id$
@@ -24,5 +26,5 @@
  */
 interface ilAssLacFormAlertProvider
 {
-    public function getFormAlert(ilLanguage $lng);
+    public function getFormAlert(ilLanguage $lng): string;
 }

--- a/components/ILIAS/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacQuestionExpressionInterface.php
+++ b/components/ILIAS/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacQuestionExpressionInterface.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 /**
  * Class QuestionExpressionInterface
  *
@@ -25,5 +27,5 @@
  */
 interface ilAssLacQuestionExpressionInterface
 {
-    public function getQuestionIndex();
+    public function getQuestionIndex(): ?int;
 }

--- a/components/ILIAS/TestQuestionPool/classes/questions/LogicalAnswerCompare/ilAssLacCompositeEvaluator.php
+++ b/components/ILIAS/TestQuestionPool/classes/questions/LogicalAnswerCompare/ilAssLacCompositeEvaluator.php
@@ -78,7 +78,7 @@ class ilAssLacCompositeEvaluator
         if ($composite->nodes[0] instanceof ilAssLacExpressionInterface &&
             $composite->nodes[1] instanceof ilAssLacExpressionInterface
         ) {
-            $question = $this->object_loader->getQuestion($composite->nodes[0]->getQuestionIndex());
+            $question = $this->object_loader->getQuestion();
             $rightNode = $composite->nodes[1];
 
             $index = $this->isInstanceOfAnswerIndexProvidingExpression($composite) ? $composite->nodes[0]->getAnswerIndex() : null;

--- a/components/ILIAS/TestQuestionPool/classes/questions/LogicalAnswerCompare/ilAssLacCompositeValidator.php
+++ b/components/ILIAS/TestQuestionPool/classes/questions/LogicalAnswerCompare/ilAssLacCompositeValidator.php
@@ -47,15 +47,16 @@ class ilAssLacCompositeValidator
         $this->randomGroup = $DIC->refinery()->random();
     }
 
+    /**
+     * @throws ilAssLacException
+     */
     public function validate(ilAssLacAbstractComposite $composite): void
     {
-        if (count($composite->nodes) > 0) {
+        if ($composite->nodes !== []) {
             $this->validate($composite->nodes[0]);
             $this->validate($composite->nodes[1]);
             $this->validateSubTree($composite);
         }
-
-        return;
     }
 
     private function validateSubTree(ilAssLacAbstractComposite $composite): void
@@ -67,7 +68,7 @@ class ilAssLacCompositeValidator
             $answer_expression = $composite->nodes[1];
             $question_index = $composite->nodes[0]->getQuestionIndex();
             $answer_index = null;
-            $question = $this->object_loader->getQuestion($question_index);
+            $question = $this->object_loader->getQuestion();
 
             $this->checkQuestionExists($question, $question_index);
             //$this->checkQuestionIsReachable($question, $question_index);

--- a/components/ILIAS/TestQuestionPool/classes/questions/LogicalAnswerCompare/ilAssLacQuestionProvider.php
+++ b/components/ILIAS/TestQuestionPool/classes/questions/LogicalAnswerCompare/ilAssLacQuestionProvider.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 /**
  * Class ilParserQuestionProvider
  *
@@ -25,36 +27,24 @@
  */
 class ilAssLacQuestionProvider
 {
-    /*
-     * @var iQuestionCondition
-     */
-    protected $question;
+    protected ?assQuestion $question = null;
 
-    /**
-     * @var integer
-     */
-    protected $questionId;
+    protected ?int $question_id = null;
 
-    /**
-     * @param integer $questionId
-     */
-    public function setQuestionId($questionId): void
+    public function setQuestionId(int $question_id): void
     {
-        $this->questionId = $questionId;
+        $this->question_id = $question_id;
     }
 
-    /**
-     * @param iQuestionCondition $question
-     */
-    public function setQuestion(iQuestionCondition $question): void
+    public function setQuestion(assQuestion $question): void
     {
         $this->question = $question;
     }
 
-    public function getQuestion(): assQuestion
+    public function getQuestion(): ?assQuestion
     {
-        if ($this->question === null && $this->questionId) {
-            $this->question = assQuestion::instantiateQuestion($this->questionId);
+        if ($this->question === null && $this->question_id !== null) {
+            $this->question = assQuestion::instantiateQuestion($this->question_id);
         }
 
         return $this->question;


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=46549

Aims to fix issues with incorrect solution compare expressions for competences for cloze questions.
@thojou 