### PR TITLE
T&A 47194: Fixes long menu question point correction modal closing issue by moving rendered modals outside of form scope

### DIFF
--- a/components/ILIAS/Form/classes/class.ilFormGUI.php
+++ b/components/ILIAS/Form/classes/class.ilFormGUI.php
@@ -33,6 +33,7 @@ class ilFormGUI
     protected string $name = '';
     protected string $target = '';
     protected bool $prevent_double_submission = false;
+    protected array $modals = [];
 
     public function setFormAction(string $a_formaction): void
     {
@@ -181,6 +182,13 @@ class ilFormGUI
         if (!$this->getKeepOpen()) {
             $tpl->setVariable("FORM_CLOSE_TAG", "</form>");
         }
+
+        if ($this->modals !== []) {
+            global $DIC;
+            $tpl->setVariable("MODALS", $DIC->ui()->renderer()->render($this->modals));
+            $tpl->parseCurrentBlock();
+        }
+
         return $tpl->get();
     }
 

--- a/components/ILIAS/Form/classes/class.ilModalFormInputGUI.php
+++ b/components/ILIAS/Form/classes/class.ilModalFormInputGUI.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\UI\Component\Modal\Lightbox;
+
+interface ilModalFormInputGUI
+{
+    public function getModal(): ?Lightbox;
+}

--- a/components/ILIAS/Form/classes/class.ilPropertyFormGUI.php
+++ b/components/ILIAS/Form/classes/class.ilPropertyFormGUI.php
@@ -559,6 +559,9 @@ class ilPropertyFormGUI extends ilFormGUI
         foreach ($this->items as $item) {
             if ($item->getType() != "hidden") {
                 $this->insertItem($item);
+                if ($item instanceof ilModalFormInputGUI && ($modal = $item->getModal())) {
+                    $this->modals[] = $modal;
+                }
             }
         }
 

--- a/components/ILIAS/Form/templates/default/tpl.form.html
+++ b/components/ILIAS/Form/templates/default/tpl.form.html
@@ -3,3 +3,4 @@
 {FORM_CONTENT}
 </div>
 {FORM_CLOSE_TAG}
+{MODALS}

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssLongmenuCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssLongmenuCorrectionsInputGUI.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+use ILIAS\UI\Component\Modal\Lightbox;
+
 /**
  * Class ilAssLongmenuCorrectionsInputGUI
  *
@@ -24,9 +26,11 @@
  *
  * @package components\ILIAS/Test(QuestionPool)
  */
-class ilAssLongmenuCorrectionsInputGUI extends ilAnswerWizardInputGUI
+class ilAssLongmenuCorrectionsInputGUI extends ilAnswerWizardInputGUI implements ilModalFormInputGUI
 {
     private \ILIAS\DI\UIServices $ui;
+
+    private ?Lightbox $modal = null;
 
     public function __construct($a_title = "", $a_postvar = "")
     {
@@ -41,21 +45,25 @@ class ilAssLongmenuCorrectionsInputGUI extends ilAnswerWizardInputGUI
         return true;
     }
 
+    public function getModal(): ?Lightbox
+    {
+        return $this->modal;
+    }
+
     public function insert(ilTemplate $a_tpl): void
     {
         // Get input
-        $inp = new ilTextWizardInputGUI('', '');
+        $inp = new ilTextWizardInputGUI($this->getTitle(), $this->getPostVar());
         $inp->setValues(current($this->values['answers_all']));
         $inp->setDisabled(true);
         $message = $inp->render();
 
         $page = $this->ui->factory()->modal()->lightboxTextPage($message, $this->lng->txt('answer_options'));
-        $modal = $this->ui->factory()->modal()->lightbox($page);
-        $button = $this->ui->factory()->button()->standard($this->lng->txt('show'), $modal->getShowSignal());
+        $this->modal = $this->ui->factory()->modal()->lightbox($page);
+        $button = $this->ui->factory()->button()->standard($this->lng->txt('show'), $this->modal->getShowSignal());
 
         $tpl = new ilTemplate('tst.longmenu_corrections_input.html', true, true, 'components/ILIAS/TestQuestionPool');
 
-        $tpl->setVariable('ANSWERS_MODAL', $this->ui->renderer()->render($modal));
         $tpl->setVariable('TAG_INPUT', $this->buildTagInput()->render());
         $tpl->setVariable('NUM_ANSWERS', $this->values['answers_all_count']);
         $tpl->setVariable('BTN_SHOW', $this->ui->renderer()->render($button));

--- a/components/ILIAS/TestQuestionPool/templates/default/tst.longmenu_corrections_input.html
+++ b/components/ILIAS/TestQuestionPool/templates/default/tst.longmenu_corrections_input.html
@@ -2,5 +2,4 @@
     <p>{TXT_ANSWERS} {NUM_ANSWERS} {BTN_SHOW}</p>
     <p>{TXT_CORRECT_ANSWERS}</p>
     {TAG_INPUT}
-    {ANSWERS_MODAL}
 </div>


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=47194

Aims to fix long menu question point correction modal closing issue by moving rendered modals outside of form scope.
@thojou 