### PR TITLE
[FEATURE] Documentation: Add chapter "Transition to Security Support"

### DIFF
--- a/docs/development/supported-versions.md
+++ b/docs/development/supported-versions.md
@@ -45,3 +45,27 @@ With that support schedule, every version will have (roughly) the following time
   in different states of their life cycle.
 * Most of the changes that fix issues will need to be included in three branches,
   fixes for security issues will need to be included in four branches.
+
+## Transition to Security Support
+
+When a version transitions from **full support** to **security support**
+(at the end of the year), open issues in the Mantis bug tracker for this version
+are handled as follows to ensure that reported problems are not lost:
+
+1. **Eligibility for Transition**: All issues with the following status are
+   considered: `open`, `unassigned`, `feedback`, `needs JF decision`,
+   `postponed`, `funding needed`, `assigned`, `fixing acc to prio`.
+2. **Automatic Target Version Update**: Instead of closing every issue, the
+   "Target Version" of the issues should be incremented to the next still
+   fully supported version.
+3. **Responsibility of the "Assignee for Issues"**: The responsible "Assignee
+   for Issues" is tasked with checking if the issue still persists in the
+   maintained versions. They should not close the issue with a request for the
+   reporter to re-test, unless there is a clear indication that the issue might
+   have been fixed already.
+4. **Communication**: When an issue is transitioned, a comment should be added
+   to inform the reporter: "This current target version of this issue has
+   entered the security-fix-only phase. We have moved this issue to the next
+   maintained version for further investigation."
+
+This applies to issues for ILIAS 10 or greater.


### PR DESCRIPTION
This PR adds a section to `supported-versions.md` outlining how "Assignees for Issues" should handle **existing** Mantis issues once a maintained release leaves the full-maintenance phase.

Best regards,
@mjansenDatabay 

on behalf on the Technical Board
