### PR TITLE
[FEATURE] Cron: Deprecate cron hook plugin and job provider interface

### DIFF
--- a/components/ILIAS/Cron/src/CronHookPlugin.php
+++ b/components/ILIAS/Cron/src/CronHookPlugin.php
@@ -22,6 +22,9 @@ namespace ILIAS\Cron;
 
 use ILIAS\Cron\Job\JobProvider;
 
+/**
+ * @deprecated 11.0 Cron jobs will be contributed by a component's <Component>.php file in future versions of ILIAS
+ */
 abstract class CronHookPlugin extends \ilPlugin implements JobProvider
 {
 }

--- a/components/ILIAS/Cron/src/Job/JobProvider.php
+++ b/components/ILIAS/Cron/src/Job/JobProvider.php
@@ -20,6 +20,9 @@ declare(strict_types=1);
 
 namespace ILIAS\Cron\Job;
 
+/**
+ * @deprecated 11.0 Cron jobs will be contributed by a component's <Component>.php file in future versions of ILIAS
+ */
 interface JobProvider
 {
     /**


### PR DESCRIPTION
This PR deprecates the cron hook plugin slot and the job provider interface, which enabled any kind of plugin to contribute cron jobs.

Since the removal (which bill be done with #11392 for ILIAS 12) is a "Breaking Change", I will announce this in the next JF meeting.