### PR TITLE
UI 47014: Benutzersuche (Hinzufügen) verschwindet hinter Data Table

### DIFF
--- a/templates/default/070-components/legacy/Services/UIComponent/_component_toolbar.scss
+++ b/templates/default/070-components/legacy/Services/UIComponent/_component_toolbar.scss
@@ -97,6 +97,11 @@ $il-toolbar-border: 1px solid $il-main-border-color !default;
 	}
 }
 
+.ilToolbarContainer {
+	position: relative;
+	z-index: 50;
+}
+
 // Dropdowns
 // -------------------------
 

--- a/templates/default/070-components/legacy/Services/_component_form.scss
+++ b/templates/default/070-components/legacy/Services/_component_form.scss
@@ -739,7 +739,7 @@ div[id$="color-picker-menu"] {
     margin: 0;
     padding: $il-form-autocomplete-padding;
     list-style: none;
-    z-index: 1;
+    z-index: 10;
     cursor: default;
 
     & li:hover {

--- a/templates/default/070-components/legacy/Services/_component_form.scss
+++ b/templates/default/070-components/legacy/Services/_component_form.scss
@@ -739,7 +739,7 @@ div[id$="color-picker-menu"] {
     margin: 0;
     padding: $il-form-autocomplete-padding;
     list-style: none;
-    z-index: 10;
+    z-index: 1;
     cursor: default;
 
     & li:hover {

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -19415,7 +19415,7 @@ div[id$=color-picker-menu] {
   margin: 0;
   padding: 3px;
   list-style: none;
-  z-index: 1;
+  z-index: 10;
   cursor: default;
 }
 .c-form__autocomplete li:hover {

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -22125,6 +22125,11 @@ a.ilMediaLightboxClose:hover {
   max-width: none;
 }
 
+.ilToolbarContainer {
+  position: relative;
+  z-index: 50;
+}
+
 .nav-tabs .dropdown-menu {
   margin-top: -1px;
   border-top-left-radius: 0;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -19415,7 +19415,7 @@ div[id$=color-picker-menu] {
   margin: 0;
   padding: 3px;
   list-style: none;
-  z-index: 10;
+  z-index: 1;
   cursor: default;
 }
 .c-form__autocomplete li:hover {


### PR DESCRIPTION
Hello everyone,

In this PR, I’m addressing the issue described in [47014](https://mantis.ilias.de/view.php?id=47014), where the user search in some data tables is obscured by the table header. The headers in the table have a z-index of 3. Therefore, with this PR, I propose changing the z-index for the autocomplete list to a higher value.

I look forward to your feedback on this proposal.

Best
@lukas-heinrich 