### PR TITLE
[FIX] #44421 Form: announce legacy radio group labels to screenreaders

### DIFF
--- a/components/ILIAS/Form/classes/class.ilRadioGroupInputGUI.php
+++ b/components/ILIAS/Form/classes/class.ilRadioGroupInputGUI.php
@@ -110,6 +110,10 @@ class ilRadioGroupInputGUI extends ilSubEnabledFormPropertyGUI implements ilTabl
     public function render(): string
     {
         $tpl = new ilTemplate("tpl.prop_radio.html", true, true, "components/ILIAS/Form");
+        $group_label = $this->getHiddenTitle() !== ""
+            ? $this->getHiddenTitle()
+            : $this->getTitle();
+        $tpl->setVariable("GROUP_LABEL", $group_label);
 
         foreach ($this->getOptions() as $option) {
             // information text for option

--- a/components/ILIAS/Form/templates/default/tpl.prop_radio.html
+++ b/components/ILIAS/Form/templates/default/tpl.prop_radio.html
@@ -1,4 +1,5 @@
-<div id="{ID}">
+<fieldset id="{ID}" style="border:0;margin:0;padding:0;min-width:0;">
+	<legend class="ilAccHeadingHidden">{GROUP_LABEL}</legend>
 	<!-- BEGIN prop_radio_option -->
 		<div class="radio">
 			<label class="radio-inline"><input <!-- BEGIN described_by -->aria-describedby="desc_{DESCRIBED_BY_FIELD_ID}" <!-- END described_by -->type="radio" onclick="il.Form.showSubForm('subform_{OP_ID}', '{FID}', null);" name="{POST_VAR}" id="{OP_ID}" value="{VAL_RADIO_OPTION}" {CHK_RADIO_OPTION} {DISABLED}/>
@@ -12,4 +13,4 @@
 		<!-- END radio_option_subform -->
 	<!-- END prop_radio_option -->
 	{HIDDEN_INPUT}
-</div>
+</fieldset>


### PR DESCRIPTION
- Fixes missing screenreader announcement for legacy radio group labels in exercise assignment settings.
- Mantis ticket: https://mantis.ilias.de/view.php?id=44421
- Implementation: use semantic radio grouping (`fieldset` + hidden `legend`) and pass the group label from `ilRadioGroupInputGUI` to the template.
- If approved, please pick this to `release_11` and `trunk`.
