### PR TITLE
[Survey] fix: Use correct HTMLPurifier to process inputs

### DIFF
--- a/components/ILIAS/Survey/Editing/class.ilSurveyEditorGUI.php
+++ b/components/ILIAS/Survey/Editing/class.ilSurveyEditorGUI.php
@@ -48,6 +48,7 @@ class ilSurveyEditorGUI
     protected ilObjSurveyGUI $parent_gui;
     protected ilObjSurvey $object;
     protected array $print_options;
+    protected \ilHtmlPurifierInterface $purifier;
 
     public function __construct(ilObjSurveyGUI $a_parent_gui)
     {
@@ -72,6 +73,7 @@ class ilSurveyEditorGUI
         $this->tpl = $tpl;
 
         $this->ctrl->saveParameter($this, array("pgov", "pgov_pos"));
+        $this->purifier = new ilSvyStandardPurifier();
 
         $this->print_options = array(
             //0 => $this->lng->txt('none'),
@@ -962,6 +964,8 @@ class ilSurveyEditorGUI
         $heading->setRows(10);
         $heading->setCols(80);
         $heading->setRequired(true);
+        $heading->usePurifier(true);
+        $heading->setPurifier($this->purifier);
         $form->addItem($heading);
 
         $insertbefore = new ilSelectInputGUI($this->lng->txt("insert"), "insertbefore");
@@ -1027,12 +1031,7 @@ class ilSurveyEditorGUI
 
         $form = $this->initHeadingForm($q_id);
         if ($form->checkInput()) {
-            $tags = ilObjAdvancedEditing::_getUsedHTMLTags("survey");
-            $purifier = new HTMLPurifier($tags);
-            $heading = $form->getInput("heading");
-
-            $heading = $purifier->purify($heading);
-
+            $heading = $this->purifier->purify($form->getInput("heading"));
             $this->object->saveHeading($heading, $form->getInput("insertbefore"));
             $this->ctrl->redirect($this, "questions");
         }

--- a/components/ILIAS/Survey/Editing/class.ilSurveyEditorGUI.php
+++ b/components/ILIAS/Survey/Editing/class.ilSurveyEditorGUI.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 use ILIAS\Survey\Editing\EditManager;
 use ILIAS\Survey\Editing\EditingGUIRequest;
 

--- a/components/ILIAS/Survey/Settings/class.SettingsFormGUI.php
+++ b/components/ILIAS/Survey/Settings/class.SettingsFormGUI.php
@@ -20,7 +20,6 @@ declare(strict_types=1);
 
 namespace ILIAS\Survey\Settings;
 
-use HTMLPurifier;
 use ILIAS\Survey\InternalGUIService;
 use ILIAS\Survey\Mode\UIModifier;
 use ILIAS\Survey\InternalDomainService;
@@ -40,13 +39,15 @@ class SettingsFormGUI
     protected \ILIAS\Survey\Mode\FeatureConfig $feature_config;
     protected \ilRbacSystem $rbacsystem;
     private \ilGlobalTemplateInterface $main_tpl;
+    protected \ilHtmlPurifierInterface $purifier;
 
     public function __construct(
         InternalGUIService $ui_service,
         InternalDomainService $domain_service,
         \ilObjectService $object_service,
         \ilObjSurvey $survey,
-        UIModifier $modifier
+        UIModifier $modifier,
+        \ilHtmlPurifierInterface $purifier
     ) {
         global $DIC;
         $this->main_tpl = $DIC->ui()->mainTemplate();
@@ -59,6 +60,7 @@ class SettingsFormGUI
         $this->domain_service = $domain_service;
         $this->modifier = $modifier;
         $this->feature_config = $this->domain_service->modeFeatureConfig($survey->getMode());
+        $this->purifier = $purifier;
     }
 
     public function checkForm(\ilPropertyFormGUI $form): bool
@@ -334,6 +336,9 @@ class SettingsFormGUI
             $intro->setUseRte(true);
             $intro->setRteTagSet("mini");
         }
+        $intro->usePurifier(true);
+        $intro->setPurifier(new \ilSvyStandardPurifier());
+
         $form->addItem($intro);
 
         return $form;
@@ -452,6 +457,8 @@ class SettingsFormGUI
             $finalstatement->setUseRte(true);
             $finalstatement->setRteTagSet("mini");
         }
+        $finalstatement->usePurifier(true);
+        $finalstatement->setPurifier(new \ilSvyStandardPurifier());
         $form->addItem($finalstatement);
 
         // mail notification
@@ -885,14 +892,10 @@ class SettingsFormGUI
         } else {
             $survey->setEndDate("");
         }
-        $tags = ilObjAdvancedEditing::_getUsedHTMLTags("survey");
-        $purifier = new HTMLPurifier($tags);
+        $introduction = $this->purifier->purify($form->getInput('introduction'));
 
-        $introduction = $form->getInput("introduction");
-        $introduction = $purifier->purify($introduction);
         $survey->setIntroduction($introduction);
-        $outro = $form->getInput("outro");
-        $outro = $purifier->purify($outro);
+        $outro = $this->purifier->purify($form->getInput('outro'));
         $survey->setOutro($outro);
         $survey->setShowQuestionTitles((bool) $form->getInput("show_question_titles"));
 

--- a/components/ILIAS/Survey/Settings/class.UIFactory.php
+++ b/components/ILIAS/Survey/Settings/class.UIFactory.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\Survey\Settings;
 

--- a/components/ILIAS/Survey/Settings/class.UIFactory.php
+++ b/components/ILIAS/Survey/Settings/class.UIFactory.php
@@ -48,7 +48,8 @@ class UIFactory
             $this->domain_service,
             $object_service,
             $survey,
-            $mode_ui_modifier
+            $mode_ui_modifier,
+            new \ilSvyStandardPurifier()
         );
     }
 

--- a/components/ILIAS/SurveyQuestionPool/Questions/class.SurveyQuestionGUI.php
+++ b/components/ILIAS/SurveyQuestionPool/Questions/class.SurveyQuestionGUI.php
@@ -18,7 +18,6 @@
 
 use ILIAS\SurveyQuestionPool\Editing\EditingGUIRequest;
 use ILIAS\SurveyQuestionPool\Editing\EditManager;
-use ILIAS\LegalDocuments\HTMLPurifier;
 
 /**
  * Basic class for all survey question types
@@ -45,6 +44,7 @@ abstract class SurveyQuestionGUI
     protected string $parent_url = "";
     protected ilLogger $log;
     public ?SurveyQuestion $object = null;
+    protected \ilHtmlPurifierInterface $purifier;
 
     public function __construct($a_id = -1)
     {
@@ -91,6 +91,7 @@ abstract class SurveyQuestionGUI
             ->editing();
         $this->gui = $DIC->survey()->internal()->gui();
         $this->domain = $DIC->survey()->internal()->domain();
+        $this->purifier = new ilSvyStandardPurifier();
     }
 
     abstract protected function initObject(): void;
@@ -265,6 +266,8 @@ abstract class SurveyQuestionGUI
             $question->setUseRte(true);
             $question->setRteTagSet("mini");
         }
+        $question->usePurifier(true);
+        $question->setPurifier($this->purifier);
         $form->addItem($question);
 
         // obligatory
@@ -330,13 +333,10 @@ abstract class SurveyQuestionGUI
             $this->object->setAuthor($form->getInput("author"));
             $this->object->setDescription($form->getInput("description"));
 
-            $tags = ilObjAdvancedEditing::_getUsedHTMLTags("survey");
-            $purifier = new HTMLPurifier($tags);
-            $question = $form->getInput("question");
+            $this->object->setQuestiontext(
+                $this->purifier->purify($form->getInput("question"))
+            );
 
-            $question = $purifier->purify($question);
-
-            $this->object->setQuestiontext($question);
             $this->object->setObligatory($form->getInput("obligatory"));
 
             $this->importEditFormValues($form);

--- a/components/ILIAS/SurveyQuestionPool/Questions/class.SurveyQuestionGUI.php
+++ b/components/ILIAS/SurveyQuestionPool/Questions/class.SurveyQuestionGUI.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 use ILIAS\SurveyQuestionPool\Editing\EditingGUIRequest;
 use ILIAS\SurveyQuestionPool\Editing\EditManager;
 


### PR DESCRIPTION
## Implement correct HTMLPurifier in Survey

Replaces `ILIAS\LegalDocuments\HTMLPurifier` with `ilSvyStandardPurifier` throughout the Survey module to remove the dependency on the LegalDocuments component.

### Changes
- Removed dependency on `LegalDocuments\HTMLPurifier`
- Introduced `ilSvyStandardPurifier` as the Survey-specific sanitizer
- Applied dependency injection where applicable
- Unified sanitization logic across affected components