### PR TITLE
News: Fix missing logger dependency

### DIFF
--- a/components/ILIAS/News/classes/class.ilNewsForContextBlockGUI.php
+++ b/components/ILIAS/News/classes/class.ilNewsForContextBlockGUI.php
@@ -50,6 +50,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
     protected ilHelpGUI $help;
     protected ilSetting $settings;
     protected ilTabsGUI $tabs;
+    protected ilLogger $logger;
 
     protected StandardGUIRequest $std_request;
     protected InternalDomainService $domain;
@@ -67,6 +68,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
         $this->help = $DIC["ilHelp"];
         $this->settings = $DIC->settings();
         $this->tabs = $DIC->tabs();
+        $this->logger = $DIC->logger()->news();
 
         $locator = $DIC->news()->internal();
         $this->std_request = $locator->gui()->standardRequest();


### PR DESCRIPTION
Hello everyone,

In this PR, I am reintroducing the missing class member `$logger` from the `ilNewsForContextBlockGUI` class. It appears to have been lost during previous pull requests and cherry-picking.

Best,
@lukas-heinrich 