### PR TITLE
[FIX] Notification: Ensure "okayish" Markdown is generated for "Addit…

### DIFF
--- a/components/ILIAS/Notification/classes/class.ilSystemNotification.php
+++ b/components/ILIAS/Notification/classes/class.ilSystemNotification.php
@@ -22,6 +22,13 @@
  * @see FeatureWiki/Guidelines/System Notification Guideline
  *
  * @author Jörg Lützenkirchen <luetzenkirchen@leifos.com>
+ *
+ * @phpstan-type SystemNotificationAdditionalInfo array{
+ *     caption: string,
+ *     content: string,
+ *     is_multiline: bool,
+ *     is_direct_translation: bool
+ * }
  */
 class ilSystemNotification extends ilMailNotification
 {
@@ -31,6 +38,7 @@ class ilSystemNotification extends ilMailNotification
     protected string $introduction_direct = "";
     protected string $task = "";
     protected string $reason = "";
+    /** @var list<SystemNotificationAdditionalInfo> */
     protected array $additional = [];
     protected string $goto_caption = "";
     protected int $changed_by = 0;
@@ -91,7 +99,12 @@ class ilSystemNotification extends ilMailNotification
         bool $a_multiline = false,
         bool $a_lang_direct = false
     ): void {
-        $this->additional[$a_lang_id] = array(trim($a_value), $a_multiline, $a_lang_direct);
+        $this->additional[] = [
+            'caption' => $a_lang_id,
+            'content' => trim($a_value),
+            'is_direct_translation' => $a_lang_direct,
+            'is_multiline' => $a_multiline
+        ];
     }
 
     /**
@@ -188,28 +201,55 @@ class ilSystemNotification extends ilMailNotification
             $this->appendBody($this->getLanguageText("obj_" . $this->getObjType()) . ": " .
                 $this->getObjectTitle() . "\n");
         }
-        if (count($this->additional) > 0) {
-            foreach ($this->additional as $lang_id => $item) {
-                $caption = "";
-                if ($lang_id) {
-                    $caption = (!$item[2])
-                        ? $this->getLanguageText($lang_id)
-                        : $lang_id;
+
+        if (!empty($this->additional)) {
+            $num_addtional_sections = 0;
+            $render_opening_block_border = true;
+
+            /** @var SystemNotificationAdditionalInfo $item */
+            foreach ($this->additional as $item) {
+                if ($num_addtional_sections > 0) {
+                    $this->appendBody("\n");
                 }
-                if (!$item[1]) {
-                    if ($caption) {
-                        $caption .= ": ";
+
+                $caption = $item['caption'];
+                if ($caption !== '') {
+                    $caption = $item['is_direct_translation']
+                        ? $caption
+                        : $this->getLanguageText($caption);
+                }
+
+                if ($item['is_multiline']) {
+                    if ($caption !== '') {
+                        $this->appendBody($caption);
+                        $this->appendBody("\n");
+                        // a) If we render a new caption, we ensure a new opening block border is rendered
+                        $render_opening_block_border = true;
                     }
-                    $this->appendBody($caption . $item[0] . "\n");
+
+                    if ($render_opening_block_border) {
+                        $this->appendBody($this->getBlockBorder());
+                    }
+
+                    $this->appendBody("\n");
+                    $this->appendBody($item['content']);
+                    $this->appendBody("\n");
+                    $this->appendBody($this->getBlockBorder());
+
+                    // b) We rendered a closing block border, the next block does not need an opening block border
+                    $render_opening_block_border = false;
                 } else {
                     if ($caption) {
-                        $caption .= "\n";
+                        $caption .= ': ';
                     }
-                    $this->appendBody("\n" . $caption .
-                        $this->getBlockBorder() .
-                        $item[0] . "\n" .
-                        $this->getBlockBorder() . "\n");
+
+                    $this->appendBody($caption . $item['content']);
+
+                    // c) If a single line was rendered, the next block needs an opening border
+                    $render_opening_block_border = true;
                 }
+
+                ++$num_addtional_sections;
             }
         }
         $this->body = trim($this->body);


### PR DESCRIPTION
…ional Information"

This change ensures the generated Markdown (that's what is expected with ILIAS >= 11) looks "okayish", by ensuring a "Block Border" is not followed by another "Block Border" (as shown in the screenshots of Mantis 47386).
Furthermore, we must ensure enough line breaks are generated before each "Block Border" (hyphens). Otherwise, this leads to unintended \<h2\> elements (Setext-style headings).

```
This will be rendered as h2, followed by a thin horiz. line!.
---

This will be rendered as regular text, followed by a thick horiz. line.

---
```

See:
- https://mantis.ilias.de/view.php?id=47386
- https://github.com/chrisalley/markdown-garden/blob/master/source/guides/headers/setext-headers.md

If approved, this has to be picked to `trunk` as well.