### PR TITLE
[FIX] News 47631: Fixes News Context Filter

### DIFF
--- a/components/ILIAS/News/Dashboard/class.DashboardNewsManager.php
+++ b/components/ILIAS/News/Dashboard/class.DashboardNewsManager.php
@@ -110,11 +110,9 @@ class DashboardNewsManager
      */
     public function getContextOptions(): array
     {
-        $context_count = $this->repo->news()->countByContextsBatch(
-            $this->domain->resolver()->getAccessibleContexts(
-                $this->domain->user(),
-                new NewsCriteria(period: $this->getDashboardNewsPeriod(), only_public: false)
-            )
+        $context_count = $this->domain->collection()->countNewsByContext(
+            $this->domain->user(),
+            new NewsCriteria(period: $this->getDashboardNewsPeriod(), only_public: false)
         );
 
         $options = [];

--- a/components/ILIAS/News/Dashboard/class.InternalGUIService.php
+++ b/components/ILIAS/News/Dashboard/class.InternalGUIService.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\News\Dashboard;
 
@@ -71,7 +71,7 @@ class InternalGUIService
                     (string) $this->manager->getDashboardNewsPeriod(),
                     true
                 )
-                ->select("news_ref_id", $lng->txt("context"), $context_options, true, null, true);
+                ->select("news_ref_id", $lng->txt("context"), $context_options, true, "0", true);
         }
         return $this->filter;
     }
@@ -79,7 +79,7 @@ class InternalGUIService
     public function getTimelineGUI(): \ilNewsTimelineGUI
     {
         $ctrl = $this->gui->ctrl();
-        if ($ctrl->isAsynch() && ! $this->gui->standardRequest()->getFilterOff()) {
+        if ($ctrl->isAsynch() && !$this->gui->standardRequest()->getFilterOff()) {
             $period = $this->manager->getDashboardNewsPeriod();
             $news_ref_id = $this->manager->getDashboardSelectedRefId();
         } else {

--- a/components/ILIAS/News/News/src/Data/LazyNewsCollection.php
+++ b/components/ILIAS/News/News/src/Data/LazyNewsCollection.php
@@ -248,4 +248,9 @@ class LazyNewsCollection extends NewsCollection
     {
         return parent::limit($limit)->withFetchCallback($this->fetch_callback);
     }
+
+    public function orderByDate(): static
+    {
+        return parent::orderByDate()->withFetchCallback($this->fetch_callback);
+    }
 }

--- a/components/ILIAS/News/News/src/Data/NewsCollection.php
+++ b/components/ILIAS/News/News/src/Data/NewsCollection.php
@@ -432,6 +432,22 @@ class NewsCollection implements \Countable, \IteratorAggregate, \JsonSerializabl
         return $filtered;
     }
 
+    /**
+     * Returns a new collection with news items ordered by creation date
+     */
+    public function orderByDate(): static
+    {
+        $ordered = new static();
+        $ordered->addNewsItems($this->news_items);
+
+        uasort(
+            $ordered->news_items,
+            fn(NewsItem $a, NewsItem $b): int => $a->getCreationDate() <=> $b->getCreationDate()
+        );
+
+        return $ordered;
+    }
+
     public function load(array $news_ids = []): static
     {
         return $this;

--- a/components/ILIAS/News/News/src/Domain/NewsCollectionService.php
+++ b/components/ILIAS/News/News/src/Domain/NewsCollectionService.php
@@ -104,7 +104,7 @@ class NewsCollectionService
             if (!\ilContainer::_lookupContainerSetting($context_obj_id, 'cont_use_news', '1')
                 || (
                     !\ilContainer::_lookupContainerSetting($context_obj_id, 'cont_use_news', '1')
-                       && !\ilContainer::_lookupContainerSetting($context_obj_id, 'news_timeline')
+                    && !\ilContainer::_lookupContainerSetting($context_obj_id, 'news_timeline')
                 )) {
                 return new NewsCollection();
             }
@@ -119,6 +119,16 @@ class NewsCollectionService
 
         $context = new NewsContext($ref_id, $context_obj_id, $context_type);
         return $this->applyFinalProcessing($this->getNewsForContexts([$context], $criteria, $user_id, $lazy), $criteria);
+    }
+
+    /**
+     * @return list<array{0: NewsContext, 1: int}>
+     */
+    public function countNewsByContext(\ilObjUser $user_id, NewsCriteria $criteria): array
+    {
+        $contexts = $this->user_context_resolver->getAccessibleContexts($user_id, $criteria);
+        $contexts = $this->fetchContextData($contexts);
+        return $this->repository->countByContextsBatch($contexts);
     }
 
     public function invalidateCache(int $user_id): void

--- a/components/ILIAS/News/classes/class.ilNewsTimelineGUI.php
+++ b/components/ILIAS/News/classes/class.ilNewsTimelineGUI.php
@@ -45,6 +45,7 @@ class ilNewsTimelineGUI
     protected ilToolbarGUI $toolbar;
     protected ilObjUser $user;
     protected ilAccessHandler $access;
+    protected ilObjectDataCache $object_data_cache;
     protected static int $items_per_load = 20;
     protected bool $user_edit_all = false;
     protected StandardGUIRequest $std_request;
@@ -67,6 +68,7 @@ class ilNewsTimelineGUI
         $this->access = $DIC->access();
         $this->http = $DIC->http();
         $this->notes = $DIC->notes();
+        $this->object_data_cache = $DIC['ilObjDataCache'];
 
         $this->std_request = $DIC->news()
             ->internal()
@@ -182,15 +184,17 @@ class ilNewsTimelineGUI
 
     protected function readNewsData($excluded = []): void
     {
+        $context_obj_id = $this->object_data_cache->lookupObjId($this->ref_id);
+
         $this->news_collection = $this->manager->getNewsData(
             $this->ref_id,
-            $this->ctrl->getContextObjId(),
-            $this->ctrl->getContextObjType(),
+            $context_obj_id,
+            $this->object_data_cache->lookupType($context_obj_id),
             $this->period,
             $this->include_auto_entries,
             self::$items_per_load,
             $excluded
-        );
+        )->orderByDate();
     }
 
     public function getHTML(ilPropertyFormGUI $form = null): string


### PR DESCRIPTION
Hello everyone,

This PR addresses a number of issues related to filtering news on the related page under the “Communication” menu. First and foremost, it addresses the TypeException from ticket [47631](https://mantis.ilias.de/view.php?id=47631). Additionally, testing revealed that filtering for certain objects yields no results, and the timeline returns incomplete results. Furthermore, sorting news by creation date was inconsistent. This PR now summarizes the solutions for all four issues.

Best,
@lukas-heinrich 