### PR TITLE
Fix 47337: Ensure $login is never null when calling ilObjUser::_lookupId() (use …

### DIFF
--- a/components/ILIAS/WebServices/ECS/classes/Course/class.ilECSCmsCourseMemberCommandQueueHandler.php
+++ b/components/ILIAS/WebServices/ECS/classes/Course/class.ilECSCmsCourseMemberCommandQueueHandler.php
@@ -364,7 +364,7 @@ class ilECSCmsCourseMemberCommandQueueHandler implements ilECSCommandQueueHandle
                         );
                     }
                     // Assign to role
-                    if ($role && $il_usr_id = ilObjUser::_lookupId($login ? "")) {
+                    if ($role && $il_usr_id = ilObjUser::_lookupId($login ?? "")) {
                         $this->log->info('Assigning new role to existing user ' . $person_id . ' ' . 'to ' . ilObject::_lookupTitle($obj_id) . ' using role: ' . $role);
                         $part->add($il_usr_id, $role);
                         $part->sendNotification(ilCourseMembershipMailNotification::TYPE_ADMISSION_MEMBER, $il_usr_id);

--- a/components/ILIAS/WebServices/ECS/classes/Course/class.ilECSCmsCourseMemberCommandQueueHandler.php
+++ b/components/ILIAS/WebServices/ECS/classes/Course/class.ilECSCmsCourseMemberCommandQueueHandler.php
@@ -345,7 +345,7 @@ class ilECSCmsCourseMemberCommandQueueHandler implements ilECSCommandQueueHandle
                     }
                 }
             } else {
-                if ($il_usr_id = ilObjUser::_lookupId($login)) {
+                if ($il_usr_id = ilObjUser::_lookupId($login ?? "")) {
                     // user exists => assign to course/group
                     if ($role) {
                         // Assign user
@@ -364,7 +364,7 @@ class ilECSCmsCourseMemberCommandQueueHandler implements ilECSCommandQueueHandle
                         );
                     }
                     // Assign to role
-                    if ($role && $il_usr_id = ilObjUser::_lookupId($login)) {
+                    if ($role && $il_usr_id = ilObjUser::_lookupId($login ? "")) {
                         $this->log->info('Assigning new role to existing user ' . $person_id . ' ' . 'to ' . ilObject::_lookupTitle($obj_id) . ' using role: ' . $role);
                         $part->add($il_usr_id, $role);
                         $part->sendNotification(ilCourseMembershipMailNotification::TYPE_ADMISSION_MEMBER, $il_usr_id);


### PR DESCRIPTION
…?? '')

Prevent cronjob failure when $login is null