### PR TITLE
[IMPROVEMENT] Finder: Add Micro Optimizations / Better Type Documentation / New API Methods

### DIFF
--- a/components/ILIAS/Filesystem/README.md
+++ b/components/ILIAS/Filesystem/README.md
@@ -629,6 +629,37 @@ foreach ($finder->files()->size('> 1Mi') as $metadata) {
 }
 ```
 
+### Limiting
+
+The result set can be limited to a fixed number of entries by calling `limit()`.
+The limit is applied to the final result set (after filtering and optional sorting).
+
+```php
+<?php
+/** @var ILIAS\Filesystem\Filesystem $web */
+$web = $DIC->filesystem()->web();
+$finder = $web->finder();
+
+foreach ($finder->files()->sortByName()->limit(5) as $metadata) {
+}
+```
+
+### Existence Check
+
+If you only need to know whether the current finder criteria matches at least one item,
+you can call `hasAny()`. This avoids counting the full result set.
+
+```php
+<?php
+/** @var ILIAS\Filesystem\Filesystem $web */
+$web = $DIC->filesystem()->web();
+$finder = $web->finder();
+
+if ($finder->files()->in(['my/path'])->hasAny()) {
+    // at least one matching file exists
+}
+```
+
 ### Sorting
 
 The found `Metadata` can be sorted by time (see: `\ILIAS\Filesystem\Provider\FileReadAccess::getTimestamp`),

--- a/components/ILIAS/Filesystem/src/Finder/Comparator/BaseComparator.php
+++ b/components/ILIAS/Filesystem/src/Finder/Comparator/BaseComparator.php
@@ -20,13 +20,6 @@ declare(strict_types=1);
 
 namespace ILIAS\Filesystem\Finder\Comparator;
 
-use InvalidArgumentException;
-
-/**
- * Class Base
- * @package ILIAS\Filesystem\Finder\Comparator
- * @author  Michael Jansen <mjansen@databay.de>
- */
 abstract class BaseComparator
 {
     private string $target = '';
@@ -53,8 +46,8 @@ abstract class BaseComparator
             $operator = '==';
         }
 
-        if (!in_array($operator, ['>', '<', '>=', '<=', '==', '!='])) {
-            throw new InvalidArgumentException(sprintf('Invalid operator "%s".', $operator));
+        if (!\in_array($operator, ['>', '<', '>=', '<=', '==', '!='], true)) {
+            throw new \InvalidArgumentException(\sprintf('Invalid operator "%s".', $operator));
         }
 
         $this->operator = $operator;

--- a/components/ILIAS/Filesystem/src/Finder/Comparator/DateComparator.php
+++ b/components/ILIAS/Filesystem/src/Finder/Comparator/DateComparator.php
@@ -20,27 +20,19 @@ declare(strict_types=1);
 
 namespace ILIAS\Filesystem\Finder\Comparator;
 
-use Exception;
-use InvalidArgumentException;
-
-/**
- * Class DateComparator
- * @package ILIAS\Filesystem\Finder\Comparator
- * @author  Michael Jansen <mjansen@databay.de>
- */
 class DateComparator extends BaseComparator
 {
     public function __construct(string $test)
     {
         if (!preg_match('#^\s*(==|!=|[<>]=?|after|since|before|until)?\s*(.+?)\s*$#i', $test, $matches)) {
-            throw new InvalidArgumentException(sprintf('Don\'t understand "%s" as a date test.', $test));
+            throw new \InvalidArgumentException(\sprintf('Don\'t understand "%s" as a date test.', $test));
         }
 
         try {
-            $date = new \DateTime($matches[2]);
+            $date = new \DateTimeImmutable($matches[2]);
             $target = $date->format('U');
-        } catch (Exception) {
-            throw new InvalidArgumentException(sprintf('"%s" is not a valid date.', $matches[2]));
+        } catch (\Throwable) {
+            throw new \InvalidArgumentException(\sprintf('"%s" is not a valid date.', $matches[2]));
         }
 
         $operator = $matches[1] ?? '==';

--- a/components/ILIAS/Filesystem/src/Finder/Comparator/NumberComparator.php
+++ b/components/ILIAS/Filesystem/src/Finder/Comparator/NumberComparator.php
@@ -20,24 +20,17 @@ declare(strict_types=1);
 
 namespace ILIAS\Filesystem\Finder\Comparator;
 
-use InvalidArgumentException;
-
-/**
- * Class NumberComparator
- * @package ILIAS\Filesystem\Finder\Comparator
- * @author  Michael Jansen <mjansen@databay.de>
- */
 class NumberComparator extends BaseComparator
 {
     public function __construct(string $test)
     {
         if (!preg_match('#^\s*(==|!=|[<>]=?)?\s*([0-9\.]+)\s*([kmg]i?)?\s*$#i', $test, $matches)) {
-            throw new InvalidArgumentException(sprintf('Don\'t understand "%s" as a number test.', $test));
+            throw new \InvalidArgumentException(\sprintf('Don\'t understand "%s" as a number test.', $test));
         }
 
         $target = $matches[2];
         if (!is_numeric($target)) {
-            throw new InvalidArgumentException(sprintf('Invalid number "%s".', $target));
+            throw new \InvalidArgumentException(\sprintf('Invalid number "%s".', $target));
         }
 
         if (isset($matches[3])) {

--- a/components/ILIAS/Filesystem/src/Finder/Finder.php
+++ b/components/ILIAS/Filesystem/src/Finder/Finder.php
@@ -20,40 +20,29 @@ declare(strict_types=1);
 
 namespace ILIAS\Filesystem\Finder;
 
-use AppendIterator;
-use ArrayIterator;
-use Closure;
-use Countable;
 use ILIAS\Filesystem\DTO\Metadata;
 use ILIAS\Filesystem\Filesystem;
-use ILIAS\Filesystem\MetadataType;
-use InvalidArgumentException;
-use Iterator as PhpIterator;
-use IteratorAggregate;
-use LogicException;
-use RecursiveIteratorIterator;
 use ILIAS\Filesystem\Finder\Iterator\SortableIterator;
+use ILIAS\Filesystem\Finder\Iterator\LazyIterator;
 
 /**
- * Class Finder
  * Port of the Symfony2 bundle to work with the ILIAS FileSystem abstraction
- * @package ILIAS\Filesystem\Finder
- * @see     : https://github.com/symfony/finder
- * @author  Michael Jansen <mjansen@databay.de>
+ * @see https://github.com/symfony/finder
+ * @implements \IteratorAggregate<non-empty-string, Metadata>
  */
-final class Finder implements IteratorAggregate, Countable
+final class Finder implements \IteratorAggregate, \Countable
 {
     private const IGNORE_VCS_FILES = 1;
     private const IGNORE_DOT_FILES = 2;
-    /** @var string[] */
+    /** @var list<string> */
     private array $vcsPatterns = ['.svn', '_svn', 'CVS', '_darcs', '.arch-params', '.monotone', '.bzr', '.git', '.hg'];
-    /** @var PhpIterator[] */
+    /** @var list<\Iterator> */
     private array $iterators = [];
-    /** @var string[] */
+    /** @var list<string> */
     protected array $dirs = [];
-    /** @var string[] */
+    /** @var list<string> */
     private array $exclude = [];
-    private int $ignore = 0;
+    private int $ignore;
     private int $mode = Iterator\FileTypeFilterIterator::ALL;
     private bool $reverseSorting = false;
     /** @var Comparator\DateComparator[] */
@@ -64,10 +53,11 @@ final class Finder implements IteratorAggregate, Countable
     private array $depths = [];
     /** @var int|Closure */
     private $sort = SortableIterator::SORT_BY_NONE;
+    private ?int $limit = null;
 
-    public function __construct(private Filesystem $filesystem)
+    public function __construct(private readonly Filesystem $filesystem)
     {
-        $this->ignore = self::IGNORE_VCS_FILES|self::IGNORE_DOT_FILES;
+        $this->ignore = self::IGNORE_VCS_FILES | self::IGNORE_DOT_FILES;
     }
 
     public function files(): self
@@ -95,14 +85,14 @@ final class Finder implements IteratorAggregate, Countable
     }
 
     /**
-     * @param string[] $directories
-     * @throws InvalidArgumentException
+     * @param list<string> $directories
+     * @throws \InvalidArgumentException
      */
     public function exclude(array $directories): self
     {
         array_walk($directories, static function ($directory): void {
-            if (!is_string($directory)) {
-                throw new InvalidArgumentException(sprintf('Invalid directory given: %s', $directory::class));
+            if (!\is_string($directory)) {
+                throw new \InvalidArgumentException(\sprintf('Invalid directory given: %s', $directory::class));
             }
         });
 
@@ -113,14 +103,14 @@ final class Finder implements IteratorAggregate, Countable
     }
 
     /**
-     * @param string[] $directories
-     * @throws InvalidArgumentException
+     * @param list<string> $directories
+     * @throws \InvalidArgumentException
      */
     public function in(array $directories): self
     {
         array_walk($directories, static function ($directory): void {
-            if (!is_string($directory)) {
-                throw new InvalidArgumentException(sprintf('Invalid directory given: %s', $directory::class));
+            if (!\is_string($directory)) {
+                throw new \InvalidArgumentException(sprintf('Invalid directory given: %s', $directory::class));
             }
         });
 
@@ -187,7 +177,7 @@ final class Finder implements IteratorAggregate, Countable
      */
     public function size(string|int|array $sizes): self
     {
-        $sizes = is_array($sizes) ? $sizes : [$sizes];
+        $sizes = \is_array($sizes) ? $sizes : [$sizes];
 
         $clone = clone $this;
 
@@ -206,6 +196,35 @@ final class Finder implements IteratorAggregate, Countable
         return $clone;
     }
 
+    public function limit(int $limit): self
+    {
+        if ($limit < 0) {
+            throw new \InvalidArgumentException('Limit must be greater than or equal to 0.');
+        }
+
+        $clone = clone $this;
+        $clone->limit = $limit;
+
+        return $clone;
+    }
+
+    /**
+     * Checks whether at least one entry matches the current finder criteria.
+     */
+    public function hasAny(): bool
+    {
+        $clone = clone $this;
+        $clone->sort = SortableIterator::SORT_BY_NONE;
+        $clone->reverseSorting = false;
+        $clone->limit = 1;
+
+        foreach ($clone->getIterator() as $_) {
+            return true;
+        }
+
+        return false;
+    }
+
     public function ignoreVCS(bool $ignoreVCS): self
     {
         $clone = clone $this;
@@ -219,14 +238,14 @@ final class Finder implements IteratorAggregate, Countable
     }
 
     /**
-     * @param string[] $pattern
-     * @throws InvalidArgumentException
+     * @param list<string> $pattern
+     * @throws \InvalidArgumentException
      */
     public function addVCSPattern(array $pattern): self
     {
         array_walk($pattern, static function ($p): void {
-            if (!is_string($p)) {
-                throw new InvalidArgumentException(sprintf('Invalid pattern given: %s', $p::class));
+            if (!\is_string($p)) {
+                throw new \InvalidArgumentException(\sprintf('Invalid pattern given: %s', $p::class));
             }
         });
 
@@ -245,7 +264,7 @@ final class Finder implements IteratorAggregate, Countable
      * The anonymous function receives two Metadata instances to compare.
      * This can be slow as all the matching files and directories must be retrieved for comparison.
      */
-    public function sort(Closure $closure): self
+    public function sort(\Closure $closure): self
     {
         $clone = clone $this;
         $clone->sort = $closure;
@@ -282,52 +301,36 @@ final class Finder implements IteratorAggregate, Countable
 
     /**
      * Appends an existing set of files/directories to the finder.
-     * The set can be another Finder, an Iterator, an IteratorAggregate, or even a plain array.
-     * @throws InvalidArgumentException when the given argument is not iterable
+     * The set can be another {@see Finder}, an {@see \Iterator}, an {@see \IteratorAggregate}, or even a plain array.
+     * @param iterable<non-empty-string, Metadata> $iterator
+     * @throws \InvalidArgumentException when the given argument is not iterable
      */
     public function append(iterable $iterator): self
     {
         $clone = clone $this;
-
-        if ($iterator instanceof IteratorAggregate) {
-            $clone->iterators[] = $iterator->getIterator();
-        } elseif ($iterator instanceof PhpIterator) {
-            $clone->iterators[] = $iterator;
-        } elseif (is_iterable($iterator)) {
-            $it = new ArrayIterator();
-            foreach ($iterator as $file) {
-                if ($file instanceof MetadataType) {
-                    $it->append($file);
-                } else {
-                    throw new InvalidArgumentException(
-                        'Finder::append() method wrong argument type in passed iterator.'
-                    );
-                }
-            }
-            $clone->iterators[] = $it;
-        } else {
-            throw new InvalidArgumentException('Finder::append() method wrong argument type.');
-        }
+        $clone->iterators[] = $iterator;
 
         return $clone;
     }
 
     private function searchInDirectory(string $dir): \Traversable
     {
-        if (self::IGNORE_VCS_FILES === (self::IGNORE_VCS_FILES&$this->ignore)) {
-            $this->exclude = array_merge($this->exclude, $this->vcsPatterns);
+        $exclude = $this->exclude;
+
+        if (self::IGNORE_VCS_FILES === (self::IGNORE_VCS_FILES & $this->ignore)) {
+            $exclude = array_merge($exclude, $this->vcsPatterns);
         }
 
         $iterator = new Iterator\RecursiveDirectoryIterator($this->filesystem, $dir);
 
-        if ($this->exclude) {
-            $iterator = new Iterator\ExcludeDirectoryFilterIterator($iterator, $this->exclude);
+        if ($exclude) {
+            $iterator = new Iterator\ExcludeDirectoryFilterIterator($iterator, ...$exclude);
         }
 
-        $iterator = new RecursiveIteratorIterator($iterator, \RecursiveIteratorIterator::SELF_FIRST);
+        $iterator = new \RecursiveIteratorIterator($iterator, \RecursiveIteratorIterator::SELF_FIRST);
 
         if ($this->depths) {
-            $iterator = new Iterator\DepthRangeFilterIterator($iterator, $this->depths);
+            $iterator = new Iterator\DepthRangeFilterIterator($iterator, ...$this->depths);
         }
 
         if ($this->mode !== 0) {
@@ -335,57 +338,77 @@ final class Finder implements IteratorAggregate, Countable
         }
 
         if ($this->dates) {
-            $iterator = new Iterator\DateRangeFilterIterator($this->filesystem, $iterator, $this->dates);
+            $iterator = new Iterator\DateRangeFilterIterator($this->filesystem, $iterator, ...$this->dates);
         }
 
         if ($this->sizes) {
-            $iterator = new Iterator\SizeRangeFilterIterator($this->filesystem, $iterator, $this->sizes);
+            $iterator = new Iterator\SizeRangeFilterIterator($this->filesystem, $iterator, ...$this->sizes);
+        }
+
+        return $iterator;
+    }
+
+    /**
+     * @return \Iterator<non-empty-string, Metadata>
+     * @throws \LogicException
+     */
+    public function getIterator(): \Iterator
+    {
+        if ([] === $this->dirs && [] === $this->iterators) {
+            throw new \LogicException('You must call one of in() or append() methods before iterating over a Finder.');
+        }
+
+        if ($this->limit === 0) {
+            return new \EmptyIterator();
+        }
+
+        if (1 === count($this->dirs) && [] === $this->iterators) {
+            $iterator = $this->searchInDirectory($this->dirs[0]);
+        } else {
+            $iterator = new \AppendIterator();
+            foreach ($this->dirs as $dir) {
+                $iterator->append(new \IteratorIterator(new LazyIterator(fn() => $this->searchInDirectory($dir))));
+            }
+
+            foreach ($this->iterators as $it) {
+                $iterator->append(
+                    new \IteratorIterator(
+                        new LazyIterator(
+                            static function () use ($it) {
+                                foreach ($it as $key => $value) {
+                                    yield $key => $value;
+                                }
+                            }
+                        )
+                    )
+                );
+            }
         }
 
         if ($this->sort || $this->reverseSorting) {
-            $iteratorAggregate = new Iterator\SortableIterator(
+            $iterator = (new SortableIterator(
                 $this->filesystem,
                 $iterator,
                 $this->sort,
                 $this->reverseSorting
+            ))->getIterator();
+        }
+
+        if ($this->limit === 0) {
+            return new \EmptyIterator();
+        }
+
+        if ($this->limit !== null) {
+            $iterator = new \LimitIterator(
+                $iterator instanceof \Iterator ? $iterator : new \IteratorIterator($iterator),
+                0,
+                $this->limit
             );
-            $iterator = $iteratorAggregate->getIterator();
         }
 
         return $iterator;
     }
 
-    /**
-     * @inheritdoc
-     * @return PhpIterator|Metadata[]
-     * @throws LogicException
-     */
-    #[\ReturnTypeWillChange]
-    public function getIterator(): \Iterator
-    {
-        if ([] === $this->dirs && [] === $this->iterators) {
-            throw new LogicException('You must call one of in() or append() methods before iterating over a Finder.');
-        }
-
-        if (1 === count($this->dirs) && [] === $this->iterators) {
-            return $this->searchInDirectory($this->dirs[0]);
-        }
-
-        $iterator = new AppendIterator();
-        foreach ($this->dirs as $dir) {
-            $iterator->append($this->searchInDirectory($dir));
-        }
-
-        foreach ($this->iterators as $it) {
-            $iterator->append($it);
-        }
-
-        return $iterator;
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function count(): int
     {
         return iterator_count($this->getIterator());

--- a/components/ILIAS/Filesystem/src/Finder/Iterator/DateRangeFilterIterator.php
+++ b/components/ILIAS/Filesystem/src/Finder/Iterator/DateRangeFilterIterator.php
@@ -20,48 +20,31 @@ declare(strict_types=1);
 
 namespace ILIAS\Filesystem\Finder\Iterator;
 
-use FilterIterator;
 use ILIAS\Filesystem\Filesystem;
 use ILIAS\Filesystem\Finder\Comparator\DateComparator;
 use ILIAS\Filesystem\DTO\Metadata;
-use InvalidArgumentException;
-use Iterator as PhpIterator;
 
 /**
- * Class DateRangeFilterIterator
- * @package ILIAS\Filesystem\Finder\Iterator
- * @author  Michael Jansen <mjansen@databay.de>
+ * @extends \FilterIterator<non-empty-string, Metadata>
  */
-class DateRangeFilterIterator extends FilterIterator
+class DateRangeFilterIterator extends \FilterIterator
 {
-    /** @var DateComparator[] */
-    private array $comparators = [];
+    /** @var list<DateComparator> */
+    private array $comparators;
 
     /**
-     * @param PhpIterator      $iterator    The Iterator to filter
-     * @param DateComparator[] $comparators An array of DateComparator instances
-     * @throws InvalidArgumentException
+     * @param \Iterator<non-empty-string, Metadata> $iterator The Iterator to filter
      */
-    public function __construct(private Filesystem $filesystem, PhpIterator $iterator, array $comparators)
-    {
-        array_walk($comparators, static function ($comparator): void {
-            if (!($comparator instanceof DateComparator)) {
-                throw new InvalidArgumentException(
-                    sprintf(
-                        'Invalid comparator given: %s',
-                        $comparator::class
-                    )
-                );
-            }
-        });
+    public function __construct(
+        private readonly Filesystem $filesystem,
+        \Iterator $iterator,
+        DateComparator ...$comparators
+    ) {
         $this->comparators = $comparators;
 
         parent::__construct($iterator);
     }
 
-    /**
-     * @inheritdoc
-     */
     public function accept(): bool
     {
         /** @var Metadata $metadata */

--- a/components/ILIAS/Filesystem/src/Finder/Iterator/DepthRangeFilterIterator.php
+++ b/components/ILIAS/Filesystem/src/Finder/Iterator/DepthRangeFilterIterator.php
@@ -21,36 +21,21 @@ declare(strict_types=1);
 namespace ILIAS\Filesystem\Finder\Iterator;
 
 use ILIAS\Filesystem\Finder\Comparator\NumberComparator;
-use InvalidArgumentException;
-use RecursiveIteratorIterator;
 
 /**
- * Class DepthRangeFilterIterator
- * @package ILIAS\Filesystem\Finder\Iterator
- * @author  Michael Jansen <mjansen@databay.de>
+ * @template-covariant TKey
+ * @template-covariant TValue
+ * @extends \FilterIterator<TKey, TValue>
  */
 class DepthRangeFilterIterator extends \FilterIterator
 {
-    private int $minDepth = 0;
+    private int $minDepth;
 
     /**
-     * DepthRangeFilterIterator constructor.
-     * @param NumberComparator[] $comparators
-     * @throws InvalidArgumentException
+     * @param \RecursiveIteratorIterator<\RecursiveIterator<TKey, TValue>> $iterator The iterator to filter
      */
-    public function __construct(RecursiveIteratorIterator $iterator, array $comparators)
+    public function __construct(\RecursiveIteratorIterator $iterator, NumberComparator ...$comparators)
     {
-        array_walk($comparators, static function ($comparator): void {
-            if (!($comparator instanceof NumberComparator)) {
-                throw new InvalidArgumentException(
-                    sprintf(
-                        'Invalid comparator given: %s',
-                        $comparator::class
-                    )
-                );
-            }
-        });
-
         $minDepth = 0;
         $maxDepth = PHP_INT_MAX;
 
@@ -79,9 +64,6 @@ class DepthRangeFilterIterator extends \FilterIterator
         parent::__construct($iterator);
     }
 
-    /**
-     * @inheritdoc
-     */
     public function accept(): bool
     {
         return $this->getInnerIterator()->getDepth() >= $this->minDepth;

--- a/components/ILIAS/Filesystem/src/Finder/Iterator/ExcludeDirectoryFilterIterator.php
+++ b/components/ILIAS/Filesystem/src/Finder/Iterator/ExcludeDirectoryFilterIterator.php
@@ -20,37 +20,25 @@ declare(strict_types=1);
 
 namespace ILIAS\Filesystem\Finder\Iterator;
 
-use FilterIterator;
 use ILIAS\Filesystem\DTO\Metadata;
-use InvalidArgumentException;
-use Iterator as PhpIterator;
-use RecursiveIterator;
 
 /**
- * Class ExcludeDirectoryFilterIterator
- * @package ILIAS\Filesystem\Finder\Iterator
- * @author  Michael Jansen <mjansen@databay.de>
+ * @extends \FilterIterator<non-empty-string, Metadata>
+ * @implements \RecursiveIterator<non-empty-string, Metadata>
  */
-class ExcludeDirectoryFilterIterator extends FilterIterator implements RecursiveIterator
+class ExcludeDirectoryFilterIterator extends \FilterIterator implements \RecursiveIterator
 {
     private bool $isRecursive;
-    /** @var string[] */
+    /** @var array<string, true> */
     private array $excludedDirs = [];
     private string $excludedPattern = '';
 
     /**
-     * @param PhpIterator $iterator    The Iterator to filter
-     * @param string[]    $directories An array of directories to exclude
-     * @throws InvalidArgumentException
+     * @param \Iterator<non-empty-string, Metadata> $iterator The Iterator to filter
      */
-    public function __construct(private PhpIterator $iterator, array $directories)
+    public function __construct(private readonly \Iterator $iterator, string ...$directories)
     {
-        array_walk($directories, static function ($directory): void {
-            if (!is_string($directory)) {
-                throw new InvalidArgumentException(sprintf('Invalid directory given: %s', $directory::class));
-            }
-        });
-        $this->isRecursive = $iterator instanceof RecursiveIterator;
+        $this->isRecursive = $iterator instanceof \RecursiveIterator;
 
         $patterns = [];
         foreach ($directories as $directory) {
@@ -69,9 +57,6 @@ class ExcludeDirectoryFilterIterator extends FilterIterator implements Recursive
         parent::__construct($iterator);
     }
 
-    /**
-     * @inheritdoc
-     */
     public function accept(): bool
     {
         /** @var Metadata $metadata */
@@ -91,20 +76,14 @@ class ExcludeDirectoryFilterIterator extends FilterIterator implements Recursive
         return true;
     }
 
-    /**
-     * @inheritdoc
-     */
     public function hasChildren(): bool
     {
         return $this->isRecursive && $this->iterator->hasChildren();
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function getChildren(): \ILIAS\Filesystem\Finder\Iterator\ExcludeDirectoryFilterIterator
+    public function getChildren(): self
     {
-        $children = new self($this->iterator->getChildren(), []);
+        $children = new self($this->iterator->getChildren());
         $children->excludedDirs = $this->excludedDirs;
         $children->excludedPattern = $this->excludedPattern;
 

--- a/components/ILIAS/Filesystem/src/Finder/Iterator/FileTypeFilterIterator.php
+++ b/components/ILIAS/Filesystem/src/Finder/Iterator/FileTypeFilterIterator.php
@@ -21,12 +21,9 @@ declare(strict_types=1);
 namespace ILIAS\Filesystem\Finder\Iterator;
 
 use ILIAS\Filesystem\DTO\Metadata;
-use Iterator as PhpIterator;
 
 /**
- * Class FileTypeFilterIterator
- * @package ILIAS\Filesystem\Finder\Iterator
- * @author  Michael Jansen <mjansen@databay.de>
+ * @extends \FilterIterator<non-empty-string, Metadata>
  */
 class FileTypeFilterIterator extends \FilterIterator
 {
@@ -35,30 +32,30 @@ class FileTypeFilterIterator extends \FilterIterator
     public const ONLY_DIRECTORIES = 2;
 
     /**
-     * @param PhpIterator $iterator The Iterator to filter
-     * @param int         $mode     The mode (self::ALL or self::ONLY_FILES or self::ONLY_DIRECTORIES)
+     * @param \Iterator<non-empty-string, Metadata> $iterator The Iterator to filter
+     * @param int                                   $mode     The mode (self::ALL or self::ONLY_FILES or self::ONLY_DIRECTORIES)
      */
-    public function __construct(PhpIterator $iterator, private int $mode)
+    public function __construct(\Iterator $iterator, private int $mode)
     {
         parent::__construct($iterator);
     }
 
-    /**
-     * @inheritdoc
-     */
     public function accept(): bool
     {
         /** @var Metadata $metadata */
         $metadata = $this->current();
-        if (self::ONLY_DIRECTORIES === (self::ONLY_DIRECTORIES&$this->mode) && $metadata->isFile()) {
+        if (self::ONLY_DIRECTORIES === (self::ONLY_DIRECTORIES & $this->mode) && $metadata->isFile()) {
             return false;
         }
-        if (self::ONLY_FILES !== (self::ONLY_FILES&$this->mode)) {
+
+        if (self::ONLY_FILES !== (self::ONLY_FILES & $this->mode)) {
             return true;
         }
+
         if (!$metadata->isDir()) {
             return true;
         }
+
         return false;
     }
 }

--- a/components/ILIAS/Filesystem/src/Finder/Iterator/LazyIterator.php
+++ b/components/ILIAS/Filesystem/src/Finder/Iterator/LazyIterator.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Filesystem\Finder\Iterator;
+
+class LazyIterator implements \IteratorAggregate
+{
+    private \Closure $iterator_factory;
+
+    public function __construct(callable $iterator_factory)
+    {
+        $this->iterator_factory = $iterator_factory(...);
+    }
+
+    public function getIterator(): \Traversable
+    {
+        yield from ($this->iterator_factory)();
+    }
+}

--- a/components/ILIAS/Filesystem/src/Finder/Iterator/RecursiveDirectoryIterator.php
+++ b/components/ILIAS/Filesystem/src/Finder/Iterator/RecursiveDirectoryIterator.php
@@ -24,78 +24,56 @@ use ILIAS\Filesystem\DTO\Metadata;
 use ILIAS\Filesystem\Filesystem;
 
 /**
- * Class RecursiveDirectoryIterator
- * @package ILIAS\Filesystem\Finder\Iterator
- * @author  Michael Jansen <mjansen@databay.de>
+ * @implements \RecursiveIterator<Metadata>
  */
 class RecursiveDirectoryIterator implements \RecursiveIterator
 {
-    /** @var Metadata[] */
-    protected array $files = [];
+    /** @var array<non-empty-string, Metadata> */
+    private array $files = [];
 
-    /**
-     * RecursiveDirectoryIterator constructor.
-     */
-    public function __construct(private Filesystem $filesystem, protected string $dir)
-    {
+    public function __construct(
+        private readonly Filesystem $filesystem,
+        private readonly string $dir
+    ) {
     }
 
     /**
-     * @inheritdoc
+     * @return non-empty-string|null
      */
-    public function key(): int|string
+    public function key(): string|null
     {
         return key($this->files);
     }
 
-    /**
-     * @inheritdoc
-     */
     public function next(): void
     {
         next($this->files);
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function current(): bool|\ILIAS\Filesystem\DTO\Metadata
+    public function current(): Metadata|false
     {
         return current($this->files);
     }
 
-    /**
-     * @inheritdoc
-     */
     public function valid(): bool
     {
         return current($this->files) instanceof Metadata;
     }
 
-    /**
-     * @inheritdoc
-     */
     public function rewind(): void
     {
-        $contents = $this->filesystem->listContents($this->dir, false);
-        $this->files = array_combine(
-            array_map(static fn (Metadata $metadata): string => $metadata->getPath(), $contents),
-            $contents
-        );
+        $this->files = [];
+        foreach ($this->filesystem->listContents($this->dir, false) as $metadata) {
+            $this->files[$metadata->getPath()] = $metadata;
+        }
     }
 
-    /**
-     * @inheritdoc
-     */
     public function hasChildren(): bool
     {
         return $this->current()->isDir();
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function getChildren(): \ILIAS\Filesystem\Finder\Iterator\RecursiveDirectoryIterator
+    public function getChildren(): self
     {
         return new self($this->filesystem, $this->current()->getPath());
     }

--- a/components/ILIAS/Filesystem/src/Finder/Iterator/SizeRangeFilterIterator.php
+++ b/components/ILIAS/Filesystem/src/Finder/Iterator/SizeRangeFilterIterator.php
@@ -24,44 +24,28 @@ use ILIAS\Data\DataSize;
 use ILIAS\Filesystem\Filesystem;
 use ILIAS\Filesystem\DTO\Metadata;
 use ILIAS\Filesystem\Finder\Comparator\NumberComparator;
-use InvalidArgumentException;
-use Iterator as PhpIterator;
 
 /**
- * Class SizeRangeFilterIterator
- * @package ILIAS\Filesystem\Finder\Iterator
- * @author  Michael Jansen <mjansen@databay.de>
+ * @extends \FilterIterator<non-empty-string, Metadata>
  */
 class SizeRangeFilterIterator extends \FilterIterator
 {
-    /** @var NumberComparator[] */
-    private array $comparators = [];
+    /** @var list<NumberComparator> */
+    private array $comparators;
 
     /**
-     * @param PhpIterator        $iterator    The Iterator to filter
-     * @param NumberComparator[] $comparators An array of NumberComparator instances
-     * @throws InvalidArgumentException
+     * @param \Iterator<non-empty-string, Metadata> $iterator The Iterator to filter
      */
-    public function __construct(private Filesystem $filesystem, PhpIterator $iterator, array $comparators)
-    {
-        array_walk($comparators, static function ($comparator): void {
-            if (!($comparator instanceof NumberComparator)) {
-                throw new InvalidArgumentException(
-                    sprintf(
-                        'Invalid comparator given: %s',
-                        $comparator::class
-                    )
-                );
-            }
-        });
+    public function __construct(
+        private readonly Filesystem $filesystem,
+        \Iterator $iterator,
+        NumberComparator ...$comparators
+    ) {
         $this->comparators = $comparators;
 
         parent::__construct($iterator);
     }
 
-    /**
-     * @inheritdoc
-     */
     public function accept(): bool
     {
         /** @var Metadata $metadata */

--- a/components/ILIAS/Filesystem/src/Finder/Iterator/SortableIterator.php
+++ b/components/ILIAS/Filesystem/src/Finder/Iterator/SortableIterator.php
@@ -20,20 +20,13 @@ declare(strict_types=1);
 
 namespace ILIAS\Filesystem\Finder\Iterator;
 
-use ArrayIterator;
 use ILIAS\Filesystem\DTO\Metadata;
 use ILIAS\Filesystem\Filesystem;
-use InvalidArgumentException;
-use IteratorAggregate;
-use Traversable;
-use Closure;
 
 /**
- * Class SortableIterator
- * @package ILIAS\Filesystem\Finder\Iterator
- * @author  Michael Jansen <mjansen@databay.de>
+ * @implements \IteratorAggregate<non-empty-string, Metadata>
  */
-class SortableIterator implements IteratorAggregate
+class SortableIterator implements \IteratorAggregate
 {
     public const SORT_BY_NONE = 0;
     public const SORT_BY_NAME = 1;
@@ -41,19 +34,20 @@ class SortableIterator implements IteratorAggregate
     public const SORT_BY_NAME_NATURAL = 4;
     public const SORT_BY_TIME = 5;
 
-    /** @var callable|Closure|int */
+    /** @var callable(Metadata, Metadata): int|Closure(Metadata, Metadata): int|int */
     private $sort;
 
     /**
-     * Sortable constructor.
-     * @param int|callable|Closure $sort
-     * @param bool                 $reverseOrder
+     * @param \Traversable<non-empty-string, Metadata>                               $iterator
+     * @param int|callable(Metadata, Metadata): int|Closure(Metadata, Metadata): int $sort
+     * @param bool                                                                   $reverseOrder
+     * @throws \InvalidArgumentException
      */
     public function __construct(
-        private Filesystem $filesystem,
-        private Traversable $iterator,
+        private readonly Filesystem $filesystem,
+        private readonly \Traversable $iterator,
         $sort,
-        $reverseOrder = false
+        bool $reverseOrder = false
     ) {
         $order = $reverseOrder ? -1 : 1;
 
@@ -94,34 +88,43 @@ class SortableIterator implements IteratorAggregate
             };
         } elseif (self::SORT_BY_NONE === $sort) {
             $this->sort = $order;
-        } elseif (is_callable($sort)) {
+        } elseif (\is_callable($sort)) {
             $this->sort = $sort;
             if ($reverseOrder) {
-                $this->sort = static fn (Metadata $left, Metadata $right): int|float => -$sort($left, $right);
+                $this->sort = static fn(Metadata $left, Metadata $right): int|float => -$sort($left, $right);
             }
         } else {
-            throw new InvalidArgumentException(
+            throw new \InvalidArgumentException(
                 'The SortableIterator takes a PHP callable or a valid built-in sort algorithm as an argument.'
             );
         }
     }
 
-    /**
-     * @inheritdoc
-     */
     public function getIterator(): \Traversable
     {
         if (1 === $this->sort) {
-            return $this->iterator;
+            yield from $this->iterator;
+            return;
         }
 
-        $array = iterator_to_array($this->iterator, true);
+        $keys = [];
+        $values = [];
+        foreach ($this->iterator as $key => $value) {
+            $keys[] = $key;
+            $values[] = $value;
+        }
+
         if (-1 === $this->sort) {
-            $array = array_reverse($array);
-        } else {
-            uasort($array, $this->sort);
+            for ($i = \count($values) - 1; $i >= 0; --$i) {
+                yield $keys[$i] => $values[$i];
+            }
+            return;
         }
 
-        return new ArrayIterator($array);
+        uasort($values, $this->sort);
+
+        foreach ($values as $i => $v) {
+            yield $keys[$i] => $v;
+        }
     }
 }

--- a/components/ILIAS/Filesystem/tests/Finder/FinderTest.php
+++ b/components/ILIAS/Filesystem/tests/Finder/FinderTest.php
@@ -30,10 +30,7 @@ use PHPUnit\Framework\TestCase;
  */
 class FinderTest extends TestCase
 {
-    /**
-     * @throws ReflectionException
-     */
-    private function getFlatFileSystemStructure(): \PHPUnit\Framework\MockObject\MockObject
+    private function getFlatFileSystemStructure(): Filesystem\Filesystem&\PHPUnit\Framework\MockObject\MockObject
     {
         $fileSystem = $this->getMockBuilder(Filesystem\Filesystem::class)->getMock();
 
@@ -57,10 +54,7 @@ class FinderTest extends TestCase
         return $fileSystem;
     }
 
-    /**
-     * @throws ReflectionException
-     */
-    private function getNestedFileSystemStructure(): \PHPUnit\Framework\MockObject\MockObject
+    private function getNestedFileSystemStructure(): Filesystem\Filesystem&\PHPUnit\Framework\MockObject\MockObject
     {
         $fileSystem = $this->getMockBuilder(Filesystem\Filesystem::class)->getMock();
 
@@ -113,9 +107,6 @@ class FinderTest extends TestCase
         return $fileSystem;
     }
 
-    /**
-     * @throws ReflectionException
-     */
     public function testFinderWillFindNoFilesOrFoldersInAnEmptyDirectory(): void
     {
         $fileSystem = $this->getMockBuilder(Filesystem\Filesystem::class)->getMock();
@@ -129,9 +120,6 @@ class FinderTest extends TestCase
         $this->assertEmpty(iterator_count($finder));
     }
 
-    /**
-     * @throws ReflectionException
-     */
     public function testFinderWillFindFilesAndFoldersInFlatStructure(): void
     {
         $finder = (new Finder($this->getFlatFileSystemStructure()))->in(['/']);
@@ -141,9 +129,6 @@ class FinderTest extends TestCase
         $this->assertCount(2, $finder->files());
     }
 
-    /**
-     * @throws ReflectionException
-     */
     public function testFinderWillFindFilesAndFoldersInNestedStructure(): void
     {
         $finder = (new Finder($this->getNestedFileSystemStructure()))->in(['/']);
@@ -153,9 +138,6 @@ class FinderTest extends TestCase
         $this->assertCount(7, $finder->files());
     }
 
-    /**
-     * @throws ReflectionException
-     */
     public function testFinderWillFindFilesAndFoldersForACertainDirectoryDepth(): void
     {
         $finder = (new Finder($this->getNestedFileSystemStructure()))->in(['/']);
@@ -191,9 +173,6 @@ class FinderTest extends TestCase
         $this->assertCount(3, $exactlyLevel2Finder->files());
     }
 
-    /**
-     * @throws ReflectionException
-     */
     public function testFinderWillNotSearchInExcludedFolders(): void
     {
         $finder = (new Finder($this->getNestedFileSystemStructure()))->in(['/']);
@@ -209,12 +188,9 @@ class FinderTest extends TestCase
         $this->assertCount(6, $finderWithMultipleExcludedDirs->files());
     }
 
-    /**
-     * @throws ReflectionException
-     */
     public function testFinderWillFilterFilesAndFoldersByCreationTimestamp(): Filesystem\Filesystem
     {
-        $now = new \DateTimeImmutable('2019-03-30 13:00:00');
+        $now = new DateTimeImmutable('2019-03-30 13:00:00');
 
         $fs = $this->getNestedFileSystemStructure();
         $fs->method('has')->willReturn(true);
@@ -222,7 +198,7 @@ class FinderTest extends TestCase
         $fs
             ->expects($this->atLeast(1))
             ->method('getTimestamp')
-            ->willReturnCallback(function ($path) use ($now): \DateTimeImmutable {
+            ->willReturnCallback(function ($path) use ($now): DateTimeImmutable {
                 return match ($path) {
                     'file_1.txt' => $now,
                     'file_2.mp3' => $now->modify('+1 hour'),
@@ -231,7 +207,7 @@ class FinderTest extends TestCase
                     'dir_1/dir_1_1/file_5.cpp' => $now->modify('+4 hour'),
                     'dir_1/dir_1_2/file_6.py' => $now->modify('+5 hour'),
                     'dir_1/dir_1_2/file_7.cpp' => $now->modify('+6 hour'),
-                    default => new \DateTimeImmutable('now'),
+                    default => new DateTimeImmutable('now'),
                 };
             });
 
@@ -250,9 +226,6 @@ class FinderTest extends TestCase
         return $fs;
     }
 
-    /**
-     * @throws ReflectionException
-     */
     public function testFinderWillFilterFilesBySize(): void
     {
         $fs = $this->getNestedFileSystemStructure();
@@ -260,7 +233,7 @@ class FinderTest extends TestCase
 
         $fs->expects($this->atLeast(1))
             ->method('getSize')
-            ->willReturnCallback(function ($path): \ILIAS\Data\DataSize {
+            ->willReturnCallback(function ($path): DataSize {
                 return match ($path) {
                     'file_1.txt' => new DataSize(PHP_INT_MAX, DataSize::Byte),
                     'file_2.mp3' => new DataSize(1024, DataSize::Byte),
@@ -315,5 +288,48 @@ class FinderTest extends TestCase
         $all = array_values(iterator_to_array($customSortFinder->reverseSorting()->getIterator()));
         $last = $all[iterator_count($customSortFinder) - 1];
         $this->assertEquals('dir_1/dir_1_1/file_5.cpp', $last->getPath());
+    }
+
+    public function testFinderCanLimitTheResultSet(): void
+    {
+        $finder = (new Finder($this->getNestedFileSystemStructure()))->in(['/']);
+
+        $this->assertCount(5, $finder->limit(5));
+        $this->assertCount(0, $finder->limit(0));
+
+        $limited_sorted_files = array_values(iterator_to_array($finder->files()->sortByName()->limit(2)));
+        $this->assertCount(2, $limited_sorted_files);
+        $this->assertEquals('dir_1/dir_1_1/file_5.cpp', $limited_sorted_files[0]->getPath());
+        $this->assertEquals('dir_1/dir_1_2/file_6.py', $limited_sorted_files[1]->getPath());
+    }
+
+    public function testFinderLimitRejectsNegativeValues(): void
+    {
+        $fs = $this->getMockBuilder(Filesystem\Filesystem::class)->getMock();
+        $finder = (new Finder($fs))->in(['/']);
+        $this->expectException(InvalidArgumentException::class);
+        $finder->limit(-1);
+    }
+
+    public function testFinderHasAnyDetectsMatchingAndMissingResults(): void
+    {
+        $empty_fs = $this->getMockBuilder(Filesystem\Filesystem::class)->getMock();
+        $empty_fs->method('listContents')->willReturn([]);
+        $empty_finder = (new Finder($empty_fs))->in(['/']);
+        $this->assertFalse($empty_finder->hasAny());
+
+        $finder = (new Finder($this->getNestedFileSystemStructure()))->in(['/']);
+        $this->assertTrue($finder->hasAny());
+        $this->assertTrue($finder->files()->hasAny());
+        $this->assertFalse($finder->files()->depth('> 2')->hasAny());
+    }
+
+    public function testFinderHasAnySkipsExpensiveSortingForExistenceChecks(): void
+    {
+        $fs = $this->getFlatFileSystemStructure();
+        $fs->expects($this->never())->method('getTimestamp');
+
+        $finder = (new Finder($fs))->in(['/']);
+        $this->assertTrue($finder->files()->sortByTime()->hasAny());
     }
 }


### PR DESCRIPTION
This PR ...

- adds micro optimizations for the `Finder`,
- introduces a fluent `limit`-API on the `Finder` to allow the iteration over a limited subset of items,
- adds `hasAny()` as an existence check optimized for performance-sensitive paths by short-circuiting after the
 first match and avoiding unnecessary sorting work,
- and improves the explicit and documented PHP types (my static analysis tools no longer report any issues)