### PR TITLE
[FIX] BGTASKS: Adjust SOAP client timeout to 1 second

### DIFF
--- a/src/BackgroundTasks/Implementation/TaskManager/AsyncTaskManager.php
+++ b/src/BackgroundTasks/Implementation/TaskManager/AsyncTaskManager.php
@@ -53,7 +53,7 @@ class AsyncTaskManager extends BasicTaskManager
 
         // Call SOAP-Server
         $soap_client = new \ilSoapClient();
-        $soap_client->setResponseTimeout(0);
+        $soap_client->setResponseTimeout(1);
         $soap_client->enableWSDL(true);
         $soap_client->init();
         $session_id = session_id();


### PR DESCRIPTION
With a timeout of `0`, the `SoapClient` waits for
the full server response before returning. Over plain HTTP, the server can close the connection early, making the call appear asynchronous. Over HTTPS, the TLS layer seems to buffer the response and prevents early connection closure, causing the client to block until the background task completes.

A timeout of `1` second allows the SOAP request to be fully delivered while ensuring the client does not wait for the server to finish processing. The server continues executing the background task after the client disconnects, provided `ignore_user_abort` is enabled on the server side.

See: https://mantis.ilias.de/view.php?id=47650