### PR TITLE
T&A 47511: Adds database update step to add introduction column to tst_tests table

### DIFF
--- a/components/ILIAS/Test/src/Setup/Test10DBUpdateSteps.php
+++ b/components/ILIAS/Test/src/Setup/Test10DBUpdateSteps.php
@@ -468,4 +468,19 @@ class Test10DBUpdateSteps implements \ilDatabaseUpdateSteps
             ['operation' => [\ilDBConstants::T_TEXT, 'tst_results']]
         );
     }
+
+    public function step_14(): void
+    {
+        if (!$this->db->tableColumnExists('tst_tests', 'introduction')) {
+            $this->db->addTableColumn(
+                'tst_tests',
+                'introduction',
+                [
+                    'type' => \ilDBConstants::T_TEXT,
+                    'length' => 4000,
+                    'default' => null
+                ]
+            );
+        }
+    }
 }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=47511

Aims to add database update step to add introduction column to tst_tests table.
@thojou 