### PR TITLE
[FIX] FileDelivery: Add ext. data directory support for `X-Accel`

### DIFF
--- a/components/ILIAS/FileDelivery/src/Delivery/ResponseBuilder/XAccelResponseBuilder.php
+++ b/components/ILIAS/FileDelivery/src/Delivery/ResponseBuilder/XAccelResponseBuilder.php
@@ -31,7 +31,13 @@ class XAccelResponseBuilder implements ResponseBuilder
 {
     private const DATA = 'data';
     private const SECURED_DATA = 'secured-data';
+    private const SECURED_EXT_DATA = 'secured-ext-data';
     private const X_ACCEL_REDIRECT_HEADER = 'X-Accel-Redirect';
+
+    public function __construct(private string $external_data_dir)
+    {
+        $this->external_data_dir = rtrim($this->external_data_dir, '/') . '/';
+    }
 
     public function getName(): string
     {
@@ -49,6 +55,12 @@ class XAccelResponseBuilder implements ResponseBuilder
                 './' . self::DATA . '/',
                 '/' . self::SECURED_DATA
                 . '/',
+                $path_to_file
+            );
+        } elseif (str_starts_with((string) $path_to_file, $this->external_data_dir)) {
+            $path_to_file = str_replace(
+                $this->external_data_dir,
+                '/' . self::SECURED_EXT_DATA . '/',
                 $path_to_file
             );
         }

--- a/components/ILIAS/FileDelivery/src/Init.php
+++ b/components/ILIAS/FileDelivery/src/Init.php
@@ -44,9 +44,13 @@ class Init
 
             switch ($settings[DeliveryMethodObjective::SETTINGS] ?? null) {
                 case DeliveryMethodObjective::XACCEL:
-                    return new XAccelResponseBuilder();
+                    return new XAccelResponseBuilder(
+                        $settings[DeliveryMethodObjective::SETTINGS_EXTERNAL_DATA_DIR]
+                    );
+
                 case DeliveryMethodObjective::XSENDFILE:
                     return new XSendFileResponseBuilder();
+
                 case DeliveryMethodObjective::PHP:
                 default:
                     return new PHPResponseBuilder();

--- a/components/ILIAS/FileDelivery/src/Setup/DeliveryMethodObjective.php
+++ b/components/ILIAS/FileDelivery/src/Setup/DeliveryMethodObjective.php
@@ -23,7 +23,8 @@ namespace ILIAS\FileDelivery\Setup;
 use ILIAS\Setup\Artifact;
 use ILIAS\Setup\Artifact\ArrayArtifact;
 use ILIAS\Setup\Environment;
-use ILIAS\Setup\Artifact\BuildArtifactObjective;
+use ILIAS\Setup\CLI\IOWrapper;
+use ILIAS\Setup\UnachievableException;
 
 /**
  * @author Fabian Schmid <fabian@sr.solutions>
@@ -31,54 +32,95 @@ use ILIAS\Setup\Artifact\BuildArtifactObjective;
 class DeliveryMethodObjective extends BuildStaticConfigStoredObjective
 {
     public const SETTINGS = 'delivery_method';
+    public const SETTINGS_EXTERNAL_DATA_DIR = 'ext_data_dir';
     public const XSENDFILE = 'xsendfile';
     public const XACCEL = 'xaccel';
     public const PHP = 'php';
 
+    private ?string $ext_data_dir = null;
+    private ?IOWrapper $io = null;
+
     public function getArtifactName(): string
     {
-        return "delivery_method";
+        return 'delivery_method';
+    }
+
+    public function getPreconditions(Environment $environment): array
+    {
+        return array_merge(
+            parent::getPreconditions($environment),
+            [
+                new \ilIniFilesPopulatedObjective()
+            ]
+        );
+    }
+
+    public function achieve(Environment $environment): Environment
+    {
+        /** @var \ilIniFile $ini */
+        $ini = $environment->getResource(Environment::RESOURCE_ILIAS_INI);
+        if ($ini instanceof \ilIniFile && $ini->variableExists('clients', 'datadir')) {
+            $this->ext_data_dir = $ini->readVariable('clients', 'datadir');
+        } else {
+            throw new UnachievableException(
+                'Could not determine external data directory from ILIAS ini file'
+            );
+        }
+
+        $io = $environment->getResource(Environment::RESOURCE_ADMIN_INTERACTION);
+        if ($io instanceof IOWrapper) {
+            $this->io = $io;
+        }
+
+        return parent::achieve($environment);
     }
 
     public function build(): Artifact
     {
-        // check if mod_xsendfile is loaded
-        if ($this->isModXSendFileLoaded()) {
-            return new ArrayArtifact([
-                self::SETTINGS => self::XSENDFILE
-            ]);
+        $delivery_method = self::PHP;
+
+        if (file_exists(self::PATH())) {
+            $settings = (@include self::PATH()) ?? [];
+            $delivery_method = $settings[self::SETTINGS] ?? self::PHP;
         }
 
-        return new ArrayArtifact([
-            self::SETTINGS => self::PHP
-        ]);
+        if ($this->isModXSendFileLoaded()) {
+            $delivery_method = self::XSENDFILE;
+        }
+
+        return new ArrayArtifact(array_filter([
+            self::SETTINGS => $delivery_method,
+            self::SETTINGS_EXTERNAL_DATA_DIR => $this->ext_data_dir
+        ]));
     }
 
     private function isModXSendFileLoaded(): bool
     {
-        if (function_exists('apache_get_modules') && in_array('mod_xsendfile', apache_get_modules(), true)) {
+        if (\function_exists('apache_get_modules') && \in_array('mod_xsendfile', apache_get_modules(), true)) {
             return true;
         }
 
         try {
-            $command_exists = shell_exec("which apache2ctl");
-            if ($command_exists === null || empty($command_exists)) {
+            $command_exists = shell_exec('which apache2ctl');
+            if (empty($command_exists)) {
                 return false;
             }
 
             $loaded_modules = array_map(
-                static fn(string $module): string => explode(" ", trim($module))[0] ?? "",
-                explode("\n", shell_exec("apache2ctl -M 2>/dev/null") ?? '')
+                static fn(string $module): string => explode(' ', trim($module))[0] ?? '',
+                explode("\n", shell_exec('apache2ctl -M 2>/dev/null') ?? '')
             );
         } catch (\Throwable $e) {
+            $this->io?->error($e->getMessage());
+            $this->io?->error($e->getTraceAsString());
             $loaded_modules = [];
         }
-        return in_array('xsendfile_module', $loaded_modules, true);
+
+        return \in_array('xsendfile_module', $loaded_modules, true);
     }
 
     public function isApplicable(Environment $environment): bool
     {
-        return !file_exists(BuildArtifactObjective::PATH());
+        return true;
     }
-
 }


### PR DESCRIPTION
This PR suggests supporting the external directory for the `XAccelResponseBuilder`.

Since we have no "Environment" (no initialized ILIAS) in the execution context of the `deliver.php`, I read the path to the external ILIAS data directory from the `ilias.ini.php` and added it to the generated artifact file when it is created by the setup on install/update.

If approved, this must be picked to `release_11` and `trunk` as well.

See: https://mantis.ilias.de/view.php?id=45048