### PR TITLE
BackgroundTasks 42358: Add grp to folder-type whitelist

### DIFF
--- a/components/ILIAS/BackgroundTasks_/classes/Jobs/class.ilCollectFilesJob.php
+++ b/components/ILIAS/BackgroundTasks_/classes/Jobs/class.ilCollectFilesJob.php
@@ -92,25 +92,41 @@ class ilCollectFilesJob extends AbstractJob
         $definition = $input[0];
         $initiated_by_folder_action = $input[1]->getValue();
         $object_ref_ids = $definition->getObjectRefIds();
-        $files = array();
+        $files = [];
 
         foreach ($object_ref_ids as $object_ref_id) {
             $object = ilObjectFactory::getInstanceByRefId($object_ref_id);
+            if (!$object instanceof ilObject) {
+                continue;
+            }
+
             $object_type = $object->getType();
             $object_name = $object->getTitle();
-            $object_temp_dir = ""; // empty as content will be added in recurseFolder and getFileDirs
+            $object_temp_dir = ''; // empty as content will be added in recurseFolder and getFileDirs
 
-            if ($object_type === "fold" || $object_type === "crs") {
+            if (in_array($object_type, ['fold', 'crs', 'grp'], true)) {
                 $num_recursions = 0;
-                $files_from_folder = $this->recurseFolder($object_ref_id, $object_name, $object_temp_dir, $num_recursions, $initiated_by_folder_action);
+                $files_from_folder = $this->recurseFolder(
+                    $object_ref_id,
+                    $object_name,
+                    $object_temp_dir,
+                    $num_recursions,
+                    $initiated_by_folder_action
+                );
                 $files = array_merge($files, $files_from_folder);
-            } elseif (($object_type === "file") && (($file_dirs = $this->getFileDirs(
-                $object_ref_id,
-                $object_name,
-                $object_temp_dir
-            )) !== false)) {
-                $files[] = $file_dirs;
+                continue;
             }
+
+            if ($object_type !== 'file') {
+                continue;
+            }
+
+            $file_dirs = $this->getFileDirs($object_ref_id, $object_name, $object_temp_dir);
+            if (!is_array($file_dirs)) {
+                continue;
+            }
+
+            $files[] = $file_dirs;
         }
         $this->logger->debug('Collected files:');
         $this->logger->dump($files);


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=42358

`ilCollectFilesJob` only treated `fold` and `crs` as folder-like objects, so selecting a group when collecting files skipped its contents. The job now recurses `grp` the same way, skips non-`ilObject` instances safely, and keeps single-file handling separate after folder traversal.

/cc @thojou 