### PR TITLE
Refinery: Remove deprecation in Parser

### DIFF
--- a/components/ILIAS/Refinery/src/Parser/ABNF/Intermediate.php
+++ b/components/ILIAS/Refinery/src/Parser/ABNF/Intermediate.php
@@ -38,7 +38,10 @@ class Intermediate
 
     public function value(): int
     {
-        return ord($this->todo);
+        if ($this->todo === '') {
+            return 0;
+        }
+        return ord($this->todo[0]);
     }
 
     public function accept(): Result


### PR DESCRIPTION
Remove deprecation `ord(...)` string is not one byte and `ord(...)` string is empty.