### PR TITLE
BookingPool 21705: Remove reservations on pool deletion

### DIFF
--- a/components/ILIAS/BookingManager/Objects/ObjectEvent.php
+++ b/components/ILIAS/BookingManager/Objects/ObjectEvent.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\BookingManager\Objects;
+
+use ilBookingObject;
+use ilObjBookingPool;
+use ilObjectTypeMismatchException;
+
+class ObjectEvent
+{
+    public function handleDeletion(array $booking_pool_ref_ids): void
+    {
+        foreach (array_unique($booking_pool_ref_ids) as $booking_pool_ref_id) {
+            try {
+                $pool_id = (new ilObjBookingPool($booking_pool_ref_id, true))->getId();
+            } catch (ilObjectTypeMismatchException) {
+                continue;
+            }
+
+            foreach (ilBookingObject::getList($pool_id) as $booking_object) {
+                $booking_object_id = $booking_object['booking_object_id'] ?? null;
+                if ($booking_object_id === null) {
+                    continue;
+                }
+
+                (new ilBookingObject($booking_object_id))->deleteReservationsAndCalEntries($booking_object_id);
+            }
+        }
+    }
+}

--- a/components/ILIAS/BookingManager/Service/class.InternalDomainService.php
+++ b/components/ILIAS/BookingManager/Service/class.InternalDomainService.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,8 +16,11 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\BookingManager;
 
+use ILIAS\BookingManager\Objects\ObjectEvent;
 use ILIAS\DI\Container;
 use ILIAS\Repository\GlobalDICDomainServices;
 use ILIAS\BookingManager\BookingProcess\BookingProcessManager;
@@ -126,6 +127,11 @@ class InternalDomainService
     public function userEvent(): UserEvent
     {
         return self::$instances["user_event"] ??= new UserEvent($this);
+    }
+
+    public function objectEvent(): ObjectEvent
+    {
+        return new ObjectEvent();
     }
 
     public function bookingSettings(): SettingsManager

--- a/components/ILIAS/BookingManager/classes/class.ilBookingManagerAppEventListener.php
+++ b/components/ILIAS/BookingManager/classes/class.ilBookingManagerAppEventListener.php
@@ -42,6 +42,14 @@ class ilBookingManagerAppEventListener
                         break;
                 }
                 break;
+            case "components/ILIAS/ILIASObject":
+                switch ($a_event) {
+                    case "toTrash":
+                    case "delete":
+                        $DIC->bookingManager()->internal()->domain()->objectEvent()->handleDeletion([$a_parameter["ref_id"]]);
+                        break;
+                }
+                break;
         }
     }
 }

--- a/components/ILIAS/BookingManager/module.xml
+++ b/components/ILIAS/BookingManager/module.xml
@@ -5,7 +5,7 @@
 	</baseclasses>
 	<objects>
 		<object id="book" class_name="BookingPool" dir="classes"
-			default_pos="250" default_pres_pos="250" allow_copy="1" 
+			default_pos="250" default_pres_pos="250" allow_copy="1"
 			checkbox="1" inherit="1" allow_link="1" rbac="1" offline_handling="1">
 			<parent id="cat">cat</parent>
 			<parent id="crs">crs</parent>
@@ -17,6 +17,7 @@
 	</objects>
 	<events>
 		<event type="listen" id="Services/User" />
+		<event type="listen" id="components/ILIAS/ILIASObject" />
 	</events>
 	<web_access_checker>
 		<secure_path path="ilBookingManager" checking-class="ilObjBookingPoolAccess"/>


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=21705

Deleting or trashing a booking pool left reservations and calendar entries behind. The Booking Manager module now listens for ILIAS object `delete` and `toTrash` events; `ObjectEvent::handleDeletion` resolves each affected pool and calls `ilBookingObject::deleteReservationsAndCalEntries` for every booking object.

/cc @thojou 