### PR TITLE
[FEATURE] Data,Refinery: add QR code support

### DIFF
--- a/components/ILIAS/Data/src/QR/ErrorCorrectionLevel.php
+++ b/components/ILIAS/Data/src/QR/ErrorCorrectionLevel.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+namespace ILIAS\Data\QR;
+
+/**
+ * Error correction levels as defined by ISO/IEC 18004.
+ *
+ * Each level specifies the percentage of codewords that can be
+ * restored if the QR code is damaged or partially obscured.
+ * Please note that increasing the error correction level will
+ * decrease the data capacity of its payload.
+ *
+ * @see https://www.qrcode.com/en/about/error_correction.html
+ */
+enum ErrorCorrectionLevel: string
+{
+    /** ~7% of codewords can be restored. */
+    case LOW = 'L';
+
+    /** ~15% of codewords can be restored (most fequently used). */
+    case MEDIUM = 'M';
+
+    /** ~25% of codewords can be restored. */
+    case QUARTILE = 'Q';
+
+    /** ~30% of codewords can be restored. */
+    case HIGH = 'H';
+}

--- a/components/ILIAS/Data/src/SVG.php
+++ b/components/ILIAS/Data/src/SVG.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+namespace ILIAS\Data;
+
+/**
+ * Data transfer object that carries the raw SVG data as a string,
+ * created from trusted sources. This object is merely a type as
+ * a mean to talk about SVG's and pass them between different layers
+ * of the system, it does not validate whether the SVG is valid or
+ * not.
+ */
+readonly class SVG implements \Stringable
+{
+    public function __construct(
+        protected string $raw_svg_string,
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        return $this->raw_svg_string;
+    }
+}

--- a/components/ILIAS/Refinery/src/URI/Group.php
+++ b/components/ILIAS/Refinery/src/URI/Group.php
@@ -21,11 +21,27 @@ declare(strict_types=1);
 namespace ILIAS\Refinery\URI;
 
 use ILIAS\Refinery\Transformation;
+use ILIAS\Data\QR\ErrorCorrectionLevel;
+use ILIAS\Refinery\URI\Transformation\ToStringTransformation;
+use ILIAS\Refinery\URI\Transformation\ToSvgQrCodeTransformation;
+use ILIAS\Refinery\URI\Transformation\FromSvgTransformation;
 
 class Group
 {
     public function toString(): Transformation
     {
-        return new StringTransformation();
+        return new ToStringTransformation();
+    }
+
+    public function toSvgQrCode(
+        ErrorCorrectionLevel $error_correction_level = ErrorCorrectionLevel::MEDIUM,
+        int $size_in_px = 400,
+    ): Transformation {
+        return new ToSvgQrCodeTransformation($error_correction_level, $size_in_px);
+    }
+
+    public function fromSvg(): Transformation
+    {
+        return new FromSvgTransformation();
     }
 }

--- a/components/ILIAS/Refinery/src/URI/Transformation/FromSvgTransformation.php
+++ b/components/ILIAS/Refinery/src/URI/Transformation/FromSvgTransformation.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+namespace ILIAS\Refinery\URI\Transformation;
+
+use ILIAS\Refinery\DeriveApplyToFromTransform;
+use ILIAS\Refinery\DeriveInvokeFromTransform;
+use ILIAS\Refinery\Transformation;
+use ILIAS\Data\SVG;
+
+/**
+ * The {@see \ILIAS\Data\URI} does not support data URI yet, therefore
+ * this transformation currently returns a string.
+ */
+class FromSvgTransformation implements Transformation
+{
+    use DeriveApplyToFromTransform;
+    use DeriveInvokeFromTransform;
+
+    protected const string SCHEME = 'data:';
+    protected const string MIME_TYPE = 'image/svg+xml';
+    protected const string ENCODING = 'base64';
+
+    public function transform(mixed $from): string
+    {
+        if (!$from instanceof SVG) {
+            throw new \InvalidArgumentException("Argument must be of type " . SVG::class);
+        }
+
+        return self::SCHEME . self::MIME_TYPE . ';' . self::ENCODING . ',' . base64_encode($from->__toString());
+    }
+}

--- a/components/ILIAS/Refinery/src/URI/Transformation/ToStringTransformation.php
+++ b/components/ILIAS/Refinery/src/URI/Transformation/ToStringTransformation.php
@@ -18,7 +18,7 @@
 
 declare(strict_types=1);
 
-namespace ILIAS\Refinery\URI;
+namespace ILIAS\Refinery\URI\Transformation;
 
 use ILIAS\Data\URI;
 use ILIAS\Refinery\ConstraintViolationException;
@@ -26,7 +26,7 @@ use ILIAS\Refinery\DeriveApplyToFromTransform;
 use ILIAS\Refinery\Transformation;
 use ILIAS\Refinery\DeriveInvokeFromTransform;
 
-class StringTransformation implements Transformation
+class ToStringTransformation implements Transformation
 {
     use DeriveApplyToFromTransform;
     use DeriveInvokeFromTransform;

--- a/components/ILIAS/Refinery/src/URI/Transformation/ToSvgQrCodeTransformation.php
+++ b/components/ILIAS/Refinery/src/URI/Transformation/ToSvgQrCodeTransformation.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+namespace ILIAS\Refinery\URI\Transformation;
+
+use ILIAS\Refinery\DeriveApplyToFromTransform;
+use ILIAS\Refinery\DeriveInvokeFromTransform;
+use ILIAS\Refinery\Transformation;
+use ILIAS\Data\QR\ErrorCorrectionLevel;
+use ILIAS\Data\SVG;
+use ILIAS\Data\URI;
+use BaconQrCode as External;
+
+class ToSvgQrCodeTransformation implements Transformation
+{
+    use DeriveApplyToFromTransform;
+    use DeriveInvokeFromTransform;
+
+    protected const string ENCODING = 'UTF-8';
+
+    public function __construct(
+        protected ErrorCorrectionLevel $error_correction_level,
+        protected int $size_in_px,
+    ) {
+        $this->assertIntGreaterThanZero($size_in_px);
+    }
+
+    public function transform(mixed $from): SVG
+    {
+        if (!$from instanceof URI) {
+            throw new \InvalidArgumentException("Argument must be of type " . URI::class);
+        }
+
+        $writer = new External\Writer(
+            new External\Renderer\ImageRenderer(
+                new External\Renderer\RendererStyle\RendererStyle($this->size_in_px),
+                new External\Renderer\Image\SvgImageBackEnd(),
+            ),
+        );
+
+        $raw_svg_string = $writer->writeString(
+            $from->__toString(),
+            self::ENCODING,
+            $this->mapErrorCorrectionLevel($this->error_correction_level),
+        );
+
+        return new SVG($raw_svg_string);
+    }
+
+    protected function mapErrorCorrectionLevel(ErrorCorrectionLevel $level): External\Common\ErrorCorrectionLevel
+    {
+        return match ($level) {
+            ErrorCorrectionLevel::LOW => External\Common\ErrorCorrectionLevel::L(),
+            ErrorCorrectionLevel::MEDIUM => External\Common\ErrorCorrectionLevel::M(),
+            ErrorCorrectionLevel::QUARTILE => External\Common\ErrorCorrectionLevel::Q(),
+            ErrorCorrectionLevel::HIGH => External\Common\ErrorCorrectionLevel::H(),
+        };
+    }
+
+    protected function assertIntGreaterThanZero(int $number): void
+    {
+        if (0 >= $number) {
+            throw new \InvalidArgumentException("Number must be greater than zero.");
+        }
+    }
+}

--- a/components/ILIAS/Refinery/tests/URI/GroupTest.php
+++ b/components/ILIAS/Refinery/tests/URI/GroupTest.php
@@ -21,15 +21,31 @@ declare(strict_types=1);
 namespace ILIAS\Tests\Refinery\URI;
 
 use ILIAS\Refinery\URI\Group as URIGroup;
-use ILIAS\Refinery\URI\StringTransformation;
+use ILIAS\Refinery\URI\Transformation\ToStringTransformation;
+use ILIAS\Refinery\URI\Transformation\FromSvgTransformation;
+use ILIAS\Refinery\URI\Transformation\ToSvgQrCodeTransformation;
 use PHPUnit\Framework\TestCase;
 
 class GroupTest extends TestCase
 {
-    public function testStringTransformationInstance(): void
+    public function testToStringTransformationInstance(): void
     {
         $group = new URIGroup();
         $transformation = $group->toString();
-        $this->assertInstanceOf(StringTransformation::class, $transformation);
+        $this->assertInstanceOf(ToStringTransformation::class, $transformation);
+    }
+
+    public function testToSvgTransformationInstance(): void
+    {
+        $group = new URIGroup();
+        $transformation = $group->toSvgQrCode();
+        $this->assertInstanceOf(ToSvgQrCodeTransformation::class, $transformation);
+    }
+
+    public function testFromSvgTransformationInstance(): void
+    {
+        $group = new URIGroup();
+        $transformation = $group->fromSvg();
+        $this->assertInstanceOf(FromSvgTransformation::class, $transformation);
     }
 }

--- a/components/ILIAS/Refinery/tests/URI/Transformation/FromSvgTransformationTest.php
+++ b/components/ILIAS/Refinery/tests/URI/Transformation/FromSvgTransformationTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+namespace ILIAS\Tests\Refinery\URI\Transformation;
+
+use ILIAS\Refinery\URI\Transformation\FromSvgTransformation;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class FromSvgTransformationTest extends TestCase
+{
+    public function testTransformWithoutSvgInstance(): void
+    {
+        $transformation = new FromSvgTransformation();
+        $this->expectException(\InvalidArgumentException::class);
+        $transformation->transform('<svg></svg>');
+    }
+
+    public function testTransformWithSvgInstance(): void
+    {
+        $transformation = new FromSvgTransformation();
+        $this->expectNotToPerformAssertions();
+        $transformation->transform($this->createSvgMock());
+    }
+
+    #[Depends('testTransformWithSvgInstance')]
+    public function testTransformResult(): void
+    {
+        $transformation = new FromSvgTransformation();
+        $svg_mock = $this->createSvgMock();
+        $result = $transformation->transform($svg_mock);
+        $this->assertIsString($result);
+        $this->assertStringStartsWith("data:image/svg+xml;base64,", $result); // ensure correct data uri format
+        $this->assertStringEndsWith(base64_encode($svg_mock->__toString()), $result); // ensure base64 encoded value
+    }
+
+    protected function createSvgMock(): \ILIAS\Data\SVG & MockObject
+    {
+        $svg_mock = $this->createMock(\ILIAS\Data\SVG::class);
+        $svg_mock->method('__toString')->willReturn('<svg></svg>');
+        return $svg_mock;
+    }
+}

--- a/components/ILIAS/Refinery/tests/URI/Transformation/StringTransformationTest.php
+++ b/components/ILIAS/Refinery/tests/URI/Transformation/StringTransformationTest.php
@@ -18,20 +18,20 @@
 
 declare(strict_types=1);
 
-namespace ILIAS\Tests\Refinery\URI;
+namespace ILIAS\Tests\Refinery\URI\Transformation;
 
 use ILIAS\Data\URI;
 use ILIAS\Refinery\ConstraintViolationException;
-use ILIAS\Refinery\URI\StringTransformation;
+use ILIAS\Refinery\URI\Transformation\ToStringTransformation;
 use PHPUnit\Framework\TestCase;
 
 class StringTransformationTest extends TestCase
 {
-    private StringTransformation $transformation;
+    private ToStringTransformation $transformation;
 
     protected function setUp(): void
     {
-        $this->transformation = new StringTransformation();
+        $this->transformation = new ToStringTransformation();
     }
 
     public function testSimpleUri(): void

--- a/components/ILIAS/Refinery/tests/URI/Transformation/ToSvgTransformationTest.php
+++ b/components/ILIAS/Refinery/tests/URI/Transformation/ToSvgTransformationTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+namespace ILIAS\Tests\Refinery\URI\Transformation;
+
+use ILIAS\Refinery\URI\Transformation\ToSvgQrCodeTransformation;
+use ILIAS\Data\QR\ErrorCorrectionLevel;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ToSvgTransformationTest extends TestCase
+{
+    public function testConstructorWithZero(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $transformation = new ToSvgQrCodeTransformation(ErrorCorrectionLevel::LOW, 0);
+    }
+
+    public function testConstructorWithNegativeNumber(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $transformation = new ToSvgQrCodeTransformation(ErrorCorrectionLevel::LOW, -1);
+    }
+
+    public function testConstructorWithPositiveNumber(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $transformation = new ToSvgQrCodeTransformation(ErrorCorrectionLevel::LOW, 1);
+    }
+
+    #[Depends('testConstructorWithPositiveNumber')]
+    public function testTransformWithoutUriInstance(): void
+    {
+        $transformation = new ToSvgQrCodeTransformation(ErrorCorrectionLevel::LOW, 1);
+        $this->expectException(\InvalidArgumentException::class);
+        $transformation->transform('https://ilias.ch');
+    }
+
+    #[Depends('testConstructorWithPositiveNumber')]
+    public function testTransformWithUriInstance(): void
+    {
+        $transformation = new ToSvgQrCodeTransformation(ErrorCorrectionLevel::LOW, 1);
+        $this->expectNotToPerformAssertions();
+        $transformation->transform($this->createUriMock());
+    }
+
+    /** @return ErrorCorrectionLevel */
+    public static function getErrorCorrectionLevels(): array
+    {
+        return [
+            [ErrorCorrectionLevel::LOW],
+            [ErrorCorrectionLevel::MEDIUM],
+            [ErrorCorrectionLevel::QUARTILE],
+            [ErrorCorrectionLevel::HIGH],
+        ];
+    }
+
+    #[Depends('testConstructorWithPositiveNumber')]
+    #[DataProvider('getErrorCorrectionLevels')]
+    public function testTransformWithErrorCorrectionLevels(ErrorCorrectionLevel $level): void
+    {
+        $transformation = new ToSvgQrCodeTransformation($level, 1);
+        $this->expectNotToPerformAssertions();
+        $code = $transformation->transform($this->createUriMock());
+    }
+
+    /** @return array<int[]> */
+    public static function getSizesInPx(): array
+    {
+        return [
+            [10],
+            [100],
+            [400],
+            [1_000],
+        ];
+    }
+
+    #[Depends('testConstructorWithPositiveNumber')]
+    #[DataProvider('getSizesInPx')]
+    public function testTransformWithSizes(int $size_in_px): void
+    {
+        $transformation = new ToSvgQrCodeTransformation(ErrorCorrectionLevel::LOW, $size_in_px);
+        $this->expectNotToPerformAssertions();
+        $code = $transformation->transform($this->createUriMock());
+    }
+
+    protected function createUriMock(): \ILIAS\Data\URI & MockObject
+    {
+        $uri_mock = $this->createMock(\ILIAS\Data\URI::class);
+        $uri_mock->method('__toString')->willReturn('https://ilias.ch');
+        return $uri_mock;
+    }
+}

--- a/components/ILIAS/UI/tests/Component/Tree/Node/NodeTest.php
+++ b/components/ILIAS/UI/tests/Component/Tree/Node/NodeTest.php
@@ -25,7 +25,7 @@ use ILIAS\Data\URI;
 use ILIAS\UI\Implementation\Component\Tree\Node\Node;
 use ILIAS\UI\Implementation\Component as I;
 use ILIAS\UI\Component\Clickable;
-use ILIAS\Refinery\URI\StringTransformation;
+use ILIAS\Refinery\URI\Transformation\ToStringTransformation;
 
 /**
  * Dummy-implementation for testing
@@ -116,7 +116,7 @@ class NodeTest extends ILIAS_UI_TestBase
 
         $node = $node->withLink($uri);
 
-        $stringTransformation = new StringTransformation();
+        $stringTransformation = new ToStringTransformation();
 
         $this->assertEquals('http://google.de:8080', $stringTransformation->transform($node->getLink()));
     }

--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,8 @@
 		"psr/http-message": "^2.0",
 		"jumbojett/openid-connect-php": "dev-master#bc719cc9930990a4a9916cc127b839b4ed1c89ad",
 		"phpunit/phpunit": "^11.5",
-		"phiki/phiki": "^2.0"
+		"phiki/phiki": "^2.0",
+		"bacon/bacon-qr-code": "^3.0"
 	},
 	"require-dev": {
 		"captainhook/captainhook": "^5.24",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,63 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6416031c9db2af93c7803503138cbfb8",
+    "content-hash": "ffd4d8aedd4395fb5ced5457f966659e",
     "packages": [
+        {
+            "name": "bacon/bacon-qr-code",
+            "version": "v3.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Bacon/BaconQrCode.git",
+                "reference": "3feed0e212b8412cc5d2612706744789b0615824"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Bacon/BaconQrCode/zipball/3feed0e212b8412cc5d2612706744789b0615824",
+                "reference": "3feed0e212b8412cc5d2612706744789b0615824",
+                "shasum": ""
+            },
+            "require": {
+                "dasprid/enum": "^1.0.3",
+                "ext-iconv": "*",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "phly/keep-a-changelog": "^2.12",
+                "phpunit/phpunit": "^10.5.11 || ^11.0.4",
+                "spatie/phpunit-snapshot-assertions": "^5.1.5",
+                "spatie/pixelmatch-php": "^1.2.0",
+                "squizlabs/php_codesniffer": "^3.9"
+            },
+            "suggest": {
+                "ext-imagick": "to generate QR code images"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "BaconQrCode\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Scholzen 'DASPRiD'",
+                    "email": "mail@dasprids.de",
+                    "homepage": "https://dasprids.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "BaconQrCode is a QR code generator for PHP.",
+            "homepage": "https://github.com/Bacon/BaconQrCode",
+            "support": {
+                "issues": "https://github.com/Bacon/BaconQrCode/issues",
+                "source": "https://github.com/Bacon/BaconQrCode/tree/v3.0.4"
+            },
+            "time": "2026-03-16T01:01:30+00:00"
+        },
         {
             "name": "brick/math",
             "version": "0.14.8",
@@ -189,6 +244,56 @@
                 }
             ],
             "time": "2024-11-12T16:29:46+00:00"
+        },
+        {
+            "name": "dasprid/enum",
+            "version": "1.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DASPRiD/Enum.git",
+                "reference": "b5874fa9ed0043116c72162ec7f4fb50e02e7cce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DASPRiD/Enum/zipball/b5874fa9ed0043116c72162ec7f4fb50e02e7cce",
+                "reference": "b5874fa9ed0043116c72162ec7f4fb50e02e7cce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1 <9.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7 || ^8 || ^9 || ^10 || ^11",
+                "squizlabs/php_codesniffer": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DASPRiD\\Enum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Scholzen 'DASPRiD'",
+                    "email": "mail@dasprids.de",
+                    "homepage": "https://dasprids.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP 7.1 enum implementation",
+            "keywords": [
+                "enum",
+                "map"
+            ],
+            "support": {
+                "issues": "https://github.com/DASPRiD/Enum/issues",
+                "source": "https://github.com/DASPRiD/Enum/tree/1.0.7"
+            },
+            "time": "2025-09-16T12:23:56+00:00"
         },
         {
             "name": "dflydev/dot-access-data",


### PR DESCRIPTION
Hi @mjansenDatabay,

This is the first iteration of my QR code abstraction for ILIAS, which I plan on using inside the UI framework to convert `ILIAS\Data\URI` objects into a QR code which can be embedded inline as a data URI.

I haven't worked out the exact details of the UI interface yet, so there may be changes in the meantime, but I'd still like to hear your 5 cents about this – it doesn't need to be an in-depth code review just yet. I will also wait with the JF label until you have approved of the details, although I will post the formal request in here some time soon already.

What I have worked out:

- I have evaluated different QR code generation libraries, the one used here is the most low-level and widely used one, but details will come soon. Important to note is that all of them require two settings in addition to the string data which should be encoded: the [error correction level](#https://www.qrcode.com/en/about/error_correction.html) and some kind of size, which is not always the same though (size in px vs. size for byte-map). Replacing the library would be very easy, since they all seem to mimic the [ZXing library for Java](https://github.com/zxing/zxing).
- I have determined that an SVG is the most suitable output format, since we do not create temporary files (although an underlying library might do so, but this one doesn't) and can always work with strings and in memory. It also allows us to easily embed this as a data URI. It also still allows us to create and store the QR code as files ourselves later on.
- I also figured we need some DTO carrying the actual SVG data so it can be passed around between layers, in addition to some transformation that serves as the actual wrapper for the external library. Similar has been done for the markdown syntax.

What I haven't worked out (yet):

- I am not yet sure how the accessibility of QR codes can be ensured and implemented centrally. I think Data and Refinery are not the most appropriate location to do so, since making the QR code accessible seems responsibility of the UI layer – be that the UI framework or not. That's why I did not introduce the "raw data" or some kind of "alternate text" attribute to the DTO, although I might change this in the future.
- I was also kind of confused where to put the newly added objects (namespace and location), I figured for Data a new namespace made sense and for Refinery the String location is right. Let me know if you feel differently.
- I would have liked to use DI for the new transformation inside the Refinery. However, this isn't done anywhere else and I wondered whether this is deliberately or not. Not doing so obviously makes the added unit tests highly dependant on the actual implementation details of the library in use. Let me know if I should wire this feature using the bootstrap mechanism.

Looking forward to your thoughts.

Thx and kind regards,
@thibsy