### PR TITLE
Search/Certificate: new required java versions

### DIFF
--- a/components/ILIAS/WebServices/RPC/lib/README.md
+++ b/components/ILIAS/WebServices/RPC/lib/README.md
@@ -48,12 +48,12 @@ Dependencies and the build process is managed via maven
 > cd components/ILIAS/WebServices/RPC/lib
 > mvn clean install
 ```
-To build/compile the jar file for older LTS release than v17, start the maven build process with the following parameters:
+To build/compile the jar file for other LTS releases than v21, start the maven build process with the following parameters:
 ```shell
-# java 11
-> mvn clean install -Dmaven.compiler.release=11
+# java 17
+> mvn clean install -Dmaven.compiler.release=17
 # java 21
-> mvn clean install -Dmaven.compiler.source=21 -Dmaven.compiler.target=21
+> mvn clean install -Dmaven.compiler.source=25 -Dmaven.compiler.target=25
 ```
 
 The newly generated ilServer.jar has been created in the target-directory.

--- a/components/ILIAS/WebServices/RPC/lib/pom.xml
+++ b/components/ILIAS/WebServices/RPC/lib/pom.xml
@@ -246,6 +246,6 @@
     <properties>
         <showDeprecation>true</showDeprecation>
         <encoding>UTF-8</encoding>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>21</maven.compiler.release>
     </properties>
 </project>

--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -67,7 +67,7 @@ current configuration of the [ILIAS test server](https://test11.ilias.de), which
 | Database     | MySQL 8.4 - 9.7 or MariaDB 11.4 - 12.3                 | MariaDB 11.8     |
 | PHP          | 8.3, 8.4                                               | 8.4              |
 | Webserver    | nginx: 1.12.x – 1.18.x, Apache: ≥ 2.4.x                | Apache 2.4.52    |
-| JDK          | Open JDK Runtime 11, 17 or 21 LTS                      | OpenJDK 17       |
+| JDK          | Open JDK Runtime 17, 21 or 25 LTS                      | OpenJDK 21       |
 | Node.js      | 22 (LTS), 24 Recommended: 24                           | v24.10.0         |
 | Ghostscript  | 10.x                                                   | 9.55             |
 | Imagemagick  | 6.9.x                                                  | 6.9.11           |
@@ -94,7 +94,7 @@ PHP version later on.
 <a name="install-dependencies"></a>
 ## Install Dependencies
 
-`openjdk-17-jdk` and `maven` are optional and are used for the ILIAS RPC server for search indexing and certificate generation. 
+`openjdk-21-jdk` and `maven` are optional and are used for the ILIAS RPC server for search indexing and certificate generation. 
 `git` is required if the source code is obtained directly from GitHub.
 `nodejs` and `npm` are required as well if you get the source directly to download the javascript dependencies in the installation process.
 Alternatively, they can be obtained directly from the distribution package at [Nodesource](https://deb.nodesource.com/) to select appropriate nodejs versions according to the [Recommended Setup for Running ILIAS](#recommended-setup-for-running-ilias).
@@ -102,7 +102,7 @@ Alternatively, they can be obtained directly from the distribution package at [N
 
 ```shell
 apt update
-apt update zip unzip openjdk-17-jdk maven ffmpeg git ghostscript nodejs npm
+apt update zip unzip openjdk-21-jdk maven ffmpeg git ghostscript nodejs npm
 ```
 
 <a name="install-webserver"></a>


### PR DESCRIPTION
This is a suggestion for the required java versions for ILIAS 12. 
As of now the following linux distributions will offer packages for minimum 2 of the required java versions:
- Debian 12,13,14
- Ubuntu 22.04, 24.04, 26.04
- Rocky, RHEL 8,9,10
