### PR TITLE
Composer: Add friendsofphp/php-cs-fixer as development dependency

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -41,6 +41,7 @@
 	"require": {
 	},
 	"require-dev": {
+		"friendsofphp/php-cs-fixer": "^3.94"
 	},
 	"autoload": {
 		"psr-4" : {


### PR DESCRIPTION
This PR proposes `friendsofphp/php-cs-fixer ` (v.3.94) as a composer development dependency.
The dependency was already used in ILIAS as Version 3.65.
Version 3.94 brings up no new conflicts.
The dependency is licensed under the [MIT License](https://mit-license.org).

Usage:
* Used in CI and dev processes to check and correct coding style.

Wrapped By:
* No

Reasoning:
* The dependency contributes to the unity of ILIASs code style and its compatibility with global standards by simplifying adaption of "dirty" code.
* By that it enhances the intercommunication within ILIAS and the intracommunication to third parties and new developers.

Maintenance:
* The library is under active maintenance. Updates occur daily.

Links:
* Packagist: https://packagist.org/packages/friendsofphp/php-cs-fixer
* GitHub: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer

Alternatives:
* There are lots of alternatives, but all are less frequently updated, less credible.
* Further, none is tried and tested in an ILIAS environment.