### PR TITLE
Component/Activities: Fix interface and implementations

### DIFF
--- a/components/ILIAS/Component/src/Activities/Activity.php
+++ b/components/ILIAS/Component/src/Activities/Activity.php
@@ -21,10 +21,10 @@ declare(strict_types=1);
 namespace ILIAS\Component\Activities;
 
 use ILIAS\Component\Dependencies\Name;
-use ILIAS\UI\Component\Input\Control\Form\FormInput;
 use ILIAS\Data\Result;
 use ILIAS\Data\Text;
 use ILIAS\Data\Description;
+use ILIAS\UI\Component\Input\Container\Form\FormInput;
 
 /**
  * An Activity is an action on the domain layer action of a component.

--- a/components/ILIAS/Setup/src/Activities/GetStatus.php
+++ b/components/ILIAS/Setup/src/Activities/GetStatus.php
@@ -20,10 +20,9 @@ declare(strict_types=1);
 
 namespace ILIAS\Setup\Activities;
 
-use ILIAS\Component\Dependencies\Name;
-use ILIAS\UI\Component\Input\Control\Form\FormInput;
 use ILIAS\Data\Result;
 use ILIAS\Data\Text;
+use ILIAS\UI\Component\Input\Container\Form\FormInput;
 
 /**
  * This is a stub...
@@ -34,7 +33,7 @@ class GetStatus extends \ILIAS\Component\Activities\Query
     {
     }
 
-    public function getInputDescription(): \ILIAS\UI\Component\Input\Control\Form\FormInput
+    public function getInputDescription(): FormInput
     {
     }
 


### PR DESCRIPTION
Currently the `\ILIAS\Component\Activities\Activity` interface defines a non existing return type for `getInputDescription(...)`.

This means it is currently not possible to implement activities.

The same issue is valid for  `components/ILIAS/Setup/src/Activities/GetStatus.php`.

Mantis Issue: https://mantis.ilias.de/view.php?id=47797