### PR TITLE
TestQuestionPool 47122: Enforce Access on Global Units

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.ilUnitConfigurationGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilUnitConfigurationGUI.php
@@ -32,6 +32,7 @@ abstract class ilUnitConfigurationGUI
     protected ilGlobalTemplateInterface $tpl;
     protected ilLanguage $lng;
     protected ilCtrlInterface $ctrl;
+    protected ilAccessHandler $access;
 
     public function __construct(
         protected ilUnitConfigurationRepository $repository
@@ -40,6 +41,7 @@ abstract class ilUnitConfigurationGUI
         $this->lng = $DIC->language();
         $this->ctrl = $DIC->ctrl();
         $this->tpl = $DIC->ui()->mainTemplate();
+        $this->access = $DIC->access();
 
         $local_dic = QuestionPoolDIC::dic();
         $this->request = $local_dic['request_data_collector'];
@@ -74,6 +76,22 @@ abstract class ilUnitConfigurationGUI
 
     protected function checkPermissions(string $cmd): void
     {
+        if (!$this->access->checkAccess('read', '', $this->request->getRefId())) {
+            $this->tpl->setOnScreenMessage('failure', $this->lng->txt('permission_denied'), true);
+            $this->ctrl->redirectToURL(ilUserUtil::getStartingPointAsUrl());
+            return;
+        }
+
+        if (in_array($cmd, ['showUnitCategories', 'showUnitsOfCategory', 'showGlobalUnitCategories'], true)) {
+            return;
+        }
+
+        if ($this->access->checkAccess('write', '', $this->request->getRefId())) {
+            return;
+        }
+
+        $this->tpl->setOnScreenMessage('failure', $this->lng->txt('permission_denied'), true);
+        $this->ctrl->redirect($this, $this->getDefaultCommand());
     }
 
     public function executeCommand(): void
@@ -462,7 +480,7 @@ abstract class ilUnitConfigurationGUI
             $this->lng->txt('back'),
             $this->ctrl->getLinkTarget($this, $this->getUnitCategoryOverviewCommand())
         );
-        if ($this->isCRUDContext()) {
+        if ($this->isCRUDContext() && $this->access->checkAccess('write', '', $this->request->getRefId())) {
             $this->ctrl->setParameterByClass(get_class($this), 'category_id', $category->getId());
             $ilToolbar->addButton(
                 $this->lng->txt('un_add_unit'),

--- a/components/ILIAS/TestQuestionPool/classes/tables/class.ilUnitTableGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/tables/class.ilUnitTableGUI.php
@@ -16,6 +16,9 @@
  *
  *********************************************************************/
 
+use ILIAS\TestQuestionPool\QuestionPoolDIC;
+use ILIAS\TestQuestionPool\RequestDataCollector;
+
 /**
  * Class ilUnitTableGUI
  */
@@ -27,6 +30,8 @@ class ilUnitTableGUI extends ilTable2GUI
     private $position = 1;
     private \ILIAS\UI\Factory $ui_factory;
     private \ILIAS\UI\Renderer $ui_renderer;
+    private ilAccessHandler $access;
+    private RequestDataCollector $request;
 
     /**
      * @param ilUnitConfigurationGUI         $controller
@@ -44,6 +49,8 @@ class ilUnitTableGUI extends ilTable2GUI
         $lng = $DIC['lng'];
         $this->ui_factory = $DIC->ui()->factory();
         $this->ui_renderer = $DIC->ui()->renderer();
+        $this->access = $DIC->access();
+        $this->request = QuestionPoolDIC::dic()['request_data_collector'];
 
         $this->setId('units_' . $controller->getUniqueId());
 
@@ -51,7 +58,10 @@ class ilUnitTableGUI extends ilTable2GUI
 
         $ilCtrl->setParameter($this->getParentObject(), 'category_id', $category->getId());
 
-        if ($this->getParentObject()->isCRUDContext()) {
+        if (
+            $this->getParentObject()?->isCRUDContext()
+            && $this->access->checkAccess('write', '', $this->request->getRefId())
+        ) {
             $this->addColumn('', '', '1%', true);
             $this->setSelectAllCheckbox('unit_ids[]');
             $this->addMultiCommand('confirmDeleteUnits', $this->lng->txt('delete'));
@@ -88,7 +98,10 @@ class ilUnitTableGUI extends ilTable2GUI
         global $DIC;
         $ilCtrl = $DIC['ilCtrl'];
 
-        if ($this->getParentObject()->isCRUDContext()) {
+        if (
+            $this->getParentObject()?->isCRUDContext()
+            && $this->access->checkAccess('write', '', $this->request->getRefId())
+        ) {
             $a_set['chb'] = ilLegacyFormElementsUtil::formCheckbox(false, 'unit_ids[]', $a_set['unit_id']);
 
             $sequence = new ilNumberInputGUI('', 'sequence[' . $a_set['unit_id'] . ']');


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=47122

`ilUnitConfigurationGUI::checkPermissions()` now validates commands via `ilRbacSystem`: overview commands require `read`, modifying commands require `write`, with failure message and redirect. The add-unit toolbar action and `ilUnitTableGUI` CRUD UI (multiselect, sequence inputs, actions) are shown only when the user has `write` on the object ref. Also normalizes newline at end of `tpl.unit_row_html`.

/cc @thojou 