### PR TITLE
Test 47413: Full Width for Cloze Inputs in Scoring

### DIFF
--- a/templates/default/070-components/legacy/Modules/_component_test.scss
+++ b/templates/default/070-components/legacy/Modules/_component_test.scss
@@ -121,3 +121,7 @@ $il-test-working-time-font-weight: $il-font-weight-bold;
 #tst_pass_details_overview tr {
     scroll-margin-top: 30px;
 }
+
+.ilc_qanswer_Answer.ilc_answers.answers.ilAssClozeTest p input[type=text] {
+	width: 100%;
+}

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -14806,6 +14806,10 @@ div.ilc_Page.readonly textarea[disabled] {
   scroll-margin-top: 30px;
 }
 
+.ilc_qanswer_Answer.ilc_answers.answers.ilAssClozeTest p input[type=text] {
+  width: 100%;
+}
+
 /* Modules/Wiki */
 a.ilWikiPageMissing:link, a.ilWikiPageMissing:visited {
   color: #d00;


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=47413

Manual scoring cloze gaps render narrow text fields by default. Added a stylesheet rule for `.ilAssClozeTest` answer areas so `input[type=text]` spans the full row width, in both `_component_test.scss` and compiled `delos.css`.

/cc @thojou 