### PR TITLE
ItemGroup 31861: Add display modes and block store URLs

### DIFF
--- a/components/ILIAS/Container/Content/class.ilContainerContentGUI.php
+++ b/components/ILIAS/Container/Content/class.ilContainerContentGUI.php
@@ -809,34 +809,24 @@ abstract class ilContainerContentGUI
             $a_itgr["title"],
             $a_itgr["description"]
         );
-        $commands_html = $item_list_gui->getCommandsHTML($a_itgr["title"], false);
 
         // determine behaviour
-        $item_group = new ilObjItemGroup($a_itgr["ref_id"]);
-        $beh = $item_group->getBehaviour();
-        $stored_val = $this->block_repo->getProperty(
-            "itgr_" . $a_itgr["ref_id"],
-            $ilUser->getId(),
-            "opened"
+        $item_group = new ilObjItemGroup($a_itgr['ref_id']);
+        $opened = $this->block_repo->getProperty("itgr_{$a_itgr['ref_id']}", $ilUser->getId(), 'opened');
+
+        $this->ctrl->setParameterByClass(ilContainerBlockPropertiesStorageGUI::class, 'cont_block_id', "itgr_{$a_itgr['ref_id']}");
+        $store_url = $this->ctrl->getLinkTargetByClass(ilContainerBlockPropertiesStorageGUI::class, 'store');
+        $this->ctrl->clearParameterByClass(ilContainerBlockPropertiesStorageGUI::class, 'cont_block_id');
+
+        $this->renderer->addCustomBlock(
+            $a_itgr["ref_id"],
+            $item_group->getShowTitle() || $this->container_gui->isActiveAdministrationPanel() ? $a_itgr['title'] : '',
+            $item_list_gui->getCommandsHTML($a_itgr['title'], false),
+            [
+                'behaviour' => $item_group->getBehaviour(in_array($opened, ['0', '1'], true) ? (bool) $opened : null),
+                'store-url' => "./{$store_url}"
+            ]
         );
-        if ($stored_val !== "" && $beh !== ilItemGroupBehaviour::ALWAYS_OPEN) {
-            $beh = ($stored_val === "1")
-                ? ilItemGroupBehaviour::EXPANDABLE_OPEN
-                : ilItemGroupBehaviour::EXPANDABLE_CLOSED;
-        }
-
-        $data = [
-            "behaviour" => $beh,
-            "store-url" => "./ilias.php?baseClass=ilcontainerblockpropertiesstoragegui&cmd=store" .
-                "&cont_block_id=itgr_" . $a_itgr['ref_id']
-        ];
-        if (ilObjItemGroup::lookupHideTitle($a_itgr["obj_id"]) &&
-            !$this->getContainerGUI()->isActiveAdministrationPanel()) {
-            $this->renderer->addCustomBlock($a_itgr["ref_id"], "", $commands_html, $data);
-        } else {
-            $this->renderer->addCustomBlock($a_itgr["ref_id"], $a_itgr["title"], $commands_html, $data);
-        }
-
 
         // render item group sub items
 

--- a/components/ILIAS/Container/Content/class.ilContainerRenderer.php
+++ b/components/ILIAS/Container/Content/class.ilContainerRenderer.php
@@ -1184,33 +1184,24 @@ class ilContainerRenderer
             $item_data["title"],
             $item_data["description"]
         );
-        $commands_html = $item_list_gui->getCommandsHTML();
 
         // determine behaviour
-        $item_group = new ilObjItemGroup($item_data["ref_id"]);
-        $beh = $item_group->getBehaviour();
-        $stored_val = $this->block_repo->getProperty(
-            "itgr_" . $item_data["ref_id"],
-            $this->user->getId(),
-            "opened"
-        );
-        if ($stored_val !== "" && $beh !== ilItemGroupBehaviour::ALWAYS_OPEN) {
-            $beh = ($stored_val === "1")
-                ? ilItemGroupBehaviour::EXPANDABLE_OPEN
-                : ilItemGroupBehaviour::EXPANDABLE_CLOSED;
-        }
+        $item_group = new ilObjItemGroup($item_data['ref_id']);
+        $opened = $this->block_repo->getProperty("itgr_{$item_data['ref_id']}", $this->user->getId(), 'opened');
 
-        $data = [
-            "behaviour" => $beh,
-            "store-url" => "./ilias.php?baseClass=ilcontainerblockpropertiesstoragegui&cmd=store" .
-                "&cont_block_id=itgr_" . $item_data['ref_id']
-        ];
-        if (ilObjItemGroup::lookupHideTitle($item_data["obj_id"]) &&
-            !$this->container_gui->isActiveAdministrationPanel()) {
-            $this->addCustomBlock($block_id, "", $commands_html, $data);
-        } else {
-            $this->addCustomBlock($block_id, $item_data["title"], $commands_html, $data);
-        }
+        $this->ctrl->setParameterByClass(ilContainerBlockPropertiesStorageGUI::class, 'cont_block_id', "itgr_{$item_data['ref_id']}");
+        $store_url = $this->ctrl->getLinkTargetByClass(ilContainerBlockPropertiesStorageGUI::class, 'store');
+        $this->ctrl->clearParameterByClass(ilContainerBlockPropertiesStorageGUI::class, 'cont_block_id');
+
+        $this->addCustomBlock(
+            $block_id,
+            $item_group->getShowTitle() || $this->container_gui->isActiveAdministrationPanel() ? $item_data['title'] : '',
+            $item_list_gui->getCommandsHTML(),
+            [
+                'behaviour' => $item_group->getBehaviour(in_array($opened, ['0', '1'], true) ? (bool) $opened : null),
+                'store-url' => "./{$store_url}"
+            ]
+        );
     }
 
     protected function getBlockPrefix($block_id): string

--- a/components/ILIAS/ItemGroup/classes/Setup/class.ilItemGroupDBUpdateSteps.php
+++ b/components/ILIAS/ItemGroup/classes/Setup/class.ilItemGroupDBUpdateSteps.php
@@ -18,6 +18,9 @@
 
 namespace ILIAS\ItemGroup\Setup;
 
+use ilDBConstants;
+use ilItemGroupAR;
+
 /**
  * @author Alexander Killing <killing@leifos.de>
  */
@@ -49,6 +52,27 @@ class ilItemGroupDBUpdateSteps implements \ilDatabaseUpdateSteps
                 "default" => 0,
                 "length" => 1
             ));
+        }
+    }
+
+    public function step_3(): void
+    {
+        if (!$this->db->tableColumnExists('itgr_data', 'display')) {
+            $this->db->addTableColumn('itgr_data', 'display', [
+                'type' => ilDBConstants::T_TEXT,
+                'notnull' => true,
+                'default' => ilItemGroupAR::DISPLAY_WITH_TITLE,
+                'length' => 255
+            ]);
+        }
+
+        if (!$this->db->tableColumnExists('itgr_data', 'toggleable_initially')) {
+            $this->db->addTableColumn('itgr_data', 'toggleable_initially', [
+                'type' => ilDBConstants::T_TEXT,
+                'notnull' => true,
+                'default' => ilItemGroupAR::DISPLAY_WITH_TITLE_AND_TOGGLEABLE_INITIALLY_OPEN,
+                'length' => 255
+            ]);
         }
     }
 }

--- a/components/ILIAS/ItemGroup/classes/class.ilItemGroupAR.php
+++ b/components/ILIAS/ItemGroup/classes/class.ilItemGroupAR.php
@@ -23,6 +23,14 @@
  */
 class ilItemGroupAR extends ActiveRecord
 {
+    public const DISPLAY = 'display';
+    public const DISPLAY_WITHOUT_TITLE = 'without_title';
+    public const DISPLAY_WITH_TITLE = 'with_title';
+    public const DISPLAY_WITH_TITLE_AND_TOGGLEABLE = 'with_title_and_toggleable';
+    public const DISPLAY_WITH_TITLE_AND_TOGGLEABLE_INITIALLY = self::DISPLAY_WITH_TITLE_AND_TOGGLEABLE . '_initially';
+    public const DISPLAY_WITH_TITLE_AND_TOGGLEABLE_INITIALLY_CLOSED = self::DISPLAY_WITH_TITLE_AND_TOGGLEABLE_INITIALLY . '_closed';
+    public const DISPLAY_WITH_TITLE_AND_TOGGLEABLE_INITIALLY_OPEN = self::DISPLAY_WITH_TITLE_AND_TOGGLEABLE_INITIALLY . '_open';
+
     public static function returnDbTableName(): string
     {
         return 'itgr_data';
@@ -45,21 +53,21 @@ class ilItemGroupAR extends ActiveRecord
      * @var string
      *
      * @con_has_field true
-     * @con_fieldtype integer
-     * @con_length    1
-     * @con_is_notnull false
+     * @con_fieldtype text
+     * @con_length    255
+     * @con_is_notnull yes
      */
-    protected ?string $hide_title = '';
+    protected string $display = self::DISPLAY_WITH_TITLE;
 
     /**
-     * @var int
+     * @var string
      *
      * @con_has_field true
-     * @con_fieldtype integer
-     * @con_length    1
-     * @con_is_notnull false
+     * @con_fieldtype text
+     * @con_length    255
+     * @con_is_notnull yes
      */
-    protected ?int $behaviour = 0;
+    protected string $toggleable_initially = self::DISPLAY_WITH_TITLE_AND_TOGGLEABLE_INITIALLY_OPEN;
 
     /**
      * @var string
@@ -91,24 +99,24 @@ class ilItemGroupAR extends ActiveRecord
         $this->id = $id;
     }
 
-    public function setHideTitle(bool $a_hide_title): void
+    public function getDisplay(): string
     {
-        $this->hide_title = $a_hide_title;
+        return $this->display;
     }
 
-    public function getHideTitle(): bool
+    public function setDisplay(string $a_val): void
     {
-        return $this->hide_title;
+        $this->display = $a_val;
     }
 
-    public function setBehaviour(int $a_val): void
+    public function getDisplayWithTitleAndToggleableInitially(): string
     {
-        $this->behaviour = $a_val;
+        return $this->toggleable_initially;
     }
 
-    public function getBehaviour(): int
+    public function setDisplayWithTitleAndToggleableInitially(string $a_val): void
     {
-        return $this->behaviour;
+        $this->toggleable_initially = $a_val;
     }
 
     public function getListPresentation(): string

--- a/components/ILIAS/ItemGroup/classes/class.ilItemGroupDataSet.php
+++ b/components/ILIAS/ItemGroup/classes/class.ilItemGroupDataSet.php
@@ -146,8 +146,16 @@ class ilItemGroupDataSet extends ilDataSet
 
                 $newObj->setTitle($a_rec["Title"]);
                 $newObj->setDescription($a_rec["Description"]);
-                $newObj->setBehaviour($a_rec["Behaviour"]);
-                $newObj->setHideTitle($a_rec["HideTitle"]);
+                $newObj->setDisplay(
+                    $a_rec["HideTitle"] === "1"
+                        ? ilItemGroupAR::DISPLAY_WITHOUT_TITLE
+                        : ilItemGroupAR::DISPLAY_WITH_TITLE
+                );
+                $newObj->setDisplayWithTitleAndToggleableInitially(
+                    $a_rec["Behaviour"] === "1"
+                        ? ilItemGroupAR::DISPLAY_WITH_TITLE_AND_TOGGLEABLE_INITIALLY_OPEN
+                        : ilItemGroupAR::DISPLAY_WITH_TITLE_AND_TOGGLEABLE_INITIALLY_CLOSED
+                );
                 $newObj->update();
                 $this->current_obj = $newObj;
                 $a_mapping->addMapping("components/ILIAS/ItemGroup", "itgr", $a_rec["Id"], $newObj->getId());

--- a/components/ILIAS/ItemGroup/classes/class.ilObjItemGroup.php
+++ b/components/ILIAS/ItemGroup/classes/class.ilObjItemGroup.php
@@ -60,22 +60,24 @@ class ilObjItemGroup extends ilObject2
         $this->type = "itgr";
     }
 
-    public function setHideTitle(bool $a_val): void
+    public function getDisplay(): string
     {
-        $this->item_data_ar->setHideTitle($a_val);
+        return $this->item_data_ar->getDisplay();
     }
 
-    public function getHideTitle(): bool
+    public function setDisplay(string $a_val): void
     {
-        return $this->item_data_ar->getHideTitle();
+        $this->item_data_ar->setDisplay($a_val);
     }
 
-    /**
-     * Set behaviour (see ilItemGroupBehaviour)
-     */
-    public function setBehaviour(int $a_val): void
+    public function getDisplayWithTitleAndToggleableInitially(): string
     {
-        $this->item_data_ar->setBehaviour($a_val);
+        return $this->item_data_ar->getDisplayWithTitleAndToggleableInitially();
+    }
+
+    public function setDisplayWithTitleAndToggleableInitially(string $a_val): void
+    {
+        $this->item_data_ar->setDisplayWithTitleAndToggleableInitially($a_val);
     }
 
     public function getListPresentation(): string
@@ -98,14 +100,33 @@ class ilObjItemGroup extends ilObject2
         $this->item_data_ar->setTileSize($a_val);
     }
 
-    public function getBehaviour(): int
+    public function getBehaviour(?bool $stored_value = null): int
     {
-        return $this->item_data_ar->getBehaviour();
+        if ($this->getDisplay() !== ilItemGroupAR::DISPLAY_WITH_TITLE_AND_TOGGLEABLE) {
+            return ilItemGroupBehaviour::ALWAYS_OPEN;
+        }
+
+        if (is_bool($stored_value)) {
+            return $stored_value ? ilItemGroupBehaviour::EXPANDABLE_OPEN : ilItemGroupBehaviour::EXPANDABLE_CLOSED;
+        }
+
+        return $this->getDisplayWithTitleAndToggleableInitially() === ilItemGroupAR::DISPLAY_WITH_TITLE_AND_TOGGLEABLE_INITIALLY_OPEN
+            ? ilItemGroupBehaviour::EXPANDABLE_OPEN
+            : ilItemGroupBehaviour::EXPANDABLE_CLOSED;
     }
 
     protected function doRead(): void
     {
         $this->item_data_ar = new ilItemGroupAR($this->getId());
+    }
+
+    public function getShowTitle(): bool
+    {
+        return in_array(
+            $this->getDisplay(),
+            [ilItemGroupAR::DISPLAY_WITH_TITLE, ilItemGroupAR::DISPLAY_WITH_TITLE_AND_TOGGLEABLE],
+            true
+        );
     }
 
     protected function doCreate(bool $clone_mode = false): void
@@ -154,8 +175,8 @@ class ilObjItemGroup extends ilObject2
     protected function doCloneObject(ilObject2 $new_obj, int $a_target_id, ?int $a_copy_id = null): void
     {
         assert($new_obj instanceof ilObjItemGroup);
-        $new_obj->setHideTitle($this->getHideTitle());
-        $new_obj->setBehaviour($this->getBehaviour());
+        $new_obj->setDisplay($this->getDisplay());
+        $new_obj->setDisplayWithTitleAndToggleableInitially($this->getDisplayWithTitleAndToggleableInitially());
         $new_obj->setListPresentation($this->getListPresentation());
         $new_obj->setTileSize($this->getTileSize());
 
@@ -211,29 +232,5 @@ class ilObjItemGroup extends ilObject2
             $new_page->update();
         }
         $ilLog->write(__METHOD__ . ': 5');
-    }
-
-    public static function lookupHideTitle(int $a_id): bool
-    {
-        return (bool) self::lookup($a_id, "hide_title");
-    }
-
-    public static function lookupBehaviour(int $a_id): int
-    {
-        return (int) self::lookup($a_id, "behaviour");
-    }
-
-    protected static function lookup(int $a_id, string $a_key): string
-    {
-        global $DIC;
-
-        $ilDB = $DIC->database();
-
-        $set = $ilDB->query(
-            "SELECT " . $a_key . " FROM itgr_data " .
-            " WHERE id = " . $ilDB->quote($a_id, "integer")
-        );
-        $rec = $ilDB->fetchAssoc($set);
-        return $rec[$a_key];
     }
 }

--- a/components/ILIAS/ItemGroup/classes/class.ilObjItemGroupGUI.php
+++ b/components/ILIAS/ItemGroup/classes/class.ilObjItemGroupGUI.php
@@ -135,17 +135,46 @@ class ilObjItemGroupGUI extends ilObject2GUI
         $pres->setTitle($this->lng->txt('obj_presentation'));
         $form->addItem($pres);
 
-        // show title
-        $cb = new ilCheckboxInputGUI($this->lng->txt("itgr_show_title"), "show_title");
-        $cb->setInfo($this->lng->txt("itgr_show_title_info"));
-        $form->addItem($cb);
+        // display
+        $display_radio_group = new ilRadioGroupInputGUI($this->lng->txt('itgr_display'), ilItemGroupAR::DISPLAY);
+        $display_radio_group->setRequired(true);
+        $form->addItem($display_radio_group);
 
-        // behaviour
-        $options = ilItemGroupBehaviour::getAll();
-        $si = new ilSelectInputGUI($this->lng->txt("itgr_behaviour"), "behaviour");
-        $si->setInfo($this->lng->txt("itgr_behaviour_info"));
-        $si->setOptions($options);
-        $cb->addSubItem($si);
+        $no_title_option = new ilRadioOption(
+            $this->lng->txt('itgr_display_without_title'),
+            ilItemGroupAR::DISPLAY_WITHOUT_TITLE
+        );
+        $display_radio_group->addOption($no_title_option);
+
+        $with_title_option = new ilRadioOption(
+            $this->lng->txt('itgr_display_with_title'),
+            ilItemGroupAR::DISPLAY_WITH_TITLE
+        );
+        $display_radio_group->addOption($with_title_option);
+
+        $with_title_and_toggleable_option = new ilRadioOption(
+            $this->lng->txt('itgr_display_with_title_and_toggleable'),
+            ilItemGroupAR::DISPLAY_WITH_TITLE_AND_TOGGLEABLE
+        );
+        $with_title_and_toggleable_option_radio_group = new ilRadioGroupInputGUI(
+            $this->lng->txt('itgr_display_with_title_and_toggleable'),
+            ilItemGroupAR::DISPLAY_WITH_TITLE_AND_TOGGLEABLE_INITIALLY
+        );
+        $with_title_and_toggleable_option_radio_group->setRequired(true);
+        $with_title_and_toggleable_option_radio_group->addOption(
+            new ilRadioOption(
+                $this->lng->txt('itgr_display_with_title_and_toggleable_initially_closed'),
+                ilItemGroupAR::DISPLAY_WITH_TITLE_AND_TOGGLEABLE_INITIALLY_CLOSED
+            )
+        );
+        $with_title_and_toggleable_option_radio_group->addOption(
+            new ilRadioOption(
+                $this->lng->txt('itgr_display_with_title_and_toggleable_initially_open'),
+                ilItemGroupAR::DISPLAY_WITH_TITLE_AND_TOGGLEABLE_INITIALLY_OPEN
+            )
+        );
+        $with_title_and_toggleable_option->addSubItem($with_title_and_toggleable_option_radio_group);
+        $display_radio_group->addOption($with_title_and_toggleable_option);
 
         // tile/list
         $lpres = new ilRadioGroupInputGUI($this->lng->txt('itgr_list_presentation'), "list_presentation");
@@ -389,21 +418,22 @@ class ilObjItemGroupGUI extends ilObject2GUI
      */
     protected function getEditFormCustomValues(array &$a_values): void
     {
-        $a_values["show_title"] = !$this->object->getHideTitle();
-        $a_values["behaviour"] = $this->object->getBehaviour();
-        $a_values["list_presentation"] = $this->object->getListPresentation();
-        $a_values["tile_size"] = $this->object->getTileSize();
+        /** @var ilObjItemGroup $object */
+        $object = $this->getObject();
+        $a_values[ilItemGroupAR::DISPLAY] = $object->getDisplay();
+        $a_values[ilItemGroupAR::DISPLAY_WITH_TITLE_AND_TOGGLEABLE_INITIALLY] = $object->getDisplayWithTitleAndToggleableInitially();
+        $a_values['list_presentation'] = $object->getListPresentation();
+        $a_values['tile_size'] = $object->getTileSize();
     }
 
     protected function updateCustom(ilPropertyFormGUI $form): void
     {
-        $this->object->setHideTitle(!$form->getInput("show_title"));
-        $behaviour = ($form->getInput("show_title"))
-            ? $form->getInput("behaviour")
-            : ilItemGroupBehaviour::ALWAYS_OPEN;
-        $this->object->setBehaviour($behaviour);
-        $this->object->setListPresentation($form->getInput("list_presentation"));
-        $this->object->setTileSize($form->getInput("tile_size"));
+        /** @var ilObjItemGroup $object */
+        $object = $this->getObject();
+        $object->setDisplay($form->getInput(ilItemGroupAR::DISPLAY));
+        $object->setDisplayWithTitleAndToggleableInitially($form->getInput(ilItemGroupAR::DISPLAY_WITH_TITLE_AND_TOGGLEABLE_INITIALLY));
+        $object->setListPresentation($form->getInput('list_presentation'));
+        $object->setTileSize($form->getInput('tile_size'));
     }
 
     protected function initCreateForm(string $new_type): \ILIAS\UI\Component\Input\Container\Form\Standard

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -10699,9 +10699,14 @@ itgr#:#itgr_always_open#:#Immer offen
 itgr#:#itgr_assign_materials#:#Objekte auswählen
 itgr#:#itgr_assigned_materials#:#Objekte im Objekteblock
 itgr#:#itgr_assignment#:#Eingebunden
-itgr#:#itgr_behaviour#:#Verhalten
-itgr#:#itgr_behaviour_info#:#Das System merkt sich den Zustand (geöffnet/geschlossen) je Benutzer bis zur Abmeldung (Logout).
 itgr#:#itgr_desc_info#:#Die Beschreibung wird bei der Anzeige des Objekteblocks nicht mit ausgegeben.
+itgr#:#itgr_display#:#Anzeige
+itgr#:#itgr_display_with_title#:#Mit Titel
+itgr#:#itgr_display_with_title_and_toggleable#:#Mit Titel, Objekteblock ein- und ausklappbar
+itgr#:#itgr_display_with_title_and_toggleable_initially#:#Ausgangszustand
+itgr#:#itgr_display_with_title_and_toggleable_initially_closed#:#zunächst geschlossen
+itgr#:#itgr_display_with_title_and_toggleable_initially_open#:#zunächst geöffnet
+itgr#:#itgr_display_without_title#:#Ohne Titel
 itgr#:#itgr_edit#:#Einstellungen des Objekteblocks
 itgr#:#itgr_expandable_closed#:#Ausklappbar (zunächst geschlossen)
 itgr#:#itgr_expandable_open#:#Ausklappbar (zunächst geöffnet)
@@ -10711,8 +10716,6 @@ itgr#:#itgr_list_default#:#Standard
 itgr#:#itgr_list_default_info#:#Übernimmt die Einstellung des übergeordneten Containers.
 itgr#:#itgr_list_presentation#:#Präsentationsansicht für Inhalte
 itgr#:#itgr_materials#:#Objekte
-itgr#:#itgr_show_title#:#Titel anzeigen
-itgr#:#itgr_show_title_info#:#Der Titel des Objekteblocks wird angezeigt.
 itgr#:#itgr_tile#:#Kacheln
 itgr#:#itgr_tile_size#:#Kachelgröße
 jscalendar#:#about_calendar#:#Über den Kalender

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -10700,9 +10700,14 @@ itgr#:#itgr_always_open#:#Always Open
 itgr#:#itgr_assign_materials#:#Assign Materials
 itgr#:#itgr_assigned_materials#:#Assigned Materials
 itgr#:#itgr_assignment#:#Assigned
-itgr#:#itgr_behaviour#:#Block Behaviour
-itgr#:#itgr_behaviour_info#:#The system will store the opened/closed state for the current user until logout.
 itgr#:#itgr_desc_info#:#The description will not be a part of the item group's presentation in its container.
+itgr#:#itgr_display#:#Display
+itgr#:#itgr_display_with_title#:#With Title
+itgr#:#itgr_display_with_title_and_toggleable#:#With Title, Item Group collapsible
+itgr#:#itgr_display_with_title_and_toggleable_initially#:#Initial state
+itgr#:#itgr_display_with_title_and_toggleable_initially_closed#:#initially closed
+itgr#:#itgr_display_with_title_and_toggleable_initially_open#:#initially opened
+itgr#:#itgr_display_without_title#:#Without Title
 itgr#:#itgr_edit#:#Edit Item Groups
 itgr#:#itgr_expandable_closed#:#Expandable (initially closed)
 itgr#:#itgr_expandable_open#:#Expandable (initially opened)
@@ -10712,8 +10717,6 @@ itgr#:#itgr_list_default#:#Default
 itgr#:#itgr_list_default_info#:#Inherits value from upper container.
 itgr#:#itgr_list_presentation#:#Item Presentation
 itgr#:#itgr_materials#:#Materials
-itgr#:#itgr_show_title#:#Show Title
-itgr#:#itgr_show_title_info#:#Shows title of item group in presentation for learner.
 itgr#:#itgr_tile#:#Tiles
 itgr#:#itgr_tile_size#:#Tile Size
 jscalendar#:#about_calendar#:#About the calendar


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=31861

Item group presentation mixed a show-title checkbox with a separate expand-behaviour field. Settings now use explicit display variants (no title, with title, with title and collapsible) plus an initial open/closed state for the collapsible mode, stored in new `display` and `toggleable_initially` columns via `ilItemGroupDBUpdateSteps::step_3` and `ilItemGroupAR`. `ilObjItemGroup` / `ilObjItemGroupGUI` read and write those values instead of the old hide-title helpers. `ilContainerContentGUI` and `ilContainerRenderer` build the block store link through `ilContainerBlockPropertiesStorageGUI` and align block headers and behaviour with the new object API. Language files add the matching UI strings.

/cc @thojou 