### PR TITLE
T&A 46713: Failed Copy Question with Gap Combination

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.assClozeTest.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assClozeTest.php
@@ -791,7 +791,12 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
                 $target->getId(),
                 $this->gap_combinations,
             );
+
+            // Mantis 46713: The maximum points may have changed due to the combinations,
+            // so the question must be saved again
+            $target->saveToDb();
         }
+
         return $target;
     }
 


### PR DESCRIPTION
Hello everyone,

This PR addresses the issue described in ticket [46713](https://mantis.ilias.de/view.php?id=46713), where the points for cloze questions are not initially displayed correctly after being copied from another test.

Best regards,
@lukas-heinrich 