### PR TITLE
[IMPROVEMENT] Test: Resize Mark Icon and Unify Summary Icons

### DIFF
--- a/components/ILIAS/Test/src/Questions/Presentation/QuestionsOfAttemptTable.php
+++ b/components/ILIAS/Test/src/Questions/Presentation/QuestionsOfAttemptTable.php
@@ -139,7 +139,6 @@ class QuestionsOfAttemptTable implements DataRetrieval
         $icon_factory = $this->ui_factory->symbol()->icon();
         $icon_checked = $icon_factory->custom('assets/images/standard/icon_checked.svg', $this->lng->txt('yes'));
         $icon_unchecked = $icon_factory->custom('assets/images/standard/icon_unchecked.svg', $this->lng->txt('no'));
-        $icon_marked = $icon_factory->custom('assets/images/object/marked.svg', $this->lng->txt('tst_question_marked'));
 
         $columns = [
             'order' => $column_factory->number($this->lng->txt('tst_qst_order')),
@@ -148,7 +147,7 @@ class QuestionsOfAttemptTable implements DataRetrieval
             'postponed' => $column_factory->boolean(ucfirst($this->lng->txt('postponed')), $this->lng->txt('yes'), ''),
             'points' => $column_factory->number($this->lng->txt('tst_maximum_points'))->withUnit($this->lng->txt('points_short')),
             'answered' => $column_factory->boolean($this->lng->txt('answered'), $icon_checked, $icon_unchecked),
-            'marked' => $column_factory->boolean($this->lng->txt('tst_question_marker'), $icon_marked, ''),
+            'marked' => $column_factory->boolean($this->lng->txt('tst_question_marker'), $icon_checked, $icon_unchecked),
         ];
 
         $optional_columns = [

--- a/templates/default/070-components/legacy/Modules/_component_test_legacy.scss
+++ b/templates/default/070-components/legacy/Modules/_component_test_legacy.scss
@@ -538,8 +538,8 @@ td.ilc_Page {
 }
 
 .ilTestMarkQuestionIcon {
-	width: 12px;
-	height: 12px;
+	width: 28px;
+	height: 28px;
 }
 
 .ilTestAnswerStatusIcon {

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -16480,8 +16480,8 @@ td.ilc_Page {
 }
 
 .ilTestMarkQuestionIcon {
-  width: 12px;
-  height: 12px;
+  width: 28px;
+  height: 28px;
 }
 
 .ilTestAnswerStatusIcon {


### PR DESCRIPTION
The test player mark-question icon was 12×12px; it is now 28×28px in `_component_test_legacy.scss` and `delos.css`. In `QuestionsOfAttemptTable`, the marked column uses the standard checked/unchecked icons like the answered column instead of `marked.svg`.

/cc @thojou 