### PR TITLE
Test 46663: Inline Error for Empty Question Delete

### DIFF
--- a/components/ILIAS/Test/classes/class.ilObjTestGUI.php
+++ b/components/ILIAS/Test/classes/class.ilObjTestGUI.php
@@ -2764,7 +2764,8 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
                 $this->getTestObject()->getGlobalSettings()->isAdjustingQuestionsWithResultsAllowed(),
                 $this->getTestObject()->evalTotalPersons() !== 0,
                 $this->getTestObject()->isRandomTest(),
-                $this->test_question_set_config_factory
+                $this->test_question_set_config_factory,
+                $this->response_handler
             );
         }
         return $this->table_actions;

--- a/components/ILIAS/Test/src/Questions/Presentation/QuestionsTableActions.php
+++ b/components/ILIAS/Test/src/Questions/Presentation/QuestionsTableActions.php
@@ -331,24 +331,6 @@ class QuestionsTableActions
             return $this->ui_factory->messageBox()->failure($this->lng->txt('msg_no_questions_selected'));
         }
 
-        $modal_factory = fn(string $msg): Interruptive =>
-            $this->ui_factory->modal()->interruptive(
-                $this->lng->txt('remove'),
-                $msg,
-                $this->table_query->getActionURL(self::ACTION_DELETE_CONFIRMED)->__toString()
-            );
-
-        if (array_filter($row_ids) === []) {
-            $msg = $this->lng->txt('msg_no_questions_selected');
-            return $modal_factory($msg);
-        }
-
-        $msg = $this->lng->txt(
-            $this->is_in_test_with_results
-                ? 'tst_remove_questions_and_results'
-                : 'tst_remove_questions'
-        );
-
         $items = [];
         foreach ($row_ids as $id) {
             $qdata = $this->test_obj->getQuestionDataset($id);
@@ -363,7 +345,17 @@ class QuestionsTableActions
                 $type
             );
         }
-        return $modal_factory($msg)->withAffectedItems($items);
+
+        return $this->ui_factory->modal()->interruptive(
+            $this->lng->txt('remove'),
+            $this->lng->txt(
+                $this->is_in_test_with_results
+                    ? 'tst_remove_questions_and_results'
+                    : 'tst_remove_questions'
+            ),
+            $this->table_query->getActionURL(self::ACTION_DELETE_CONFIRMED)->__toString()
+        )
+        ->withAffectedItems($items);
     }
 
     private function redirectWithQuestionParameters(

--- a/components/ILIAS/Test/src/Questions/Presentation/QuestionsTableActions.php
+++ b/components/ILIAS/Test/src/Questions/Presentation/QuestionsTableActions.php
@@ -21,10 +21,12 @@ declare(strict_types=1);
 namespace ILIAS\Test\Questions\Presentation;
 
 use ILIAS\Test\Questions\Properties\Repository as TestQuestionsRepository;
+use ILIAS\Test\ResponseHandler;
 use ILIAS\UI\Factory as UIFactory;
 use ILIAS\UI\Renderer as UIRenderer;
 use ILIAS\UI\Component\Table\OrderingRow;
 use ILIAS\UI\Component\Table\Action\Action as TableAction;
+use ILIAS\UI\Component\MessageBox\MessageBox;
 use ILIAS\UI\Component\Modal\Interruptive;
 use ILIAS\Data\URI;
 use ILIAS\Language\Language;
@@ -66,7 +68,8 @@ class QuestionsTableActions
         private readonly bool $is_adjusting_questions_with_results_allowed,
         private readonly bool $is_in_test_with_results,
         private readonly bool $is_in_test_with_random_question_set,
-        private readonly \ilTestQuestionSetConfigFactory $test_question_set_config_factory
+        private readonly \ilTestQuestionSetConfigFactory $test_question_set_config_factory,
+        private readonly ResponseHandler $test_response
     ) {
         $this->table_id = (string) $test_obj->getId();
     }
@@ -220,10 +223,12 @@ class QuestionsTableActions
                 return false;
 
             case self::ACTION_DELETE:
-                echo $this->ui_renderer->renderAsync(
-                    $this->getDeleteConfirmation(array_filter($row_ids))
+                $this->test_response->sendAsync(
+                    $this->ui_renderer->renderAsync(
+                        $this->getDeleteConfirmation(array_filter($row_ids))
+                    )
                 );
-                exit();
+                return false;
 
             case self::ACTION_DELETE_CONFIRMED:
                 $row_ids = $this->request->getParsedBody()['interruptive_items'] ?? [];
@@ -320,8 +325,12 @@ class QuestionsTableActions
         }
     }
 
-    private function getDeleteConfirmation(array $row_ids): Interruptive
+    private function getDeleteConfirmation(array $row_ids): Interruptive|MessageBox
     {
+        if ($row_ids === []) {
+            return $this->ui_factory->messageBox()->failure($this->lng->txt('msg_no_questions_selected'));
+        }
+
         $modal_factory = fn(string $msg): Interruptive =>
             $this->ui_factory->modal()->interruptive(
                 $this->lng->txt('remove'),


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=46663

Aims to add no questions selected error message directly to question deletion modal.
@thojou 