### PR TITLE
BookingPool 46909: Render Pool Without Booking Info

### DIFF
--- a/components/ILIAS/BookingManager/BookingProcess/class.ProcessUtilGUI.php
+++ b/components/ILIAS/BookingManager/BookingProcess/class.ProcessUtilGUI.php
@@ -37,6 +37,8 @@ class ProcessUtilGUI
     protected InternalGUIService $gui;
     protected InternalDomainService $domain;
     protected object $parent_gui;
+    protected \ilLanguage $lng;
+    protected \ilGlobalTemplateInterface $tpl;
 
     public function __construct(
         InternalDomainService $domain_service,
@@ -53,6 +55,8 @@ class ProcessUtilGUI
         $this->ctrl = $this->gui->ctrl();
         $this->request = $this->gui->standardRequest();
         $this->objects_manager = $domain_service->objects($pool->getId());
+        $this->lng = $domain_service->lng();
+        $this->tpl = $this->gui->mainTemplate();
     }
 
     // Back to parent
@@ -126,38 +130,50 @@ class ProcessUtilGUI
     public function handleBookingSuccess(
         int $a_obj_id,
         string $post_info_cmd,
-        ?array $a_rsv_ids = null
+        ?array $a_rsv_ids = null,
+        ?string $message = null
     ): void {
-        $this->log->debug("handleBookingSuccess");
-        $main_tpl = $this->gui->mainTemplate();
-        $ctrl = $this->gui->ctrl();
-        $lng = $this->domain->lng();
-        $request = $this->gui->standardRequest();
+        $this->log->debug('handleBookingSuccess');
+        $this->tpl->setOnScreenMessage(
+            'success',
+            $message ?: $this->lng->txt('book_reservation_confirmed'),
+            true
+        );
 
-        $main_tpl->setOnScreenMessage('success', $lng->txt('book_reservation_confirmed'), true);
+        $this->redirectToReturnCmdIfAsynchronous();
+        $this->redirectToBookingInformationIfAvailable($a_obj_id, $post_info_cmd, $a_rsv_ids);
+        $this->redirectToRender();
+    }
 
-        // show post booking information?
+    public function redirectToBookingInformationIfAvailable(int $a_obj_id, string $post_info_cmd, ?array $a_rsv_ids = null): void
+    {
         $obj = new \ilBookingObject($a_obj_id);
-        $pfile = $this->objects_manager->getBookingInfoFilename($a_obj_id);
-        $ptext = $obj->getPostText();
-
-        if (trim($ptext) || $pfile) {
-            if (count($a_rsv_ids)) {
-                $ctrl->setParameter(
-                    $this->parent_gui,
-                    'rsv_ids',
-                    implode(";", $a_rsv_ids)
-                );
-            }
-            $ctrl->redirect($this->parent_gui, $post_info_cmd);
-        } else {
-            if ($ctrl->isAsynch()) {
-                $this->gui->send("<script>window.location.href = '" .
-                    $ctrl->getLinkTarget($this->parent_gui, $request->getReturnCmd()) . "';</script>");
-            } else {
-                $this->back();
-            }
+        if (trim($obj->getPostText()) === '' && $this->objects_manager->getBookingInfoFilename($a_obj_id) === '') {
+            return;
         }
+
+        $a_rsv_ids ??= [];
+        if ($a_rsv_ids !== []) {
+            $this->ctrl->setParameter($this->parent_gui, 'rsv_ids', implode(';', $a_rsv_ids));
+        }
+        $this->ctrl->redirect($this->parent_gui, $post_info_cmd);
+    }
+
+    private function redirectToReturnCmdIfAsynchronous(): void
+    {
+        if (!$this->ctrl->isAsynch()) {
+            return;
+        }
+
+        $this->gui->send(
+            "<script>window.location.href = '{$this->ctrl->getLinkTarget($this->parent_gui, $this->request->getReturnCmd())}';</script>"
+        );
+    }
+
+    private function redirectToRender(): void
+    {
+        $this->ctrl->saveParameterByClass(\ilObjBookingPoolGUI::class, 'ref_id');
+        $this->ctrl->redirectByClass(\ilObjBookingPoolGUI::class, 'render');
     }
 
     /**

--- a/components/ILIAS/BookingManager/BookingProcess/class.ilBookingProcessWithScheduleGUI.php
+++ b/components/ILIAS/BookingManager/BookingProcess/class.ilBookingProcessWithScheduleGUI.php
@@ -513,12 +513,13 @@ class ilBookingProcessWithScheduleGUI implements \ILIAS\BookingManager\BookingPr
             $until,
             $message
         );
-        if (count($booked) > 0) {
-            $this->util_gui->handleBookingSuccess($obj_id, "displayPostInfo", $booked);
-        } else {
-            $this->tpl->setOnScreenMessage('failure', $this->lng->txt('book_reservation_failed'), true);
-            $this->util_gui->back();
+        if ($booked !== []) {
+            $this->util_gui->handleBookingSuccess($obj_id, 'displayPostInfo', $booked);
+            return;
         }
+
+        $this->tpl->setOnScreenMessage('failure', $this->lng->txt('book_reservation_failed'), true);
+        $this->util_gui->back();
     }
 
     protected function getBookAvailableTarget(

--- a/components/ILIAS/BookingManager/BookingProcess/class.ilBookingProcessWithoutScheduleGUI.php
+++ b/components/ILIAS/BookingManager/BookingProcess/class.ilBookingProcessWithoutScheduleGUI.php
@@ -285,12 +285,12 @@ class ilBookingProcessWithoutScheduleGUI implements \ILIAS\BookingManager\Bookin
     {
         $participants = $this->book_request->getParticipants();
         $object_id = $this->book_request->getObjectId();
-        if (count($participants) > 0 && $object_id > 0) {
+        if ($participants !== [] && $object_id > 0) {
             $this->book_obj_id = $object_id;
         } else {
             $this->util_gui->back();
         }
-        $rsv_ids = array();
+        $rsv_ids = [];
         foreach ($participants as $id) {
             if (!$this->access->canManageReservationForUser($this->pool->getRefId(), $id)) {
                 $this->showNoPermission();
@@ -305,24 +305,29 @@ class ilBookingProcessWithoutScheduleGUI implements \ILIAS\BookingManager\Bookin
             );
         }
 
-        if (count($rsv_ids)) {
-            $this->tpl->setOnScreenMessage('success', "booking_multiple_succesfully");
-        } else {
-            $this->tpl->setOnScreenMessage('failure', $this->lng->txt('book_reservation_failed_overbooked'), true);
+        if ($rsv_ids !== []) {
+            $this->util_gui->handleBookingSuccess(
+                $object_id,
+                'displayPostInfo',
+                $rsv_ids,
+                $this->lng->txt('booking_multiple_succesfully')
+            );
+            return;
         }
+
+        $this->tpl->setOnScreenMessage('failure', $this->lng->txt('book_reservation_failed_overbooked'), true);
         $this->util_gui->back();
     }
-
 
     //
     // Step 2: Confirmation
     //
 
     // Book object - either of type or specific - for given dates
-    public function confirmedBooking($message = ""): bool
+    public function confirmedBooking($message = ''): void
     {
         $success = false;
-        $rsv_ids = array();
+        $rsv_ids = [];
 
         if ($this->book_obj_id > 0) {
             $object_id = $this->book_obj_id;
@@ -349,12 +354,12 @@ class ilBookingProcessWithoutScheduleGUI implements \ILIAS\BookingManager\Bookin
         }
 
         if ($success) {
-            $this->util_gui->handleBookingSuccess($success, "displayPostInfo", $rsv_ids);
-        } else {
-            $this->tpl->setOnScreenMessage('failure', $this->lng->txt('book_reservation_failed'), true);
-            $this->ctrl->redirect($this, 'book');
+            $this->util_gui->handleBookingSuccess($success, 'displayPostInfo', $rsv_ids);
+            return;
         }
-        return true;
+
+        $this->tpl->setOnScreenMessage('failure', $this->lng->txt('book_reservation_failed'), true);
+        $this->ctrl->redirect($this, 'book');
     }
 
     public function displayPostInfo(): void


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=46909

`ProcessUtilGUI::handleBookingSuccess()` only redirects to `displayPostInfo` when the bookable object has post text or a booking info file; otherwise, after the success message (and async return-URL handling when needed), it redirects to `ilObjBookingPoolGUI::render` so the pool view opens instead of stopping on an empty info step. Added an optional custom success message, split redirect logic into helpers, and aligned with/without-schedule booking flows (including `void` `confirmedBooking()` and translated text for multiple bookings).

/cc @thojou 