### PR TITLE
T&A 46666: Fixes redirect to blank page when resuming a test and error that a started test pass does not contain any questions

### DIFF
--- a/components/ILIAS/Course/classes/Objectives/class.ilLOTestQuestionAdapter.php
+++ b/components/ILIAS/Course/classes/Objectives/class.ilLOTestQuestionAdapter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -155,10 +156,12 @@ class ilLOTestQuestionAdapter
 
         $this->updateQuestions($a_test_session, $a_test_sequence);
 
-        if ($this->getSettings()->getPassedObjectiveMode() == ilLOSettings::MARK_PASSED_OBJECTIVE_QST) {
-            $this->setQuestionsOptional($a_test_sequence);
-        } elseif ($this->getSettings()->getPassedObjectiveMode() == ilLOSettings::HIDE_PASSED_OBJECTIVE_QST) {
-            $this->hideQuestions($a_test_sequence);
+        if ($this->getSettings()->getQualifiedTest() === $a_test_session->getRefId()) {
+            if ($this->getSettings()->getPassedObjectiveMode() == ilLOSettings::MARK_PASSED_OBJECTIVE_QST) {
+                $this->setQuestionsOptional($a_test_sequence);
+            } elseif ($this->getSettings()->getPassedObjectiveMode() == ilLOSettings::HIDE_PASSED_OBJECTIVE_QST) {
+                $this->hideQuestions($a_test_sequence);
+            }
         }
 
         $this->storeTestRun();

--- a/components/ILIAS/Test/src/Presentation/class.TestScreenGUI.php
+++ b/components/ILIAS/Test/src/Presentation/class.TestScreenGUI.php
@@ -291,8 +291,11 @@ class TestScreenGUI
 
     private function getResumeLauncherLink(): Link
     {
-        $url = $this->ctrl->getLinkTarget(
-            (new \ilTestPlayerFactory($this->object))->getPlayerGUI(),
+        $class = $this->object->isFixedTest()
+            ? \ilTestPlayerFixedQuestionSetGUI::class
+            : \ilTestPlayerRandomQuestionSetGUI::class;
+        $url = $this->ctrl->getLinkTargetByClass(
+            [\ilRepositoryGUI::class, \ilObjTestGUI::class, $class],
             \ilTestPlayerCommands::RESUME_PLAYER
         );
         return $this->data_factory->link($this->lng->txt('tst_resume_test'), $this->data_factory->uri(ILIAS_HTTP_PATH . '/' . $url));
@@ -391,8 +394,11 @@ class TestScreenGUI
 
     private function getStartLauncherLink(): Link
     {
-        $url = $this->ctrl->getLinkTarget(
-            (new \ilTestPlayerFactory($this->object))->getPlayerGUI(),
+        $class = $this->object->isFixedTest()
+            ? \ilTestPlayerFixedQuestionSetGUI::class
+            : \ilTestPlayerRandomQuestionSetGUI::class;
+        $url = $this->ctrl->getLinkTargetByClass(
+            [\ilRepositoryGUI::class, \ilObjTestGUI::class, $class],
             \ilTestPlayerCommands::INIT_TEST
         );
         return $this->data_factory->link($this->lng->txt('tst_exam_start'), $this->data_factory->uri(ILIAS_HTTP_PATH . '/' . $url));


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=46666

Aims to fix redirect to blank page when resuming a test and error that a started test pass does not contain any questions.
@thojou 