### PR TITLE
#47496 fix: add missing return statements in ilSoapUserAdministration

### DIFF
--- a/components/ILIAS/soap/classes/class.ilSoapUserAdministration.php
+++ b/components/ILIAS/soap/classes/class.ilSoapUserAdministration.php
@@ -671,11 +671,11 @@ class ilSoapUserAdministration extends ilSoapAdministration
             return $this->raiseError('Check access failed.', 'Server');
         }
         if (!count($a_keyfields)) {
-            $this->raiseError('At least one keyfield is needed', 'Client');
+            return $this->raiseError('At least one keyfield is needed', 'Client');
         }
 
         if (!count($a_keyvalues)) {
-            $this->raiseError('At least one keyvalue is needed', 'Client');
+            return $this->raiseError('At least one keyvalue is needed', 'Client');
         }
 
         if (strcasecmp($query_operator, "and") !== 0 || strcasecmp($query_operator, "or") !== 0) {
@@ -844,7 +844,7 @@ class ilSoapUserAdministration extends ilSoapAdministration
         $data = $ilDB->fetchAssoc($res);
 
         if (!(int) $data['usr_id']) {
-            $this->raiseError('User does not exist', 'Client');
+            return $this->raiseError('User does not exist', 'Client');
         }
         return (int) $data['usr_id'];
     }


### PR DESCRIPTION
raiseError() calls without return do not abort method execution, causing the code to continue running after an error condition.