### PR TITLE
Forum: Persist thread sorting in session

### DIFF
--- a/components/ILIAS/Forum/classes/class.ilObjForumGUI.php
+++ b/components/ILIAS/Forum/classes/class.ilObjForumGUI.php
@@ -828,8 +828,15 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling, ilForu
             ])
         );
 
+        $session_key = 'frm_' . $this->object->getRefId() . '_thread_sortation';
+        if ($requested_sortation !== null) {
+            ilSession::set($session_key, (int) $requested_sortation);
+        } else {
+            $requested_sortation = ilSession::get($session_key);
+        }
+
         $sortation = ThreadSortation::tryFrom(
-            $requested_sortation ?? ThreadSortation::DEFAULT_SORTATION->value
+            (int) ($requested_sortation ?? ThreadSortation::DEFAULT_SORTATION->value)
         );
         if ($sortation === null) {
             $sortation = ThreadSortation::DEFAULT_SORTATION;


### PR DESCRIPTION

This fix is for the issue where a user's selected sorting of forum threads is overwritten when the "All threads" button is clicked (as described in [this mantis report](https://mantis.ilias.de/view.php?id=47321)). 

The new code changes this such that:

- When a user selects a sorting option, it is saved in the session.
- When the thread overview is accessed and no sorting option is submitted through the request, the system checks if a sorting option exists in the session and uses it if found. 

This ensures the user's preferred sorting option is retained across sessions.