### PR TITLE
[FIX] LTI: Resolve result service requests dynamically

### DIFF
--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResultService.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResultService.php
@@ -115,7 +115,7 @@ class ilLTIConsumerResultService
             $logger->info('LTI Consumer Result Service: request loaded');
             $this->operation = str_replace('Request', '', $request->getName());
 
-            $request = $body->replaceResultRequest;
+            $request = $body->{$this->operation . 'Request'};
             $token = ilCmiXapiAuthToken::getInstanceByToken((string) $request->resultRecord->sourcedGUID->sourcedId);
             $logger->info("LTI Consumer Result Service: operation loaded ($this->operation), user " . $token->getUsrId() . " and objId " . $token->getObjId());
 


### PR DESCRIPTION
The service now resolves the operation-specific request dynamically instead of always accessing the replaceResult request, which allows the correct payload to be processed for different result service operations.
