### PR TITLE
[FIX]: make map containers responsive (fix mantix #47698)

### DIFF
--- a/components/ILIAS/Maps/templates/default/tpl.google_map.html
+++ b/components/ILIAS/Maps/templates/default/tpl.google_map.html
@@ -1,1 +1,1 @@
-<div id="{MAP_ID}" class="ilGoogleMap" style="max-width: {WIDTH}; height: {HEIGHT};"></div>
+<div id="{MAP_ID}" class="ilGoogleMap" style="width: 100%; max-width: {WIDTH}; height: {HEIGHT};"></div>

--- a/components/ILIAS/Maps/templates/default/tpl.openlayers_map.html
+++ b/components/ILIAS/Maps/templates/default/tpl.openlayers_map.html
@@ -1,4 +1,9 @@
-<div id="{MAP_ID}_wrapper">
-	<div id="{MAP_ID}" class="map" style="width: {WIDTH}; height: {HEIGHT};"><div id="popup_{MAP_ID}"></div></div>
-	<span class="xsmall" style="color:grey;">&copy; <a href="https://www.openstreetmap.org">OpenStreetMap</a> contributors, <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a></span>
+<div id="{MAP_ID}_wrapper" style="width: 100%; max-width: {WIDTH};">
+	<div id="{MAP_ID}" class="map" style="width: 100%; height: {HEIGHT};">
+		<div id="popup_{MAP_ID}"></div>
+	</div>
+	<span class="xsmall" style="color:grey;">
+		&copy; <a href="https://www.openstreetmap.org">OpenStreetMap</a> contributors,
+		<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>
+	</span>
 </div>


### PR DESCRIPTION
- `tpl.openlayers_map.html`: replace fixed inline `width: {WIDTH}` with `width: 100%` and apply `{WIDTH}` as `max-width` on the wrapper to prevent overflow in responsive layouts
- `tpl.google_map.html`: add `width: 100%` while keeping `{WIDTH}` as `max-width` for consistent responsive behavior
