### PR TITLE
News 47580: Fixes Dashboard News Period not changeable

### DIFF
--- a/components/ILIAS/News/classes/class.ilPDNewsBlockGUI.php
+++ b/components/ILIAS/News/classes/class.ilPDNewsBlockGUI.php
@@ -64,18 +64,10 @@ class ilPDNewsBlockGUI extends ilNewsForContextBlockGUI
     {
         global $DIC;
 
-        $cmd = $DIC->ctrl()->getCmd();
-
-        switch ($cmd) {
-            case "showNews":
-            case "showFeedUrl":
-            case "editSettings":
-            case "changeFeedSettings":
-                return IL_SCREEN_CENTER;
-
-            default:
-                return IL_SCREEN_SIDE;
-        }
+        return match($DIC->ctrl()->getCmd()) {
+            'showNews', 'showFeedUrl', 'editSettings', 'saveSettings', 'changeFeedSettings' => IL_SCREEN_CENTER,
+            default => IL_SCREEN_SIDE
+        };
     }
 
     public function executeCommand()


### PR DESCRIPTION
This PR attempts to fix https://mantis.ilias.de/view.php?id=47580.

The saveSettings action wasn’t handled like the settings screen. After clicking Save, the request didn’t reliably reach the news block’s save logic, and the period stayed unchanged.

Kind regards,
@aaronbidzan 

/cc @thojou 