### PR TITLE
add phpunit/phpunit as a development dependency

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -41,6 +41,7 @@
 	"require": {
 	},
 	"require-dev": {
+		"phpunit/phpunit": "^13.0"
 	},
 	"autoload": {
 		"psr-4" : {


### PR DESCRIPTION
This PR proposes to add phpunit/phpunit (^13.0) as a composer development dependency. The dependency was already used in ILIAS 11 and below.

**Description:**
The PHPUnit dependency is used to run unit tests. 

**Reason to introduce this dependency:**
The PHPUnit dependency phpunit/phpunit is the standard framework to run unit tests in PHP. It is developed by Sebastian Bergmann, well maintained with regular commits and lists about 900 million installs on packagist. As of today we consider this as the de facto standard for php Unit testing and thus would like to introduce this development dependency into the next ILIAS release.

**Version:** ^13.0
**Licence:** BSD 3
**Type of dependency:** composer
**Dev-Dependency:** yes


**Vendor information:**

Packagist/NPM: https://packagist.org/packages/phpunit/phpunit
Github: https://github.com/sebastianbergmann/phpunit
Vendor Homepage: https://phpunit.de/index.html

Dep consolidation PR: https://github.com/ILIAS-eLearning/ILIAS/pull/11255