### PR TITLE
Fix #47085 Tag example contrast

### DIFF
--- a/components/ILIAS/UI/src/examples/Button/Tag/base.php
+++ b/components/ILIAS/UI/src/examples/Button/Tag/base.php
@@ -56,7 +56,7 @@ function base()
 
     $lightcol = $df->color('#00ff00');
     $darkcol = $df->color('#00aa00');
-    $forecol = $df->color('#d4190b');
+    $forecol = $df->color('#990000');
 
     $buffer[] = '<hr>with fix colors:<br>';
     $tag = $tag->withBackgroundColor($lightcol);


### PR DESCRIPTION
## Summary
- Adjust the fixed foreground color in the Button/Tag Kitchen Sink example to meet WCAG 2.1 AA contrast for normal text.
- Keep scope minimal: only `components/ILIAS/UI/src/examples/Button/Tag/base.php` is changed.

If approved, please pick this to release_11 and trunk.

https://mantis.ilias.de/view.php?id=47085 

## Test plan
- [ ] Open `goto.php/stys/21/ButtonTagTag/default/delos`
- [ ] Verify the red/green `simple tag` in "with fix colors" reaches at least `4.5:1`