### PR TITLE
[IMPROVEMENT] ilServer: Improve performance of `CommandQueue.addComma…

### DIFF
--- a/components/ILIAS/WebServices/RPC/lib/src/main/java/de/ilias/services/lucene/index/CommandQueue.java
+++ b/components/ILIAS/WebServices/RPC/lib/src/main/java/de/ilias/services/lucene/index/CommandQueue.java
@@ -38,7 +38,6 @@ import de.ilias.services.object.ObjectDefinitions;
 import de.ilias.services.settings.ClientSettings;
 import de.ilias.services.settings.ConfigurationException;
 import de.ilias.services.settings.LocalSettings;
-import java.util.logging.Level;
 import org.apache.logging.log4j.Logger;
 
 
@@ -82,8 +81,8 @@ public class CommandQueue {
 				"AND obj_type = ? " +
 				"AND sub_id = ? " +
 				"AND sub_type = ? ");
-		sta.setInt(1, el.getObjId());
-		sta.setTimestamp(2,new java.sql.Timestamp(new java.util.Date().getTime()));
+		sta.setTimestamp(1,new java.sql.Timestamp(new java.util.Date().getTime()));
+		sta.setInt(2, el.getObjId());
 		DBFactory.setString(sta, 3, el.getObjType());
 		sta.setInt(4, el.getSubId());
 		DBFactory.setString(sta, 5, el.getSubType());
@@ -278,68 +277,43 @@ public class CommandQueue {
 
 		try {
 			
-			ResultSet res = null;
 			PreparedStatement sta = null;
 			
 			if(objType.equalsIgnoreCase("help")) {
 				
 				sta = DBFactory.getPreparedStatement(
-					"SELECT lm_id obj_id FROM help_module "
+					"INSERT IGNORE INTO search_command_queue " +
+					"(obj_id, obj_type, sub_id, sub_type, command, last_update, finished) " +
+					"SELECT help_module.lm_id, ?, 0, '', 'reset', NOW(), 0 " +
+					"FROM help_module"
 				);
+				DBFactory.setString(sta, 1, objType);
 			}
 			else if(!objType.equalsIgnoreCase("usr"))
 			{
 				sta = DBFactory.getPreparedStatement(
-					"SELECT DISTINCT(oda.obj_id) FROM object_data oda JOIN object_reference ore ON oda.obj_id = ore.obj_id " +
-					"WHERE (deleted IS NULL) AND type = ? " +
-					"GROUP BY oda.obj_id");
+					"INSERT IGNORE INTO search_command_queue " +
+					"(obj_id, obj_type, sub_id, sub_type, command, last_update, finished) " +
+					"SELECT oda.obj_id, oda.type, 0, '', 'reset', NOW(), 0 " +
+					"FROM object_data oda " +
+					"JOIN object_reference ore ON oda.obj_id = ore.obj_id " +
+					"WHERE (ore.deleted IS NULL) AND oda.type = ? " +
+					"GROUP BY oda.obj_id, oda.type");
 				DBFactory.setString(sta, 1, objType);
 			}
 			else {
 				sta = DBFactory.getPreparedStatement(
-					"SELECT obj_id FROM object_data " + 
-					"WHERE type = ? "
+					"INSERT IGNORE INTO search_command_queue " +
+					"(obj_id, obj_type, sub_id, sub_type, command, last_update, finished) " +
+					"SELECT object_data.obj_id, object_data.type, 0, '', 'reset', NOW(), 0 " +
+					"FROM object_data " + 
+					"WHERE object_data.type = ? "
 				);
 				DBFactory.setString(sta, 1, objType);
 			}
 
-			res = sta.executeQuery();
-			logger.info("Adding new commands for object type: " + objType);
-
-			// Add each single object
-			PreparedStatement objReset = DBFactory.getPreparedStatement(
-					"INSERT INTO search_command_queue (obj_id, obj_type, sub_id, sub_type, command, last_update, finished) " + 
-					"VALUES (?, ?, ?, ?, ?, ?, ?)");
-
-			while(res.next()) {
-
-				logger.debug("Added new reset command for " + res.getInt("obj_id"));
-				
-				objReset.setInt(1,res.getInt("obj_id"));
-				objReset.setString(2, objType);
-				objReset.setInt(3,0);
-				objReset.setString(4,"");
-				objReset.setString(5,"reset");
-				objReset.setTimestamp(6,new java.sql.Timestamp(new java.util.Date().getTime()));
-				objReset.setInt(7,0);
-
-				try {
-					objReset.executeUpdate();
-				}
-				catch(SQLException e) {
-					logger.info("Ignoring duplicate key failure for obj_id: " + res.getInt("obj_id"));
-				}
-			}
-			
-			try {
-				if(res != null)
-				{
-					res.close();
-				}
-			} 
-			catch (SQLException e) {
-				logger.warn("Cannot close result set: " + e);
-			}
+			int inserted = sta.executeUpdate();
+			logger.info("Added " + inserted + " new commands for object type: " + objType);
 		}
 		catch(SQLException e) {
 			


### PR DESCRIPTION
…ndsByType`

This PR suggest letting the database do the work when calling `addCommandsByType`. Currently, the application code first selects the relevant tuples and then iterates over them to do the manipulation. This could be also achieved by atomic INSERT/SELECT statements.

See: https://mantis.ilias.de/view.php?id=47683

If approved, please pick this to all maintained branches.