### PR TITLE
[FIX] ilServer: Ignore ".git" instead of ".svn"

### DIFF
--- a/components/ILIAS/WebServices/RPC/lib/src/main/java/de/ilias/services/object/DirectoryDataSource.java
+++ b/components/ILIAS/WebServices/RPC/lib/src/main/java/de/ilias/services/object/DirectoryDataSource.java
@@ -119,7 +119,7 @@ public class DirectoryDataSource extends FileDataSource {
 						public boolean accept(File path) {
 							
 							if(path.isDirectory()) {
-								return !path.getName().equals(".svn");
+								return !path.getName().equals(".git");
 							}
 							else
 							{

--- a/components/ILIAS/WebServices/RPC/lib/src/main/java/de/ilias/services/object/ObjectDefinitionReader.java
+++ b/components/ILIAS/WebServices/RPC/lib/src/main/java/de/ilias/services/object/ObjectDefinitionReader.java
@@ -136,7 +136,7 @@ public class ObjectDefinitionReader {
 						
 						if(path.isDirectory()) {
                             //logger.debug("Found new directory: " + path.getAbsolutePath());
-                            return !path.getName().equals(".svn");
+                            return !path.getName().equals(".git");
                         }
 						//logger.debug(path.getName() + " <-> " + objectPropertyName);
 						if(path.getName().equalsIgnoreCase(objectPropertyName)) {


### PR DESCRIPTION
This PR suggests ignoring the ".git" directory instead of ".svn".

See: https://mantis.ilias.de/view.php?id=47682

If approved, please pick this to all maintained branches.