### PR TITLE
add style build for ILIAS 11

### DIFF
--- a/.github/workflows/style-to-repo_trunk.yml
+++ b/.github/workflows/style-to-repo_trunk.yml
@@ -2,7 +2,7 @@ name: Build and deploy style files
 on:
   push:
     branches:
-      - "release_9"
+      - "release_11"
 
 jobs:
   style-to-repo:


### PR DESCRIPTION
This commit should create a new release_11 branch in the delos (https://github.com/ILIAS-eLearning/delos) repository and allow to auto-push to it.

Background information:

- The github workflow on release_11 is now executed as soon as there is a push on release_11. Before it checked for the branch release_11 if there was a push on release_9 which means it never got executed
- When this is executed the scripts/Style-To-Repo/build-and-deploy.sh script checks out the latest commit to the release_11 branch  (https://github.com/ILIAS-eLearning/ILIAS/blob/release_11/scripts/Style-To-Repo/build-and-deploy.sh#L32) and adds as a branch name "release_11", see https://github.com/ILIAS-eLearning/ILIAS/blob/release_11/scripts/Style-To-Repo/build-and-deploy.sh#L33
- This is then executed in https://github.com/ILIAS-eLearning/ILIAS/blob/release_11/scripts/Style-To-Repo/build-and-deploy.sh#L45 and uses the new branch name (https://github.com/ILIAS-eLearning/ILIAS/blob/release_11/scripts/Style-To-Repo/deploy.sh#L45) on the first run (or on another run: https://github.com/ILIAS-eLearning/ILIAS/blob/909f67551a5cfa243f04f412c2d425ec5e2e9005/scripts/Style-To-Repo/deploy.sh#L43) to later push to the delos repo (https://github.com/ILIAS-eLearning/ILIAS/blob/release_11/scripts/Style-To-Repo/deploy.sh#L82). 