### PR TITLE
[IMPROVEMENT] User: Improve PHP types in `User/Settings`

### DIFF
--- a/components/ILIAS/Mail/classes/class.ilAccountMail.php
+++ b/components/ILIAS/Mail/classes/class.ilAccountMail.php
@@ -171,7 +171,7 @@ class ilAccountMail
         } else {
             $attachment = $amail->getAttachment($this->irss);
             if ($attachment !== null) {
-                $mmail->Attach($attachment[0], '', 'attachment', $attachment[1]);
+                $mmail->Attach($attachment->getPath(), '', 'attachment', $attachment->getFilename());
             }
 
             // replace placeholders

--- a/components/ILIAS/User/src/Settings/Administration/class.SettingsGUI.php
+++ b/components/ILIAS/User/src/Settings/Administration/class.SettingsGUI.php
@@ -28,7 +28,7 @@ use ILIAS\UI\Renderer as UIRenderer;
 use ILIAS\UI\Component\Input\Container\Form\Standard as StandardForm;
 use ILIAS\UI\Component\Input\Field\Section;
 use ILIAS\Refinery\Factory as Refinery;
-use ILIAS\Refinery\Custom\Constraint;
+use ILIAS\Refinery\Constraint;
 use ILIAS\Refinery\Transformation;
 use ILIAS\Authentication\Password\LocalUserPasswordManager;
 use Psr\Http\Message\ServerRequestInterface;

--- a/components/ILIAS/User/src/Settings/DataRepository.php
+++ b/components/ILIAS/User/src/Settings/DataRepository.php
@@ -22,6 +22,9 @@ namespace ILIAS\User\Settings;
 
 interface DataRepository
 {
+    /**
+     * @return array<string, string|null>
+     */
     public function getFor(int $user_id): array;
     public function deleteFor(int $user_id): void;
     public function deleteSingleFor(int $user_id, string $key): void;

--- a/components/ILIAS/User/src/Settings/DatabaseDataRepository.php
+++ b/components/ILIAS/User/src/Settings/DatabaseDataRepository.php
@@ -32,7 +32,7 @@ class DatabaseDataRepository implements DataRepository
     {
         $query = $this->db->queryF(
             'SELECT * FROM ' . self::TABLE_NAME . ' WHERE usr_id = %s',
-            ['integer'],
+            [\ilDBConstants::T_INTEGER],
             [$user_id]
         );
 

--- a/components/ILIAS/User/src/Settings/NewAccountMail/Mail.php
+++ b/components/ILIAS/User/src/Settings/NewAccountMail/Mail.php
@@ -30,5 +30,5 @@ interface Mail
     public function getSalutationNoneSpecific(): string;
     public function getSalutationMale(): string;
     public function getSalutationFemale(): string;
-    public function getAttachment(ResourceStorage $irss): ?array;
+    public function getAttachment(ResourceStorage $irss): ?MailAttachment;
 }

--- a/components/ILIAS/User/src/Settings/NewAccountMail/MailAttachment.php
+++ b/components/ILIAS/User/src/Settings/NewAccountMail/MailAttachment.php
@@ -18,15 +18,23 @@
 
 declare(strict_types=1);
 
-namespace ILIAS\User\Settings;
+namespace ILIAS\User\Settings\NewAccountMail;
 
-interface ConfigurationRepository
+final readonly class MailAttachment
 {
-    /**
-     * @return list<Setting>
-     */
-    public function get(): array;
-    public function getByIdentifier(string $identifier): ?Setting;
-    public function getByDefinitionClass(string $class): ?Setting;
-    public function storeConfiguration(Setting $setting): void;
+    public function __construct(
+        private string $path,
+        private string $filename
+    ) {
+    }
+
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    public function getFilename(): string
+    {
+        return $this->filename;
+    }
 }

--- a/components/ILIAS/User/src/Settings/NewAccountMail/MailImplementation.php
+++ b/components/ILIAS/User/src/Settings/NewAccountMail/MailImplementation.php
@@ -74,7 +74,7 @@ class MailImplementation implements Mail
         return $this->attachment_rid;
     }
 
-    public function getAttachment(ResourceStorage $irss): ?array
+    public function getAttachment(ResourceStorage $irss): ?MailAttachment
     {
         if ($this->attachment_rid !== null) {
             $rid = $irss->manage()->find($this->attachment_rid);
@@ -82,10 +82,10 @@ class MailImplementation implements Mail
                 return null;
             }
             $this->ensureAttachmentFileExists($irss, $rid);
-            return [
+            return new MailAttachment(
                 $this->temp_file_path . $this->lang_code,
                 $irss->manage()->getCurrentRevision($rid)->getTitle()
-            ];
+            );
         }
 
         if ($this->legacy_attachment_filename !== null) {
@@ -100,7 +100,7 @@ class MailImplementation implements Mail
                 )
             );
 
-            return [$path, $this->legacy_attachment_filename];
+            return new MailAttachment($path, $this->legacy_attachment_filename);
         }
 
         return null;
@@ -113,6 +113,9 @@ class MailImplementation implements Mail
         }
     }
 
+    /**
+     * @return array<string, array{0: string, 1: mixed}>
+     */
     public function toStorage(): array
     {
         return [

--- a/components/ILIAS/User/src/Settings/Setting.php
+++ b/components/ILIAS/User/src/Settings/Setting.php
@@ -116,6 +116,9 @@ class Setting implements Property
         return $input;
     }
 
+    /**
+     * @return array<string, Input>
+     */
     public function getForm(
         Language $lng,
         FieldFactory $ff,
@@ -166,7 +169,7 @@ class Setting implements Property
         ?\ilPropertyFormGUI $form = null
     ): \ilObjUser {
         if (!$context->isSettingAvailable($this)) {
-            throw \Exception('It is not possible to Change this from here!');
+            throw new \DomainException('It is not possible to Change this from here!');
         }
         return $this->definition->persistUserInput($user, $input, $form);
     }

--- a/components/ILIAS/User/src/Settings/SettingsImplementation.php
+++ b/components/ILIAS/User/src/Settings/SettingsImplementation.php
@@ -38,7 +38,8 @@ class SettingsImplementation implements Settings
     }
 
     /**
-     * @param array<ILIAS\User\Settings\AvailablePages> $pages
+     * @param array<AvailablePages> $pages
+     * @return array<string, \ILIAS\UI\Component\Input\Input>
      */
     public function buildFormInputs(
         array $pages,
@@ -84,7 +85,7 @@ class SettingsImplementation implements Settings
     }
 
     /**
-     * @param array<ILIAS\User\Settings\AvailablePages> $pages
+     * @param array<AvailablePages> $pages
      */
     public function addSectionsToLegacyForm(
         \ilPropertyFormGUI $form,
@@ -117,7 +118,7 @@ class SettingsImplementation implements Settings
      * If it is possible to set the preference on the user, this is what will be
      * done, the user needs to be updated/stored after calling this function.
      *
-     * @param array<ILIAS\User\Settings\AvailablePages> $pages
+     * @param array<AvailablePages> $pages
      */
     public function saveForm(
         \ilPropertyFormGUI|array $form,
@@ -183,17 +184,20 @@ class SettingsImplementation implements Settings
         return $this->user_settings_data_repository->getFor($user_id)[$key] ?? null;
     }
 
+    /**
+     * @return list<Setting>
+     */
     public function getExportableSettings(): array
     {
         $context = Context::Export;
         return array_filter(
             $this->user_settings_configuration_repository->get(),
-            fn(Setting $v): bool => $context->isSettingAvailable($v)
+            static fn(Setting $v): bool => $context->isSettingAvailable($v)
         );
     }
 
     /**
-     * @param array<ILIAS\User\Settings\AvailablePages> $pages
+     * @param array<AvailablePages> $pages
      */
     private function getSettingsForPagesBySections(
         array $pages
@@ -353,7 +357,7 @@ class SettingsImplementation implements Settings
         );
     }
 
-    private function retrieveValuefromInputs(
+    private function retrieveValueFromInputs(
         \ilPropertyFormGUI|array $form,
         Setting $setting
     ): mixed {

--- a/components/ILIAS/User/src/Settings/StartingPoint/Repository.php
+++ b/components/ILIAS/User/src/Settings/StartingPoint/Repository.php
@@ -166,7 +166,7 @@ class Repository
 
         $roles = [];
         while ($sp = $this->db->fetchAssoc($res)) {
-            $options = unserialize($sp['rule_options']);
+            $options = unserialize($sp['rule_options'], ['allowed_classes' => false]);
 
             $roles[(int) $options['role_id']] = [
                 'id' => (int) $sp['id'],
@@ -182,6 +182,9 @@ class Repository
         return $roles;
     }
 
+    /**
+     * @return list<array{id: int, title: string}>
+     */
     public function getGlobalRolesWithoutStartingPoint(): array
     {
         $global_roles = $this->rbac_review->getGlobalRoles();
@@ -308,6 +311,10 @@ class Repository
         return $order_val;
     }
 
+    /**
+     * @param list<array<string, mixed>> $a_items
+     * @return array<int, array<string, mixed>>
+     */
     public function reArrangePositions(array $a_items): array
     {
         $ord_const = 0;
@@ -336,7 +343,10 @@ class Repository
         }
     }
 
-    public function getPossibleStartingPoints(bool $force_all = false): array //checked
+    /**
+     * @return array<int, string>
+     */
+    public function getPossibleStartingPoints(bool $force_all = false): array
     {
         $all = [];
 

--- a/components/ILIAS/User/src/Settings/StartingPoint/Setting.php
+++ b/components/ILIAS/User/src/Settings/StartingPoint/Setting.php
@@ -256,6 +256,9 @@ class Setting implements SettingDefinition
         );
     }
 
+    /**
+     * @return array{start: int, ref_id: int|null}
+     */
     public function retrieveValueFromUser(\ilObjUser $user): array
     {
         return [

--- a/components/ILIAS/User/src/Settings/StartingPoint/class.SettingsGUI.php
+++ b/components/ILIAS/User/src/Settings/StartingPoint/class.SettingsGUI.php
@@ -44,12 +44,13 @@ class SettingsGUI
     private Renderer $ui_renderer;
     private UserGUIRequest $user_request;
     private Repository $starting_point_repository;
+    private \ilErrorHandling $error;
 
     private int $parent_ref_id;
 
     public function __construct(int $a_parent_ref_id)
     {
-        /** @var ILIAS\DI\Container $DIC */
+        /** @var \ILIAS\DI\Container $DIC */
         global $DIC;
 
         $this->log = \ilLoggerFactory::getLogger("user");
@@ -62,6 +63,7 @@ class SettingsGUI
         $this->tree = $DIC['tree'];
         $this->user = $DIC['ilUser'];
         $this->db = $DIC['ilDB'];
+        $this->error = $DIC['ilErr'];
         $this->rbac_review = $DIC['rbacreview'];
         $this->rbac_system = $DIC['rbacsystem'];
         $this->ui_factory = $DIC['ui.factory'];

--- a/components/ILIAS/User/src/Settings/UserSettings.php
+++ b/components/ILIAS/User/src/Settings/UserSettings.php
@@ -25,7 +25,7 @@ interface UserSettings
     /**
      * Return all User Settings provided by the component
      *
-     * @return array<string>
+     * @return list<class-string<SettingDefinition>>
      */
     public function getSettingConfigurations(): array;
 }


### PR DESCRIPTION
This PR improves the type documentation in the
`Settings` sub-namespace of the "User" component.

Other Changes:
- Usage of `unserialize` without 2nd parameter
- `throw \Exception('It is not possible to Change this from here!');` (`new` operator missing)
- Missing member variable `error` in `components/ILIAS/User/src/Settings/StartingPoint/class.SettingsGUI.php`

If approved. please pick to `trunk` as well.