### PR TITLE
Add dependency `flip/whoops` for ILIAS 12

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -39,6 +39,7 @@
 		]
 	},
 	"require": {
+		"flip/whoops": "^2.18"
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
This PR suggests addding `flip/whoops` (v2.18) as a composer dependency.

- [x] this dependency was already used in ILIAS.
- [x] License: MIT

### Usage

Used for error handling in ILIAS.
The library is used for debugging ILIAS in a development environment.
Additionally this library is used as a backend for all error handling in ILIAS in production environments.

### Wrapped By

Not exposed publicly, only used by the `Init` component to set up proper error handling.

### Maintenance

The library is relatively small with ~4000 lines of code.
The last release is from 08-08-2025 and the last commit from 28-11-2025.
There are 1-2 minor releases every year.
Development isn't fast paced, probably because it is feature complete at this point.
The project is maintained by one developer, with many contributions from other people.
It is sponsored by blackfire.io (https://www.blackfire.io/open-source/).

### Reasoning

The small size and the sponsoring by an established PHP company makes this IMO a good choice.

Dropping this dependency would be possible but will require us to reimplement the error backend ourself and which will certainly result in loosing the niceties for development.

### Links

Composer pkg: https://packagist.org/packages/filp/whoops
GitHub: https://github.com/filp/whoops
Homepage: https://filp.github.io/whoops/