### PR TITLE
T&A 47332: Fixes SQLSTATE[22003]: Numeric value out of range: 1264 Out of range value for column 'try' in table page_qst_answer

### DIFF
--- a/components/ILIAS/Test/src/Setup/Test10DBUpdateSteps.php
+++ b/components/ILIAS/Test/src/Setup/Test10DBUpdateSteps.php
@@ -514,4 +514,9 @@ class Test10DBUpdateSteps implements \ilDatabaseUpdateSteps
             ]
         );
     }
+
+    public function step_18(): void
+    {
+        $this->db->modifyTableColumn('page_qst_answer', 'try', ['length' => 4]);
+    }
 }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=47332

Aims to fix SQLSTATE[22003]: Numeric value out of range: 1264 Out of range value for column 'try' in table page_qst_answer when question tries exceed 127 (128).
@thojou 