### PR TITLE
Removing redundant call to re-initialize user in ilAbstractSoapMethod after integratring PR (11213)

### DIFF
--- a/components/ILIAS/WebServices/SOAP/classes/class.ilAbstractSoapMethod.php
+++ b/components/ILIAS/WebServices/SOAP/classes/class.ilAbstractSoapMethod.php
@@ -61,7 +61,6 @@ abstract class ilAbstractSoapMethod extends ilSoapAdministration implements ilSo
     protected function initIliasAndCheckSession(string $session_id): void
     {
         $this->initAuth($session_id);
-        $this->reInitUser();
         if (!$this->checkSession($session_id)) {
             throw new ilSoapPluginException($this->getMessage());
         }


### PR DESCRIPTION
As already discussed in: https://github.com/ILIAS-eLearning/ILIAS/pull/11213
Removing the redundant call in \ilAbstractSoapMethod::initIliasAndCheckSession
https://mantis.ilias.de/view.php?id=46273