### PR TITLE
WorkspaceFolder 46038: Add constructor default for limit

### DIFF
--- a/components/ILIAS/WorkspaceFolder/BackgroundTask/classes/class.ilWorkspaceCopyDefinition.php
+++ b/components/ILIAS/WorkspaceFolder/BackgroundTask/classes/class.ilWorkspaceCopyDefinition.php
@@ -38,7 +38,14 @@ class ilWorkspaceCopyDefinition extends AbstractValue
     private array $object_wsp_ids = [];
     private int $num_files = 0;
     private int $sum_file_sizes = 0;
-    private ?BooleanValue $adheres_to_limit = null;
+    private BooleanValue $adheres_to_limit;
+
+    public function __construct()
+    {
+        $adheres_to_limit = new BooleanValue();
+        $adheres_to_limit->setValue(false);
+        $this->adheres_to_limit = $adheres_to_limit;
+    }
 
     public function getCopyDefinitions(): array
     {


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=46038

The `adheres_to_limit` property was nullable and never initialized before use. A constructor now creates a `BooleanValue`, sets it to `false`, and assigns it so the property is always defined.

/cc @thojou 