### PR TITLE
0047750: check if email in test is already sent

### DIFF
--- a/components/ILIAS/Test/classes/class.ilTestPassFinishTasks.php
+++ b/components/ILIAS/Test/classes/class.ilTestPassFinishTasks.php
@@ -36,13 +36,15 @@ class ilTestPassFinishTasks
 
     public function performFinishTasks(ilTestProcessLocker $process_locker, StatusOfAttempt $status_of_attempt)
     {
-        $process_locker->executeTestFinishOperation(function () use ($status_of_attempt) {
+        $should_send_notification = false;
+        $process_locker->executeTestFinishOperation(function () use ($status_of_attempt, &$should_send_notification) {
             $pass = $this->test_session->getPass();
 
             if (!$this->test_session->isSubmitted()) {
                 $this->test_session->setSubmitted();
                 $this->test_session->setSubmittedTimestamp();
                 $this->test_session->saveToDb();
+                $should_send_notification = true;
             }
 
             $last_started_pass = (
@@ -68,6 +70,7 @@ class ilTestPassFinishTasks
         $this->obj_test->updateTestResultCache($this->test_session->getActiveId(), null);
 
         $this->updateLearningProgressAfterPassFinishedIsWritten();
+        return $should_send_notification;
     }
 
     protected function updateLearningProgressAfterPassFinishedIsWritten()

--- a/components/ILIAS/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -1051,17 +1051,19 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
 
     protected function performTestPassFinishedTasks(StatusOfAttempt $status_of_attempt): void
     {
-        (new ilTestPassFinishTasks(
+        $should_notify = (new ilTestPassFinishTasks(
             $this->test_session,
             $this->object,
             $this->test_pass_result_repository
         ))->performFinishTasks($this->process_locker, $status_of_attempt);
         $this->object->updateTestResultCache($this->test_session->getActiveId(), null);
 
-        $this->sendNewPassFinishedNotificationEmailIfActivated(
-            $this->test_session->getActiveId(),
-            $this->test_session->getPass()
-        );
+        if ($should_notify) {
+            $this->sendNewPassFinishedNotificationEmailIfActivated(
+                $this->test_session->getActiveId(),
+                $this->test_session->getPass()
+            );
+        }
     }
 
     protected function sendNewPassFinishedNotificationEmailIfActivated(int $active_id, int $pass)


### PR DESCRIPTION
When a test has 'Notification' enabled in the finishing settings and the time limit expires, the test owner receives a large number of duplicate email notifications instead of just one.
With this pr, it is checked whether the email has already been sent.