### PR TITLE
[FIX] Use `release_11` for "Workflow Status Badge" in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![checks](https://github.com/ILIAS-eLearning/ILIAS/actions/workflows/checks.yml/badge.svg?branch=trunk)](https://github.com/ILIAS-eLearning/ILIAS/actions/workflows/checks.yml)
+[![checks](https://github.com/ILIAS-eLearning/ILIAS/actions/workflows/checks.yml/badge.svg?branch=release_11)](https://github.com/ILIAS-eLearning/ILIAS/actions/workflows/checks.yml)
 [![Supported PHP Version](https://img.shields.io/badge/php-%3E%3D8.3%7C%3C%3D8.4-8892BF.svg)](https://php.net/)
 
 # ILIAS


### PR DESCRIPTION
This PR suggests using the correct branch (`release_11`) for the workflow status badge in our `README.md` file.