### PR TITLE
[IMPROVEMENT] User: Improve PHP types in `User/Search`

### DIFF
--- a/components/ILIAS/User/src/Search/AutocompleteItem.php
+++ b/components/ILIAS/User/src/Search/AutocompleteItem.php
@@ -28,8 +28,10 @@ interface AutocompleteItem
      * The returned tags will then again be filtered by the value in the property
      * "searchBy". If you need to show the tag even if you are not allowed to
      * divulge the full value of the field the search string was found in, you
-     * can simply reuse the search term here. See the
-     * `\ILIAS\User\Search\DefaultAutocompleteItem for an implementation of this.
+     * can simply reuse the search term here. See the {@see DefaultAutocompleteItem}
+     * for an implementation of this.
+     *
+     * @return array{value: string, display: string, searchBy: string}
      */
     public function getTagArray(): array;
 }

--- a/components/ILIAS/User/src/Search/DefaultEndpointConfigurator.php
+++ b/components/ILIAS/User/src/Search/DefaultEndpointConfigurator.php
@@ -20,12 +20,10 @@ declare(strict_types=1);
 
 namespace ILIAS\User\Search;
 
-class DefaultEndpointConfigurator implements EndpointConfigurator
+readonly class DefaultEndpointConfigurator implements EndpointConfigurator
 {
     /**
-     *
-     * @param list<string> $parent_class_path see:
-     * `\ILIAS\User\Search\EndpointConfigurator::getParentClassPath()`
+     * @param list<string> $parent_class_path like in {@see EndpointConfigurator::getParentClassPath()}
      */
     public function __construct(
         private array $parent_class_path

--- a/components/ILIAS/User/src/Search/EndpointConfigurator.php
+++ b/components/ILIAS/User/src/Search/EndpointConfigurator.php
@@ -24,13 +24,13 @@ interface EndpointConfigurator
 {
     /**
      * @return list<string> MUST return an array containing all class names in
-     * the path to be prepended to the EndpointGUI in order to build the URL
-     * with `ilCtrl`
+     * the path to be prepended to the EndpointGUI to build the URL
+     * with {@see \ilCtrlInterface}
      */
     public function getParentClassPath(): array;
 
     /**
-     * @return list<\ILIAS\User\Search\AutocompleteItem> Items that should be
+     * @return list<AutocompleteItem> Items that should be
      * added to the list the user can select from.
      */
     public function getAdditionalAnswerElements(


### PR DESCRIPTION
This PR improves the type documentation in the
`Search` sub-namespace of the "User" component.

If approved. please pick to `trunk` as well.