### PR TITLE
TestQuestionPool 47211: Escape long menu template values

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.assLongMenuGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assLongMenuGUI.php
@@ -593,7 +593,10 @@ class assLongMenuGUI extends assQuestionGUI implements ilGuiQuestionScoringAdjus
             if ($user_value == -1) {
                 $tpl->setVariable("SOLUTION", $this->lng->txt("please_select"));
             } else {
-                $tpl->setVariable('SOLUTION', $user_value);
+                $tpl->setVariable(
+                    'SOLUTION',
+                    $this->refinery->encode()->htmlSpecialCharsAsEntities()->transform($user_value)
+                );
             }
             if ($graphical) {
                 $correctness_icon = $this->generateCorrectnessIconsForCorrectness(self::CORRECTNESS_NOT_OK);
@@ -607,8 +610,11 @@ class assLongMenuGUI extends assQuestionGUI implements ilGuiQuestionScoringAdjus
             $tpl->setVariable("PLEASE_SELECT", $this->lng->txt("please_select"));
             foreach ($answers as $value) {
                 $tpl->setCurrentBlock('select_option');
-                $tpl->setVariable('VALUE', $value);
-                if ($value == $user_value) {
+                $tpl->setVariable(
+                    'VALUE',
+                    $this->refinery->encode()->htmlSpecialCharsAsEntities()->transform($value)
+                );
+                if ($value === $user_value) {
                     $tpl->setVariable('SELECTED', 'selected');
                 }
                 $tpl->parseCurrentBlock();


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=47211

Gap answers that contained double quotes were injected verbatim into HTML attributes for the long-menu preview, which broke markup and prevented reliable evaluation of the learner selection. `assLongMenuGUI` now escapes solution text and option values with `htmlspecialchars(..., ENT_QUOTES | ENT_SUBSTITUTE, 'utf-8')` and compares the learner answer to options with `===` when marking the selected entry.

/cc @thojou 