### PR TITLE
[IMPROVEMENT] User: Improve PHP types in `User/Profile`

### DIFF
--- a/components/ILIAS/User/src/Profile/ChangeMail/DBRepository.php
+++ b/components/ILIAS/User/src/Profile/ChangeMail/DBRepository.php
@@ -139,7 +139,7 @@ class DBRepository implements Repository
         $this->db->replace(
             self::TABLE_NAME,
             [
-                'token' => ['text', $token->getToken()]
+                'token' => [\ilDBConstants::T_TEXT, $token->getToken()]
             ],
             [
                 'usr_id' => [\ilDBConstants::T_TEXT, $token->getUserId()],

--- a/components/ILIAS/User/src/Profile/ChangeMail/Repository.php
+++ b/components/ILIAS/User/src/Profile/ChangeMail/Repository.php
@@ -26,9 +26,6 @@ interface Repository
     /**
      * This Function will check if the token is actually valid for the given user
      * before returning the new email.
-     *
-     * @return string The new email a user wishes to be used or an empty string
-     * if validation failed or there is no usable entry.
      */
     public function getTokenForTokenString(string $token_string, \ilObjUser $user): ?Token;
     public function moveToNextStep(Token $token, int $now): Token;

--- a/components/ILIAS/User/src/Profile/DataRepository.php
+++ b/components/ILIAS/User/src/Profile/DataRepository.php
@@ -28,11 +28,9 @@ interface DataRepository
 {
     public function getDefault(): Data;
     public function getSingle(int $id): Data;
-
     /**
-     *
-     * @param array<int> $user_ids
-     * @return Generator<UserData>
+     * @param list<int> $user_ids
+     * @return \Generator<int, Data>
      */
     public function getMultiple(array $user_ids): \Generator;
     public function store(Data $user_data): void;
@@ -51,17 +49,18 @@ interface DataRepository
     public function storeLastVisitedFor(
         int $usr_id,
         array $last_visited
-    );
+    ): void;
+    /**
+     * @return list<\ILIAS\User\Search\AutocompleteItem>
+     */
     public function searchUsers(
         SettingsDataRepository $settings_data_repository,
         ProfileFieldsConfigurationRepository $profile_fields_config_repo,
         AutocompleteQuery $search_term
     ): array;
-
     public function getProfileDataQuery(array $select_fields): DataQuery;
-
     /**
-     * @return array{cnt: int, set: array{string, mixed}}
+     * @return array{cnt: int, set: list<array<string, mixed>>}
      */
     public function getCountAndRecordsForQuery(
         DataQuery $query,

--- a/components/ILIAS/User/src/Profile/DatabaseDataRepository.php
+++ b/components/ILIAS/User/src/Profile/DatabaseDataRepository.php
@@ -69,7 +69,7 @@ class DatabaseDataRepository implements DataRepository
 
         $base_data = $this->db->fetchObject($base_query);
         if ($base_data === null) {
-            throw \InvalidArgumentException(
+            throw new \InvalidArgumentException(
                 'This user does not exist.'
             );
         }
@@ -188,7 +188,7 @@ class DatabaseDataRepository implements DataRepository
 
     public function deleteForFieldIdentifier(string $identifier): void
     {
-        $this->db->manipulateF(
+        $this->db->manipulate(
             'DELETE FROM ' . self::USER_VALUES_TABLE
                 . " WHERE field_id='{$this->db->quote($identifier, \ilDBConstants::T_TEXT)}'"
         );
@@ -245,9 +245,6 @@ class DatabaseDataRepository implements DataRepository
         );
     }
 
-    /**
-     * @return list<\ILIAS\User\Search\AutocompleteItem>
-     */
     public function searchUsers(
         SettingsDataRepository $settings_data_repository,
         ProfileFieldsConfigurationRepository $profile_fields_config_repo,
@@ -293,9 +290,6 @@ class DatabaseDataRepository implements DataRepository
         );
     }
 
-    /**
-     * @return array{cnt: int, set: array{string, mixed}}
-     */
     public function getCountAndRecordsForQuery(
         DataQuery $query,
         int $offset,

--- a/components/ILIAS/User/src/Profile/Fields/CachedConfigurationRepository.php
+++ b/components/ILIAS/User/src/Profile/Fields/CachedConfigurationRepository.php
@@ -26,14 +26,20 @@ class CachedConfigurationRepository implements ConfigurationRepository
 {
     private const string USER_FIELD_CONFIGURATION_TABLE = 'usr_field_config';
     private const string UDF_DEFINITIONS_TABLE = 'udf_definition';
+    /**
+     * @var list<FieldDefinition>
+     */
     private array $available_profile_fields;
 
     /**
-     *
-     * @var array<string, stdClass>
+     * @var array<string, \stdClass>
      */
     private array $fields_data = [];
 
+    /**
+     * @param list<class-string<Custom\Type>> $available_custom_field_types
+     * @param list<FieldDefinition> $available_standard_profile_fields
+     */
     public function __construct(
         private readonly \ilDBInterface $db,
         private readonly UUIDFactory $uuid_factory,
@@ -159,7 +165,7 @@ class CachedConfigurationRepository implements ConfigurationRepository
     public function getCustomFieldTypes(): array
     {
         return array_map(
-            fn(string $v): Custom\Type => new $v(),
+            static fn(string $v): Custom\Type => new $v(),
             $this->available_custom_field_types
         );
     }
@@ -189,6 +195,10 @@ class CachedConfigurationRepository implements ConfigurationRepository
         $this->available_profile_fields = $this->generateAvailableProfielFields();
     }
 
+    /**
+     * @param list<class-string<Custom\Type>> $available_custom_field_types
+     * @return list<Custom\Custom>
+     */
     private function buildCustomFieldDefinitions(
         array $available_custom_field_types
     ): array {
@@ -199,9 +209,10 @@ class CachedConfigurationRepository implements ConfigurationRepository
         $custom_field_definitions = [];
         while (($field = $this->db->fetchObject($query_result)) !== null) {
             $field_type = array_search($field->field_type, $available_custom_field_types);
-            if ($field_type === null) {
+            if ($field_type === false) {
                 continue;
             }
+
             $custom_field_definitions[] = new Custom\Custom(
                 $this->uuid_factory->fromString($field->field_id),
                 new $available_custom_field_types[$field_type](),

--- a/components/ILIAS/User/src/Profile/Fields/ConfigurationRepository.php
+++ b/components/ILIAS/User/src/Profile/Fields/ConfigurationRepository.php
@@ -25,7 +25,7 @@ interface ConfigurationRepository
     public function hasMigrationBeenRun(): bool;
 
     /**
-     * @return array<\ILIAS\User\Profile\Fields\Field>
+     * @return list<Field>
      */
     public function get(): array;
     public function getByIdentifier(string $identifier): ?Field;
@@ -33,7 +33,7 @@ interface ConfigurationRepository
     public function storeConfiguration(Field $field): void;
 
     /**
-     * @return array<\ILIAS\User\Profile\Fields\FieldDefinition>
+     * @return list<Custom\Type>
      */
     public function getCustomFieldTypes(): array;
     public function getUnspecifiedCustomField(): Field;

--- a/components/ILIAS/User/src/Profile/Profile.php
+++ b/components/ILIAS/User/src/Profile/Profile.php
@@ -24,7 +24,9 @@ use ILIAS\User\Profile\Fields\Field as ProfileField;
 interface Profile
 {
     /**
-     * @return array<\ILIAS\User\Profile\Fields\Field>
+     * @param list<\ILIAS\User\Profile\Fields\AvailableSections> $fields_to_skip
+     * @param list<class-string<\ILIAS\User\Profile\Fields\FieldDefinition>> $fields_to_skip
+     * @return array<string, ProfileField>
      */
     public function getFields(
         array $sections_to_skip = [],
@@ -32,7 +34,9 @@ interface Profile
     ): array;
 
     /**
-     * @return array<\ILIAS\User\Profile\Fields\Field>
+     * @param list<\ILIAS\User\Profile\Fields\AvailableSections> $fields_to_skip
+     * @param list<class-string<\ILIAS\User\Profile\Fields\FieldDefinition>> $fields_to_skip
+     * @return array<int, ProfileField>
      */
     public function getVisibleFields(
         Context $context,
@@ -43,6 +47,9 @@ interface Profile
 
     public function getFieldByIdentifier(string $identifier): ?ProfileField;
 
+    /**
+     * @param list<class-string<\ILIAS\User\Profile\Fields\FieldDefinition>> $fields_to_skip
+     */
     public function addFieldsToForm(
         \ilPropertyFormGUI $form,
         Context $context,
@@ -64,7 +71,7 @@ interface Profile
     /**
      *
      * @param array $usr_ids
-     * @return \Generator<ILIAS\User\Profile\Data>
+     * @return \Generator<int, Data>
      */
     public function getDataForMultiple(
         array $usr_ids
@@ -79,18 +86,18 @@ interface Profile
     public function userFieldEditableByUser(string $definition_class): bool;
 
     /**
-     * @return array<\ILIAS\User\Profile\Fields\Field>
+     * @return list<ProfileField>
      */
     public function getIgnorableRequiredFields(): array;
 
     /**
      * @deprecated since version 11 will be removed with 13
-     * @return array<string, \ILIAS\User\Profile\Field>
+     * @return array<string, ProfileField>
      */
     public function getAllUserDefinedFields(): array;
     /**
      * @deprecated since version 11 will be removed with 13
-     * @return array<string, \ILIAS\User\Profile\Field>
+     * @return array<string, ProfileField>
      */
     public function getVisibleUserDefinedFields(
         Context $context

--- a/components/ILIAS/User/src/Profile/ProfileImplementation.php
+++ b/components/ILIAS/User/src/Profile/ProfileImplementation.php
@@ -25,9 +25,13 @@ use ILIAS\User\Profile\Fields\Field as ProfileField;
 use ILIAS\User\Profile\Fields\AvailableSections as AvailableProfileSections;
 use ILIAS\User\Profile\Fields\ConfigurationRepository as FieldsConfigurationRepository;
 use ILIAS\Language\Language;
+use ILIAS\User\Profile\Fields\AvailableSections;
 
 class ProfileImplementation implements Profile
 {
+    /**
+     * @var list<ProfileField>
+     */
     private array $user_fields;
 
     public function __construct(
@@ -38,16 +42,13 @@ class ProfileImplementation implements Profile
         $this->user_fields = $this->profile_fields_repository->get();
     }
 
-    /**
-     * @return array<\ILIAS\User\Profile\Fields\Field>
-     */
     public function getFields(
         array $sections_to_skip = [],
         array $fields_to_skip = []
     ): array {
         return array_reduce(
             $this->user_fields,
-            function (array $c, ProfileField $v) use ($sections_to_skip, $fields_to_skip): array {
+            static function (array $c, ProfileField $v) use ($sections_to_skip, $fields_to_skip): array {
                 if (!in_array($v->getSection(), $sections_to_skip)
                     && !in_array(get_class($v->getDefinition()), $fields_to_skip)) {
                     $c[$v->getIdentifier()] = $v;
@@ -58,9 +59,6 @@ class ProfileImplementation implements Profile
         );
     }
 
-    /**
-     * @return array<\ILIAS\User\Profile\Fields\Field>
-     */
     public function getVisibleFields(
         Context $context,
         ?\ilObjUser $user = null,
@@ -69,7 +67,7 @@ class ProfileImplementation implements Profile
     ): array {
         return array_filter(
             $this->user_fields,
-            fn(ProfileField $v) => !in_array($v->getSection(), $sections_to_skip)
+            static fn(ProfileField $v) => !in_array($v->getSection(), $sections_to_skip)
                     && !in_array($v->getDefinition()::class, $fields_to_skip)
                     && $context->isFieldVisible($v, $user)
                 ? true : false
@@ -174,7 +172,7 @@ class ProfileImplementation implements Profile
         return $field->isVisibleToUser() && $field->isChangeableByUser();
     }
 
-    public function getIgnorableRequiredFields(): array // Missing array type.
+    public function getIgnorableRequiredFields(): array
     {
         return array_reduce(
             $this->user_fields,
@@ -192,15 +190,11 @@ class ProfileImplementation implements Profile
         );
     }
 
-    /**
-     * @deprecated since version 11 will be removed with 13
-     * @return array<string, \ILIAS\User\Profile\Field>
-     */
     public function getAllUserDefinedFields(): array
     {
         return array_reduce(
             $this->user_fields,
-            function (array $c, ProfileField $v): array {
+            static function (array $c, ProfileField $v): array {
                 if ($v->isCustom()) {
                     $c[$v->getIdentifier()] = $v;
                 }
@@ -210,16 +204,12 @@ class ProfileImplementation implements Profile
         );
     }
 
-    /**
-     * @deprecated since version 11 will be removed with 13
-     * @return array<string, \ILIAS\User\Profile\Field>
-     */
     public function getVisibleUserDefinedFields(
         Context $context
     ): array {
         return array_reduce(
             $this->getVisibleFields($context),
-            function (array $c, ProfileField $v): array {
+            static function (array $c, ProfileField $v): array {
                 if ($v->isCustom()) {
                     $c[$v->getIdentifier()] = $v;
                 }
@@ -239,6 +229,9 @@ class ProfileImplementation implements Profile
             ->getDefinition()->tempStorePicture($form);
     }
 
+    /**
+     * @return array<value-of<AvailableSections>, array<int, ProfileField>>
+     */
     private function getVisibleFieldsBySection(
         Context $context,
         ?\ilObjUser $user,
@@ -247,7 +240,7 @@ class ProfileImplementation implements Profile
         return array_filter(
             array_reduce(
                 $this->getVisibleFields($context, $user, [], $fields_to_skip),
-                function (array $c, ProfileField $v): array {
+                static function (array $c, ProfileField $v): array {
                     $c[$v->getSection()->value][] = $v;
                     return $c;
                 },


### PR DESCRIPTION
This PR improves the type documentation in the
`Profile` sub-namespace of the "User" component.

Other (relevant) Changes:
- `throw \InvalidArgumentException('This user does not exist.');` (`new` operator missing)
- In `DatabaseDataRepository::deleteForFieldIdentifier` we called `manipulateF` instead of `manipulate`
- `CachedConfigurationRepository::buildCustomFieldDefinitions` expected a wrong return type from `array_search` (which will return `false` and not `null` in case a value could not be found)

If approved. please pick to `trunk` as well.