### PR TITLE
Advanced Metadata: Allow options in FieldDefinitionSelect to be null

### DIFF
--- a/components/ILIAS/AdvancedMetaData/classes/Types/class.ilAdvancedMDFieldDefinitionSelect.php
+++ b/components/ILIAS/AdvancedMetaData/classes/Types/class.ilAdvancedMDFieldDefinitionSelect.php
@@ -38,7 +38,7 @@ class ilAdvancedMDFieldDefinitionSelect extends ilAdvancedMDFieldDefinition
     protected array $confirm_objects_values = [];
     protected ?array $confirmed_objects = null;
     protected ?array $old_options_array = null;
-    protected SelectSpecificData $options;
+    protected ?SelectSpecificData $options = null;
 
     protected string $default_language;
 


### PR DESCRIPTION
An exception is thrown if `db_gateway->readByID` in `readOptions` returns null because `options` is not allowed to be assigned null. 

```
TypeError thrown with message "Cannot assign null to property ilAdvancedMDFieldDefinitionSelect::$options of type ILIAS
\AdvancedMetaData\Data\FieldDefinition\TypeSpecificData\Select\SelectSpecificData"
```

`readOptions` handles a null value by generating a new SelectSpecificDataImplementation object.