### PR TITLE
[FIX] LTI: Adjust certificate integration types

### DIFF
--- a/components/ILIAS/LTIConsumer/classes/Certificate/class.ilCertificateSettingsLTIConsumerFormRepository.php
+++ b/components/ILIAS/LTIConsumer/classes/Certificate/class.ilCertificateSettingsLTIConsumerFormRepository.php
@@ -35,7 +35,7 @@ class ilCertificateSettingsLTIConsumerFormRepository implements ilCertificateFor
     //    private \ilObjLTIConsumer $object;
 
     public function __construct(
-        ilObjLTIConsumer $object,
+        ilObject $object,
         string $certificatePath,
         bool $hasAdditionalElements,
         ilLanguage $language,

--- a/components/ILIAS/LTIConsumer/classes/Certificate/class.ilLTIConsumerPlaceholderDescription.php
+++ b/components/ILIAS/LTIConsumer/classes/Certificate/class.ilLTIConsumerPlaceholderDescription.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\User\Profile\Profile;
+
 /**
  * Class ilLTIConsumerPlaceholderDescription
  *
@@ -37,7 +39,8 @@ class ilLTIConsumerPlaceholderDescription implements ilCertificatePlaceholderDes
     public function __construct(
         ?ilDefaultPlaceholderDescription $defaultPlaceholderDescriptionObject = null,
         ?ilLanguage $language = null,
-        ?ilUserDefinedFieldsPlaceholderDescription $userDefinedFieldPlaceHolderDescriptionObject = null
+        ?ilUserDefinedFieldsPlaceholderDescription $userDefinedFieldPlaceHolderDescriptionObject = null,
+        ?Profile $profile = null
     ) {
         global $DIC;
 
@@ -48,7 +51,7 @@ class ilLTIConsumerPlaceholderDescription implements ilCertificatePlaceholderDes
         $this->language = $language;
 
         if (null === $defaultPlaceholderDescriptionObject) {
-            $defaultPlaceholderDescriptionObject = new ilDefaultPlaceholderDescription($language, $userDefinedFieldPlaceHolderDescriptionObject);
+            $defaultPlaceholderDescriptionObject = new ilDefaultPlaceholderDescription($language, $profile ?? $DIC['user']->getProfile(), $userDefinedFieldPlaceHolderDescriptionObject);
         }
         $this->defaultPlaceHolderDescriptionObject = $defaultPlaceholderDescriptionObject;
 


### PR DESCRIPTION
This fixes type mismatches in the certificate-related LTI consumer integration. The certificate settings form repository now accepts the compatible base object type, and the placeholder description now passes the expected profile object when creating the default placeholder description.