### PR TITLE
[FIX] Object/CustomIcon: Fix building "AccessFailureResult"

### DIFF
--- a/components/ILIAS/ILIASObject/classes/Properties/AdditionalProperties/Icon/class.ilObjectCustomIconUploadHandlerGUI.php
+++ b/components/ILIAS/ILIASObject/classes/Properties/AdditionalProperties/Icon/class.ilObjectCustomIconUploadHandlerGUI.php
@@ -69,7 +69,7 @@ class ilObjectCustomIconUploadHandlerGUI extends AbstractCtrlAwareUploadHandler 
         if ($this->has_access === false) {
             return $this->getAccessFailureResult(
                 $this->getFileIdentifierParameterName(),
-                $file_name,
+                '',
                 $this->language
             );
         }

--- a/components/ILIAS/ILIASObject/traits/Properties/ilObjectPropertiesUploadSecurityFunctionsTrait.php
+++ b/components/ILIAS/ILIASObject/traits/Properties/ilObjectPropertiesUploadSecurityFunctionsTrait.php
@@ -19,6 +19,7 @@
 declare(strict_types=1);
 
 use ILIAS\FileUpload\Handler\BasicHandlerResult;
+use ILIAS\FileUpload\Handler\HandlerResult;
 
 trait ilObjectPropertiesUploadSecurityFunctionsTrait
 {


### PR DESCRIPTION
This commit fixes an undefined variable when building the
`HandlerResult`.

1. An undefined variable `$file_name` is passed
2. The PHP namespace import is missing

Mantis Issue: https://mantis.ilias.de/view.php?id=47629