### PR TITLE
UI 46861: Failed test: Input - Field/File: show

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Dropzone/File/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Dropzone/File/Renderer.php
@@ -37,9 +37,6 @@ class Renderer extends AbstractComponentRenderer
 {
     public function render(Component $component, RenderInterface $default_renderer): string
     {
-        if ($component instanceof \ILIAS\UI\Component\Triggerer) {
-            $component = $this->addTriggererOnLoadCode($component);
-        }
         if ($component instanceof \ILIAS\UI\Component\Dropzone\File\Wrapper) {
             return $this->renderWrapper($component, $default_renderer);
         }
@@ -67,6 +64,7 @@ class Renderer extends AbstractComponentRenderer
 
         $dropzone = $this->initClientsideDropzone($dropzone);
         $dropzone = $dropzone->withAdditionalDrop($modal->getShowSignal());
+        $dropzone = $this->addTriggererOnLoadCode($dropzone);
 
         $this->bindAndApplyJavaScript($dropzone, $template);
 
@@ -100,6 +98,7 @@ class Renderer extends AbstractComponentRenderer
 
         $dropzone = $this->initClientsideDropzone($dropzone);
         $dropzone = $dropzone->withAdditionalDrop($modal->getShowSignal());
+        $dropzone = $this->addTriggererOnLoadCode($dropzone);
 
         $this->bindAndApplyJavaScript($dropzone, $template);
 


### PR DESCRIPTION
This PR attempts to fix https://mantis.ilias.de/view.php?id=46861.

The universal `addTriggererOnLoadCode` was always called before the dropzone triggers were actually initialized, resulting in the onLoadCode not being added.

Kind regards,
@aaronbidzan 

/cc @oliversamoila 