### PR TITLE
News 47534: Fix Undefined Logger Property

### DIFF
--- a/components/ILIAS/News/classes/class.ilNewsForContextBlockGUI.php
+++ b/components/ILIAS/News/classes/class.ilNewsForContextBlockGUI.php
@@ -57,6 +57,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
 
     protected bool $prevent_initial_loading = false;
     protected NewsCollection $collection;
+    protected ilLogger $logger;
 
     public function __construct()
     {
@@ -64,6 +65,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
 
         parent::__construct();
 
+        $this->logger = $DIC->logger()->news();
         $this->help = $DIC["ilHelp"];
         $this->settings = $DIC->settings();
         $this->tabs = $DIC->tabs();


### PR DESCRIPTION
This PR attempts to fix https://mantis.ilias.de/view.php?id=47534.

ilNewsForContextBlockGUI used $this->logger when logging errors without declaring or initializing the property, which caused an undefined property notice.

Kind regards,
@aaronbidzan 

/cc @thojou 