### PR TITLE
[FIX] SOAP: Fix fragile HTTPS detection which can lead to PHP error

### DIFF
--- a/components/ILIAS/soap/resources/soap/server.php
+++ b/components/ILIAS/soap/resources/soap/server.php
@@ -40,7 +40,7 @@ if ($ilIliasIniFile->readVariable('https', 'auto_https_detect_enabled')) {
     $headerValue = $ilIliasIniFile->readVariable('https', 'auto_https_detect_header_value');
 
     $headerName = 'HTTP_' . str_replace('-', '_', strtoupper($headerName));
-    if (strcasecmp($_SERVER[$headerName], $headerValue) === 0) {
+    if (strcasecmp($_SERVER[$headerName] ?? '', $headerValue) === 0) {
         $_SERVER['HTTPS'] = 'on';
     }
 }


### PR DESCRIPTION
If approved, this must be picked to `release_11` and `trunk`.

Mantis Issue: https://mantis.ilias.de/view.php?id=47377