### PR TITLE
T&A 47410: Removes double encoding of question titles

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionPreviewGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionPreviewGUI.php
@@ -403,7 +403,7 @@ class ilAssQuestionPreviewGUI
 
         $page_gui->setQuestionHTML([$this->question_obj->getId() => $question_html]);
 
-        $page_gui->setPresentationTitle($this->question_obj->getTitleForHTMLOutput());
+        $page_gui->setPresentationTitle($this->question_obj->getTitle());
 
         $tpl->setVariable('QUESTION_OUTPUT', $page_gui->preview());
         // \ilPageObjectGUI::preview sets an undefined tab, so the "question" tab has to be activated again


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=47410

Aims to remove double encoding of question titles.
@thojou 