### PR TITLE
Repository: remove direct check for preconditions in tree view (45985)

### DIFF
--- a/components/ILIAS/Repository/classes/class.ilRepositoryExplorerGUI.php
+++ b/components/ILIAS/Repository/classes/class.ilRepositoryExplorerGUI.php
@@ -424,11 +424,6 @@ class ilRepositoryExplorerGUI extends ilTreeExplorerGUI
             return [];
         }
 
-        $obj_id = ilObject::_lookupObjId($a_parent_node_id);
-        if (!ilConditionHandler::_checkAllConditionsOfTarget($a_parent_node_id, $obj_id)) {
-            return [];
-        }
-
         $childs = parent::getChildsOfNode($a_parent_node_id);
 
         foreach ($childs as $c) {


### PR DESCRIPTION
This PR fixes [45985](https://mantis.ilias.de/view.php?id=45985) by removing a direct check for preconditions in `ilRepositoryExplorerGUI`. That check should be unnecessary anyways, as preconditions are also covered by the access check directly above it anyways.