### PR TITLE
Object: fix unlinked container titles when below their own reference (47391)

### DIFF
--- a/components/ILIAS/ILIASObject/classes/class.ilObjectListGUI.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObjectListGUI.php
@@ -1810,7 +1810,7 @@ class ilObjectListGUI
             $this->lng->loadLanguageModule('dash');
             if (!$this->fav_manager->ifIsFavourite($this->user->getId(), $this->getCommandId())) {
                 // Pass type and object ID to ilAccess to improve performance
-                if ($this->checkCommandAccess('read', '', $this->ref_id, $this->type, $this->obj_id)) {
+                if ($this->checkCommandAccess('read', '', $this->ref_id, ilObject::_lookupType($this->obj_id), $this->obj_id)) {
                     $cmd_link = $this->ctrl->getLinkTarget($this->container_obj, 'addToDesk');
                     $this->insertCommand($cmd_link, $this->lng->txt('add_to_favourites'));
                 }


### PR DESCRIPTION
This PR is a possible quick fix [47391](https://mantis.ilias.de/view.php?id=47391). I doesn't really get to the root of the issue, but also carries a much lower risk for side effect than the proper fix, see the ticket for details.

For a proper but riskier fix, see #11478.