### PR TITLE
[FIX] LTI: Improve LTI 1.3 tool connection handling

### DIFF
--- a/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
@@ -645,7 +645,6 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
         $err = $DIC['ilErr'];
         /* @var ilErrorHandling $err */
         $ctrl = $DIC->ctrl();
-        $request = $DIC->http()->request();
         $access = $DIC->access();
         $lng = $DIC->language();
 
@@ -659,6 +658,20 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
         if ($access->checkAccess('read', '', $id)) {
             $ctrl->setTargetScript('ilias.php');
             $ctrl->setParameterByClass(ilObjLTIConsumerGUI::class, 'ref_id', $id);
+            if (session_status() === PHP_SESSION_ACTIVE && session_id() !== '') {
+                $cookieParams = session_get_cookie_params();
+                if ((bool) ($cookieParams['secure'] ?? false)) {
+                    setcookie(session_name(), session_id(), [
+                        'expires' => 0,
+                        'path' => (string) ($cookieParams['path'] ?? '/'),
+                        'domain' => (string) ($cookieParams['domain'] ?? ''),
+                        'secure' => true,
+                        'httponly' => (bool) ($cookieParams['httponly'] ?? true),
+                        'samesite' => 'None'
+                    ]);
+                }
+            }
+
             $ctrl->redirectByClass([ilRepositoryGUI::class, ilObjLTIConsumerGUI::class]);
         } elseif ($access->checkAccess('visible', '', $id)) {
             ilObjectGUI::_gotoRepositoryNode($id, 'infoScreen');

--- a/components/ILIAS/LTIConsumer/resources/ltiauth.php
+++ b/components/ILIAS/LTIConsumer/resources/ltiauth.php
@@ -126,14 +126,53 @@ if ($isContentSelection) {
 } else {
     $url = "../../../goto.php?target=lti_" . $ref_id . "&client_id=" . $il_client_id;
 }
-if (!$DIC->http()->wrapper()->query()->has("prompt")) {
-    dump("kjbvi");
-    exit();
+
+function buildSameSiteNoneSessionCookieHeader(): ?string
+{
+    if (session_status() !== PHP_SESSION_ACTIVE || session_id() === '') {
+        return null;
+    }
+
+    $cookieParams = session_get_cookie_params();
+    $secure = (bool) ($cookieParams['secure'] ?? false);
+    if (!$secure) {
+        return null;
+    }
+
+    $cookieName = session_name();
+    $cookieValue = session_id();
+    $path = (string) ($cookieParams['path'] ?? '/');
+    $domain = (string) ($cookieParams['domain'] ?? '');
+    $httpOnly = (bool) ($cookieParams['httponly'] ?? true);
+
+    $parts = [
+        rawurlencode($cookieName) . '=' . rawurlencode($cookieValue),
+        'Path=' . $path,
+        'Secure',
+        'SameSite=None'
+    ];
+
+    if ($domain !== '') {
+        $parts[] = 'Domain=' . $domain;
+    }
+    if ($httpOnly) {
+        $parts[] = 'HttpOnly';
+    }
+
+    return implode('; ', $parts);
 }
+
+$response = $DIC->http()->response()
+    ->withStatus(302)
+    ->withAddedHeader('Location', $url);
+
+$sessionCookieHeader = buildSameSiteNoneSessionCookieHeader();
+if ($sessionCookieHeader !== null) {
+    $response = $response->withAddedHeader('Set-Cookie', $sessionCookieHeader);
+}
+
 $DIC->http()->saveResponse(
-    $DIC->http()->response()
-        ->withStatus(302)
-        ->withAddedHeader('Location', $url)
+    $response
 );
 
 try {


### PR DESCRIPTION
This improves the LTI 1.3 connection flow for certain external tools. Session state is now preserved more reliably across redirects in both the authentication entry point and the consumer GUI flow, which prevents connection failures with tools such as saLTIre.