### PR TITLE
LegacyForms: Fix TypeError for attachments exceeding upload limit

### DIFF
--- a/components/ILIAS/Form/classes/class.ilTextAreaInputGUI.php
+++ b/components/ILIAS/Form/classes/class.ilTextAreaInputGUI.php
@@ -293,15 +293,17 @@ class ilTextAreaInputGUI extends ilSubEnabledFormPropertyGUI
 
     public function getInput(): string
     {
+        $raw_post_var = (string) ($this->raw($this->getPostVar()) ?? "");
+
         if ($this->usePurifier() && $this->getPurifier()) {
-            $value = $this->getPurifier()->purify($this->raw($this->getPostVar()));
+            $value = $this->getPurifier()->purify($raw_post_var);
         } else {
             $allowed = $this->getRteTagString();
             if (isset($this->plugins["latex"]) && $this->plugins["latex"] == "latex" && !is_int(strpos($allowed, "<span>"))) {
                 $allowed .= "<span>";
             }
             $value = ($this->getUseRte() || !$this->getUseTagsForRteOnly())
-                ? ilUtil::stripSlashes($this->raw($this->getPostVar()), true, $allowed)
+                ? ilUtil::stripSlashes($raw_post_var, true, $allowed)
                 : $this->str($this->getPostVar());
         }
 


### PR DESCRIPTION
This MR resolves an issue described in [this mantis report](https://mantis.ilias.de/view.php?id=47314). 

This fix prevents the TypeError from occurring when uploading attachments that exceed the file size limit if an `ilTextAreaInputGUI` element is contained in the same legacy property form.
It is fixed by adding safeguard checks to ensure that in ilTextAreaInputGUI the getInput() function only attempts to purify the PostVar if it is not null. 