### PR TITLE
TestQuestionPool 47194: Fix LongMenuQuestion Answers Modal

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssLongmenuCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssLongmenuCorrectionsInputGUI.php
@@ -18,6 +18,9 @@
 
 declare(strict_types=1);
 
+use ILIAS\DI\UIServices;
+use ILIAS\UI\Component\Modal\Lightbox;
+
 /**
  * Class ilAssLongmenuCorrectionsInputGUI
  *
@@ -28,8 +31,8 @@ declare(strict_types=1);
  */
 class ilAssLongmenuCorrectionsInputGUI extends ilAnswerWizardInputGUI
 {
-    private \ILIAS\DI\UIServices $ui;
-    private \ILIAS\UI\Component\Modal\Modal $modal;
+    private UIServices $ui;
+    private ?Lightbox $answer_options_modal = null;
 
     public function __construct($a_title = "", $a_postvar = "")
     {
@@ -53,8 +56,11 @@ class ilAssLongmenuCorrectionsInputGUI extends ilAnswerWizardInputGUI
         $message = $inp->render();
 
         $page = $this->ui->factory()->modal()->lightboxTextPage($message, $this->lng->txt('answer_options'));
-        $this->modal = $this->ui->factory()->modal()->lightbox($page);
-        $button = $this->ui->factory()->button()->standard($this->lng->txt('show'), $this->modal->getShowSignal());
+        $this->answer_options_modal = $this->ui->factory()->modal()->lightbox($page);
+        $button = $this->ui->factory()->button()->standard(
+            $this->lng->txt('show'),
+            $this->answer_options_modal->getShowSignal()
+        );
 
         $tpl = new ilTemplate('tst.longmenu_corrections_input.html', true, true, 'components/ILIAS/TestQuestionPool');
 
@@ -73,7 +79,10 @@ class ilAssLongmenuCorrectionsInputGUI extends ilAnswerWizardInputGUI
 
     public function getContentOutsideFormTag(): string
     {
-        return $this->ui->renderer()->render($this->modal);
+        if ($this->answer_options_modal === null) {
+            return '';
+        }
+        return $this->ui->renderer()->render($this->answer_options_modal);
     }
 
     protected function buildTagInput(): ilTagInputGUI

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssLongmenuCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssLongmenuCorrectionsInputGUI.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 /**
  * Class ilAssLongmenuCorrectionsInputGUI
  *
@@ -27,6 +29,7 @@
 class ilAssLongmenuCorrectionsInputGUI extends ilAnswerWizardInputGUI
 {
     private \ILIAS\DI\UIServices $ui;
+    private \ILIAS\UI\Component\Modal\Modal $modal;
 
     public function __construct($a_title = "", $a_postvar = "")
     {
@@ -50,12 +53,11 @@ class ilAssLongmenuCorrectionsInputGUI extends ilAnswerWizardInputGUI
         $message = $inp->render();
 
         $page = $this->ui->factory()->modal()->lightboxTextPage($message, $this->lng->txt('answer_options'));
-        $modal = $this->ui->factory()->modal()->lightbox($page);
-        $button = $this->ui->factory()->button()->standard($this->lng->txt('show'), $modal->getShowSignal());
+        $this->modal = $this->ui->factory()->modal()->lightbox($page);
+        $button = $this->ui->factory()->button()->standard($this->lng->txt('show'), $this->modal->getShowSignal());
 
         $tpl = new ilTemplate('tst.longmenu_corrections_input.html', true, true, 'components/ILIAS/TestQuestionPool');
 
-        $tpl->setVariable('ANSWERS_MODAL', $this->ui->renderer()->render($modal));
         $tpl->setVariable('TAG_INPUT', $this->buildTagInput()->render());
         $tpl->setVariable('NUM_ANSWERS', $this->values['answers_all_count']);
         $tpl->setVariable('BTN_SHOW', $this->ui->renderer()->render($button));
@@ -67,6 +69,11 @@ class ilAssLongmenuCorrectionsInputGUI extends ilAnswerWizardInputGUI
         $a_tpl->setCurrentBlock("prop_generic");
         $a_tpl->setVariable("PROP_GENERIC", $tpl->get());
         $a_tpl->parseCurrentBlock();
+    }
+
+    public function getContentOutsideFormTag(): string
+    {
+        return $this->ui->renderer()->render($this->modal);
     }
 
     protected function buildTagInput(): ilTagInputGUI

--- a/components/ILIAS/TestQuestionPool/templates/default/tst.longmenu_corrections_input.html
+++ b/components/ILIAS/TestQuestionPool/templates/default/tst.longmenu_corrections_input.html
@@ -2,5 +2,4 @@
     <p>{TXT_ANSWERS} {NUM_ANSWERS} {BTN_SHOW}</p>
     <p>{TXT_CORRECT_ANSWERS}</p>
     {TAG_INPUT}
-    {ANSWERS_MODAL}
 </div>


### PR DESCRIPTION
See https://mantis.ilias.de/view.php?id=47194

The LongMenuQuestion points correction rendered the lightbox modal inside the surrounding property form. Since the lightbox close button uses its own dialog form, this produced invalid nested form markup and caused browsers to repair the DOM differently for the first and following modals. This moves the answers modal out of the parent form via `getContentOutsideFormTag()` while keeping the show button in the correction input markup.