### PR TITLE
[FIX] News 47761: News cache is not being invalidated properly

### DIFF
--- a/components/ILIAS/News/src/Domain/NewsCollectionService.php
+++ b/components/ILIAS/News/src/Domain/NewsCollectionService.php
@@ -93,7 +93,7 @@ class NewsCollectionService
 
     public function invalidateCache(int $user_id): void
     {
-        $this->cache->invalidateNewsForUser($user_id, new NewsCriteria());
+        $this->cache->invalidateNewsForUser($user_id);
     }
 
     /**

--- a/components/ILIAS/News/src/Persistence/NewsCache.php
+++ b/components/ILIAS/News/src/Persistence/NewsCache.php
@@ -193,13 +193,14 @@ class NewsCache
 
         $this->il_cache->storeEntry(
             $this->generateL3Key($user_id, $criteria),
-            serialize($news->getUserReadStatus($user_id))
+            serialize($news->getUserReadStatus($user_id)),
+            $user_id
         );
     }
 
-    public function invalidateNewsForUser(int $user_id, NewsCriteria $criteria): void
+    public function invalidateNewsForUser(int $user_id): void
     {
-        $this->il_cache->deleteEntry($this->generateL3Key($user_id, $criteria));
+        $this->il_cache->deleteByAdditionalKeys($user_id);
     }
 
     protected function generateL3Key(int $user_id, NewsCriteria $criteria): string


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=47761