### PR TITLE
Missing Note Lang Entry

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -13085,6 +13085,7 @@ notes#:#notes_latest_comment#:#Letzter Kommentar
 notes#:#notes_latest_message#:#Letzte Mitteilung
 notes#:#notes_message_author_counterpart#:#Gesprächspartner
 notes#:#notes_message_author_you#:#Sie
+notes#:#notes_message_deleted#:#Die Mitteilung wurde gelöscht.
 notes#:#notes_messages#:#Mitteilungen
 notes#:#notes_my_comments#:#Meine Kommentare
 notes#:#notes_no_comments#:#Bisher wurde noch kein Kommentar abgegeben.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -13058,6 +13058,7 @@ notes#:#notes_latest_comment#:#Latest Comment
 notes#:#notes_latest_message#:#Latest Message
 notes#:#notes_message_author_counterpart#:#Respondent
 notes#:#notes_message_author_you#:#You
+notes#:#notes_message_deleted#:#Message deleted.
 notes#:#notes_messages#:#Messages
 notes#:#notes_my_comments#:#My Comments
 notes#:#notes_no_comments#:#No comment has been posted yet.


### PR DESCRIPTION
I have noticed that there is a language entry missing for Messages - notes_message_deleted 
<img width="1340" height="318" alt="Screenshot 2026-03-25 171251" src="https://github.com/user-attachments/assets/519c6848-5d1e-4c56-9c22-1760d16d1f35" />

I propose the following content in English and German.

notes#:#notes_message_deleted#:#Message deleted.

notes#:#notes_message_deleted#:#Die Mitteilung wurde gelöscht.

If I have done this pull request correctly and you agree with my proposed entries, I can either create another pull request for Trunk and 10(?) or I can simply update them manually.
