### PR TITLE
[FIX] Search: Fix missing term for Lucene-based search in "MetaBar"

### DIFF
--- a/components/ILIAS/Search/classes/class.ilSearchBaseGUI.php
+++ b/components/ILIAS/Search/classes/class.ilSearchBaseGUI.php
@@ -395,6 +395,11 @@ class ilSearchBaseGUI implements ilDesktopItemHandling, ilAdministrationCommandH
                 'term',
                 $this->refinery->kindlyTo()->string()
             );
+        } elseif ($this->http->wrapper()->query()->has('term')) {
+            $query = $this->http->wrapper()->query()->retrieve(
+                'term',
+                $this->refinery->kindlyTo()->string()
+            );
         }
         $list = ilSearchAutoComplete::getList($query);
         echo $list;


### PR DESCRIPTION
If approved, the fix has to be picked to `trunk` and `release_11` as well.

Mantis Issue: https://mantis.ilias.de/view.php?id=47338