### PR TITLE
Chatroom: Bump npm dep path-to-regexp (ILIAS 11)

### DIFF
--- a/components/ILIAS/Chatroom/chat/package-lock.json
+++ b/components/ILIAS/Chatroom/chat/package-lock.json
@@ -886,9 +886,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.1.tgz",
+      "integrity": "sha512-fvU78fIjZ+SBM9YwCknCvKOUKkLVqtWDVctl0s7xIqfmfb38t2TT4ZU2gHm+Z8xGwgW+QWEU3oQSAzIbo89Ggw==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"


### PR DESCRIPTION
Bump transitive dependency [path-to-regexp](https://www.npmjs.com/package/path-to-regexp).

This fixes:
- [CVE-2026-4926](https://www.cve.org/CVERecord?id=CVE-2026-4926)
- [CVE-2026-4923](https://www.cve.org/CVERecord?id=CVE-2026-4923)