### PR TITLE
UI 45579-2: Removes try catch from ILIAS\UI\Implementation\Component\Launcher::getResult method

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Launcher/Inline.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Launcher/Inline.php
@@ -145,11 +145,11 @@ class Inline implements C\Launcher\Inline
 
     public function getResult(): ?Result
     {
-        try {
-            return $this->modal?->getForm()?->getInputGroup()?->getContent();
-        } catch (\Throwable) {
+        if ($this->request === null) {
             return null;
         }
+
+        return $this->modal?->getForm()?->getInputGroup()?->getContent();
     }
 
     public function getModal(): ?Modal\Roundtrip


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45579

This is a follow up PR of https://github.com/ILIAS-eLearning/ILIAS/pull/10323.

Best regards
@matheuszych 