### PR TITLE
News 42549: Public Notifications Cannot Be Activated

### DIFF
--- a/components/ILIAS/Container/News/class.ilContainerNewsSettingsGUI.php
+++ b/components/ILIAS/Container/News/class.ilContainerNewsSettingsGUI.php
@@ -187,7 +187,14 @@ class ilContainerNewsSettingsGUI
                 $this->lng->txt("news_notifications_public"),
                 "public_notifications"
             );
-            $ch->setInfo($this->lng->txt("news_notifications_public_info"));
+
+            $info = $this->lng->txt("news_notifications_public_info");
+            if (!$this->setting->get("block_activated_news")) {
+                $info .= " {$this->lng->txt("news_notifications_public_info_disabled")}";
+                $ch->setDisabled(true);
+            }
+
+            $ch->setInfo($info);
             $ch->setChecked((bool) $public);
             $form->addItem($ch);
         }

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -12967,6 +12967,7 @@ news#:#news_not_available#:#Neuigkeit nicht verfügbar
 news#:#news_notifications#:#Benachrichtigungen
 news#:#news_notifications_public#:#Öffentliche Benachrichtigungen
 news#:#news_notifications_public_info#:#Wenn diese Option gewählt wird, können Benachrichtigungen auch außerhalb von ILIAS über den persönlichen Newsfeed empfangen werden. Beachten Sie bitte, dass diese Benachrichtigungen ohne Authentifizierung zugänglich sind.
+news#:#news_notifications_public_info_disabled#:#Um diese Einstellung zu ändern, aktivieren Sie die internen Neuigkeiten in der Administration.
 news#:#news_nr_of_items#:#Anzahl der maximalen Neuigkeiten pro Objekt
 news#:#news_nr_of_items_info#:#Anzahl der Neuigkeiten, die für ein Objekt (z. B. eine Datei oder ein Lernmodul) in der Datenbank vorgehalten werden. Beachten Sie bitte, dass Containerobjekte wie Kategorien oder Kurse mehr Neuigkeiten enthalten können, da Sie auch die Neuigkeiten ihrer Unterobjekte anzeigen.
 news#:#news_pd_period#:#Zeitraum für Neuigkeitenanzeige auf dem Dashboard

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -12968,6 +12968,7 @@ news#:#news_not_available#:#Unavailable News
 news#:#news_notifications#:#Notifications
 news#:#news_notifications_public#:#Public Notifications
 news#:#news_notifications_public_info#:#If this option is enabled, notifications can be obtained by personal RSS feeds outside of ILIAS. Please note that this makes notifications accessible without authentication.
+news#:#news_notifications_public_info_disabled#:#To change this setting, activate the internal news in the administration settings.
 news#:#news_nr_of_items#:#Number of Maximum News Items per Object
 news#:#news_nr_of_items_info#:#Number of news items that are kept for an object (e.g. a file or a learning module) in the database. Please note, that container objects (e.g. categories, courses) may list more items, because they aggregate news of sub-objects.
 news#:#news_pd_period#:#Dashboard News Period


### PR DESCRIPTION
This PR attempts to fix https://mantis.ilias.de/view.php?id=42549.

Even though global internal news was turned off, the user could still change the public notifications checkbox, but it would not save. I have now added an info text into the byline and disabled the checkbox in this case.

Kind regards,
@aaronbidzan 

/cc @thojou 