### PR TITLE
UI: ignore null value on dynamic inputs

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/File.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/File.php
@@ -140,12 +140,14 @@ class File extends HasDynamicInputs implements C\Input\Field\File
         $this->checkArg("value", $this->isClientSideValueOk($value), "Display value does not match input type.");
 
         $clone = clone $this;
-        foreach ($value as $data) {
-            $file_id = ($clone->hasMetadataInputs()) ? $data[0] : $data;
+        if (is_array($value)) {
+            foreach ($value as $data) {
+                $file_id = ($clone->hasMetadataInputs()) ? $data[0] : $data;
 
-            // that was not implicitly intended, but mapping dynamic inputs
-            // to the file-id is also a duplicate protection.
-            $clone->generated_dynamic_inputs[$file_id] = $clone->getTemplateForDynamicInputs()->withValue($data);
+                // that was not implicitly intended, but mapping dynamic inputs
+                // to the file-id is also a duplicate protection.
+                $clone->generated_dynamic_inputs[$file_id] = $clone->getTemplateForDynamicInputs()->withValue($data);
+            }
         }
 
         return $clone;

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/HasDynamicInputs.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/HasDynamicInputs.php
@@ -95,13 +95,13 @@ abstract class HasDynamicInputs extends FormInput
         $this->checkArg('value', $this->isClientSideValueOk($value), "Display value does not match input(-template) type.");
         $clone = clone $this;
 
-        if (!is_array($value)) {
+        if (is_array($value)) {
+            foreach ($value as $input_name => $input_value) {
+                $clone->generated_dynamic_inputs[$input_name] = $clone->getTemplateForDynamicInputs()->withValue($input_value);
+            }
+        } elseif ($value !== null) {
             $clone->generated_dynamic_inputs[] = $clone->getTemplateForDynamicInputs()->withValue($value);
             return $clone;
-        }
-
-        foreach ($value as $input_name => $input_value) {
-            $clone->generated_dynamic_inputs[$input_name] = $clone->getTemplateForDynamicInputs()->withValue($input_value);
         }
 
         return $clone;

--- a/components/ILIAS/UI/tests/Component/Input/Field/TreeSelectTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/TreeSelectTest.php
@@ -148,12 +148,20 @@ class TreeSelectTest extends \ILIAS_UI_TestBase
     }
 
     /** @dataProvider getValidArgumentsForWithValue */
-    public function testWithValueForValidArguments(string|int|null $value): void
+    public function testWithValueForValidArguments(string|int $value): void
     {
         $node_retrieval = $this->getNodeRetrieval();
         $component = $this->getFieldFactory()->treeSelect($node_retrieval, '');
         $component = $component->withValue($value);
         $this->assertEquals([$value], $component->getValue());
+    }
+
+    public function testWithValueForEmptyValidArguments(): void
+    {
+        $node_retrieval = $this->getNodeRetrieval();
+        $component = $this->getFieldFactory()->treeSelect($node_retrieval, '');
+        $component = $component->withValue(null);
+        $this->assertEquals([], $component->getValue());
     }
 
     public function testRenderWithValue(): void
@@ -332,7 +340,6 @@ HTML;
             ['1'],
             [''],
             [' '],
-            [null],
         ];
     }
 


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=46020

This PR allows/ignores null values for dynamic inputs so that sections with such inputs can have a set value (wich requires at least null).