### PR TITLE
Fix undefined array keys 'explanation' and 'consultation_hours' in course members list with consultation hour column

### DIFF
--- a/components/ILIAS/Group/classes/class.ilGroupParticipantsTableGUI.php
+++ b/components/ILIAS/Group/classes/class.ilGroupParticipantsTableGUI.php
@@ -152,12 +152,12 @@ class ilGroupParticipantsTableGUI extends ilParticipantTableGUI
                 case 'consultation_hour':
                     $this->tpl->setCurrentBlock('custom_fields');
                     $dts = array();
-                    foreach ((array) $a_set['consultation_hours'] as $ch) {
+                    foreach ((array) ($a_set['consultation_hours'] ?? []) as $ch) {
                         $tmp = ilDatePresentation::formatPeriod(
                             new ilDateTime($ch['dt'], IL_CAL_UNIX),
                             new ilDateTime($ch['dtend'], IL_CAL_UNIX)
                         );
-                        if ($ch['explanation']) {
+                        if (isset($ch['explanation'])) {
                             $tmp .= ' ' . $ch['explanation'];
                         }
                         $dts[] = $tmp;


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=47672