### PR TITLE
[Survey]: Trunk survey participants info message

### DIFF
--- a/components/ILIAS/Survey/Participants/class.ilSurveyParticipantsGUI.php
+++ b/components/ILIAS/Survey/Participants/class.ilSurveyParticipantsGUI.php
@@ -139,6 +139,8 @@ class ilSurveyParticipantsGUI
                         array(
                             )
                     );
+                    $this->tpl->setOnScreenMessage('info', $lng->txt("svy_info_participants"), true);
+
                     $rep_search->setTitle($lng->txt("svy_invite_participants"));
                     // Set tabs
                     $this->ctrl->setReturn($this, 'maintenance');

--- a/lang/ilias_ar.lang
+++ b/lang/ilias_ar.lang
@@ -16987,6 +16987,7 @@ svy#:#svy_codes#:#Access Codes###07 02 2020 new variable
 svy#:#svy_current_page#:#Current Page###29 07 2022 new variable
 svy#:#svy_finish_survey#:#Finish survey '%1'###07 02 2020 new variable
 svy#:#svy_finished_x_appraisees#:#You have finished the survey for %s appraisee(s).###28 10 2024 new variable
+svy#:#svy_info_participants#:#أضف المستخدمين كمشاركين في هذا الاستبيان باستخدام أحد خيارات البحث التالية. ستتم إضافة الاستبيان لهؤلاء المستخدمين كمهمة في لوحة التحكم الخاصة بهم.
 svy#:#svy_information#:#Information###28 10 2024 new variable
 svy#:#svy_invite_participants#:#Invite Participants###07 02 2020 new variable
 svy#:#svy_link_to_svy#:#Link to Survey###26 08 2024 new variable

--- a/lang/ilias_bg.lang
+++ b/lang/ilias_bg.lang
@@ -16987,6 +16987,7 @@ svy#:#svy_codes#:#Access Codes###07 02 2020 new variable
 svy#:#svy_current_page#:#Current Page###29 07 2022 new variable
 svy#:#svy_finish_survey#:#Finish survey '%1'###07 02 2020 new variable
 svy#:#svy_finished_x_appraisees#:#You have finished the survey for %s appraisee(s).###28 10 2024 new variable
+svy#:#svy_info_participants#:#Добавете потребители като участници в тази анкета, като използвате една от следните опции за търсене. Анкетата ще бъде добавена за тези потребители като задача в таблото им.
 svy#:#svy_information#:#Information###28 10 2024 new variable
 svy#:#svy_invite_participants#:#Invite Participants###07 02 2020 new variable
 svy#:#svy_link_to_svy#:#Link to Survey###26 08 2024 new variable

--- a/lang/ilias_cs.lang
+++ b/lang/ilias_cs.lang
@@ -16987,6 +16987,7 @@ svy#:#svy_codes#:#Access Codes###07 02 2020 new variable
 svy#:#svy_current_page#:#Current Page###29 07 2022 new variable
 svy#:#svy_finish_survey#:#Finish survey '%1'###07 02 2020 new variable
 svy#:#svy_finished_x_appraisees#:#You have finished the survey for %s appraisee(s).###28 10 2024 new variable
+svy#:#svy_info_participants#:#Přidejte uživatele jako účastníky tohoto průzkumu pomocí jedné z následujících možností vyhledávání. Tento průzkum bude těmto uživatelům přidán jako úkol na jejich nástěnce.
 svy#:#svy_information#:#Information###28 10 2024 new variable
 svy#:#svy_invite_participants#:#Invite Participants###07 02 2020 new variable
 svy#:#svy_link_to_svy#:#Link to Survey###26 08 2024 new variable

--- a/lang/ilias_da.lang
+++ b/lang/ilias_da.lang
@@ -16987,6 +16987,7 @@ svy#:#svy_codes#:#Access Codes###07 02 2020 new variable
 svy#:#svy_current_page#:#Current Page###29 07 2022 new variable
 svy#:#svy_finish_survey#:#Finish survey '%1'###07 02 2020 new variable
 svy#:#svy_finished_x_appraisees#:#You have finished the survey for %s appraisee(s).###28 10 2024 new variable
+svy#:#svy_info_participants#:#Tilføj brugere som deltagere i denne undersøgelse ved at bruge en af følgende søgemuligheder. Undersøgelsen bliver tilføjet som en opgave på disse brugeres dashboard.
 svy#:#svy_information#:#Information###28 10 2024 new variable
 svy#:#svy_invite_participants#:#Invite Participants###07 02 2020 new variable
 svy#:#svy_link_to_svy#:#Link to Survey###26 08 2024 new variable

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -17082,6 +17082,7 @@ svy#:#svy_codes#:#Zugangscodes
 svy#:#svy_current_page#:#Aktuelle Seite
 svy#:#svy_finish_survey#:#An Umfrage "%1" teilnehmen
 svy#:#svy_finished_x_appraisees#:#Sie haben Bewertungen bereits für %s Feedback-Nehmer abgegeben. 
+svy#:#svy_info_participants#:#Fügen Sie Personen zu der Umfrage hinzu. Hierfür stehen unterschiedliche Suchmöglichkeiten zur Auswahl. Nach dem Hinzufügen wird die Umfrage den ausgewählten Personen automatisch als „To-Do“ im Dashboard angezeigt.
 svy#:#svy_information#:#Information
 svy#:#svy_invite_participants#:#Personen hinzufügen
 svy#:#svy_link_to_svy#:#Link zur Umfrage

--- a/lang/ilias_el.lang
+++ b/lang/ilias_el.lang
@@ -16988,6 +16988,7 @@ svy#:#svy_codes#:#Access Codes###07 02 2020 new variable
 svy#:#svy_current_page#:#Current Page###29 07 2022 new variable
 svy#:#svy_finish_survey#:#Finish survey '%1'###07 02 2020 new variable
 svy#:#svy_finished_x_appraisees#:#You have finished the survey for %s appraisee(s).###28 10 2024 new variable
+svy#:#svy_info_participants#:#Προσθέστε χρήστες ως συμμετέχοντες σε αυτήν την έρευνα χρησιμοποιώντας μία από τις ακόλουθες επιλογές αναζήτησης. Η έρευνα θα προστεθεί για αυτούς τους χρήστες ως εργασία στον πίνακα ελέγχου τους.
 svy#:#svy_information#:#Information###28 10 2024 new variable
 svy#:#svy_invite_participants#:#Invite Participants###07 02 2020 new variable
 svy#:#svy_link_to_svy#:#Link to Survey###26 08 2024 new variable

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -17034,6 +17034,7 @@ svy#:#svy_codes#:#Access Codes
 svy#:#svy_current_page#:#Current Page
 svy#:#svy_finish_survey#:#Take part in survey ‘%1’
 svy#:#svy_finished_x_appraisees#:#You have already left feedback for %s appraisee(s).
+svy#:#svy_info_participants#:#Add users as participants of this survey using one of the following search options. These users will have the survey added as a task on their dashboard.
 svy#:#svy_information#:#Information
 svy#:#svy_invite_participants#:#Add to Tasks of Users
 svy#:#svy_link_to_svy#:#Link to Survey

--- a/lang/ilias_es.lang
+++ b/lang/ilias_es.lang
@@ -16989,6 +16989,7 @@ svy#:#svy_codes#:#Access Codes###07 02 2020 new variable
 svy#:#svy_current_page#:#Current Page###29 07 2022 new variable
 svy#:#svy_finish_survey#:#Finish survey '%1'###07 02 2020 new variable
 svy#:#svy_finished_x_appraisees#:#You have finished the survey for %s appraisee(s).###28 10 2024 new variable
+svy#:#svy_info_participants#:#Añada usuarios como participantes de esta encuesta utilizando una de las siguientes opciones de búsqueda. La encuesta se añadirá como tarea en el panel de estos usuarios.
 svy#:#svy_information#:#Information###28 10 2024 new variable
 svy#:#svy_invite_participants#:#Invite Participants###07 02 2020 new variable
 svy#:#svy_link_to_svy#:#Link to Survey###26 08 2024 new variable

--- a/lang/ilias_et.lang
+++ b/lang/ilias_et.lang
@@ -16987,6 +16987,7 @@ svy#:#svy_codes#:#Access Codes###07 02 2020 new variable
 svy#:#svy_current_page#:#Current Page###29 07 2022 new variable
 svy#:#svy_finish_survey#:#Finish survey '%1'###07 02 2020 new variable
 svy#:#svy_finished_x_appraisees#:#You have finished the survey for %s appraisee(s).###28 10 2024 new variable
+svy#:#svy_info_participants#:#Lisage kasutajad selle küsitluse osalejateks, kasutades üht järgmistest otsinguvõimalustest. Küsitlus lisatakse nende kasutajate töölauale ülesandena.
 svy#:#svy_information#:#Information###28 10 2024 new variable
 svy#:#svy_invite_participants#:#Invite Participants###07 02 2020 new variable
 svy#:#svy_link_to_svy#:#Link to Survey###26 08 2024 new variable

--- a/lang/ilias_fa.lang
+++ b/lang/ilias_fa.lang
@@ -16988,6 +16988,7 @@ svy#:#svy_codes#:#Access Codes###07 02 2020 new variable
 svy#:#svy_current_page#:#Current Page###29 07 2022 new variable
 svy#:#svy_finish_survey#:#Finish survey '%1'###07 02 2020 new variable
 svy#:#svy_finished_x_appraisees#:#You have finished the survey for %s appraisee(s).###28 10 2024 new variable
+svy#:#svy_info_participants#:#کاربران را با استفاده از یکی از گزینه‌های جست‌وجوی زیر به عنوان شرکت‌کنندگان این نظرسنجی اضافه کنید. این نظرسنجی به صورت یک وظیفه در پیشخوان این کاربران اضافه خواهد شد.
 svy#:#svy_information#:#Information###28 10 2024 new variable
 svy#:#svy_invite_participants#:#Invite Participants###07 02 2020 new variable
 svy#:#svy_link_to_svy#:#Link to Survey###26 08 2024 new variable

--- a/lang/ilias_fr.lang
+++ b/lang/ilias_fr.lang
@@ -16972,6 +16972,7 @@ svy#:#svy_codes#:#Access Codes
 svy#:#svy_current_page#:#Current Page###31 10 2023 new variable
 svy#:#svy_finish_survey#:#Finish survey '%1'
 svy#:#svy_finished_x_appraisees#:#You have finished the survey for %s appraisee(s).###28 10 2024 new variable
+svy#:#svy_info_participants#:#Ajoutez des utilisateurs comme participants à cette enquête en utilisant l'une des options de recherche suivantes. L'enquête sera ajoutée comme tâche sur le tableau de bord de ces utilisateurs.
 svy#:#svy_information#:#Information###28 10 2024 new variable
 svy#:#svy_invite_participants#:#Invite Participants
 svy#:#svy_link_to_svy#:#Link to Survey###31 10 2023 new variable

--- a/lang/ilias_hr.lang
+++ b/lang/ilias_hr.lang
@@ -16987,6 +16987,7 @@ svy#:#svy_codes#:#Access Codes###04 06 2021 new variable
 svy#:#svy_current_page#:#Current Page###29 07 2022 new variable
 svy#:#svy_finish_survey#:#Finish survey '%1'###04 06 2021 new variable
 svy#:#svy_finished_x_appraisees#:#You have finished the survey for %s appraisee(s).###28 10 2024 new variable
+svy#:#svy_info_participants#:#Dodajte korisnike kao sudionike ove ankete koristeći jednu od sljedećih mogućnosti pretraživanja. Anketa će tim korisnicima biti dodana kao zadatak na njihovoj nadzornoj ploči.
 svy#:#svy_information#:#Information###28 10 2024 new variable
 svy#:#svy_invite_participants#:#Invite Participants###04 06 2021 new variable
 svy#:#svy_link_to_svy#:#Link to Survey###26 08 2024 new variable

--- a/lang/ilias_hu.lang
+++ b/lang/ilias_hu.lang
@@ -16988,6 +16988,7 @@ svy#:#svy_codes#:#Hozzáférési kódok
 svy#:#svy_current_page#:#Current Page###29 07 2022 new variable
 svy#:#svy_finish_survey#:#'%1' kérdőív befejezése
 svy#:#svy_finished_x_appraisees#:#You have finished the survey for %s appraisee(s).###28 10 2024 new variable
+svy#:#svy_info_participants#:#Adjon hozzá felhasználókat a felmérés résztvevőiként az alábbi keresési lehetőségek egyikével. A felmérés feladatként jelenik meg ezeknek a felhasználóknak az irányítópultján.
 svy#:#svy_information#:#Information###28 10 2024 new variable
 svy#:#svy_invite_participants#:#Résztvevők meghívása
 svy#:#svy_link_to_svy#:#Link to Survey###26 08 2024 new variable

--- a/lang/ilias_it.lang
+++ b/lang/ilias_it.lang
@@ -16994,6 +16994,7 @@ svy#:#svy_codes#:#Codici di accesso
 svy#:#svy_current_page#:#Current Page###31 03 2023 new variable
 svy#:#svy_finish_survey#:#Finish survey '%1'
 svy#:#svy_finished_x_appraisees#:#You have already completed the survey for %s appraisee(s).###28 11 2025 new variable
+svy#:#svy_info_participants#:#Aggiungi utenti come partecipanti a questo sondaggio utilizzando una delle seguenti opzioni di ricerca. Il sondaggio verrà aggiunto come attività nella dashboard di questi utenti.
 svy#:#svy_information#:#Information###28 11 2025 new variable
 svy#:#svy_invite_participants#:#Invita partecipanti
 svy#:#svy_link_to_svy#:#Link to Survey###31 03 2023 new variable

--- a/lang/ilias_ja.lang
+++ b/lang/ilias_ja.lang
@@ -16988,6 +16988,7 @@ svy#:#svy_codes#:#アクセスコード
 svy#:#svy_current_page#:#Current Page###19 08 2022 new variable
 svy#:#svy_finish_survey#:#サーベイ'%1'を修了
 svy#:#svy_finished_x_appraisees#:#You have finished the survey for %s appraisee(s).###28 10 2024 new variable
+svy#:#svy_info_participants#:#次のいずれかの検索オプションを使用して、このアンケートにユーザーを参加者として追加します。追加されたユーザーには、このアンケートがダッシュボード上のタスクとして表示されます。
 svy#:#svy_information#:#Information###28 10 2024 new variable
 svy#:#svy_invite_participants#:#参加者を招待
 svy#:#svy_link_to_svy#:#Link to Survey###26 08 2024 new variable

--- a/lang/ilias_ka.lang
+++ b/lang/ilias_ka.lang
@@ -16987,6 +16987,7 @@ svy#:#svy_codes#:#Access Codes###07 02 2020 new variable
 svy#:#svy_current_page#:#Current Page###29 07 2022 new variable
 svy#:#svy_finish_survey#:#Finish survey '%1'###07 02 2020 new variable
 svy#:#svy_finished_x_appraisees#:#You have finished the survey for %s appraisee(s).###28 10 2024 new variable
+svy#:#svy_info_participants#:#დაამატეთ მომხმარებლები ამ გამოკითხვის მონაწილეებად ქვემოთ მოცემული ძიების ერთ-ერთი ვარიანტის გამოყენებით. გამოკითხვა ამ მომხმარებლებს დაფაზე ამოცანის სახით დაემატება.
 svy#:#svy_information#:#Information###28 10 2024 new variable
 svy#:#svy_invite_participants#:#Invite Participants###07 02 2020 new variable
 svy#:#svy_link_to_svy#:#Link to Survey###26 08 2024 new variable

--- a/lang/ilias_lt.lang
+++ b/lang/ilias_lt.lang
@@ -16987,6 +16987,7 @@ svy#:#svy_codes#:#Access Codes###07 02 2020 new variable
 svy#:#svy_current_page#:#Current Page###29 07 2022 new variable
 svy#:#svy_finish_survey#:#Finish survey '%1'###07 02 2020 new variable
 svy#:#svy_finished_x_appraisees#:#You have finished the survey for %s appraisee(s).###28 10 2024 new variable
+svy#:#svy_info_participants#:#Pridėkite naudotojus kaip šios apklausos dalyvius naudodami vieną iš šių paieškos parinkčių. Ši apklausa bus pridėta šiems naudotojams kaip užduotis jų valdymo skydelyje.
 svy#:#svy_information#:#Information###28 10 2024 new variable
 svy#:#svy_invite_participants#:#Invite Participants###07 02 2020 new variable
 svy#:#svy_link_to_svy#:#Link to Survey###26 08 2024 new variable

--- a/lang/ilias_nl.lang
+++ b/lang/ilias_nl.lang
@@ -16988,6 +16988,7 @@ svy#:#svy_codes#:#Access Codes###07 02 2020 new variable
 svy#:#svy_current_page#:#Current Page###29 07 2022 new variable
 svy#:#svy_finish_survey#:#Finish survey '%1'###07 02 2020 new variable
 svy#:#svy_finished_x_appraisees#:#You have finished the survey for %s appraisee(s).###28 10 2024 new variable
+svy#:#svy_info_participants#:#Voeg gebruikers als deelnemers aan deze enquête toe met een van de volgende zoekopties. De enquête wordt voor deze gebruikers als taak toegevoegd aan hun dashboard.
 svy#:#svy_information#:#Information###28 10 2024 new variable
 svy#:#svy_invite_participants#:#Invite Participants###07 02 2020 new variable
 svy#:#svy_link_to_svy#:#Link to Survey###26 08 2024 new variable

--- a/lang/ilias_pl.lang
+++ b/lang/ilias_pl.lang
@@ -16987,6 +16987,7 @@ svy#:#svy_codes#:#Access Codes###07 02 2020 new variable
 svy#:#svy_current_page#:#Current Page###29 07 2022 new variable
 svy#:#svy_finish_survey#:#Finish survey '%1'###07 02 2020 new variable
 svy#:#svy_finished_x_appraisees#:#You have finished the survey for %s appraisee(s).###28 10 2024 new variable
+svy#:#svy_info_participants#:#Dodaj użytkowników jako uczestników tej ankiety, korzystając z jednej z poniższych opcji wyszukiwania. Ankieta zostanie dodana tym użytkownikom jako zadanie na ich pulpicie.
 svy#:#svy_information#:#Information###28 10 2024 new variable
 svy#:#svy_invite_participants#:#Invite Participants###07 02 2020 new variable
 svy#:#svy_link_to_svy#:#Link to Survey###26 08 2024 new variable

--- a/lang/ilias_pt.lang
+++ b/lang/ilias_pt.lang
@@ -16987,6 +16987,7 @@ svy#:#svy_codes#:#Access Codes###07 02 2020 new variable
 svy#:#svy_current_page#:#Current Page###29 07 2022 new variable
 svy#:#svy_finish_survey#:#Finish survey '%1'###07 02 2020 new variable
 svy#:#svy_finished_x_appraisees#:#You have finished the survey for %s appraisee(s).###28 10 2024 new variable
+svy#:#svy_info_participants#:#Adicione utilizadores como participantes deste inquérito utilizando uma das seguintes opções de pesquisa. O inquérito será adicionado como tarefa ao painel destes utilizadores.
 svy#:#svy_information#:#Information###28 10 2024 new variable
 svy#:#svy_invite_participants#:#Invite Participants###07 02 2020 new variable
 svy#:#svy_link_to_svy#:#Link to Survey###26 08 2024 new variable

--- a/lang/ilias_ro.lang
+++ b/lang/ilias_ro.lang
@@ -16987,6 +16987,7 @@ svy#:#svy_codes#:#Access Codes###07 02 2020 new variable
 svy#:#svy_current_page#:#Current Page###29 07 2022 new variable
 svy#:#svy_finish_survey#:#Finish survey '%1'###07 02 2020 new variable
 svy#:#svy_finished_x_appraisees#:#You have finished the survey for %s appraisee(s).###28 10 2024 new variable
+svy#:#svy_info_participants#:#Adăugați utilizatori ca participanți la acest sondaj folosind una dintre următoarele opțiuni de căutare. Sondajul va fi adăugat pentru acești utilizatori ca sarcină în tabloul lor de bord.
 svy#:#svy_information#:#Information###28 10 2024 new variable
 svy#:#svy_invite_participants#:#Invite Participants###07 02 2020 new variable
 svy#:#svy_link_to_svy#:#Link to Survey###26 08 2024 new variable

--- a/lang/ilias_ru.lang
+++ b/lang/ilias_ru.lang
@@ -16987,6 +16987,7 @@ svy#:#svy_codes#:#Access Codes###07 02 2020 new variable
 svy#:#svy_current_page#:#Current Page###29 07 2022 new variable
 svy#:#svy_finish_survey#:#Finish survey '%1'###07 02 2020 new variable
 svy#:#svy_finished_x_appraisees#:#You have finished the survey for %s appraisee(s).###28 10 2024 new variable
+svy#:#svy_info_participants#:#Добавьте пользователей в качестве участников этого опроса, используя один из следующих вариантов поиска. Опрос будет добавлен для этих пользователей как задача на их панели управления.
 svy#:#svy_information#:#Information###28 10 2024 new variable
 svy#:#svy_invite_participants#:#Invite Participants###07 02 2020 new variable
 svy#:#svy_link_to_svy#:#Link to Survey###26 08 2024 new variable

--- a/lang/ilias_sk.lang
+++ b/lang/ilias_sk.lang
@@ -16987,6 +16987,7 @@ svy#:#svy_codes#:#Access Codes###07 02 2020 new variable
 svy#:#svy_current_page#:#Current Page###29 07 2022 new variable
 svy#:#svy_finish_survey#:#Finish survey '%1'###07 02 2020 new variable
 svy#:#svy_finished_x_appraisees#:#You have finished the survey for %s appraisee(s).###28 10 2024 new variable
+svy#:#svy_info_participants#:#Pridajte používateľov ako účastníkov tohto prieskumu pomocou jednej z nasledujúcich možností vyhľadávania. Prieskum bude týmto používateľom pridaný ako úloha na ich nástenke.
 svy#:#svy_information#:#Information###28 10 2024 new variable
 svy#:#svy_invite_participants#:#Invite Participants###07 02 2020 new variable
 svy#:#svy_link_to_svy#:#Link to Survey###26 08 2024 new variable

--- a/lang/ilias_sl.lang
+++ b/lang/ilias_sl.lang
@@ -16987,6 +16987,7 @@ svy#:#svy_codes#:#Access Codes
 svy#:#svy_current_page#:#Current Page###19 08 2022 new variable
 svy#:#svy_finish_survey#:#Finish survey '%1'
 svy#:#svy_finished_x_appraisees#:#You have finished the survey for %s appraisee(s).###28 10 2024 new variable
+svy#:#svy_info_participants#:#Dodajte uporabnike kot udeležence te ankete z eno od naslednjih možnosti iskanja. Anketa bo tem uporabnikom dodana kot naloga na njihovi nadzorni plošči.
 svy#:#svy_information#:#Information###28 10 2024 new variable
 svy#:#svy_invite_participants#:#Invite Participants
 svy#:#svy_link_to_svy#:#Link to Survey###26 08 2024 new variable

--- a/lang/ilias_sq.lang
+++ b/lang/ilias_sq.lang
@@ -16987,6 +16987,7 @@ svy#:#svy_codes#:#Access Codes###07 02 2020 new variable
 svy#:#svy_current_page#:#Current Page###29 07 2022 new variable
 svy#:#svy_finish_survey#:#Finish survey '%1'###07 02 2020 new variable
 svy#:#svy_finished_x_appraisees#:#You have finished the survey for %s appraisee(s).###28 10 2024 new variable
+svy#:#svy_info_participants#:#Shtoni përdorues si pjesëmarrës në këtë anketë duke përdorur një nga opsionet e mëposhtme të kërkimit. Anketa do t'u shtohet këtyre përdoruesve si detyrë në panelin e tyre.
 svy#:#svy_information#:#Information###28 10 2024 new variable
 svy#:#svy_invite_participants#:#Invite Participants###07 02 2020 new variable
 svy#:#svy_link_to_svy#:#Link to Survey###26 08 2024 new variable

--- a/lang/ilias_sr.lang
+++ b/lang/ilias_sr.lang
@@ -16987,6 +16987,7 @@ svy#:#svy_codes#:#Access Codes###07 02 2020 new variable
 svy#:#svy_current_page#:#Current Page###29 07 2022 new variable
 svy#:#svy_finish_survey#:#Finish survey '%1'###07 02 2020 new variable
 svy#:#svy_finished_x_appraisees#:#You have finished the survey for %s appraisee(s).###28 10 2024 new variable
+svy#:#svy_info_participants#:#Dodajte korisnike kao učesnike ove ankete koristeći jednu od sledećih opcija pretrage. Anketa će ovim korisnicima biti dodata kao zadatak na njihovoj kontrolnoj tabli.
 svy#:#svy_information#:#Information###28 10 2024 new variable
 svy#:#svy_invite_participants#:#Invite Participants###07 02 2020 new variable
 svy#:#svy_link_to_svy#:#Link to Survey###26 08 2024 new variable

--- a/lang/ilias_sv.lang
+++ b/lang/ilias_sv.lang
@@ -16987,6 +16987,7 @@ svy#:#svy_codes#:#Nyckel för åtkomst
 svy#:#svy_current_page#:#Aktuell sida
 svy#:#svy_finish_survey#:#Redigera undersökning "%1
 svy#:#svy_finished_x_appraisees#:#You have finished the survey for %s appraisee(s).###28 10 2024 new variable
+svy#:#svy_info_participants#:#Lägg till användare som deltagare i den här enkäten med ett av följande sökalternativ. Enkäten läggs till för dessa användare som en uppgift på deras instrumentpanel.
 svy#:#svy_information#:#Information###28 10 2024 new variable
 svy#:#svy_invite_participants#:#Bjud in deltagare
 svy#:#svy_link_to_svy#:#Länk till undersökningen

--- a/lang/ilias_tr.lang
+++ b/lang/ilias_tr.lang
@@ -16987,6 +16987,7 @@ svy#:#svy_codes#:#Access Codes###07 02 2020 new variable
 svy#:#svy_current_page#:#Current Page###29 07 2022 new variable
 svy#:#svy_finish_survey#:#Finish survey '%1'###07 02 2020 new variable
 svy#:#svy_finished_x_appraisees#:#You have finished the survey for %s appraisee(s).###28 10 2024 new variable
+svy#:#svy_info_participants#:#Aşağıdaki arama seçeneklerinden birini kullanarak kullanıcıları bu anketin katılımcıları olarak ekleyin. Anket, bu kullanıcıların panosuna bir görev olarak eklenecektir.
 svy#:#svy_information#:#Information###28 10 2024 new variable
 svy#:#svy_invite_participants#:#Invite Participants###07 02 2020 new variable
 svy#:#svy_link_to_svy#:#Link to Survey###26 08 2024 new variable

--- a/lang/ilias_uk.lang
+++ b/lang/ilias_uk.lang
@@ -16987,6 +16987,7 @@ svy#:#svy_codes#:#Access Codes###07 02 2020 new variable
 svy#:#svy_current_page#:#Current Page###29 07 2022 new variable
 svy#:#svy_finish_survey#:#Finish survey '%1'###07 02 2020 new variable
 svy#:#svy_finished_x_appraisees#:#You have finished the survey for %s appraisee(s).###28 10 2024 new variable
+svy#:#svy_info_participants#:#Додайте користувачів як учасників цього опитування, використовуючи один із наведених нижче варіантів пошуку. Це опитування буде додано для цих користувачів як завдання на їхній інформаційній панелі.
 svy#:#svy_information#:#Information###28 10 2024 new variable
 svy#:#svy_invite_participants#:#Invite Participants###07 02 2020 new variable
 svy#:#svy_link_to_svy#:#Link to Survey###26 08 2024 new variable

--- a/lang/ilias_vi.lang
+++ b/lang/ilias_vi.lang
@@ -16989,6 +16989,7 @@ svy#:#svy_codes#:#Access Codes###07 02 2020 new variable
 svy#:#svy_current_page#:#Current Page###29 07 2022 new variable
 svy#:#svy_finish_survey#:#Finish survey '%1'###07 02 2020 new variable
 svy#:#svy_finished_x_appraisees#:#You have finished the survey for %s appraisee(s).###28 10 2024 new variable
+svy#:#svy_info_participants#:#Thêm người dùng làm người tham gia khảo sát này bằng một trong các tùy chọn tìm kiếm sau. Khảo sát sẽ được thêm vào bảng điều khiển của những người dùng này dưới dạng một tác vụ.
 svy#:#svy_information#:#Information###28 10 2024 new variable
 svy#:#svy_invite_participants#:#Invite Participants###07 02 2020 new variable
 svy#:#svy_link_to_svy#:#Link to Survey###26 08 2024 new variable

--- a/lang/ilias_zh.lang
+++ b/lang/ilias_zh.lang
@@ -16986,6 +16986,7 @@ svy#:#svy_codes#:#Access Codes###07 02 2020 new variable
 svy#:#svy_current_page#:#Current Page###29 07 2022 new variable
 svy#:#svy_finish_survey#:#Finish survey '%1'###07 02 2020 new variable
 svy#:#svy_finished_x_appraisees#:#You have finished the survey for %s appraisee(s).###28 10 2024 new variable
+svy#:#svy_info_participants#:#使用以下任一搜索方式将用户添加为此调查的参与者。该调查将作为任务添加到这些用户的仪表板中。
 svy#:#svy_information#:#Information###28 10 2024 new variable
 svy#:#svy_invite_participants#:#Invite Participants###07 02 2020 new variable
 svy#:#svy_link_to_svy#:#Link to Survey###26 08 2024 new variable


### PR DESCRIPTION
**Add language variable and info message & language variable cleaning up**

- This PR was implemented following @Chris-Squirrel’s suggestion and feedback add a message providing information to the user when adding participants
-  It also cleans up language variables related to the investigation Chris and Nicole did

Related to : https://mantis.ilias.de/view.php?id=47350