### PR TITLE
Update class.Server.php

### DIFF
--- a/components/ILIAS/COPage/Editor/Server/class.Server.php
+++ b/components/ILIAS/COPage/Editor/Server/class.Server.php
@@ -73,6 +73,10 @@ class Server
                 $response = $action_handler->handle($query);
             } else {
                 //sleep(5);
+                // Argument #2 ($body) must be of type array, null given
+                 if (!is_array($body)) {
+                $body = array();
+                }
                 $action_handler = $this->getActionHandlerForCommand($query, $body);
                 $response = $action_handler->handle($query, $body);
             }
@@ -115,8 +119,10 @@ class Server
         array $body
     ): CommandActionHandler {
         $handler = null;
-
-        switch ($body["component"]) {
+        //Undefined array key "component
+        //switch ($body["component"]) {
+        $component = isset($body['component']) ? $body['component'] : null;
+         switch ($component) {
             case "Paragraph":
                 $handler = new ParagraphCommandActionHandler($this->page_gui);
                 break;
@@ -157,7 +163,8 @@ class Server
         }
 
         if ($handler === null) {
-            throw new Exception("Unknown component " . ((string) $body["component"]));
+    // throw new Exception("Unknown component " . ((string) $body["component"]));
+         throw new Exception("Unknown component " . ((string) $component))   
         }
         return $handler;
     }


### PR DESCRIPTION
Vorschlag FIX für Mantis-Bug: 47331: 
https://mantis.ilias.de/view.php?id=47331
ILIAS-Fehler: 
1.  TypeError thrown with message "ILIAS\COPage\Editor\Server\Server::getActionHandlerForCommand(): Argument #2 ($body) must be of type array, null given, called in components/ILIAS/COPage/Editor/Server/class.Server.php on line 76"
2. Whoops\Exception\ErrorException thrown with message "Undefined array key "component""