### PR TITLE
[FIX] FileDelivery: Depend on `ilIniFilesLoadedObjective` when writin…

### DIFF
--- a/components/ILIAS/FileDelivery/src/Setup/DeliveryMethodObjective.php
+++ b/components/ILIAS/FileDelivery/src/Setup/DeliveryMethodObjective.php
@@ -50,7 +50,7 @@ class DeliveryMethodObjective extends BuildStaticConfigStoredObjective
         return array_merge(
             parent::getPreconditions($environment),
             [
-                new \ilIniFilesPopulatedObjective()
+                new \ilIniFilesLoadedObjective()
             ]
         );
     }


### PR DESCRIPTION
…g delivery artifact

The current approach of depending on `ilIniFilesPopulatedObjective` appears insufficient for generating delivery artifacts. Circumstances may arise, contingent upon the execution graph of the objectives, where the INI file has not yet been processed.

See: https://mantis.ilias.de/view.php?id=47566

If approved, this has to be picked to `release_10` and `trunk`.