### PR TITLE
Fix #47463 Fatal error in showCertificateFor when score reporting date is used

### DIFF
--- a/components/ILIAS/Test/classes/class.ilObjTestAccess.php
+++ b/components/ILIAS/Test/classes/class.ilObjTestAccess.php
@@ -754,7 +754,7 @@ class ilObjTestAccess extends ilObjectAccess implements ilConditionHandling
         }
 
         if ($score_reporting === ScoreReportingTypes::SCORE_REPORTING_DATE
-            && self::$settings_result_summaries_by_obj_id->getReportingDate() < new \DateTimeImmutable('now', new DateTimeZone('UTC'))) {
+            && self::$settings_result_summaries_by_obj_id[$obj_id]->getReportingDate() < new \DateTimeImmutable('now', new DateTimeZone('UTC'))) {
             return true;
         }
 


### PR DESCRIPTION
This PR fixes a fatal error in:

components/ILIAS/Test/classes/class.ilObjTestAccess.php

Problem:
When score reporting is configured with "Date", the code incorrectly accesses an array as an object:

self::$settings_result_summaries_by_obj_id->getReportingDate()

Since self::$settings_result_summaries_by_obj_id is an array indexed by obj_id, this causes:

Call to a member function getReportingDate() on array

Fix:
The correct implementation is:

self::$settings_result_summaries_by_obj_id[$obj_id]->getReportingDate()

Testing:
The issue was reproduced in a clean environment (ILIAS 10.5) and resolved after applying this fix.

Related Mantis issue: #47463