### PR TITLE
[fix] wrong input for loglevel

### DIFF
--- a/components/ILIAS/Container/classes/class.ilContainer.php
+++ b/components/ILIAS/Container/classes/class.ilContainer.php
@@ -887,7 +887,7 @@ class ilContainer extends ilObject
 
         $log = ilLoggerFactory::getLogger("cont");
         $log->debug(":::::::::::::::::::::::::::");
-        $log->logStack(10);
+        $log->logStack(ilLogLevel::DEBUG);
 
         //ilObjStyleSheet::writeStyleUsage($this->getId(), $this->getStyleSheetId());
 


### PR DESCRIPTION
Hello,

I was looking for an error related to a plugin and came across this one. I’m not sure which log level is the right one here, so I’m open to suggestions.

Kind regards,
UB