### PR TITLE
[FIX] 0047627: UpdateSteps werfen Fehler (Database flatten broke getDeclaration)

### DIFF
--- a/components/ILIAS/Database/classes/PDO/FieldDefinition/ilDBPdoMySQLFieldDefinition.php
+++ b/components/ILIAS/Database/classes/PDO/FieldDefinition/ilDBPdoMySQLFieldDefinition.php
@@ -1082,11 +1082,56 @@ class ilDBPdoMySQLFieldDefinition implements FieldDefinition
             $field['type'] = $type;
         }
 
-        if (!method_exists($this, "get{$type}Declaration")) {
+        if (!array_key_exists($type, $this->getValidTypes())) {
             throw new ilDatabaseException('type not defined: ' . $type);
         }
 
-        return $this->{"get{$type}Declaration"}($name, $field);
+        $quoted_name = $db->quoteIdentifier($name, true);
+        $type_declaration = $this->getTypeDeclaration($field);
+
+        if ($type === 'clob' || $type === 'blob') {
+            $notnull = empty($field['notnull']) ? '' : ' NOT NULL';
+            return $quoted_name . ' ' . $type_declaration . $notnull;
+        }
+
+        return $quoted_name . ' ' . $type_declaration . $this->getDeclarationOptions($field);
+    }
+
+    private function getDeclarationOptions(array $field): string
+    {
+        $charset = empty($field['charset']) ? '' : ' ' . $field['charset'];
+
+        $default = '';
+        if (array_key_exists('default', $field)) {
+            if ($field['default'] === '') {
+                $db = $this->getDBInstance();
+
+                if (empty($field['notnull'])) {
+                    $field['default'] = null;
+                } else {
+                    $valid_default_values = $this->getValidTypes();
+                    $field['default'] = $valid_default_values[$field['type']];
+                }
+                if ($field['default'] === ''
+                    && isset($db->options['portability'])
+                    && ($db->options['portability'] & 32)
+                ) {
+                    $field['default'] = ' ';
+                }
+            }
+            $default = ' DEFAULT ' . $this->quote($field['default'], $field['type']);
+        } elseif (empty($field['notnull'])) {
+            $default = ' DEFAULT NULL';
+        }
+
+        $notnull = empty($field['notnull']) ? '' : ' NOT NULL';
+        if (isset($field['notnull']) && $field['notnull'] === false) {
+            $notnull = ' NULL';
+        }
+
+        $collation = empty($field['collation']) ? '' : ' ' . $field['collation'];
+
+        return $charset . $default . $notnull . $collation;
     }
 
     /**


### PR DESCRIPTION
## Summary

- The commit `acdcd2ff7b3` ("Database: Flatten field definition") removed all individual `get{Type}Declaration` methods and the `getDeclarationOptions` / `getInternalDeclaration` helpers from `ilDBPdoFieldDefinition` when merging into `ilDBPdoMySQLFieldDefinition`.
- `getDeclaration()` was copied verbatim and still used dynamic dispatch via `$this->{"get{$type}Declaration"}($name, $field)`, which no longer exists — causing `ilDatabaseException: type not defined: text` on any `modifyTableColumn()` call for text columns.
- This broke `Test11DBUpdateSteps::step_6()` (and potentially other DB update steps).

## Fix

- Replace the broken dynamic dispatch in `getDeclaration()` with direct logic.
- Restore `getDeclarationOptions()` as a `private` helper handling DEFAULT, NOT NULL, and collation — matching the original logic from `ilDBPdoFieldDefinition`.
- CLOB/BLOB columns retain their special handling (no DEFAULT clause, only NOT NULL).

## Test plan

- [ ] Run `php cli/setup.php update -y` — `Test11DBUpdateSteps::step_6()` and `step_7()` complete without exception.
- [ ] All 49 Database unit tests pass (`phpunit components/ILIAS/Database/tests/`).
- [ ] All 863 Test component unit tests pass (`phpunit components/ILIAS/Test/tests/`).

Fixes: https://mantis.ilias.de/view.php?id=47627