### PR TITLE
[Survey] fix: Types in Editor and Question GUI

### DIFF
--- a/components/ILIAS/Survey/Editing/class.ilSurveyEditorGUI.php
+++ b/components/ILIAS/Survey/Editing/class.ilSurveyEditorGUI.php
@@ -224,7 +224,7 @@ class ilSurveyEditorGUI
             $ilToolbar->setFormAction($this->ctrl->getFormAction($this));
             $types = new ilSelectInputGUI($this->lng->txt("create_new"), "sel_question_types");
             $types->setOptions($qtypes);
-            $ilToolbar->addStickyItem($types, "");
+            $ilToolbar->addStickyItem($types, false);
 
             $this->gui->button(
                 $this->lng->txt("svy_create_question"),

--- a/components/ILIAS/SurveyQuestionPool/Questions/class.SurveyQuestionGUI.php
+++ b/components/ILIAS/SurveyQuestionPool/Questions/class.SurveyQuestionGUI.php
@@ -268,7 +268,7 @@ abstract class SurveyQuestionGUI
 
         // obligatory
         $shuffle = new ilCheckboxInputGUI($this->lng->txt("obligatory"), "obligatory");
-        $shuffle->setValue(1);
+        $shuffle->setValue("1");
         $shuffle->setRequired(false);
         $form->addItem($shuffle);
 


### PR DESCRIPTION
## Fix types along these classes

We have found that some types error appear after adding declare_strict types in these classes 

### Changes

- ```class.ilSurveyEditorGUI.php```
- ```class.SurveyQuestionGUI.php```

### Notes
- No functional changes intended