### PR TITLE
[FIX] OrgUnit: Hide "Export" tab except for the root node

### DIFF
--- a/components/ILIAS/OrgUnit/classes/class.ilObjOrgUnitGUI.php
+++ b/components/ILIAS/OrgUnit/classes/class.ilObjOrgUnitGUI.php
@@ -238,13 +238,13 @@ class ilObjOrgUnitGUI extends ilContainerGUI
                 $this->ctrl->forwardCommand($new_gui);
                 break;
             case 'ilorgunitexportgui':
-                if (!ilObjOrgUnitAccess::_checkAccessExport($this->ref_id)) {
+                if (!ilObjOrgUnitAccess::_checkAccessExport($this->ref_id) ||
+                    $this->object->getRefId() !== ilObjOrgUnit::getRootOrgRefId()) {
                     $this->tpl->setOnScreenMessage('failure', $this->lng->txt("permission_denied"), true);
                     $this->ctrl->redirect($this);
                 }
                 $this->tabs_gui->activateTab(self::TAB_EXPORT);
                 $ilOrgUnitExportGUI = new ilOrgUnitExportGUI($this);
-                $ilOrgUnitExportGUI->addFormat('xml');
                 $this->ctrl->forwardCommand($ilOrgUnitExportGUI);
                 break;
             case strtolower(TranslationGUI::class):
@@ -563,14 +563,15 @@ class ilObjOrgUnitGUI extends ilContainerGUI
                         [self::class, ilOrgUnitGlobalSettingsGUI::class]
                     )
                 );
+
+                $this->tabs_gui->addTab(
+                    self::TAB_EXPORT,
+                    $this->lng->txt(self::TAB_EXPORT),
+                    $this->ctrl->getLinkTargetByClass(
+                        [self::class, ilOrgUnitExportGUI::class]
+                    )
+                );
             }
-            $this->tabs_gui->addTab(
-                self::TAB_EXPORT,
-                $this->lng->txt(self::TAB_EXPORT),
-                $this->ctrl->getLinkTargetByClass(
-                    [self::class, ilOrgUnitExportGUI::class]
-                )
-            );
 
             // Add OrgUnit types and positions tabs
             if ($this->object->getRefId() == ilObjOrgUnit::getRootOrgRefId()) {


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=47210

If approved, please pick this to `trunk` (and maybe `release_10`, I leave this up to you).