### PR TITLE
[Survey] update: Bring detailed result toolbar to KS

### DIFF
--- a/components/ILIAS/Survey/Evaluation/class.ilSurveyEvaluationGUI.php
+++ b/components/ILIAS/Survey/Evaluation/class.ilSurveyEvaluationGUI.php
@@ -25,7 +25,7 @@ use ILIAS\UI\Component\Modal;
  * The ilSurveyEvaluationGUI class creates the evaluation output for the ilObjSurveyGUI
  * class. This saves some heap space because the ilObjSurveyGUI class will be
  * smaller.
- * @author		Helmut Schottmüller <helmut.schottmueller@mac.com>
+ * @author        Helmut Schottmüller <helmut.schottmueller@mac.com>
  */
 class ilSurveyEvaluationGUI
 {
@@ -99,20 +99,20 @@ class ilSurveyEvaluationGUI
         );
 
         $this->ui_modifier = $DIC->survey()
-             ->internal()
-             ->gui()
-             ->modeUIModifier($this->object->getMode());
+                                 ->internal()
+                                 ->gui()
+                                 ->modeUIModifier($this->object->getMode());
         $this->print = $DIC->survey()
-            ->internal()
-            ->gui()
-            ->print();
+                           ->internal()
+                           ->gui()
+                           ->print();
         $this->access_manager = $DIC->survey()
-            ->internal()
-            ->domain()
-            ->access(
-                $this->object->getRefId(),
-                $DIC->user()->getId()
-            );
+                                    ->internal()
+                                    ->domain()
+                                    ->access(
+                                        $this->object->getRefId(),
+                                        $DIC->user()->getId()
+                                    );
         $this->skill_profile_service = $DIC->skills()->profile();
         $this->gui = $DIC->survey()->internal()->gui();
     }
@@ -186,7 +186,6 @@ class ilSurveyEvaluationGUI
         }
     }
 
-
     public function setAppraiseeId(
         int $a_val
     ): void {
@@ -227,11 +226,22 @@ class ilSurveyEvaluationGUI
 
             // code needed
             $this->tpl->setVariable("TABS", "");
-            $this->tpl->addBlockFile("ADM_CONTENT", "adm_content", "tpl.il_svy_svy_evaluation_checkaccess.html", "components/ILIAS/Survey");
+            $this->tpl->addBlockFile(
+                "ADM_CONTENT",
+                "adm_content",
+                "tpl.il_svy_svy_evaluation_checkaccess.html",
+                "components/ILIAS/Survey"
+            );
             $this->tpl->setCurrentBlock("adm_content");
-            $this->tpl->setVariable("AUTHENTICATION_NEEDED", $this->lng->txt("svy_check_evaluation_authentication_needed"));
+            $this->tpl->setVariable(
+                "AUTHENTICATION_NEEDED",
+                $this->lng->txt("svy_check_evaluation_authentication_needed")
+            );
             $this->tpl->setVariable("FORM_ACTION", $this->ctrl->getFormAction($this, "checkEvaluationAccess"));
-            $this->tpl->setVariable("EVALUATION_CHECKACCESS_INTRODUCTION", $this->lng->txt("svy_check_evaluation_access_introduction"));
+            $this->tpl->setVariable(
+                "EVALUATION_CHECKACCESS_INTRODUCTION",
+                $this->lng->txt("svy_check_evaluation_access_introduction")
+            );
             $this->tpl->setVariable("VALUE_CHECK", $this->lng->txt("ok"));
             $this->tpl->setVariable("VALUE_CANCEL", $this->lng->txt("cancel"));
             $this->tpl->setVariable("TEXT_SURVEY_CODE", $this->lng->txt("survey_code"));
@@ -341,7 +351,6 @@ class ilSurveyEvaluationGUI
                 break;
         }
 
-
         // parse answer data in evaluation results
         $ov_row = 2;
         $question_index = 1;
@@ -371,7 +380,14 @@ class ilSurveyEvaluationGUI
             if ($details) {
                 switch ($this->request->getExportFormat()) {
                     case self::TYPE_XLS:
-                        $this->exportResultsDetailsExcel($excel, $q_eval, $q_res, $do_title, $do_label, $question_index++);
+                        $this->exportResultsDetailsExcel(
+                            $excel,
+                            $q_eval,
+                            $q_res,
+                            $do_title,
+                            $do_label,
+                            $question_index++
+                        );
                         break;
                 }
             }
@@ -427,7 +443,6 @@ class ilSurveyEvaluationGUI
 
         $a_excel->addSheet($question_index . "_" . $question->getTitle());
 
-
         // question "overview"
 
         $kv = array();
@@ -449,7 +464,7 @@ class ilSurveyEvaluationGUI
 
         // answered and skipped users
         $kv[$this->lng->txt("users_answered")] = $question_res->getUsersAnswered();
-        $kv[$this->lng->txt("users_skipped")] = $question_res->getUsersSkipped();		// #0021671
+        $kv[$this->lng->txt("users_skipped")] = $question_res->getUsersSkipped();        // #0021671
 
         $excel_row = 1;
 
@@ -595,8 +610,7 @@ class ilSurveyEvaluationGUI
                 $a_excel->setColors("B" . $a_excel_row . ":C" . $a_excel_row, self::EXCEL_SUBTITLE);
                 $a_excel->setCell($a_excel_row, 1, $this->lng->txt("title"));
                 $a_excel->setCell($a_excel_row++, 2, $this->lng->txt("answer"));
-            }
-            // mtx (row), txt
+            } // mtx (row), txt
             else {
                 $a_excel->setColors("B" . $a_excel_row . ":B" . $a_excel_row, self::EXCEL_SUBTITLE);
                 $a_excel->setCell($a_excel_row++, 1, $this->lng->txt("answer"));
@@ -658,7 +672,7 @@ class ilSurveyEvaluationGUI
         $toolbar->addComponent($modal);
     }
 
-    protected function getExportModal(): Modal\RoundTrip | Form\Standard
+    protected function getExportModal(): Modal\RoundTrip|Form\Standard
     {
         $lng = $this->lng;
         $ctrl = $this->ctrl;
@@ -673,8 +687,8 @@ class ilSurveyEvaluationGUI
                 \ilSurveyEvaluationGUI::TYPE_SPSS => $lng->txt("exp_type_csv")
             ]
         )
-        //->withValue(\ilSurveyEvaluationGUI::TYPE_XLS)
-        ->withRequired(true);
+            //->withValue(\ilSurveyEvaluationGUI::TYPE_XLS)
+                                          ->withRequired(true);
 
         $inputs["export_label"] = $ui_fac->input()->field()->select(
             $lng->txt("title"),
@@ -684,8 +698,8 @@ class ilSurveyEvaluationGUI
                 "title_label" => $lng->txt("export_title_label")
             ]
         )
-        //->withValue("label_only")
-        ->withRequired(true);
+            //->withValue("label_only")
+                                         ->withRequired(true);
 
         $modal = $ui_fac->modal()->roundtrip(
             $lng->txt("svy_export_format"),
@@ -693,7 +707,7 @@ class ilSurveyEvaluationGUI
             $inputs,
             $post_url
         )
-        ->withSubmitLabel($lng->txt("export"));
+                        ->withSubmitLabel($lng->txt("export"));
 
         return $modal;
     }
@@ -781,7 +795,6 @@ class ilSurveyEvaluationGUI
             $this->tabs->activateSubTab("svy_eval_detail");
         }
 
-
         // auth
         if (!$this->hasResultsAccess()) {
             if (!$this->access->checkAccess('read', '', $this->object->getRefId())) {
@@ -815,7 +828,6 @@ class ilSurveyEvaluationGUI
 
         $eval_tpl = new ilTemplate("tpl.il_svy_svy_evaluation.html", true, true, "components/ILIAS/Survey");
 
-
         if ($details) {
             $toolbar_components = $this->ui_modifier->setResultsDetailToolbar(
                 $this->object,
@@ -836,7 +848,12 @@ class ilSurveyEvaluationGUI
         if (!$this->object->get360Mode() || $appr_id) {
             if ($details) {
                 //templates: results, table of contents
-                $dtmpl = new ilTemplate("tpl.il_svy_svy_results_details.html", true, true, "components/ILIAS/Survey/Evaluation");
+                $dtmpl = new ilTemplate(
+                    "tpl.il_svy_svy_results_details.html",
+                    true,
+                    true,
+                    "components/ILIAS/Survey/Evaluation"
+                );
                 $this->lng->loadLanguageModule("content");
             }
             $finished_ids = $this->evaluation_manager->getFilteredFinishedIds();
@@ -887,7 +904,10 @@ class ilSurveyEvaluationGUI
 
             if ($details) {
                 //TABLE OF CONTENTS
-                $panel_toc = $ui_factory->panel()->standard($this->lng->txt('cont_toc'), $ui_factory->legacy()->content($listing->render()));
+                $panel_toc = $ui_factory->panel()->standard(
+                    $this->lng->txt('cont_toc'),
+                    $ui_factory->legacy()->content($listing->render())
+                );
                 $render_toc = $ui_renderer->render($panel_toc);
                 $dtmpl->setVariable("PANEL_TOC", $render_toc);
 
@@ -942,8 +962,8 @@ class ilSurveyEvaluationGUI
     /**
      * Processes an array as a CSV row and converts the array values to correct CSV
      * values. The "converted" array is returned
-     * @param array $row The array containing the values for a CSV row
-     * @param bool $quoteAll Indicates to quote every value (=TRUE) or only values containing quotes and separators (=FALSE, default)
+     * @param array  $row       The array containing the values for a CSV row
+     * @param bool   $quoteAll  Indicates to quote every value (=TRUE) or only values containing quotes and separators (=FALSE, default)
      * @param string $separator The value separator in the CSV row (used for quoting) (; = default)
      * @return array The converted array ready for CSV use
      */
@@ -1149,7 +1169,6 @@ class ilSurveyEvaluationGUI
             $this->gui->toolbar()->addComponent($component);
         }
 
-
         $appr_id = null;
         $data = [];
 
@@ -1159,7 +1178,6 @@ class ilSurveyEvaluationGUI
 
         if (!$this->object->get360Mode() || $appr_id) {
             $this->buildExportButtonAndModal("exportEvaluationUser");
-
 
             $this->gui->toolbar()->addSeparator();
 
@@ -1194,7 +1212,6 @@ class ilSurveyEvaluationGUI
         $ilTabs->activateSubTab("svy_eval_competences");
         $ilTabs->activateTab("svy_results");
 
-
         $appr_id = $this->getAppraiseeId();
 
         if ($appr_id === 0) {
@@ -1219,8 +1236,13 @@ class ilSurveyEvaluationGUI
         $skills = array();
         foreach ($opts as $id => $o) {
             $idarr = explode(":", $id);
-            $skills[$id] = array("id" => $id, "title" => $o, "profiles" => array(),
-                "base_skill" => $idarr[0], "tref_id" => $idarr[1]);
+            $skills[$id] = array(
+                "id" => $id,
+                "title" => $o,
+                "profiles" => array(),
+                "base_skill" => $idarr[0],
+                "tref_id" => $idarr[1]
+            );
         }
 
         // get matching user competence profiles
@@ -1269,9 +1291,8 @@ class ilSurveyEvaluationGUI
 
         $this->gui->toolbar()->addComponent(
             $this->ui->factory()->dropdown()->standard($dropdown_items)
-                ->withLabel($eval_modes[$comp_eval_mode] ?? $lng->txt("svy_analysis"))
+                     ->withLabel($eval_modes[$comp_eval_mode] ?? $lng->txt("svy_analysis"))
         );
-
 
         $pskills_gui = new ilPersonalSkillsGUI();
         $rater = $this->evaluation_manager->getCurrentRater(
@@ -1315,7 +1336,7 @@ class ilSurveyEvaluationGUI
                 $sk[] = array(
                     "base_skill_id" => (int) $skill["base_skill"],
                     "tref_id" => (int) $skill["tref_id"]
-                    );
+                );
             }
             $html = $pskills_gui->getGapAnalysisHTML($appr_id, $sk);
         }
@@ -1328,7 +1349,11 @@ class ilSurveyEvaluationGUI
      */
     protected function hasResultsAccess(): bool
     {
-        return $this->access->checkRbacOrPositionPermissionAccess('read_results', 'access_results', $this->object->getRefId());
+        return $this->access->checkRbacOrPositionPermissionAccess(
+            'read_results',
+            'access_results',
+            $this->object->getRefId()
+        );
     }
 
     /**
@@ -1342,7 +1367,10 @@ class ilSurveyEvaluationGUI
             $this->ctrl->redirectByClass("ilObjSurveyGUI", "infoScreen");
         }
 
-        $this->tpl->setOnScreenMessage('info', $this->lng->txt("svy_max_sum_score") . ": " . $this->object->getMaxSumScore());
+        $this->tpl->setOnScreenMessage(
+            'info',
+            $this->lng->txt("svy_max_sum_score") . ": " . $this->object->getMaxSumScore()
+        );
 
         $this->gui->button(
             $this->lng->txt("print"),

--- a/components/ILIAS/Survey/Evaluation/class.ilSurveyEvaluationGUI.php
+++ b/components/ILIAS/Survey/Evaluation/class.ilSurveyEvaluationGUI.php
@@ -49,7 +49,6 @@ class ilSurveyEvaluationGUI
     protected ilObjUser $user;
     protected ilRbacSystem $rbacsystem;
     protected ilTree $tree;
-    protected ilToolbarGUI $toolbar;
     protected ilObjSurvey $object;
     protected ilLanguage $lng;
     protected ilGlobalTemplateInterface $tpl;
@@ -69,7 +68,6 @@ class ilSurveyEvaluationGUI
         $this->user = $DIC->user();
         $this->rbacsystem = $DIC->rbac()->system();
         $this->tree = $DIC->repositoryTree();
-        $this->toolbar = $DIC->toolbar();
         $this->ui = $DIC->ui();
         $lng = $DIC->language();
         $tpl = $DIC["tpl"];
@@ -646,7 +644,7 @@ class ilSurveyEvaluationGUI
     ): void {
         $lng = $this->lng;
         $ctrl = $this->ctrl;
-        $toolbar = $this->toolbar;
+        $toolbar = $this->gui->toolbar();
         $ui_fac = $this->gui->ui()->factory();
 
         $ctrl->setParameter($this, "export_cmd", $export_cmd);
@@ -705,7 +703,7 @@ class ilSurveyEvaluationGUI
         $lng = $this->lng;
         $ctrl = $this->ctrl;
         $tabs = $this->tabs;
-        $toolbar = $this->toolbar;
+        $toolbar = $this->gui->toolbar();
         $request = $this->request;
         $ui_request = $this->gui->http()->request();
 
@@ -767,7 +765,6 @@ class ilSurveyEvaluationGUI
     public function evaluation(
         int $details = 0
     ): void {
-        $ilToolbar = $this->toolbar;
         $tree = $this->tree;
         $ui = $this->ui;
 
@@ -814,26 +811,26 @@ class ilSurveyEvaluationGUI
         // setup toolbar
 
         $appr_id = $this->evaluation_manager->getCurrentAppraisee();
-        $ilToolbar->setFormAction($this->ctrl->getFormAction($this));
         $results = array();
 
         $eval_tpl = new ilTemplate("tpl.il_svy_svy_evaluation.html", true, true, "components/ILIAS/Survey");
 
 
         if ($details) {
-            $this->ui_modifier->setResultsDetailToolbar(
+            $toolbar_components = $this->ui_modifier->setResultsDetailToolbar(
                 $this->object,
-                $ilToolbar,
                 $this->user->getId(),
                 $eval_tpl
             );
         } else {
-            $this->ui_modifier->setResultsOverviewToolbar(
+            $toolbar_components = $this->ui_modifier->setResultsOverviewToolbar(
                 $this->object,
-                $ilToolbar,
                 $this->user->getId(),
                 $eval_tpl
             );
+        }
+        foreach ($toolbar_components as $component) {
+            $this->gui->toolbar()->addComponent($component);
         }
 
         if (!$this->object->get360Mode() || $appr_id) {
@@ -905,7 +902,6 @@ class ilSurveyEvaluationGUI
             }
         }
 
-        //$eval_tpl->setVariable('MODAL', $modal);
         if (!$details) {
             $table_gui = new ilSurveyResultsCumulatedTableGUI($this, 'evaluation', $results);
             $eval_tpl->setVariable('CUMULATED', $table_gui->getHTML());
@@ -1139,23 +1135,21 @@ class ilSurveyEvaluationGUI
      */
     public function evaluationuser(): void
     {
-        $ilToolbar = $this->toolbar;
-
         if (!$this->hasResultsAccess() &&
             $this->object->getMode() !== ilObjSurvey::MODE_SELF_EVAL) {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt("no_permission"), true);
             $this->ctrl->redirectByClass("ilObjSurveyGUI", "infoScreen");
         }
 
-        $this->ui_modifier->setResultsParticipantToolbar(
+        $toolbar_components = $this->ui_modifier->setResultsParticipantToolbar(
             $this->object,
-            $ilToolbar,
             $this->user->getId()
         );
+        foreach ($toolbar_components as $component) {
+            $this->gui->toolbar()->addComponent($component);
+        }
 
-        $ilToolbar->setFormAction($this->ctrl->getFormAction($this, "evaluationuser"));
 
-        $modal = "";
         $appr_id = null;
         $data = [];
 
@@ -1166,7 +1160,8 @@ class ilSurveyEvaluationGUI
         if (!$this->object->get360Mode() || $appr_id) {
             $this->buildExportButtonAndModal("exportEvaluationUser");
 
-            $ilToolbar->addSeparator();
+
+            $this->gui->toolbar()->addSeparator();
 
             $pv = $this->print->resultsDetails($this->object->getRefId());
             $modal_elements = $pv->getModalElements(
@@ -1175,8 +1170,9 @@ class ilSurveyEvaluationGUI
                     "printResultsPerUserSelection"
                 )
             );
-            $ilToolbar->addComponent($modal_elements->button);
-            $ilToolbar->addComponent($modal_elements->modal);
+
+            $this->gui->toolbar()->addComponent($modal_elements->button);
+            $this->gui->toolbar()->addComponent($modal_elements->modal);
 
             $data = $this->evaluation_manager->getUserSpecificResults();
         }
@@ -1190,7 +1186,6 @@ class ilSurveyEvaluationGUI
     {
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
-        $ilToolbar = $this->toolbar;
         $tpl = $this->tpl;
         $ilTabs = $this->tabs;
 
@@ -1199,7 +1194,6 @@ class ilSurveyEvaluationGUI
         $ilTabs->activateSubTab("svy_eval_competences");
         $ilTabs->activateTab("svy_results");
 
-        $ilToolbar->setFormAction($this->ctrl->getFormAction($this, "competenceEval"));
 
         $appr_id = $this->getAppraiseeId();
 
@@ -1208,11 +1202,13 @@ class ilSurveyEvaluationGUI
             return;
         }
 
-        $this->ui_modifier->setResultsCompetenceToolbar(
+        $toolbar_components = $this->ui_modifier->setResultsCompetenceToolbar(
             $this->object,
-            $ilToolbar,
             $this->user->getId()
         );
+        foreach ($toolbar_components as $component) {
+            $this->gui->toolbar()->addComponent($component);
+        }
 
         // evaluation modes
         $eval_modes = array();
@@ -1261,12 +1257,21 @@ class ilSurveyEvaluationGUI
 
         $ilCtrl->saveParameter($this, "comp_eval_mode");
 
-        $mode_sel = new ilSelectInputGUI($lng->txt("svy_analysis"), "comp_eval_mode");
-        $mode_sel->setOptions($eval_modes);
-        $mode_sel->setValue($comp_eval_mode);
-        $ilToolbar->addInputItem($mode_sel, true);
+        $dropdown_items = [];
+        foreach ($eval_modes as $mode_key => $mode_label) {
+            $ilCtrl->setParameter($this, "comp_eval_mode", $mode_key);
+            $dropdown_items[] = $this->ui->factory()->button()->shy(
+                $mode_label,
+                $ilCtrl->getLinkTarget($this, "competenceEval")
+            );
+        }
+        $ilCtrl->setParameter($this, "comp_eval_mode", $comp_eval_mode);
 
-        $ilToolbar->addFormButton($lng->txt("select"), "competenceEval");
+        $this->gui->toolbar()->addComponent(
+            $this->ui->factory()->dropdown()->standard($dropdown_items)
+                ->withLabel($eval_modes[$comp_eval_mode] ?? $lng->txt("svy_analysis"))
+        );
+
 
         $pskills_gui = new ilPersonalSkillsGUI();
         $rater = $this->evaluation_manager->getCurrentRater(

--- a/components/ILIAS/Survey/Mode/IndividualFeedback/class.UIModifier.php
+++ b/components/ILIAS/Survey/Mode/IndividualFeedback/class.UIModifier.php
@@ -75,11 +75,13 @@ class UIModifier extends Mode\AbstractUIModifier
         $cb->setOptionTitle($lng->txt("survey_360_appraisees"));
         $cb->setInfo($lng->txt("survey_360_appraisees_remind_info"));
         $cb->setValue("1");
-        $cb->setChecked(in_array(
-            $survey->getReminderTarget(),
-            array(\ilObjSurvey::NOTIFICATION_APPRAISEES, \ilObjSurvey::NOTIFICATION_APPRAISEES_AND_RATERS),
-            true
-        ));
+        $cb->setChecked(
+            in_array(
+                $survey->getReminderTarget(),
+                array(\ilObjSurvey::NOTIFICATION_APPRAISEES, \ilObjSurvey::NOTIFICATION_APPRAISEES_AND_RATERS),
+                true
+            )
+        );
         $items[] = $cb;
 
         // remind raters
@@ -87,11 +89,13 @@ class UIModifier extends Mode\AbstractUIModifier
         $cb->setOptionTitle($lng->txt("survey_360_raters"));
         $cb->setInfo($lng->txt("survey_360_raters_remind_info"));
         $cb->setValue("1");
-        $cb->setChecked(in_array(
-            $survey->getReminderTarget(),
-            array(\ilObjSurvey::NOTIFICATION_RATERS, \ilObjSurvey::NOTIFICATION_APPRAISEES_AND_RATERS),
-            true
-        ));
+        $cb->setChecked(
+            in_array(
+                $survey->getReminderTarget(),
+                array(\ilObjSurvey::NOTIFICATION_RATERS, \ilObjSurvey::NOTIFICATION_APPRAISEES_AND_RATERS),
+                true
+            )
+        );
         $items[] = $cb;
 
         return $items;
@@ -172,7 +176,6 @@ class UIModifier extends Mode\AbstractUIModifier
             $req->getRaterId()
         );
 
-
         if (!$evaluation_manager->isMultiParticipantsView()) {
             $raters = $evaluation_manager->getSelectableRaters();
 
@@ -193,12 +196,10 @@ class UIModifier extends Mode\AbstractUIModifier
                     $ctrl->getCmd()
                 )->submit()->toToolbar(false, $toolbar);
 
-
                 $toolbar->addSeparator();
             }
         }
     }
-
 
     protected function getPanelChart(
         \ILIAS\Survey\Evaluation\EvaluationGUIRequest $request,
@@ -243,10 +244,14 @@ class UIModifier extends Mode\AbstractUIModifier
             //exit;
         }
 
-
         \ilDatePresentation::setUseRelativeDates(false);
 
-        $a_tpl = new \ilTemplate("tpl.svy_results_details_table.html", true, true, "components/ILIAS/Survey/Evaluation");
+        $a_tpl = new \ilTemplate(
+            "tpl.svy_results_details_table.html",
+            true,
+            true,
+            "components/ILIAS/Survey/Evaluation"
+        );
 
         // table
         $ret = "";
@@ -381,7 +386,12 @@ class UIModifier extends Mode\AbstractUIModifier
 
                     $a_tpl->setVariable("HEADER", $part_caption);
                     $ret .= $a_tpl->get();
-                    $a_tpl = new \ilTemplate("tpl.svy_results_details_table.html", true, true, "components/ILIAS/Survey/Evaluation");
+                    $a_tpl = new \ilTemplate(
+                        "tpl.svy_results_details_table.html",
+                        true,
+                        true,
+                        "components/ILIAS/Survey/Evaluation"
+                    );
                 }
             }
         }

--- a/components/ILIAS/Survey/Mode/IndividualFeedback/class.UIModifier.php
+++ b/components/ILIAS/Survey/Mode/IndividualFeedback/class.UIModifier.php
@@ -114,22 +114,19 @@ class UIModifier extends Mode\AbstractUIModifier
         $survey->set360Results((int) $form->getInput("ts_res"));
     }
 
-
     public function setResultsDetailToolbar(
         \ilObjSurvey $survey,
-        \ilToolbarGUI $toolbar,
         int $user_id,
         \ilTemplate $eval_tpl
-    ): void {
+    ): array {
         $this->addApprSelectionToToolbar(
             $survey,
-            $toolbar,
+            $this->gui->toolbar(),
             $user_id
         );
 
-        $this->addExportAndPrintButton(
+        return $this->getExportAndPrintComponents(
             $survey,
-            $toolbar,
             true,
             $eval_tpl
         );
@@ -137,9 +134,10 @@ class UIModifier extends Mode\AbstractUIModifier
 
     public function setResultsCompetenceToolbar(
         \ilObjSurvey $survey,
-        \ilToolbarGUI $toolbar,
         int $user_id
-    ): void {
+    ): array {
+        $toolbar = $this->gui->toolbar();
+
         $this->addApprSelectionToToolbar(
             $survey,
             $toolbar,
@@ -151,6 +149,8 @@ class UIModifier extends Mode\AbstractUIModifier
             $toolbar,
             $user_id
         );
+
+        return [];
     }
 
     /**

--- a/components/ILIAS/Survey/Mode/class.AbstractUIModifier.php
+++ b/components/ILIAS/Survey/Mode/class.AbstractUIModifier.php
@@ -51,40 +51,35 @@ abstract class AbstractUIModifier implements UIModifier
 
     public function getSurveySettingsGeneral(
         \ilObjSurvey $survey
-    ): array
-    {
+    ): array {
         return [];
     }
 
     public function getSurveySettingsReminderTargets(
-        \ilObjSurvey       $survey,
+        \ilObjSurvey $survey,
         InternalGUIService $ui_service
-    ): array
-    {
+    ): array {
         return [];
     }
 
     public function getSurveySettingsResults(
-        \ilObjSurvey       $survey,
+        \ilObjSurvey $survey,
         InternalGUIService $ui_service
-    ): array
-    {
+    ): array {
         return [];
     }
 
     public function setValuesFromForm(
-        \ilObjSurvey       $survey,
+        \ilObjSurvey $survey,
         \ilPropertyFormGUI $form
-    ): void
-    {
+    ): void {
     }
 
     public function setResultsOverviewToolbar(
         \ilObjSurvey $survey,
-        int          $user_id,
-        \ilTemplate  $eval_tpl
-    ): array
-    {
+        int $user_id,
+        \ilTemplate $eval_tpl
+    ): array {
         $components = [];
 
         $config = $this->getInternalService()->domain()->modeFeatureConfig($survey->getMode());
@@ -105,9 +100,8 @@ abstract class AbstractUIModifier implements UIModifier
 
     public function setResultsCompetenceToolbar(
         \ilObjSurvey $survey,
-        int          $user_id
-    ): array
-    {
+        int $user_id
+    ): array {
         return $this->getApprSelectionComponents($survey, $user_id);
     }
 
@@ -116,10 +110,9 @@ abstract class AbstractUIModifier implements UIModifier
      */
     public function setResultsDetailToolbar(
         \ilObjSurvey $survey,
-        int          $user_id,
-        \ilTemplate  $eval_tpl
-    ): array
-    {
+        int $user_id,
+        \ilTemplate $eval_tpl
+    ): array {
         $components = [];
 
         $request = $this->service
@@ -158,7 +151,7 @@ abstract class AbstractUIModifier implements UIModifier
         // reset parameter
         $ctrl->setParameterByClass("ilSurveyEvaluationGUI", "cp", $current_cp);
         $components[] = $ui_fac->dropdown()->standard($caption_items)
-            ->withLabel($caption_options[$current_cp] ?? $lng->txt("svy_eval_captions"));
+                               ->withLabel($caption_options[$current_cp] ?? $lng->txt("svy_eval_captions"));
 
         // View dropdown (replaces ilSelectInputGUI "vw")
         $view_options = [
@@ -179,7 +172,7 @@ abstract class AbstractUIModifier implements UIModifier
         // reset parameter
         $ctrl->setParameterByClass("ilSurveyEvaluationGUI", "vw", $current_vw);
         $components[] = $ui_fac->dropdown()->standard($view_items)
-            ->withLabel($view_options[$current_vw] ?? $lng->txt("svy_eval_view"));
+                               ->withLabel($view_options[$current_vw] ?? $lng->txt("svy_eval_view"));
 
         // Separator + export/print
         $components = array_merge(
@@ -195,9 +188,8 @@ abstract class AbstractUIModifier implements UIModifier
      */
     public function setResultsParticipantToolbar(
         \ilObjSurvey $survey,
-        int          $user_id
-    ): array
-    {
+        int $user_id
+    ): array {
         $components = [];
 
         $config = $this->getInternalService()->domain()->modeFeatureConfig($survey->getMode());
@@ -213,10 +205,9 @@ abstract class AbstractUIModifier implements UIModifier
 
     protected function getExportAndPrintComponents(
         \ilObjSurvey $survey,
-        bool         $details,
-        \ilTemplate  $eval_tpl
-    ): array
-    {
+        bool $details,
+        \ilTemplate $eval_tpl
+    ): array {
         $components = [];
 
         // Export button + modal
@@ -258,9 +249,8 @@ abstract class AbstractUIModifier implements UIModifier
 
     protected function getApprSelectionComponents(
         \ilObjSurvey $survey,
-        int          $user_id
-    ): array
-    {
+        int $user_id
+    ): array {
         $this->addApprSelectionToToolbar(
             $survey,
             $this->gui->toolbar(),
@@ -271,9 +261,8 @@ abstract class AbstractUIModifier implements UIModifier
 
     protected function buildExportButtonAndModal(
         \ilTemplate $eval_tpl,
-        string      $export_cmd
-    ): void
-    {
+        string $export_cmd
+    ): void {
         $lng = $this->gui->lng();
         $ctrl = $this->gui->ctrl();
         $toolbar = $this->gui->toolbar();
@@ -315,7 +304,7 @@ abstract class AbstractUIModifier implements UIModifier
             ]
         )
             //->withValue(\ilSurveyEvaluationGUI::TYPE_XLS)
-            ->withRequired(true);
+                                          ->withRequired(true);
 
         $inputs["export_label"] = $ui_fac->input()->field()->select(
             $lng->txt("title"),
@@ -326,7 +315,7 @@ abstract class AbstractUIModifier implements UIModifier
             ]
         )
             //->withValue("label_only")
-            ->withRequired(true);
+                                         ->withRequired(true);
 
         $modal = $ui_fac->modal()->roundtrip(
             $lng->txt("svy_export_format"),
@@ -334,17 +323,16 @@ abstract class AbstractUIModifier implements UIModifier
             $inputs,
             $post_url
         )
-            ->withSubmitLabel($lng->txt("export"));
+                        ->withSubmitLabel($lng->txt("export"));
 
         return $modal;
     }
 
     public function addApprSelectionToToolbar(
-        \ilObjSurvey  $survey,
+        \ilObjSurvey $survey,
         \ilToolbarGUI $toolbar,
-        int           $user_id
-    ): void
-    {
+        int $user_id
+    ): void {
         $lng = $this->service->gui()->lng();
         $ctrl = $this->service->gui()->ctrl();
         $req = $this->service->gui()->evaluation($survey)->request();
@@ -390,16 +378,20 @@ abstract class AbstractUIModifier implements UIModifier
     }
 
     public function getDetailPanels(
-        array                                         $participants,
+        array $participants,
         \ILIAS\Survey\Evaluation\EvaluationGUIRequest $request,
-        \SurveyQuestionEvaluation                     $a_eval
-    ): array
-    {
+        \SurveyQuestionEvaluation $a_eval
+    ): array {
         $a_results = $a_eval->getResults();
         $panels = [];
         $ui_factory = $this->service->gui()->ui()->factory();
 
-        $a_tpl = new \ilTemplate("tpl.svy_results_details_panel.html", true, true, "components/ILIAS/Survey/Evaluation");
+        $a_tpl = new \ilTemplate(
+            "tpl.svy_results_details_panel.html",
+            true,
+            true,
+            "components/ILIAS/Survey/Evaluation"
+        );
 
         $question_res = $a_results;
         $matrix = false;
@@ -420,40 +412,53 @@ abstract class AbstractUIModifier implements UIModifier
         $anchor_id = "svyrdq" . $question->getId();
         $title = "<span id='$anchor_id'>$qst_title</span>";
         $panel_qst_card = $ui_factory->panel()->sub($title, $ui_factory->legacy()->content($svy_text))
-            ->withFurtherInformation($this->getPanelCard($question_res));
+                                     ->withFurtherInformation($this->getPanelCard($question_res));
 
         $panels[] = $panel_qst_card;
 
-        $a_tpl->setVariable("TABLE", $this->getPanelTable(
-            $participants,
-            $request,
-            $a_eval
-        ));
+        $a_tpl->setVariable(
+            "TABLE",
+            $this->getPanelTable(
+                $participants,
+                $request,
+                $a_eval
+            )
+        );
 
-        $a_tpl->setVariable("TEXT", $this->getPanelText(
-            $request,
-            $a_eval,
-            $question_res
-        ));
+        $a_tpl->setVariable(
+            "TEXT",
+            $this->getPanelText(
+                $request,
+                $a_eval,
+                $question_res
+            )
+        );
 
-        $a_tpl->setVariable("CHART", $this->getPanelChart(
-            $request,
-            $a_eval
-        ));
+        $a_tpl->setVariable(
+            "CHART",
+            $this->getPanelChart(
+                $request,
+                $a_eval
+            )
+        );
 
         $panels[] = $ui_factory->panel()->sub("", $ui_factory->legacy()->content($a_tpl->get()));
         return $panels;
     }
 
     protected function getPanelTable(
-        array                                         $participants,
+        array $participants,
         \ILIAS\Survey\Evaluation\EvaluationGUIRequest $request,
-        \SurveyQuestionEvaluation                     $a_eval
-    ): string
-    {
+        \SurveyQuestionEvaluation $a_eval
+    ): string {
         $a_results = $a_eval->getResults();
 
-        $a_tpl = new \ilTemplate("tpl.svy_results_details_table.html", true, true, "components/ILIAS/Survey/Evaluation");
+        $a_tpl = new \ilTemplate(
+            "tpl.svy_results_details_table.html",
+            true,
+            true,
+            "components/ILIAS/Survey/Evaluation"
+        );
 
         if ($request->getShowTable()) {
             $grid = $a_eval->getGrid(
@@ -474,7 +479,7 @@ abstract class AbstractUIModifier implements UIModifier
                         }
 
                         $a_tpl->setCurrentBlock("grid_col_bl");
-                        $a_tpl->setVariable("COL_CAPTION", trim((string)($col ?? "")));
+                        $a_tpl->setVariable("COL_CAPTION", trim((string) ($col ?? "")));
                         $a_tpl->parseCurrentBlock();
                     }
 
@@ -487,12 +492,16 @@ abstract class AbstractUIModifier implements UIModifier
 
     protected function getPanelChart(
         \ILIAS\Survey\Evaluation\EvaluationGUIRequest $request,
-        \SurveyQuestionEvaluation                     $a_eval
-    ): string
-    {
+        \SurveyQuestionEvaluation $a_eval
+    ): string {
         $a_results = $a_eval->getResults();
 
-        $a_tpl = new \ilTemplate("tpl.svy_results_details_chart.html", true, true, "components/ILIAS/Survey/Evaluation");
+        $a_tpl = new \ilTemplate(
+            "tpl.svy_results_details_chart.html",
+            true,
+            true,
+            "components/ILIAS/Survey/Evaluation"
+        );
         if ($request->getShowChart()) {
             $chart = $a_eval->getChart($a_results);
             if ($chart) {
@@ -523,10 +532,9 @@ abstract class AbstractUIModifier implements UIModifier
 
     protected function getPanelText(
         \ILIAS\Survey\Evaluation\EvaluationGUIRequest $request,
-        \SurveyQuestionEvaluation                     $a_eval,
-        \ilSurveyEvaluationResults                    $question_res
-    ): string
-    {
+        \SurveyQuestionEvaluation $a_eval,
+        \ilSurveyEvaluationResults $question_res
+    ): string {
         $a_results = $a_eval->getResults();
         $question = $question_res->getQuestion();
         $lng = $this->service->gui()->lng();
@@ -554,7 +562,7 @@ abstract class AbstractUIModifier implements UIModifier
                         $list[] = "<li>" . nl2br(htmlentities($item)) . "</li>";
                     }
                     $list[] = "</ul>";
-                    $acc->addItem((string)$var, implode("\n", $list));
+                    $acc->addItem((string) $var, implode("\n", $list));
                 }
 
                 $a_tpl->setVariable("TEXT_ACC", $acc->getHTML());
@@ -565,8 +573,7 @@ abstract class AbstractUIModifier implements UIModifier
 
     protected function getPanelCard(
         \ilSurveyEvaluationResults $question_res
-    ): \ILIAS\UI\Component\Card\Card
-    {
+    ): \ILIAS\UI\Component\Card\Card {
         $ui_factory = $this->service->gui()->ui()->factory();
         $lng = $this->service->gui()->lng();
 
@@ -605,9 +612,9 @@ abstract class AbstractUIModifier implements UIModifier
         $svy_type_title = \SurveyQuestion::_getQuestionTypeName($question->getQuestionType());
 
         return $ui_factory->card()
-            ->standard($svy_type_title)
-            ->withSections(
-                array($ui_factory->legacy()->content($card_table_tpl->get()))
-            );
+                          ->standard($svy_type_title)
+                          ->withSections(
+                              array($ui_factory->legacy()->content($card_table_tpl->get()))
+                          );
     }
 }

--- a/components/ILIAS/Survey/Mode/class.AbstractUIModifier.php
+++ b/components/ILIAS/Survey/Mode/class.AbstractUIModifier.php
@@ -51,72 +51,77 @@ abstract class AbstractUIModifier implements UIModifier
 
     public function getSurveySettingsGeneral(
         \ilObjSurvey $survey
-    ): array {
+    ): array
+    {
         return [];
     }
 
     public function getSurveySettingsReminderTargets(
-        \ilObjSurvey $survey,
+        \ilObjSurvey       $survey,
         InternalGUIService $ui_service
-    ): array {
+    ): array
+    {
         return [];
     }
 
     public function getSurveySettingsResults(
-        \ilObjSurvey $survey,
+        \ilObjSurvey       $survey,
         InternalGUIService $ui_service
-    ): array {
+    ): array
+    {
         return [];
     }
 
     public function setValuesFromForm(
-        \ilObjSurvey $survey,
+        \ilObjSurvey       $survey,
         \ilPropertyFormGUI $form
-    ): void {
+    ): void
+    {
     }
 
     public function setResultsOverviewToolbar(
         \ilObjSurvey $survey,
-        \ilToolbarGUI $toolbar,
-        int $user_id,
-        \ilTemplate $eval_tpl
-    ): void {
+        int          $user_id,
+        \ilTemplate  $eval_tpl
+    ): array
+    {
+        $components = [];
+
         $config = $this->getInternalService()->domain()->modeFeatureConfig($survey->getMode());
         if ($config->usesAppraisees()) {
-            $this->addApprSelectionToToolbar(
-                $survey,
-                $toolbar,
-                $user_id
+            $components = array_merge(
+                $components,
+                $this->getApprSelectionComponents($survey, $user_id)
             );
         }
 
-        $this->addExportAndPrintButton(
-            $survey,
-            $toolbar,
-            false,
-            $eval_tpl
+        $components = array_merge(
+            $components,
+            $this->getExportAndPrintComponents($survey, false, $eval_tpl)
         );
+
+        return $components;
     }
 
     public function setResultsCompetenceToolbar(
         \ilObjSurvey $survey,
-        \ilToolbarGUI $toolbar,
-        int $user_id
-    ): void {
-        $this->addApprSelectionToToolbar(
-            $survey,
-            $toolbar,
-            $user_id
-        );
+        int          $user_id
+    ): array
+    {
+        return $this->getApprSelectionComponents($survey, $user_id);
     }
 
-
+    /**
+     * @return \ILIAS\UI\Component\Component[]
+     */
     public function setResultsDetailToolbar(
         \ilObjSurvey $survey,
-        \ilToolbarGUI $toolbar,
-        int $user_id,
-        \ilTemplate $eval_tpl
-    ): void {
+        int          $user_id,
+        \ilTemplate  $eval_tpl
+    ): array
+    {
+        $components = [];
+
         $request = $this->service
             ->gui()
             ->evaluation($survey)
@@ -124,73 +129,98 @@ abstract class AbstractUIModifier implements UIModifier
 
         $gui = $this->service->gui();
         $lng = $gui->lng();
+        $ctrl = $gui->ctrl();
+        $ui_fac = $gui->ui()->factory();
 
         $config = $this->getInternalService()->domain()->modeFeatureConfig($survey->getMode());
         if ($config->usesAppraisees()) {
-            $this->addApprSelectionToToolbar(
-                $survey,
-                $toolbar,
-                $user_id
+            $components = array_merge(
+                $components,
+                $this->getApprSelectionComponents($survey, $user_id)
             );
         }
 
-        $captions = new \ilSelectInputGUI($lng->txt("svy_eval_captions"), "cp");
-        $captions->setOptions(array(
+        $caption_options = [
             "ap" => $lng->txt("svy_eval_captions_abs_perc"),
             "a" => $lng->txt("svy_eval_captions_abs"),
-            "p" => $lng->txt("svy_eval_captions_perc")
-        ));
-        $captions->setValue($request->getCP());
-        $toolbar->addInputItem($captions, true);
-
-        $view = new \ilSelectInputGUI($lng->txt("svy_eval_view"), "vw");
-        $view->setOptions(array(
-            "tc" => $lng->txt("svy_eval_view_tables_charts"),
-            "t" => $lng->txt("svy_eval_view_tables"),
-            "c" => $lng->txt("svy_eval_view_charts")
-        ));
-        $view->setValue($request->getVW());
-        $toolbar->addInputItem($view, true);
-
-        $this->gui->button(
-            $this->gui->lng()->txt("ok"),
-            "evaluationdetails"
-        )->submit()->toToolbar(false, $toolbar);
-
-        $toolbar->addSeparator();
-
-        $this->addExportAndPrintButton(
-            $survey,
-            $toolbar,
-            true,
-            $eval_tpl
-        );
-    }
-
-    public function setResultsParticipantToolbar(
-        \ilObjSurvey $survey,
-        \ilToolbarGUI $toolbar,
-        int $user_id
-    ): void {
-        $config = $this->getInternalService()->domain()->modeFeatureConfig($survey->getMode());
-        if ($config->usesAppraisees()) {
-            $this->addApprSelectionToToolbar(
-                $survey,
-                $toolbar,
-                $user_id
+            "p" => $lng->txt("svy_eval_captions_perc"),
+        ];
+        $current_cp = $request->getCP();
+        $caption_items = [];
+        foreach ($caption_options as $key => $label) {
+            $ctrl->setParameterByClass("ilSurveyEvaluationGUI", "cp", $key);
+            $ctrl->setParameterByClass("ilSurveyEvaluationGUI", "vw", $request->getVW());
+            $caption_items[] = $ui_fac->button()->shy(
+                $label,
+                $ctrl->getLinkTargetByClass("ilSurveyEvaluationGUI", "evaluationdetails")
             );
         }
+        // reset parameter
+        $ctrl->setParameterByClass("ilSurveyEvaluationGUI", "cp", $current_cp);
+        $components[] = $ui_fac->dropdown()->standard($caption_items)
+            ->withLabel($caption_options[$current_cp] ?? $lng->txt("svy_eval_captions"));
+
+        // View dropdown (replaces ilSelectInputGUI "vw")
+        $view_options = [
+            "tc" => $lng->txt("svy_eval_view_tables_charts"),
+            "t" => $lng->txt("svy_eval_view_tables"),
+            "c" => $lng->txt("svy_eval_view_charts"),
+        ];
+        $current_vw = $request->getVW();
+        $view_items = [];
+        foreach ($view_options as $key => $label) {
+            $ctrl->setParameterByClass("ilSurveyEvaluationGUI", "vw", $key);
+            $ctrl->setParameterByClass("ilSurveyEvaluationGUI", "cp", $request->getCP());
+            $view_items[] = $ui_fac->button()->shy(
+                $label,
+                $ctrl->getLinkTargetByClass("ilSurveyEvaluationGUI", "evaluationdetails")
+            );
+        }
+        // reset parameter
+        $ctrl->setParameterByClass("ilSurveyEvaluationGUI", "vw", $current_vw);
+        $components[] = $ui_fac->dropdown()->standard($view_items)
+            ->withLabel($view_options[$current_vw] ?? $lng->txt("svy_eval_view"));
+
+        // Separator + export/print
+        $components = array_merge(
+            $components,
+            $this->getExportAndPrintComponents($survey, true, $eval_tpl)
+        );
+
+        return $components;
     }
 
-    protected function addExportAndPrintButton(
+    /**
+     * @return \ILIAS\UI\Component\Component[]
+     */
+    public function setResultsParticipantToolbar(
         \ilObjSurvey $survey,
-        \ilToolbarGUI $toolbar,
-        bool $details,
-        \ilTemplate $eval_tpl
-    ): void {
-        $this->buildExportButtonAndModal($eval_tpl, $details ? "exportDetailData" : "exportData");
+        int          $user_id
+    ): array
+    {
+        $components = [];
 
-        $toolbar->addSeparator();
+        $config = $this->getInternalService()->domain()->modeFeatureConfig($survey->getMode());
+        if ($config->usesAppraisees()) {
+            $components = array_merge(
+                $components,
+                $this->getApprSelectionComponents($survey, $user_id)
+            );
+        }
+
+        return $components;
+    }
+
+    protected function getExportAndPrintComponents(
+        \ilObjSurvey $survey,
+        bool         $details,
+        \ilTemplate  $eval_tpl
+    ): array
+    {
+        $components = [];
+
+        // Export button + modal
+        $this->buildExportButtonAndModal($eval_tpl, $details ? "exportDetailData" : "exportData");
 
         if ($details) {
             $pv = $this->service->gui()->print()->resultsDetails($survey->getRefId());
@@ -220,21 +250,30 @@ abstract class AbstractUIModifier implements UIModifier
             );
         }
 
-        $toolbar->addComponent($modal_elements->button);
-        $toolbar->addComponent($modal_elements->modal);
+        $components[] = $modal_elements->button;
+        $components[] = $modal_elements->modal;
 
-        /*
-        $button = \ilLinkButton::getInstance();
-        $button->setCaption("print");
-        $button->setOnClick("if(il.Accordion) { il.Accordion.preparePrint(); } window.print(); return false;");
-        $button->setOmitPreventDoubleSubmission(true);
-        $toolbar->addButtonInstance($button);*/
+        return $components;
+    }
+
+    protected function getApprSelectionComponents(
+        \ilObjSurvey $survey,
+        int          $user_id
+    ): array
+    {
+        $this->addApprSelectionToToolbar(
+            $survey,
+            $this->gui->toolbar(),
+            $user_id
+        );
+        return [];
     }
 
     protected function buildExportButtonAndModal(
         \ilTemplate $eval_tpl,
-        string $export_cmd
-    ): void {
+        string      $export_cmd
+    ): void
+    {
         $lng = $this->gui->lng();
         $ctrl = $this->gui->ctrl();
         $toolbar = $this->gui->toolbar();
@@ -260,7 +299,7 @@ abstract class AbstractUIModifier implements UIModifier
         }
     }
 
-    protected function getExportModal(): Modal\RoundTrip | Form\Standard
+    protected function getExportModal(): Modal\RoundTrip|Form\Standard
     {
         $lng = $this->gui->lng();
         $ctrl = $this->gui->ctrl();
@@ -275,8 +314,8 @@ abstract class AbstractUIModifier implements UIModifier
                 \ilSurveyEvaluationGUI::TYPE_SPSS => $lng->txt("exp_type_csv")
             ]
         )
-        //->withValue(\ilSurveyEvaluationGUI::TYPE_XLS)
-        ->withRequired(true);
+            //->withValue(\ilSurveyEvaluationGUI::TYPE_XLS)
+            ->withRequired(true);
 
         $inputs["export_label"] = $ui_fac->input()->field()->select(
             $lng->txt("title"),
@@ -286,8 +325,8 @@ abstract class AbstractUIModifier implements UIModifier
                 "title_label" => $lng->txt("export_title_label")
             ]
         )
-        //->withValue("label_only")
-        ->withRequired(true);
+            //->withValue("label_only")
+            ->withRequired(true);
 
         $modal = $ui_fac->modal()->roundtrip(
             $lng->txt("svy_export_format"),
@@ -295,16 +334,17 @@ abstract class AbstractUIModifier implements UIModifier
             $inputs,
             $post_url
         )
-        ->withSubmitLabel($lng->txt("export"));
+            ->withSubmitLabel($lng->txt("export"));
 
         return $modal;
     }
 
     public function addApprSelectionToToolbar(
-        \ilObjSurvey $survey,
+        \ilObjSurvey  $survey,
         \ilToolbarGUI $toolbar,
-        int $user_id
-    ): void {
+        int           $user_id
+    ): void
+    {
         $lng = $this->service->gui()->lng();
         $ctrl = $this->service->gui()->ctrl();
         $req = $this->service->gui()->evaluation($survey)->request();
@@ -349,12 +389,12 @@ abstract class AbstractUIModifier implements UIModifier
         }
     }
 
-
     public function getDetailPanels(
-        array $participants,
+        array                                         $participants,
         \ILIAS\Survey\Evaluation\EvaluationGUIRequest $request,
-        \SurveyQuestionEvaluation $a_eval
-    ): array {
+        \SurveyQuestionEvaluation                     $a_eval
+    ): array
+    {
         $a_results = $a_eval->getResults();
         $panels = [];
         $ui_factory = $this->service->gui()->ui()->factory();
@@ -368,18 +408,15 @@ abstract class AbstractUIModifier implements UIModifier
             $matrix = true;
         }
 
-        // see #28507 (matrix question without a row)
         if (!is_object($question_res)) {
             return [];
         }
 
         $question = $question_res->getQuestion();
 
-        // question "overview"
         $qst_title = $question->getTitle();
         $svy_text = nl2br($question->getQuestiontext());
 
-        // Question title anchor
         $anchor_id = "svyrdq" . $question->getId();
         $title = "<span id='$anchor_id'>$qst_title</span>";
         $panel_qst_card = $ui_factory->panel()->sub($title, $ui_factory->legacy()->content($svy_text))
@@ -404,21 +441,20 @@ abstract class AbstractUIModifier implements UIModifier
             $a_eval
         ));
 
-
         $panels[] = $ui_factory->panel()->sub("", $ui_factory->legacy()->content($a_tpl->get()));
         return $panels;
     }
 
     protected function getPanelTable(
-        array $participants,
+        array                                         $participants,
         \ILIAS\Survey\Evaluation\EvaluationGUIRequest $request,
-        \SurveyQuestionEvaluation $a_eval
-    ): string {
+        \SurveyQuestionEvaluation                     $a_eval
+    ): string
+    {
         $a_results = $a_eval->getResults();
 
         $a_tpl = new \ilTemplate("tpl.svy_results_details_table.html", true, true, "components/ILIAS/Survey/Evaluation");
 
-        // grid
         if ($request->getShowTable()) {
             $grid = $a_eval->getGrid(
                 $a_results,
@@ -438,7 +474,7 @@ abstract class AbstractUIModifier implements UIModifier
                         }
 
                         $a_tpl->setCurrentBlock("grid_col_bl");
-                        $a_tpl->setVariable("COL_CAPTION", trim((string) ($col ?? "")));
+                        $a_tpl->setVariable("COL_CAPTION", trim((string)($col ?? "")));
                         $a_tpl->parseCurrentBlock();
                     }
 
@@ -451,17 +487,16 @@ abstract class AbstractUIModifier implements UIModifier
 
     protected function getPanelChart(
         \ILIAS\Survey\Evaluation\EvaluationGUIRequest $request,
-        \SurveyQuestionEvaluation $a_eval
-    ): string {
+        \SurveyQuestionEvaluation                     $a_eval
+    ): string
+    {
         $a_results = $a_eval->getResults();
 
         $a_tpl = new \ilTemplate("tpl.svy_results_details_chart.html", true, true, "components/ILIAS/Survey/Evaluation");
-        // chart
         if ($request->getShowChart()) {
             $chart = $a_eval->getChart($a_results);
             if ($chart) {
                 if (is_array($chart)) {
-                    // legend
                     if (is_array($chart[1])) {
                         foreach ($chart[1] as $legend_item) {
                             $r = hexdec(substr($legend_item[1], 1, 2));
@@ -488,16 +523,16 @@ abstract class AbstractUIModifier implements UIModifier
 
     protected function getPanelText(
         \ILIAS\Survey\Evaluation\EvaluationGUIRequest $request,
-        \SurveyQuestionEvaluation $a_eval,
-        \ilSurveyEvaluationResults $question_res
-    ): string {
+        \SurveyQuestionEvaluation                     $a_eval,
+        \ilSurveyEvaluationResults                    $question_res
+    ): string
+    {
         $a_results = $a_eval->getResults();
         $question = $question_res->getQuestion();
         $lng = $this->service->gui()->lng();
 
         $a_tpl = new \ilTemplate("tpl.svy_results_details_text.html", true, true, "components/ILIAS/Survey/Evaluation");
 
-        // text answers
         $texts = $a_eval->getTextAnswers($a_results);
         if ($texts) {
             if (array_key_exists("", $texts)) {
@@ -519,7 +554,7 @@ abstract class AbstractUIModifier implements UIModifier
                         $list[] = "<li>" . nl2br(htmlentities($item)) . "</li>";
                     }
                     $list[] = "</ul>";
-                    $acc->addItem((string) $var, implode("\n", $list));
+                    $acc->addItem((string)$var, implode("\n", $list));
                 }
 
                 $a_tpl->setVariable("TEXT_ACC", $acc->getHTML());
@@ -528,11 +563,10 @@ abstract class AbstractUIModifier implements UIModifier
         return $a_tpl->get();
     }
 
-    // in fact we want a \ILIAS\UI\Component\Card\Standard
-    // see #31743
     protected function getPanelCard(
         \ilSurveyEvaluationResults $question_res
-    ): \ILIAS\UI\Component\Card\Card {
+    ): \ILIAS\UI\Component\Card\Card
+    {
         $ui_factory = $this->service->gui()->ui()->factory();
         $lng = $this->service->gui()->lng();
 
@@ -571,9 +605,9 @@ abstract class AbstractUIModifier implements UIModifier
         $svy_type_title = \SurveyQuestion::_getQuestionTypeName($question->getQuestionType());
 
         return $ui_factory->card()
-                          ->standard($svy_type_title)
-                          ->withSections(
-                              array($ui_factory->legacy()->content($card_table_tpl->get()))
-                          );
+            ->standard($svy_type_title)
+            ->withSections(
+                array($ui_factory->legacy()->content($card_table_tpl->get()))
+            );
     }
 }

--- a/components/ILIAS/Survey/Mode/interface.UIModifier.php
+++ b/components/ILIAS/Survey/Mode/interface.UIModifier.php
@@ -31,6 +31,7 @@ use ILIAS\Survey\InternalService;
 interface UIModifier
 {
     public function setInternalService(InternalService $internal_service): void;
+
     public function getInternalService(): InternalService;
 
     /**

--- a/components/ILIAS/Survey/Mode/interface.UIModifier.php
+++ b/components/ILIAS/Survey/Mode/interface.UIModifier.php
@@ -63,29 +63,25 @@ interface UIModifier
 
     public function setResultsOverviewToolbar(
         \ilObjSurvey $survey,
-        \ilToolbarGUI $toolbar,
         int $user_id,
         \ilTemplate $eval_tpl
-    ): void;
+    ): array;
 
     public function setResultsDetailToolbar(
         \ilObjSurvey $survey,
-        \ilToolbarGUI $toolbar,
         int $user_id,
         \ilTemplate $eval_tpl
-    ): void;
+    ): array;
 
     public function setResultsParticipantToolbar(
         \ilObjSurvey $survey,
-        \ilToolbarGUI $toolbar,
         int $user_id
-    ): void;
+    ): array;
 
     public function setResultsCompetenceToolbar(
         \ilObjSurvey $survey,
-        \ilToolbarGUI $toolbar,
         int $user_id
-    ): void;
+    ): array;
 
     public function getDetailPanels(
         array $participants,


### PR DESCRIPTION
## Add Kitchen Sink Component to Toolbar in Survey Results Detail View

This PR integrates the Kitchen Sink component into the toolbar of the survey results detailed view, aligning it with the KitchenSink UI used across the platform.

### Changes
- Replaced legacy toolbar elements with the Kitchen Sink component in the survey results detail view
- Ensured visual consistency with other views that already use the KitchenSink framework

### Impact
- **Usability:** Toolbar interactions are now more intuitive and consistent with the rest of the UI
- **Maintainability:** Reduces custom toolbar logic in favor of the standardized KitchenSink component