### PR TITLE
BookingPool 47260: Disambiguate Info Stakeholders

### DIFF
--- a/components/ILIAS/BookingManager/Objects/class.ilBookBookingInfoStakeholder.php
+++ b/components/ILIAS/BookingManager/Objects/class.ilBookBookingInfoStakeholder.php
@@ -33,6 +33,11 @@ class ilBookBookingInfoStakeholder extends AbstractResourceStakeholder
         return $this->default_owner;
     }
 
+    public function getConsumerNameForPresentation(): string
+    {
+        return parent::getConsumerNameForPresentation() . '/BookingInfo';
+    }
+
     public function canBeAccessedByCurrentUser(ResourceIdentification $identification): bool
     {
         global $DIC;

--- a/components/ILIAS/BookingManager/Objects/class.ilBookObjectInfoStakeholder.php
+++ b/components/ILIAS/BookingManager/Objects/class.ilBookObjectInfoStakeholder.php
@@ -34,6 +34,11 @@ class ilBookObjectInfoStakeholder extends AbstractResourceStakeholder
         return $this->default_owner;
     }
 
+    public function getConsumerNameForPresentation(): string
+    {
+        return parent::getConsumerNameForPresentation() . '/ObjectInfo';
+    }
+
     public function canBeAccessedByCurrentUser(ResourceIdentification $identification): bool
     {
         global $DIC;


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=47260

Both `ilBookBookingInfoStakeholder` and `ilBookObjectInfoStakeholder` inherited the same `getConsumerNameForPresentation()` label from the parent, which made the two resource consumers hard to tell apart. Each class now appends a suffix (`/BookingInfo` or `/ObjectInfo`) to the parent name.

/cc @thojou 