### PR TITLE
feat: Send welcome mail via SOAP call

### DIFF
--- a/components/ILIAS/soap/classes/class.ilSoapCourseAdministration.php
+++ b/components/ILIAS/soap/classes/class.ilSoapCourseAdministration.php
@@ -130,14 +130,14 @@ class ilSoapCourseAdministration extends ilSoapAdministration
      * @return bool|soap_fault|SoapFault|null
      */
     public function assignCourseMember(
-        string $sid, int $course_id,
+        string $sid,
+        int $course_id,
         int $user_id,
         string $type,
-        ?bool $notification =  null,
+        ?bool $notification = null,
         ?bool $contact_person = null,
         ?bool $blocked = null
-    )
-    {
+    ) {
         $this->initAuth($sid);
         $this->initIlias();
 
@@ -188,7 +188,12 @@ class ilSoapCourseAdministration extends ilSoapAdministration
 
         $course_members->add($tmp_user->getId(), $valid_roles[$type]);
 
-        if($type === 'Admin' || $type === 'Tutor') {
+        $course_members->sendNotification(
+            ilCourseMembershipMailNotification::TYPE_ADMISSION_MEMBER,
+            $tmp_user->getId()
+        );
+
+        if ($type === 'Admin' || $type === 'Tutor') {
             if ($notification !== null) {
                 $course_members->updateNotification($tmp_user->getId(), $notification);
             }
@@ -196,7 +201,7 @@ class ilSoapCourseAdministration extends ilSoapAdministration
             if ($contact_person !== null) {
                 $course_members->updateContact($tmp_user->getId(), $contact_person);
             }
-        }elseif( $type === "Member" && $blocked !== null) {
+        } elseif ($type === "Member" && $blocked !== null) {
             $course_members->updateBlocked($tmp_user->getId(), $blocked);
         }
         return true;
@@ -419,9 +424,11 @@ class ilSoapCourseAdministration extends ilSoapAdministration
 
         $ref_ids = array();
 
-        if (self::MEMBER == ($status & self::MEMBER) ||
+        if (
+            self::MEMBER == ($status & self::MEMBER) ||
             self::TUTOR == ($status & self::TUTOR) ||
-            self::ADMIN == ($status & self::ADMIN)) {
+            self::ADMIN == ($status & self::ADMIN)
+        ) {
             foreach ($rbacreview->assignedRoles($user_id) as $role_id) {
                 if ($role = ilObjectFactory::getInstanceByObjId($role_id, false)) {
                     #echo $role->getType();
@@ -438,23 +445,29 @@ class ilSoapCourseAdministration extends ilSoapAdministration
                             continue;
                         }
 
-                        if (self::MEMBER == ($status & self::MEMBER) && strpos(
-                            $role_title,
-                            "member"
-                        ) !== false) {
-                            $ref_ids [] = $ref_id;
-                        } elseif (self::TUTOR == ($status & self::TUTOR) && strpos(
-                            $role_title,
-                            "tutor"
-                        ) !== false) {
-                            $ref_ids [] = $ref_id;
-                        } elseif (self::ADMIN == ($status & self::ADMIN) && strpos(
-                            $role_title,
-                            "admin"
-                        ) !== false) {
-                            $ref_ids [] = $ref_id;
+                        if (
+                            self::MEMBER == ($status & self::MEMBER) && strpos(
+                                $role_title,
+                                "member"
+                            ) !== false
+                        ) {
+                            $ref_ids[] = $ref_id;
+                        } elseif (
+                            self::TUTOR == ($status & self::TUTOR) && strpos(
+                                $role_title,
+                                "tutor"
+                            ) !== false
+                        ) {
+                            $ref_ids[] = $ref_id;
+                        } elseif (
+                            self::ADMIN == ($status & self::ADMIN) && strpos(
+                                $role_title,
+                                "admin"
+                            ) !== false
+                        ) {
+                            $ref_ids[] = $ref_id;
                         } elseif (($status & self::OWNER) == self::OWNER && $ilObjDataCache->lookupOwner($ilObjDataCache->lookupObjId($ref_id)) == $user_id) {
-                            $ref_ids [] = $ref_id;
+                            $ref_ids[] = $ref_id;
                         }
                     }
                 }


### PR DESCRIPTION
Extends the assignCourseMember() SOAP method to send a welcome email to the member assigned to a course via SOAP.
The "Welcome Mail" setting in the course is respected meaning if disabled, no email is sent.

Expected Behaviour:
1. Welcome Mail 'ON' in course setting
via UI: Mail Sent
via SOAP: Mail Sent

2. Welcome Mail 'OFF' in course setting
via UI: No Mail
via SOAP: No Mail


To test:

```
curl -X POST http://<ilias-URL>/soap/server.php \
  -H "Content-Type: text/xml;charset=UTF-8" \
  -d '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:ilUserAdministration">
         <soapenv:Header/>
         <soapenv:Body>
            <urn:assignCourseMember>
               <sid>REPLACE_SID::REPLACE_CLIENT</sid>
               <course_id>REPLACE_COURSE_REF_ID</course_id>
               <user_id>REPLACE_USER_ID</user_id>
               <type>REPLACE_WITH_TYPE</type>
            </urn:assignCourseMember>
         </soapenv:Body>
      </soapenv:Envelope>'
```


[Feature Request: Already presented in JF and accepted]