### PR TITLE
Fix DST-aware UTC conversion for EXDATE and RRULE UNTIL in iCal export

### DIFF
--- a/components/ILIAS/Calendar/classes/Export/class.ilCalendarExport.php
+++ b/components/ILIAS/Calendar/classes/Export/class.ilCalendarExport.php
@@ -306,7 +306,7 @@ class ilCalendarExport
         $str_writer = new ilICalWriter();
         foreach (ilCalendarRecurrences::_getRecurrences($app->getEntryId()) as $rec) {
             foreach (ilCalendarRecurrenceExclusions::getExclusionDates($app->getEntryId()) as $excl) {
-                $str_writer->addLine($excl->toICal());
+                $str_writer->addLine($excl->toICal($this->il_user->getTimeZone()));
             }
             $recurrence_ical = $rec->toICal($this->il_user->getId());
             if (strlen($recurrence_ical)) {

--- a/components/ILIAS/Calendar/classes/class.ilCalendarRecurrence.php
+++ b/components/ILIAS/Calendar/classes/class.ilCalendarRecurrence.php
@@ -106,8 +106,13 @@ class ilCalendarRecurrence implements ilCalendarRecurrenceCalculation
             if ($entry->isFullday()) {
                 $ical .= (';UNTIL=' . $this->getFrequenceUntilDate()->get(IL_CAL_FKT_DATE, 'Ymd'));
             } else {
-                $his = $entry->getStart()->get(IL_CAL_FKT_DATE, 'His');
-                $ical .= (';UNTIL=' . $this->getFrequenceUntilDate()->get(IL_CAL_FKT_DATE, 'Ymd') . 'T' . $his);
+                $user = new ilObjUser($a_user_id);
+                $tz = $user->getTimeZone();
+                $local_time = $entry->getStart()->get(IL_CAL_FKT_DATE, 'H:i:s', $tz);
+                $until_date = $this->getFrequenceUntilDate()->get(IL_CAL_FKT_DATE, 'Y-m-d');
+                $until_dt = new ilDateTime($until_date . ' ' . $local_time, IL_CAL_DATETIME, $tz);
+                $ical .= ';UNTIL=' . $until_dt->get(IL_CAL_FKT_DATE, 'Ymd', ilTimeZone::UTC) .
+                         'T' . $until_dt->get(IL_CAL_FKT_DATE, 'His', ilTimeZone::UTC) . 'Z';
             }
         }
         if ($this->getBYMONTH()) {

--- a/components/ILIAS/Calendar/classes/class.ilCalendarRecurrenceExclusion.php
+++ b/components/ILIAS/Calendar/classes/class.ilCalendarRecurrenceExclusion.php
@@ -67,7 +67,7 @@ class ilCalendarRecurrenceExclusion
         $this->exclusion = $dt;
     }
 
-    public function toICal(): string
+    public function toICal(string $a_tz = ''): string
     {
         $entry = new ilCalendarEntry($this->getEntryId());
         $start = $entry->getStart();
@@ -75,9 +75,13 @@ class ilCalendarRecurrenceExclusion
         if ($entry->isFullday()) {
             return 'EXDATE;VALUE=DATE:' . $this->getDate()->get(IL_CAL_FKT_DATE, 'Ymd');
         } else {
+            $tz = $a_tz ?: ilTimeZone::UTC;
+            $local_time = $start->get(IL_CAL_FKT_DATE, 'H:i:s', $tz);
+            $excl_date = $this->getDate()->get(IL_CAL_FKT_DATE, 'Y-m-d');
+            $excl_dt = new ilDateTime($excl_date . ' ' . $local_time, IL_CAL_DATETIME, $tz);
             return 'EXDATE:' .
-                $this->getDate()->get(IL_CAL_FKT_DATE, 'Ymd', ilTimeZone::UTC) .
-                'T' . $start->get(IL_CAL_FKT_DATE, 'His', ilTimeZone::UTC) . 'Z';
+                $excl_dt->get(IL_CAL_FKT_DATE, 'Ymd', ilTimeZone::UTC) .
+                'T' . $excl_dt->get(IL_CAL_FKT_DATE, 'His', ilTimeZone::UTC) . 'Z';
         }
     }
 


### PR DESCRIPTION
The EXDATE and RRULE UNTIL timestamps were created by combining the target date with the UTC time of the DTSTART timestamp. When DTSTART falls in CET but the target date falls in CEST (or vice versa), the resulting UTC timestamp differs by one hour. Therefore, calendar clients that compare occurrences in UTC would not match the exception and display the excluded date anyway.

The fix involves constructing a proper datetime from the target date and the event's local start time in the user's configured time zone, and then converting to UTC.

Example:
- Series begins at 2026-03-18 08:15 Europe/Berlin
- Remove single date at 2026-03-25 -> workes because same timezone
- Remove single date at 2026-05-27 -> doesn't work because of DST

Other Example: Series begins in DST (now)
- Series begins at 2026-04-01 08:15 Europe/Berlin (->DST!)
- Remove single date at 2026-05-27 -> workes because same timezone

Screenshot with both examples from Thunderbird BEFORE my change:

<img width="2196" height="1485" alt="Screenshot From 2026-05-15 10-51-34" src="https://github.com/user-attachments/assets/6cd2c801-6032-464f-9af8-49607e818fda" />

Screenshot with both examples from Thunderbird AFTER my change:

<img width="2196" height="1485" alt="Screenshot From 2026-05-15 10-59-14" src="https://github.com/user-attachments/assets/10bdad64-d190-4ee9-a2ba-95b58e4792b9" />
