### PR TITLE
[Footer] 47483: Wrong footerlink "Translation"

### DIFF
--- a/components/ILIAS/GlobalScreen_/classes/UI/Footer/class.ilFooterStandardGroupsProvider.php
+++ b/components/ILIAS/GlobalScreen_/classes/UI/Footer/class.ilFooterStandardGroupsProvider.php
@@ -65,7 +65,10 @@ final class ilFooterStandardGroupsProvider extends AbstractStaticFooterProvider
     private function buildURI(string $from_path): URI
     {
         $request = $this->dic->http()->request()->getUri();
-        return new URI($request->getScheme() . '://' . $request->getHost() . '/' . ltrim($from_path, '/'));
+
+        return new URI($request->getScheme() . '://' . $request->getHost()
+            . (dirname($request->getPath()) == '/' ? '/' : dirname($request->getPath()) . '/')
+            . ltrim($from_path, '/'));
     }
 
     public function getEntries(): array


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=47483

This fix treats a potential local ilias path in \ilFooterStandardGroupsProvider::buildURI