### PR TITLE
References: make type match ref_id and obj_id in list GUIs (47391)

### DIFF
--- a/components/ILIAS/CategoryReference/classes/class.ilObjCategoryReferenceListGUI.php
+++ b/components/ILIAS/CategoryReference/classes/class.ilObjCategoryReferenceListGUI.php
@@ -71,7 +71,7 @@ class ilObjCategoryReferenceListGUI extends ilObjCategoryListGUI
         $this->subscribe_enabled = true;
         $this->link_enabled = false;
         $this->info_screen_enabled = true;
-        $this->type = 'catr';
+        $this->type = 'cat';
         $this->gui_class_name = "ilobjcategorygui";
 
         $this->substitutions = ilAdvancedMDSubstitution::_getInstanceByObjectType($this->type);

--- a/components/ILIAS/Course/classes/class.ilObjCourseListGUI.php
+++ b/components/ILIAS/Course/classes/class.ilObjCourseListGUI.php
@@ -178,7 +178,6 @@ class ilObjCourseListGUI extends ilObjectListGUI
         }
 
         if ($permission == 'crs_linked') {
-            $type = ilObject::_lookupType($ref_id, true);
             return
                 parent::checkCommandAccess('read', $cmd, $ref_id, $type, $obj_id) ||
                 parent::checkCommandAccess('join', $cmd, $ref_id, $type, $obj_id);

--- a/components/ILIAS/CourseReference/classes/class.ilObjCourseReferenceListGUI.php
+++ b/components/ILIAS/CourseReference/classes/class.ilObjCourseReferenceListGUI.php
@@ -78,7 +78,7 @@ class ilObjCourseReferenceListGUI extends ilObjCourseListGUI
         $this->subscribe_enabled = true;
         $this->link_enabled = false;
         $this->info_screen_enabled = true;
-        $this->type = 'crsr';
+        $this->type = 'crs';
         $this->gui_class_name = "ilobjcoursegui";
 
         $this->substitutions = ilAdvancedMDSubstitution::_getInstanceByObjectType($this->type);

--- a/components/ILIAS/Group/classes/class.ilObjGroupListGUI.php
+++ b/components/ILIAS/Group/classes/class.ilObjGroupListGUI.php
@@ -159,7 +159,6 @@ class ilObjGroupListGUI extends ilObjectListGUI
         ?int $obj_id = null
     ): bool {
         if ($permission == 'grp_linked') {
-            $type = ilObject::_lookupType($ref_id, true);
             return
                 parent::checkCommandAccess('read', '', $ref_id, $type, $obj_id) ||
                 parent::checkCommandAccess('join', 'join', $ref_id, $type, $obj_id);

--- a/components/ILIAS/GroupReference/classes/class.ilObjGroupReferenceListGUI.php
+++ b/components/ILIAS/GroupReference/classes/class.ilObjGroupReferenceListGUI.php
@@ -79,7 +79,7 @@ class ilObjGroupReferenceListGUI extends ilObjGroupListGUI
         $this->subscribe_enabled = true;
         $this->link_enabled = false;
         $this->info_screen_enabled = true;
-        $this->type = 'grpr';
+        $this->type = 'grp';
         $this->gui_class_name = "ilobjgroupgui";
 
         $this->substitutions = ilAdvancedMDSubstitution::_getInstanceByObjectType($this->type);

--- a/components/ILIAS/StudyProgrammeReference/classes/class.ilObjStudyProgrammeReferenceListGUI.php
+++ b/components/ILIAS/StudyProgrammeReference/classes/class.ilObjStudyProgrammeReferenceListGUI.php
@@ -75,7 +75,7 @@ class ilObjStudyProgrammeReferenceListGUI extends ilObjStudyProgrammeListGUI
         $this->subscribe_enabled = false;
         $this->link_enabled = false;
 
-        $this->type = "prgr";
+        $this->type = "prg";
         $this->gui_class_name = "ilobjstudyprogrammegui";
 
         $this->substitutions = ilAdvancedMDSubstitution::_getInstanceByObjectType($this->type);


### PR DESCRIPTION
This PR fixes [47391](https://mantis.ilias.de/view.php?id=47391) by making sure that `ilObjectListGUI::$ref_id`, `ilObjectListGUI::$obj_id` and `ilObjectListGUI::$type` of container references match. This seems a bit of a risky change, `ilObjectListGUI::$type` shows up a lot in `ilObjectListGUI`, see the ticket for details.

@kergomard, there are no code changes in your components, but this PR mainly concerns how an "interface" of your component should be used, so as far as I'm concerned this is your call to make. Let me know how you want to proceed with this and [47391](https://mantis.ilias.de/view.php?id=47391), I can take of merging and whatnot.

@maalers, you should also have quick look here, `ilObjStudyProgrammeReferenceListGUI` is also affected. If you have any doubts or questions, let me know!