### PR TITLE
[FIX] Object 47771: Custom command modals are not available for item groups

### DIFF
--- a/components/ILIAS/Container/Content/class.ilContainerRenderer.php
+++ b/components/ILIAS/Container/Content/class.ilContainerRenderer.php
@@ -1181,6 +1181,7 @@ class ilContainerRenderer
             $item_data["description"]
         );
         $commands_html = $item_list_gui->getCommandsHTML();
+        $commands_html .= $item_list_gui->getCustomModalsHTML();
 
         // determine behaviour
         $item_group = new ilObjItemGroup($item_data["ref_id"]);

--- a/components/ILIAS/ILIASObject/classes/class.ilObjectListGUI.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObjectListGUI.php
@@ -2887,6 +2887,11 @@ class ilObjectListGUI
         return $this->ui->renderer()->render($this->getCommandsDropdown($title, false));
     }
 
+    public function getCustomModalsHTML(): string
+    {
+        return $this->ui->renderer()->render($this->cust_modals);
+    }
+
     private function getCommandsDropdown(string $title, bool $for_header = false): StandardDropdown
     {
         $this->populateCommands($for_header);


### PR DESCRIPTION
Hi everyone,

This PR addresses the issue described in [47771](https://mantis.ilias.de/view.php?id=47771), where modals for custom commands are not rendered in the header of ItemGroup-Lists. In this PR, I propose adding a method for rendering these modals and integrating it into the ItemGroups renderer.

I appreciate any feedback or suggestions.

Best
@lukas-heinrich 