### PR TITLE
Registration: Move Dual Opt-In cleanup from User Cron to Registration component

### DIFF
--- a/components/ILIAS/Registration/service.xml
+++ b/components/ILIAS/Registration/service.xml
@@ -3,4 +3,7 @@
 	<events>
 		<event type="listen" id="Services/User" />
 	</events>
+	<crons>
+		<cron id="reg_delete_expired_pending_registrations" class="ILIAS\Registration\DualOptIn\Cron\DeleteExpiredPendingRegistrationsCronJob" />
+	</crons>
 </service>

--- a/components/ILIAS/Registration/src/DualOptIn/Cron/DeleteExpiredPendingRegistrationsCronJob.php
+++ b/components/ILIAS/Registration/src/DualOptIn/Cron/DeleteExpiredPendingRegistrationsCronJob.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Registration\DualOptIn\Cron;
+
+use ILIAS\Cron\Job\Schedule\JobScheduleType;
+use ILIAS\Cron\Job\JobResult;
+use ILIAS\Cron\CronJob;
+use ILIAS\Registration\DualOptIn\Service\DualOptInService;
+use ilLanguage;
+
+/**
+ * Cronjob to delete user accounts for which the registration (dual opt-in) has never been finalized.
+ */
+final class DeleteExpiredPendingRegistrationsCronJob extends CronJob
+{
+    private ilLanguage $lng;
+    private DualOptInService $dual_opt_in_service;
+
+    public function init(): void
+    {
+        global $DIC;
+
+        $this->lng = $DIC->language();
+        $this->dual_opt_in_service = new \ILIAS\Registration\DualOptIn\Service\DualOptInServiceImpl(
+            new \ilRegistrationSettings(),
+            new \ILIAS\Registration\DualOptIn\Repository\PendingRegistrationDatabaseRepository($DIC->database()),
+            $DIC->database(),
+            $DIC->logger()->user(),
+            (new \ILIAS\Data\Factory())->clock()
+        );
+    }
+
+    public function getId(): string
+    {
+        return 'reg_delete_expired_pending_registrations';
+    }
+
+    public function getTitle(): string
+    {
+        $this->init();
+
+        return $this->lng->txt('reg_delete_expired_pending_registrations');
+    }
+
+    public function getDescription(): string
+    {
+        $this->init();
+
+        return $this->lng->txt('reg_delete_expired_pending_registrations_desc');
+    }
+
+    public function getDefaultScheduleType(): JobScheduleType
+    {
+        return JobScheduleType::DAILY;
+    }
+
+    public function getDefaultScheduleValue(): ?int
+    {
+        return null;
+    }
+
+    public function hasAutoActivation(): bool
+    {
+        return false;
+    }
+
+    public function hasFlexibleSchedule(): bool
+    {
+        return false;
+    }
+
+    public function run(): JobResult
+    {
+        $this->init();
+
+        $num_deleted_users = $this->dual_opt_in_service->deleteExpiredUserObjects();
+
+        $result = new JobResult();
+        $result->setStatus(JobResult::STATUS_OK);
+        $result->setMessage(sprintf('%d inactive user objects with expired confirmation hash values (dual opt-in) deleted.', $num_deleted_users));
+
+        return $result;
+    }
+}

--- a/components/ILIAS/Registration/src/DualOptIn/Repository/PendingRegistrationDatabaseRepository.php
+++ b/components/ILIAS/Registration/src/DualOptIn/Repository/PendingRegistrationDatabaseRepository.php
@@ -132,7 +132,7 @@ final readonly class PendingRegistrationDatabaseRepository implements PendingReg
     /**
      * @return list<PendingRegistration>
      */
-    public function findExpired(int $cutoff_ts, ?int $prioritize_usr_id = null): array
+    public function findExpired(int $cutoff_ts, ?int $usr_id_to_prioritize = null): array
     {
         $except_anon_and_sys = $this->db->in(
             'pr.usr_id',
@@ -154,7 +154,7 @@ final readonly class PendingRegistrationDatabaseRepository implements PendingReg
         $res = $this->db->queryF(
             $query,
             [\ilDBConstants::T_INTEGER, \ilDBConstants::T_INTEGER],
-            [$cutoff_ts, $prioritize_usr_id ?? 0]
+            [$cutoff_ts, $usr_id_to_prioritize ?? 0]
         );
 
         $expired_registrations = [];

--- a/components/ILIAS/Registration/src/DualOptIn/Repository/PendingRegistrationRepository.php
+++ b/components/ILIAS/Registration/src/DualOptIn/Repository/PendingRegistrationRepository.php
@@ -39,5 +39,5 @@ interface PendingRegistrationRepository
     public function deleteByUserId(int $usr_id): void;
 
     /** @return list<PendingRegistration> */
-    public function findExpired(int $cutoff_ts, ?int $prioritize_usr_id = null): array;
+    public function findExpired(int $cutoff_ts, ?int $usr_id_to_prioritize = null): array;
 }

--- a/components/ILIAS/Registration/src/DualOptIn/Service/DualOptInService.php
+++ b/components/ILIAS/Registration/src/DualOptIn/Service/DualOptInService.php
@@ -37,5 +37,5 @@ interface DualOptInService
 
     public function distributeMailsOnRegistration(\ilObjUser $user): void;
 
-    public function deleteExpiredUserObjects(int $usr_id): void;
+    public function deleteExpiredUserObjects(?int $usr_id_to_prioritize = null): int;
 }

--- a/components/ILIAS/Registration/src/DualOptIn/Service/DualOptInServiceImpl.php
+++ b/components/ILIAS/Registration/src/DualOptIn/Service/DualOptInServiceImpl.php
@@ -115,7 +115,7 @@ final readonly class DualOptInServiceImpl implements DualOptInService
         return $pending_reg;
     }
 
-    public function deleteExpiredUserObjects(int $usr_id): void
+    public function deleteExpiredUserObjects(?int $usr_id_to_prioritize = null): int
     {
         $this->logger->debug(
             'Started deletion of inactive user objects with expired confirmation hash values (dual opt in) ...'
@@ -124,7 +124,7 @@ final readonly class DualOptInServiceImpl implements DualOptInService
         $lifetime = $this->settings->getRegistrationHashLifetime();
         if ($lifetime <= 0) {
             $this->logger->debug('Registration hash lifetime is <= 0, skipping deletion.');
-            return;
+            return 0;
         }
 
         $now = $this->clock_factory->utc()->now();
@@ -134,7 +134,7 @@ final readonly class DualOptInServiceImpl implements DualOptInService
         $expired_regs = array_filter(
             array_map(
                 static fn(PendingRegistration $reg): PendingRegistration => $reg->withEvaluatedState($now, $lifetime),
-                $this->pending_reg_repository->findExpired($cutoff->getTimestamp(), $usr_id)
+                $this->pending_reg_repository->findExpired($cutoff->getTimestamp(), $usr_id_to_prioritize)
             ),
             static fn(PendingRegistration $reg): bool => $reg->isExpired()
         );
@@ -178,6 +178,8 @@ final readonly class DualOptInServiceImpl implements DualOptInService
                 $num_deleted_users
             )
         );
+
+        return $num_deleted_users;
     }
 
     private function activateUser(\ilObjUser $user): void

--- a/components/ILIAS/User/classes/Cron/class.ilUserCronCheckAccounts.php
+++ b/components/ILIAS/User/classes/Cron/class.ilUserCronCheckAccounts.php
@@ -147,35 +147,11 @@ class ilUserCronCheckAccounts extends CronJob
             $this->counter++;
         }
 
-        $this->checkNotConfirmedUserAccounts();
-
         if ($this->counter) {
             $status = JobResult::STATUS_OK;
         }
         $result = new JobResult();
         $result->setStatus($status);
         return $result;
-    }
-
-    protected function checkNotConfirmedUserAccounts(): void
-    {
-        $registration_settings = new ilRegistrationSettings();
-
-        $query = 'SELECT usr_id FROM usr_data '
-               . 'WHERE (reg_hash IS NOT NULL AND reg_hash != %s)'
-               . 'AND active = %s '
-               . 'AND create_date < %s';
-        $res = $this->db->queryF(
-            $query,
-            ['text', 'integer', 'timestamp'],
-            ['', 0, date('Y-m-d H:i:s', time() - $registration_settings->getRegistrationHashLifetime())]
-        );
-        while ($row = $this->db->fetchAssoc($res)) {
-            $user = ilObjectFactory::getInstanceByObjId((int) $row['usr_id']);
-            $user->delete();
-            $this->log->write('Cron: Deleted ' . $user->getLogin() . ' [' . $user->getId() . '] ' . __METHOD__);
-
-            $this->counter++;
-        }
     }
 }

--- a/components/ILIAS/soap/classes/class.ilSoapUtils.php
+++ b/components/ILIAS/soap/classes/class.ilSoapUtils.php
@@ -451,7 +451,7 @@ class ilSoapUtils extends ilSoapAdministration
      * Method for soap webservice: deleteExpiredDualOptInUserObjects
      * This service will run in background. The client has not to wait for response.
      */
-    public function deleteExpiredDualOptInUserObjects(string $sid, int $usr_id): bool
+    public function deleteExpiredDualOptInUserObjects(string $sid, int $usr_id_to_prioritize): bool
     {
         $this->initAuth($sid);
         $this->initIlias();
@@ -467,7 +467,7 @@ class ilSoapUtils extends ilSoapAdministration
             $DIC->logger()->user(),
             (new \ILIAS\Data\Factory())->clock()
         );
-        $dual_opt_in_service->deleteExpiredUserObjects($usr_id);
+        $dual_opt_in_service->deleteExpiredUserObjects($usr_id_to_prioritize);
 
         return true;
     }

--- a/components/ILIAS/soap/include/inc.soap_functions.php
+++ b/components/ILIAS/soap/include/inc.soap_functions.php
@@ -819,12 +819,12 @@ class ilSoapFunctions
         return $swa->updateWebLink($sid, $ref_id, $xml);
     }
 
-    public static function deleteExpiredDualOptInUserObjects(string $sid, int $usr_id): bool
+    public static function deleteExpiredDualOptInUserObjects(string $sid, int $usr_id_to_prioritize): bool
     {
         $sou = new ilSoapUtils();
         $sou->disableSOAPCheck();
         $sou->ignoreUserAbort();
-        return $sou->deleteExpiredDualOptInUserObjects($sid, $usr_id);
+        return $sou->deleteExpiredDualOptInUserObjects($sid, $usr_id_to_prioritize);
     }
 
     /**

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -3705,7 +3705,7 @@ common#:#check_languages#:#Alle Sprachen überprüfen
 common#:#check_link#:#Externe Links überprüfen
 common#:#check_link_desc#:#Wenn eingeschaltet, werden alle ILIAS-Lernmodule auf ungültige externe Links überprüft.
 common#:#check_user_accounts#:#ILIAS-Konten überprüfen
-common#:#check_user_accounts_desc#:#Personen, deren ILIAS-Konten zeitlich begrenzt sind, werden zwei Wochen vor Fristende per E-Mail informiert, dass ihr Konto abläuft. Außerdem löscht der Cron-Job alle ILIAS-Konten, bei denen der E-Mail-Bestätigungslink nicht fristgerecht angeklickt wurde.
+common#:#check_user_accounts_desc#:#Personen, deren ILIAS-Konten zeitlich begrenzt sind, werden zwei Wochen vor Fristende per E-Mail informiert, dass ihr Konto abläuft.
 common#:#check_web_resources#:#Weblinks überprüfen
 common#:#check_web_resources_desc#:#Wenn eingeschaltet, werden alle Weblinks auf ungültige externe Links überprüft und gegebenenfalls deaktiviert.
 common#:#checked#:#Ausgewählt
@@ -5407,6 +5407,8 @@ common#:#refresh#:#Aktualisieren
 common#:#refresh_languages#:#Alle Sprachen aktualisieren
 common#:#refuse#:#Antrag ablehnen
 common#:#reg_account_confirmation_successful#:#Das ILIAS-Konto wurde bestätigt und aktiviert.
+common#:#reg_delete_expired_pending_registrations#:#Abgelaufene Registrierungen löschen
+common#:#reg_delete_expired_pending_registrations_desc#:#Löscht alle ILIAS-Konten, bei denen der E-Mail-Bestätigungslink nicht fristgerecht angeklickt wurde.
 common#:#reg_goto_parent_membership_info#:#Nur Mitglieder können auf das Zielobjekt zugreifen.
 common#:#reg_mail_body_2_confirmation#:#Der Link wird nur für %s gültig sein, danach müssen Sie sich erneut registrieren.
 common#:#reg_mail_body_3_confirmation#:#Falls Sie diese E-Mail unerwartet erhalten haben, ist es möglich, dass eine andere Person Ihre E-Mail-Adresse versehentlich oder vorsätzlich angegeben hat. In diesem Fall ignorieren Sie diese Mail bitte.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -3706,7 +3706,7 @@ common#:#check_languages#:#Check All Languages
 common#:#check_link#:#Weblink check
 common#:#check_link_desc#:#If enabled all external links in ILIAS learning modules will be checked if they are active.
 common#:#check_user_accounts#:#Check user accounts
-common#:#check_user_accounts_desc#:#If enabled, all users whose account expires will be informed by e-mail two weeks before. Furthermore all users which have not confirmed their account after a registration with e-mail confirmation will be deleted.
+common#:#check_user_accounts_desc#:#If enabled, all users whose account expires will be informed by e-mail two weeks before.
 common#:#check_web_resources#:#Check Weblinks
 common#:#check_web_resources_desc#:#If enabled all Weblinks will be checked if they are active.
 common#:#checked#:#Checked
@@ -5407,6 +5407,8 @@ common#:#refresh#:#Refresh
 common#:#refresh_languages#:#Refresh All Languages
 common#:#refuse#:#Refuse Request
 common#:#reg_account_confirmation_successful#:#Your user account has been activated.
+common#:#reg_delete_expired_pending_registrations#:#Delete Expired Pending Registrations
+common#:#reg_delete_expired_pending_registrations_desc#:#Deletes all ILIAS accounts that have not been confirmed after a registration with e-mail confirmation.
 common#:#reg_goto_parent_membership_info#:#Only members can access the target object.
 common#:#reg_mail_body_2_confirmation#:#This link is only valid for %s. After this period has passed, the link will expire and you will have to restart the registration process from the beginning.
 common#:#reg_mail_body_3_confirmation#:#If this e-mail means nothing to you, then it is possible that somebody else has entered your e-mail address either deliberately or accidentally, so please ignore this e-mail.


### PR DESCRIPTION
This PR moves the cleanup logic for expired pending registrations to a dedicated cron job within the Registration component.
This addresses the issue where the `ilUserCronCheckAccounts` cron job was crashing due to the separation of Dual Opt-In registration data into its own table ([Mantis #47669](https://mantis.ilias.de/view.php?id=47669)).
Additionally, internal naming has been improved for better clarity.

Changes in Detail
- User Component:
  - Removed `checkNotConfirmedUserAccounts` logic from `ilUserCronCheckAccounts`
  - Updated language variables for `check_user_accounts` to reflect this change
- Registration Component:
  - Introduced `DeleteExpiredPendingRegistrationsCronJob` to handle the logic from the removed `checkNotConfirmedUserAccounts` method
  - Renamed the variable `$prioritize_usr_id` to `$usr_id_to_prioritize` across multiple layers to clarify its purpose