### PR TITLE
Database: Fix wrong namespace in ilDBPdoManager

### DIFF
--- a/components/ILIAS/Database/classes/PDO/Manager/class.ilDBPdoManager.php
+++ b/components/ILIAS/Database/classes/PDO/Manager/class.ilDBPdoManager.php
@@ -18,7 +18,7 @@
 
 declare(strict_types=1);
 
-use ILIAS\Services\Database\PDO\FieldDefinition\ForeignKeyConstraints;
+use ILIAS\components\Database\PDO\FieldDefinition\ForeignKeyConstraints;
 
 /**
  * Class ilDBPdoManager


### PR DESCRIPTION
Fix mantis bug: https://mantis.ilias.de/view.php?id=47460

Wrong / old namespace used in `ilDBPdoManager`