### PR TITLE
Container/Export: patch to remove faulty multilingalism entries after container import

### DIFF
--- a/components/ILIAS/Container/Export/class.ilContainerImporter.php
+++ b/components/ILIAS/Container/Export/class.ilContainerImporter.php
@@ -16,6 +16,9 @@
  *
  *********************************************************************/
 
+use ILIAS\ILIASObject\Properties\Translations\CachedRepository as TranslationsRepository;
+use ILIAS\ILIASObject\Properties\Translations\Translations as Translations;
+
 /**
  * container xml importer
  *
@@ -29,12 +32,14 @@ class ilContainerImporter extends ilXmlImporter
 
     # Patch Start: Fix multilingualism replaces course title
     protected string $import_id;
+    protected TranslationsRepository $translations_repository;
     # Patch End: Fix multilingualism replaces course title
 
     public function init(): void
     {
         global $DIC;
 
+        $this->translations_repository = new TranslationsRepository($DIC->database());
         $this->cont_log = ilLoggerFactory::getLogger('cont');
         $this->skill_profile_service = $DIC->skills()->profile();
     }
@@ -106,9 +111,16 @@ class ilContainerImporter extends ilXmlImporter
         }
 
         # Patch Start: Fix multilingualism replaces course title
-        global $DIC;
         $obj_id = (int) $a_mapping->getMapping('components/ILIAS/ILIASObject', 'obj', $this->import_id);
-        $DIC->database()->manipulate("DELETE FROM object_translation WHERE title = 'pU76w5DUIuCLCtFEsvhUdS' AND " . " obj_id = " . $DIC->database()->quote($obj_id, ilDBConstants::T_INTEGER));
+        $translations = $this->translations_repository->getFor($obj_id);
+        $translations_new = new Translations($translations->getObjId(), [], $translations->getDefaultLanguage(), $translations->getBaseLanguage());
+        $languages = $translations->getLanguages();
+        foreach ($languages as $language) {
+            $translations_new = $language->getTitle() === 'NO TITLE'
+                ? $translations_new
+                : $translations_new->withLanguage($language);
+        }
+        $this->translations_repository->store($translations_new);
         # Patch End: Fix multilingualism replaces course title
     }
 

--- a/components/ILIAS/Container/Export/class.ilContainerImporter.php
+++ b/components/ILIAS/Container/Export/class.ilContainerImporter.php
@@ -27,6 +27,10 @@ class ilContainerImporter extends ilXmlImporter
     protected ilLogger $cont_log;
     protected \ILIAS\Skill\Service\SkillProfileService $skill_profile_service;
 
+    # Patch Start: Fix multilingualism replaces course title
+    protected string $import_id;
+    # Patch End: Fix multilingualism replaces course title
+
     public function init(): void
     {
         global $DIC;
@@ -48,6 +52,10 @@ class ilContainerImporter extends ilXmlImporter
 
         $parser = new ilContainerXmlParser($a_mapping, trim($a_xml));
         $parser->parse($a_id);
+
+        # Patch Start: Fix multilingualism replaces course title
+        $this->import_id = $a_id;
+        # Patch End: Fix multilingualism replaces course title
     }
 
     /**
@@ -96,6 +104,12 @@ class ilContainerImporter extends ilXmlImporter
                 ilParticipants::getDefaultMemberRole((int) $new_crs_ref_id)
             );
         }
+
+        # Patch Start: Fix multilingualism replaces course title
+        global $DIC;
+        $obj_id = (int) $a_mapping->getMapping('components/ILIAS/ILIASObject', 'obj', $this->import_id);
+        $DIC->database()->manipulate("DELETE FROM object_translation WHERE title = 'pU76w5DUIuCLCtFEsvhUdS' AND " . " obj_id = " . $DIC->database()->quote($obj_id, ilDBConstants::T_INTEGER));
+        # Patch End: Fix multilingualism replaces course title
     }
 
     protected function handleOfflineStatus(string $xml, ilImportMapping $mapping): void

--- a/components/ILIAS/Export/classes/class.ilImportContainer.php
+++ b/components/ILIAS/Export/classes/class.ilImportContainer.php
@@ -77,7 +77,7 @@ class ilImportContainer extends ilImport
         $new = new $class_name();
 
         # Patch Start: Fix multilingualism replaces course title
-        $new->setTitle('pU76w5DUIuCLCtFEsvhUdS');
+        $new->setTitle('NO TITLE');
         # Patch End: Fix multilingualism replaces course title
 
         $new->create(true);

--- a/components/ILIAS/Export/classes/class.ilImportContainer.php
+++ b/components/ILIAS/Export/classes/class.ilImportContainer.php
@@ -75,7 +75,11 @@ class ilImportContainer extends ilImport
         $class_name = "ilObj" . $this->objDefinition->getClassName($a_type);
 
         $new = new $class_name();
-        $new->setTitle('Import');
+
+        # Patch Start: Fix multilingualism replaces course title
+        $new->setTitle('pU76w5DUIuCLCtFEsvhUdS');
+        # Patch End: Fix multilingualism replaces course title
+
         $new->create(true);
         $new->createReference();
         $new->putInTree($this->getMapping()->getTargetId());


### PR DESCRIPTION
LINKS:
https://mantis.ilias.de/view.php?id=40201
https://mantis.ilias.de/view.php?id=47159
https://mantis.ilias.de/view.php?id=47208

This patch removes faulty multilingualism entries that are created during the container import. This patch does not remove the core issue, which is the creation of the multilingualism entries with the default object title. It only removes the symptoms of the problem.