### PR TITLE
Container: fix download link when downloading multiple objects (47798)

### DIFF
--- a/components/ILIAS/Container/classes/class.ilContainerGUI.php
+++ b/components/ILIAS/Container/classes/class.ilContainerGUI.php
@@ -601,19 +601,19 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             $num_files = $this->tree->getChildsByType($ref_id, "file");
             $num_folders = $this->tree->getChildsByType($ref_id, "fold");
             if (count($num_files) > 0 || count($num_folders) > 0) {
-                // #11843
-                $GLOBALS['tpl']->setPageFormAction($this->ctrl->getFormAction($this));
-
                 $toolbar = new ilToolbarGUI();
                 $this->ctrl->setParameter($this, "type", "");
                 $this->ctrl->setParameter($this, "item_ref_id", "");
+
+                // #11843
+                $main_tpl->setPageFormAction($this->ctrl->getFormAction($this));
 
                 $toolbar->addFormButton(
                     $this->lng->txt('download_selected_items'),
                     'download'
                 );
 
-                $GLOBALS['tpl']->addAdminPanelToolbar(
+                $main_tpl->addAdminPanelToolbar(
                     $toolbar,
                     $this->gotItems(),
                     $this->gotItems()


### PR DESCRIPTION
This PR fixes [47798](https://mantis.ilias.de/view.php?id=47798) by cleaning up parameters a bit more thoroughly before building the 'Download' form action. In principle this shouldn't be necessary, `ilObjectListGUI` should reset ctrl parameters more thoroughly, but this fix here seems less prone to follow up issues.