### PR TITLE
Fix Mantis #47300: "Permission Denied" in "LP Settings" Scorm Object action

### DIFF
--- a/components/ILIAS/ILIASObject/classes/class.ilObjectListGUI.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObjectListGUI.php
@@ -3332,12 +3332,21 @@ class ilObjectListGUI
                         break;
                 }
 
-                $cmd_link = $this->ctrl->getLinkTargetByClass([
-                    ilSAHSEditGUI::class,
-                    $scorm_class,
-                    ilLearningProgressGUI::class,
-                    ilLPListOfSettingsGUI::class
-                ]);
+                if ( $this->checkCommandAccess('write', '', $this->ref_id, $this->type) ){
+                    $cmd_link = $this->ctrl->getLinkTargetByClass([
+                        ilSAHSEditGUI::class,
+                        $scorm_class,
+                        ilLearningProgressGUI::class,
+                        ilLPListOfSettingsGUI::class
+                    ]);
+                }
+                else {
+                    $cmd_link = $this->ctrl->getLinkTargetByClass([
+                        ilSAHSPresentationGUI::class,
+                        ilLearningProgressGUI::class,
+                        ilLPListOfSettingsGUI::class
+                    ]);
+                }
                 break;
 
             case 'lm':


### PR DESCRIPTION
Mantis: https://mantis.ilias.de/view.php?id=47300

If a user only has "Edit Learning Progress Settings" permission, but not "Edit Settings", he gets denied access to "Learning Progress Settings" in Scorm Object action menu because he is not allowed to be routed through "ilSAHSEditGUI". This menu action was added in ILIAS 9 and the problem was present ever since. However going through "Info -> Learning Progress", as it was manually done before ILIAS 9, shows a valid route through "ilSAHSPresentationGUI".

Has to be cherry-picked to 11 and trunk if accepted.