### PR TITLE
Improvement: remove leftover debug statement in DObject

### DIFF
--- a/components/ILIAS/Data/src/Description/DObject.php
+++ b/components/ILIAS/Data/src/Description/DObject.php
@@ -87,7 +87,6 @@ class DObject extends Description
         }
 
         if ($errors) {
-            die("foo");
             return $this->mergeErrors($errors);
         }
 


### PR DESCRIPTION
Remove an accidental die() call found in `DObject::validate()`.

This leftover debug code caused immediate script termination, blocking valid error processing.

Safe to cherry-pick to `release_11`.