### PR TITLE
[CLI] Added quotation marks inform in CLI migration command

### DIFF
--- a/components/ILIAS/Setup/src/CLI/MigrateCommand.php
+++ b/components/ILIAS/Setup/src/CLI/MigrateCommand.php
@@ -156,7 +156,8 @@ class MigrateCommand extends Command
             $status = $steps === 0 ? "[<fg=green>done</>]" : "[<fg=yellow>remaining steps: $steps</>]";
             $io->text($migration_key . ": " . $migration->getLabel() . " " . $status);
         }
-        $io->inform('Run them by passing --run <migration_id>, e.g. --run ' . $migration_key);
+        $io->inform('Run them by passing --run "<migration_id>", e.g. --run ' . $migration_key);
+        $io->inform('Don\'t forget quotation marks if the migration_id includes a "\\"');
     }
 
     protected function prepareEnvironmentForMigration(


### PR DESCRIPTION
This PR improves the `cli/setup.php` migration tool by adding an extra `$io->inform` to the migrations overview. This informs the user on how to use the fully qualified class name migration_ids correctly (using quotation marks), for example, `ILIAS\Test\Setup\TestSetupAgent.RemoveLegacyTestSettingsMigration`.

Since I have struggled with this whilst upgrading our ILIAS instance, I would find it quite useful if this hint was displayed when using the tool.