### PR TITLE
[Fix] UI 0047403: HTML validator: Use role='group' for tree-containing slates

### DIFF
--- a/components/ILIAS/GlobalScreen/src/Scope/Tool/Collector/Renderer/TreeToolItemRenderer.php
+++ b/components/ILIAS/GlobalScreen/src/Scope/Tool/Collector/Renderer/TreeToolItemRenderer.php
@@ -23,6 +23,8 @@ namespace ILIAS\GlobalScreen\Scope\Tool\Collector\Renderer;
 use ILIAS\GlobalScreen\Scope\MainMenu\Collector\Renderer\BaseTypeRenderer;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\isItem;
 use ILIAS\UI\Component\Component;
+use ILIAS\GlobalScreen\Scope\Tool\Factory\TreeTool;
+use ILIAS\UI\Implementation\Component\MainControls\Slate\Slate;
 
 /**
  * Class TreeToolItemRenderer
@@ -45,6 +47,12 @@ class TreeToolItemRenderer extends BaseTypeRenderer
 
         $symbol = $this->getStandardSymbol($item);
 
-        return $this->ui_factory->mainControls()->slate()->legacy($item->getTitle(), $symbol, $this->ui_factory->legacy()->content($DIC->ui()->renderer()->render([$item->getTree()])));
+        $slate = $this->ui_factory->mainControls()->slate()->legacy(
+            $item->getTitle(),
+            $symbol,
+            $this->ui_factory->legacy()->content($DIC->ui()->renderer()->render([$item->getTree()]))
+        );
+
+        return $slate->withAriaRole(Slate::GROUP);
     }
 }

--- a/components/ILIAS/Style/System/classes/Provider/SystemStylesGlobalScreenToolProvider.php
+++ b/components/ILIAS/Style/System/classes/Provider/SystemStylesGlobalScreenToolProvider.php
@@ -19,7 +19,7 @@
 declare(strict_types=1);
 
 use ILIAS\GlobalScreen\Scope\Tool\Provider\AbstractDynamicToolProvider;
-use ILIAS\GlobalScreen\Scope\Tool\Factory\Tool;
+use ILIAS\GlobalScreen\Scope\Tool\Factory\TreeTool;
 use ILIAS\UI\Component\Tree\Tree;
 use ILIAS\UI\Implementation\Crawler\Entry\ComponentEntries as Entries;
 use ILIAS\Data\URI;
@@ -55,7 +55,7 @@ class SystemStylesGlobalScreenToolProvider extends AbstractDynamicToolProvider
         return [];
     }
 
-    protected function buildTreeAsTool(): Tool
+    protected function buildTreeAsTool(): TreeTool
     {
         $id_generator = function ($id) {
             return $this->identification_provider->contextAwareIdentifier($id);
@@ -64,14 +64,11 @@ class SystemStylesGlobalScreenToolProvider extends AbstractDynamicToolProvider
         $title = $this->dic->language()->txt('documentation');
         $icon = $this->dic->ui()->factory()->symbol()->icon()->standard('stys', $title);
 
-        /**
-         * @Todo, replace this with a proper Tree Slate
-         */
         return $this->factory
-            ->tool($id_generator('system_styles_tree'))
+            ->treeTool($id_generator('system_styles_tree'))
             ->withTitle($title)
             ->withSymbol($icon)
-            ->withContent($this->dic->ui()->factory()->legacy()->content($this->dic->ui()->renderer()->render($this->getUITree())));
+            ->withTree($this->getUITree());
     }
 
     protected function getUITree(): Tree

--- a/components/ILIAS/Style/System/test/Provider/SystemStylesGlobalScreenToolProviderTest.php
+++ b/components/ILIAS/Style/System/test/Provider/SystemStylesGlobalScreenToolProviderTest.php
@@ -22,7 +22,6 @@ require_once('vendor/composer/vendor/autoload.php');
 include_once('./components/ILIAS/UI/tests/UITestHelper.php');
 
 use PHPUnit\Framework\TestCase;
-
 use ILIAS\UI\Implementation\Crawler\Entry\ComponentEntry as Entry;
 use ILIAS\UI\Implementation\Crawler\Entry\ComponentEntries as Entries;
 use ILIAS\Data\URI;

--- a/components/ILIAS/Style/System/test/Provider/SystemStylesGlobalScreenToolProviderTest.php
+++ b/components/ILIAS/Style/System/test/Provider/SystemStylesGlobalScreenToolProviderTest.php
@@ -29,7 +29,7 @@ use ILIAS\Data\URI;
 use ILIAS\DI\Container;
 use ILIAS\GlobalScreen\Identification\IdentificationFactory;
 use ILIAS\GlobalScreen\Provider\ProviderFactory;
-use ILIAS\GlobalScreen\Scope\Tool\Factory\Tool;
+use ILIAS\GlobalScreen\Scope\Tool\Factory\TreeTool;
 use ILIAS\GlobalScreen\ScreenContext\ContextRepository;
 use ILIAS\GlobalScreen\ScreenContext\Stack\CalledContexts;
 
@@ -108,7 +108,7 @@ class SystemStylesGlobalScreenToolProviderTest extends TestCase
         $tools = $this->tool_provider->getToolsForContextStack($contexts);
         $this->assertCount(1, $tools);
         $tool = array_pop($tools);
-        $this->assertInstanceOf(Tool::class, $tool);
+        $this->assertInstanceOf(TreeTool::class, $tool);
         $this->assertEquals('documentation', $tool->getTitle());
     }
 }

--- a/components/ILIAS/UI/src/Component/MainControls/Slate/Slate.php
+++ b/components/ILIAS/UI/src/Component/MainControls/Slate/Slate.php
@@ -84,4 +84,6 @@ interface Slate extends Component, JavaScriptBindable, Triggerer, HasHelpTopics
     public function withMainBarTreePosition(string $tree_pos): Slate;
 
     public function getMainBarTreePosition(): ?string;
+
+    public function getAriaRole(): ?string;
 }

--- a/components/ILIAS/UI/src/Implementation/Component/MainControls/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/MainControls/Renderer.php
@@ -166,7 +166,9 @@ class Renderer extends AbstractComponentRenderer
             $tpl->parseCurrentBlock();
 
             if ($slate) {
-                $entry = $entry->withAriaRole(ISlate::MENU);
+                if ($entry->getAriaRole() === null) {
+                    $entry = $entry->withAriaRole(ISlate::MENU);
+                }
 
                 $tpl->setCurrentBlock("slate_item");
                 $tpl->setVariable("SLATE", $default_renderer->render($entry));

--- a/components/ILIAS/UI/src/Implementation/Component/MainControls/Slate/Slate.php
+++ b/components/ILIAS/UI/src/Implementation/Component/MainControls/Slate/Slate.php
@@ -40,12 +40,14 @@ abstract class Slate implements ISlate\Slate
 
     // allowed ARIA roles
     public const MENU = 'menu';
+    public const GROUP = 'group';
 
     /**
      * @var string[]
      */
     protected static array $allowed_aria_roles = array(
-        self::MENU
+        self::MENU,
+        self::GROUP
     );
 
     protected string $name;

--- a/components/ILIAS/UI/tests/Component/MainControls/Slate/SlateTest.php
+++ b/components/ILIAS/UI/tests/Component/MainControls/Slate/SlateTest.php
@@ -92,6 +92,13 @@ class SlateTest extends ILIAS_UI_TestBase
     }
 
     #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
+    public function testWithAriaRoleGroup(Slate $slate): void
+    {
+        $slate = $slate->withAriaRole(Slate::GROUP);
+        $this->assertEquals("group", $slate->getAriaRole());
+    }
+
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testWithAriaRoleIncorrect(Slate $slate): void
     {
         try {


### PR DESCRIPTION
**Problem:** The UI Component documentation tool window triggered HTML validator errors: `role="tree"` and `role="treeitem"` are not allowed inside `role="menu"` (only menuitem, menuitemcheckbox, etc. are valid).

**Solution:**
- Add `role="group"` as an allowed ARIA role for Slates (valid container for tree content)
- Switch UI Component documentation from `Tool` to `TreeTool` so it uses the TreeToolItemRenderer
- TreeToolItemRenderer sets `role="group"` on its slate
- Main Bar Renderer no longer overwrites an existing ARIA role on slates

https://mantis.ilias.de/view.php?id=47403