### PR TITLE
[FIX] UI: add `Filter\ProxyFilterField` trigger on-load-code.

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/FilterContextRenderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/FilterContextRenderer.php
@@ -199,6 +199,7 @@ class FilterContextRenderer extends Renderer
 
         $prox = new ProxyFilterField();
         $prox = $prox->withOnClick($popover->getShowSignal());
+        $prox = $this->addTriggererOnLoadCode($prox);
         $tpl->touchBlock("tabindex");
 
         $this->bindJSandApplyId($prox, $tpl);


### PR DESCRIPTION
This is an addendum to #11103 for release_11 and trunk, making the filter proxy fields work again (triggerer on-load-code was missing).