### PR TITLE
Test11 47413: Full Width for Cloze Inputs in Scoring

### DIFF
--- a/templates/default/070-components/legacy/Modules/_component_test.scss
+++ b/templates/default/070-components/legacy/Modules/_component_test.scss
@@ -172,9 +172,15 @@ $cons-scoring-bottom-fade-height: $il-padding-xxxlarge-vertical * 2;
       display: none;
     }
 
-    // fix for ordering question
-    .ilc_qanswer_Answer.solutionbox {
-      width: auto;
+    .ilc_qanswer_Answer {
+      // fix for ordering question
+      .solutionbox {
+        width: auto;
+      }
+  
+      .ilc_answers.answers.ilAssClozeTest div input[type=text] {
+        width: 100%;
+      }
     }
   }
 

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -16762,6 +16762,9 @@ div.ilc_Page.readonly textarea[disabled] {
 .c-consecutive-scoring__answer__body .ilc_qanswer_Answer.solutionbox {
   width: auto;
 }
+.c-consecutive-scoring__answer__body .ilc_qanswer_Answer.ilc_answers.answers.ilAssClozeTest div input[type=text] {
+  width: 100%;
+}
 .c-consecutive-scoring__answer__grade-card {
   width: 40%;
   border-left: 1px solid #dddddd;


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=47413

Manual scoring cloze gaps render narrow text fields by default. Added a stylesheet rule for `.ilAssClozeTest` answer areas so `input[type=text]` spans the full row width, in both `_component_test.scss` and compiled `delos.css`.

/cc @thojou 