### PR TITLE
TA 46884: Fixes long menu question incorrect autocomplete

### DIFF
--- a/components/ILIAS/TestQuestionPool/resources/js/dist/longMenuQuestionPlayer.js
+++ b/components/ILIAS/TestQuestionPool/resources/js/dist/longMenuQuestionPlayer.js
@@ -30,7 +30,7 @@
             return a.length > b.length ? a : b;
           });
           input.setAttribute('size', longest.length);
-          input.addEventListener('keydown', keyHandler);
+          input.addEventListener('input', keyHandler);
         }
       });
 


### PR DESCRIPTION
Hey,

This PR is related to Mantis Ticket https://mantis.ilias.de/view.php?id=46884

The issue was caused by a race condition where keydown fired before the input value was updated. This lead to the recorded input length to be off by one and autocomplete to match incomplete terms (e.g. P+ was interpreted as P, showing Paracetamol

Best Regards,
@thojou 