### PR TITLE
10/install md

### DIFF
--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -568,7 +568,6 @@ will have to execute the npm and composer command first:
 cd /var/www/ilias
 sudo -u www-data npm clean-install --omit=dev --ignore-scripts
 sudo -u www-data composer install --no-dev
-sudo -u www-data mkdir -p public/Customizing/global/plugins
 mv data/* public/data/
 mv Customizing/global/plugins/* public/Customizing/global/plugins/
 ```

--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -567,7 +567,6 @@ will have to execute the npm and composer command first:
 cd /var/www/ilias
 sudo -u www-data npm clean-install --omit=dev --ignore-scripts
 sudo -u www-data composer install --no-dev
-sudo -uwww-data mkdir -p public/Customizing/global/plugins
 mv data/* public/data/
 mv Customizing/global/plugins/* public/Customizing/global/plugins/
 ```

--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -559,8 +559,8 @@ sudo -u www-data rsync -av --exclude='/public/' --exclude='/Customizing/' --excl
 rm -rf /tmp/ilias_update
 ```
 </details>
-After upgrading the code from ILIAS 9 to ILIAS 10 due to structural changes, you need to move the `/Customizing/global/plugins`
-and `/data` folder to its new destination (please beware that custom skins moved to `public/Customizing/skin`). 
+After upgrading the code from ILIAS 9 to ILIAS 10 due to structural changes, you need to move the `/Customizing`
+and `/data` folder to its new destination (please beware that custom skins moved to `public/Customizing/skin`. Please handle them separately). 
 Both are now located in the newly created `public` folder. If this `public` folder does not exist yet you 
 will have to execute the npm and composer command first: 
 
@@ -568,8 +568,8 @@ will have to execute the npm and composer command first:
 cd /var/www/ilias
 sudo -u www-data npm clean-install --omit=dev --ignore-scripts
 sudo -u www-data composer install --no-dev
-mv data/* public/data/
-mv Customizing/global/plugins/* public/Customizing/global/plugins/
+mv data public/
+mv Customizing public/
 ```
 
 Then update the code of your plugins according to their documentation to ensure they are compatible with the new ILIAS version.

--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -560,13 +560,15 @@ rm -rf /tmp/ilias_update
 ```
 </details>
 After upgrading the code from ILIAS 9 to ILIAS 10 due to structural changes, you need to move the `/Customizing/global/plugins`
-and `/data` folder to its new destination. Both are now located in the newly created `public` folder. If this `public` folder does not exist yet you 
+and `/data` folder to its new destination (please beware that custom skins moved to `public/Customizing/skin`). 
+Both are now located in the newly created `public` folder. If this `public` folder does not exist yet you 
 will have to execute the npm and composer command first: 
 
 ```shell
 cd /var/www/ilias
 sudo -u www-data npm clean-install --omit=dev --ignore-scripts
 sudo -u www-data composer install --no-dev
+sudo -u www-data mkdir -p public/Customizing/global/plugins
 mv data/* public/data/
 mv Customizing/global/plugins/* public/Customizing/global/plugins/
 ```
@@ -615,6 +617,8 @@ As soon as all migrations are done you can do the database update:
 
 ```shell
 cd /var/www/ilias
+sudo -u www-data npm clean-install --omit=dev --ignore-scripts
+sudo -u www-data composer install --no-dev
 sudo -u www-data php cli/setup.php update
 ```
 


### PR DESCRIPTION
I did a re-check of the upgrade process from ILIAS 9 to ILIAS 10. 

1. Install a clean ILIAS 9
2. Git checkout release_10 in the same directory
3. ran npm according to docu + composer afterwards (this works and it creates the public/  according to https://github.com/ILIAS-eLearning/ILIAS/blob/fb0d7a57de56bcdc97aef4c0112f7757e39ed4d7/composer.json#L21)
4. This means we don't need the step sudo -u www-data mkdir -p public/Customizing/global/plugins anymore
5. However, I added npm and composer below since you should install the locked packages before running an upgrade.