### PR TITLE
COPage 47569: Use integer id for embedded answer save

### DIFF
--- a/components/ILIAS/COPage/classes/class.ilPageObjectGUI.php
+++ b/components/ILIAS/COPage/classes/class.ilPageObjectGUI.php
@@ -2999,7 +2999,7 @@ class ilPageObjectGUI
     {
         ilPageQuestionProcessor::saveQuestionAnswer(
             $this->request->getString("type"),
-            $this->request->getString("id"),
+            $this->request->getInt("id"),
             $this->request->getString("answer")
         );
     }

--- a/components/ILIAS/COPage/classes/class.ilPageQuestionProcessor.php
+++ b/components/ILIAS/COPage/classes/class.ilPageQuestionProcessor.php
@@ -287,9 +287,7 @@ class ilPageQuestionProcessor
 
         $ilDB = $DIC->database();
 
-        $a_q_id = is_array($a_q_id) ? $a_q_id : [(int) $a_q_id];
-
-        $qst = $ilDB->in("qst_id", $a_q_id, false, "integer");
+        $qst = $ilDB->in("qst_id", is_array($a_q_id) ? $a_q_id : [(int) $a_q_id], false, "integer");
 
         $and = ($a_user_id > 0)
             ? " AND user_id = " . $ilDB->quote($a_user_id, "integer")


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=47569

Posting an answer from a learning-module page sent the embedded question `id` as a string while downstream handling expects an integer, which broke loading answer status (for example missing expected fields such as `try`). `ilPageObjectGUI` now passes `getInt("id")` into `ilPageQuestionProcessor::saveQuestionAnswer`. `getAnswerStatus` still builds the same `IN` clause; only the intermediate assignment was inlined.

/cc @thojou 