### PR TITLE
[Fix] Container 0046958: Rating redraw for objects in item group blocks

### DIFF
--- a/components/ILIAS/Container/Content/class.ItemRenderer.php
+++ b/components/ILIAS/Container/Content/class.ItemRenderer.php
@@ -284,8 +284,7 @@ class ItemRenderer
             $item_list_gui = $this->list_gui[$item_data["type"]];
         }
 
-        // unique js-ids
-        $item_list_gui->setParentRefId((int) ($item_data["parent"] ?? 0));
+        $item_list_gui->setParentRefId((int) ($item_data["block_parent"] ?? $item_data["parent"] ?? 0));
 
         $item_list_gui->setDefaultCommandParameters(array());
         $item_list_gui->disableTitleLink(false);

--- a/components/ILIAS/Container/Content/class.ilContainerRenderer.php
+++ b/components/ILIAS/Container/Content/class.ilContainerRenderer.php
@@ -935,6 +935,10 @@ class ilContainerRenderer
                 if ($item_data === null) {
                     continue;
                 }
+                // use block_id as parent for unique IDs when item appears in multiple blocks
+                if ($block->getBlock() instanceof \ILIAS\Container\Content\ItemGroupBlock) {
+                    $item_data["block_parent"] = (int) $block_id;
+                }
                 $checkbox = \ILIAS\Containter\Content\ItemRenderer::CHECKBOX_NONE;
                 if ($this->container_gui->isActiveAdministrationPanel()) {
                     $checkbox = \ILIAS\Containter\Content\ItemRenderer::CHECKBOX_ADMIN;

--- a/components/ILIAS/Container/classes/class.ilContainerGUI.php
+++ b/components/ILIAS/Container/classes/class.ilContainerGUI.php
@@ -23,6 +23,7 @@ use ILIAS\Repository\Clipboard\ClipboardManager;
 use ILIAS\Container\StandardGUIRequest;
 use ILIAS\Container\Content\ModeManager;
 use ILIAS\ILIASObject\Properties\Translations\TranslationGUI;
+use ILIAS\UI\Component\Card\RepositoryObject;
 
 /**
  * Class ilContainerGUI
@@ -2171,6 +2172,8 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $item_data = $this->object->getSubItems(false, false, $child_ref_id);
         $container_view = $this->getContentGUI();
 
+        $item_group_list_presentation = $this->getListPresentationForRedraw($parent_ref_id);
+
         // see #41377 (material not redrawn, when not a direct child)
         $sess_data = [];
         if (isset($this->object->items["sess"])) {
@@ -2192,7 +2195,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                         if ($parent_ref_id > 0) {
                             $event_item["parent"] = $parent_ref_id;
                         }
-                        $html = $container_view->renderItem($event_item);
+                        $html = $container_view->renderItem($event_item, 0, false, "", $item_group_list_presentation);
                     }
                 }
             }
@@ -2202,12 +2205,19 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         if (!$html) {
             foreach (($this->object->items["_all"] ?? []) as $id) {
                 if ($id["child"] == $child_ref_id) {
-                    $html = $container_view->renderItem($id);
+                    $id_with_block = $id;
+                    if ($parent_ref_id > 0 && ilObject::_lookupType($parent_ref_id, true) === "itgr") {
+                        $id_with_block["block_parent"] = $parent_ref_id;
+                    }
+                    $html = $container_view->renderItem($id_with_block, 0, false, "", $item_group_list_presentation);
                 }
             }
         }
 
         if ($html) {
+            if ($html instanceof RepositoryObject) {
+                $html = $this->ui->renderer()->renderAsync($html);
+            }
             echo $html;
 
             // we need to add onload code manually (rating, comments, etc.)
@@ -2215,6 +2225,21 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         }
 
         exit;
+    }
+
+    protected function getListPresentationForRedraw(int $parent_ref_id): string
+    {
+        if ($parent_ref_id > 0 && ilObject::_lookupType($parent_ref_id, true) === "itgr") {
+            $item_group = new \ilObjItemGroup($parent_ref_id, true);
+            $presentation = $item_group->getListPresentation();
+            if ($presentation === "tile" || $presentation === "list") {
+                return $presentation;
+            }
+        }
+        $list_presentation = ilContainer::_lookupContainerSetting($this->object->getId(), "list_presentation");
+        return ($list_presentation === "tile" && !$this->isActiveAdministrationPanel() && !$this->isActiveItemOrdering())
+            ? "tile"
+            : "list";
     }
 
     protected function initEditForm(): ilPropertyFormGUI


### PR DESCRIPTION
**Presentation**: List/tile is now taken from the block/container context instead of always using list.
**Multiple blocks**: Objects in several item group blocks get unique IDs via block_parent, so each block updates correctly after rating.
**Tile view**: RepositoryObject is rendered with renderAsync() before output to avoid the "Object could not be converted to string" error.

https://mantis.ilias.de/view.php?id=46958