### PR TITLE
[FIX] LTI: Improve LTI consumer label in authentication mode filter

### DIFF
--- a/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilAuthProviderLTI.php
+++ b/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilAuthProviderLTI.php
@@ -120,7 +120,10 @@ class ilAuthProviderLTI extends \ilAuthProvider implements \ilAuthProviderInterf
     {
         $connector = new ilLTIDataConnector();
         $consumer = ilLTIPlatform::fromRecordId($a_sid, $connector);
-        return $consumer->getTitle();
+
+        $object_ref = $consumer->getRefId();
+        $object_title = ilObject2::_lookupTitle(ilObject2::_lookupObjectId($object_ref));
+        return $consumer->getTitle() . " / " . $object_title;
     }
 
     /**


### PR DESCRIPTION
Multiple LTI consumers can share the same title, which results in identical
entries in the "Authentication Mode" filter dropdown of the ILIAS user
administration.

This makes it difficult to select the correct consumer when filtering users.

To improve distinguishability, the dropdown label now includes the title of
the associated object:

    Consumer Title / Object Title

This does not change the underlying data but ensures that entries that would
otherwise appear identical can be differentiated.

Related: Mantis 0046324
Test case: T87474