### PR TITLE
FIX 39967 number of required materials for preconditions

### DIFF
--- a/components/ILIAS/Conditions/classes/class.ilConditionHandlerGUI.php
+++ b/components/ILIAS/Conditions/classes/class.ilConditionHandlerGUI.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -15,8 +17,6 @@
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
-
-declare(strict_types=1);
 
 use ILIAS\Refinery\Factory;
 use ILIAS\HTTP\GlobalHttpState;
@@ -919,7 +919,7 @@ class ilConditionHandlerGUI
             }
         }
 
-        $all_conditions_number = count($all_conditions) - 1;
+        $all_conditions_number = count($all_conditions);
         if ($all_conditions_number > 1) {
 
             $num_required = ilConditionHandler::lookupObligatoryConditionsOfTarget(
@@ -932,7 +932,6 @@ class ilConditionHandlerGUI
                     $this->lng->txt('precondition_num_optional_info')
                 )
                 ->withValue($num_required > 0 ? $num_required : null)
-                // absolute ceilings: from 1 to # of preconditions + 1
                 ->withAdditionalTransformation(
                     $this->refinery->custom()->constraint(
                         fn($val) => $val >= 1,

--- a/components/ILIAS/Conditions/classes/class.ilConditionHandlerGUI.php
+++ b/components/ILIAS/Conditions/classes/class.ilConditionHandlerGUI.php
@@ -893,9 +893,10 @@ class ilConditionHandlerGUI
             $this->getTargetId(),
             $this->getTargetType()
         );
+        $is_subset_mode = count($optional_conditions) > 0;
 
         $old_status = $this->ui_factory->input()->field()->hidden()->withValue(
-            (string) (count($optional_conditions) ? self::LIST_MODE_SUBSET : self::LIST_MODE_ALL)
+            (string) ($is_subset_mode ? self::LIST_MODE_SUBSET : self::LIST_MODE_ALL)
         );
 
         $hidden = $this->ui_factory->input()->field()->checkbox(
@@ -911,28 +912,50 @@ class ilConditionHandlerGUI
         $list_mode_items[self::LIST_MODE_ALL] = $condition_mode_all;
 
         $subset_limit = [];
-        if (count($all_conditions) > 1) {
+        $compulsory_count = 0;
+        foreach ($all_conditions as $condition) {
+            if ($condition['obligatory']) $compulsory_count++;
+        }
+
+        $all_conditions_number = count($all_conditions) - 1;
+        if ($all_conditions_number > 1) {
 
             $num_required = ilConditionHandler::lookupObligatoryConditionsOfTarget(
                 $this->getTargetRefId(),
                 $this->getTargetId()
             );
-            $subset_limit['num_compulsory'] =
-                $this->ui_factory->input()
-                                 ->field()
-                                 ->numeric(
-                                     $this->lng->txt('precondition_num_obligatory'),
-                                     $this->lng->txt('precondition_num_optional_info')
-                                 )
-                                 ->withValue($num_required > 0 ? $num_required : null)
-                                 ->withAdditionalTransformation(
-                                     $this->refinery->logical()->parallel(
-                                         [
-                                             $this->refinery->int()->isGreaterThan(0),
-                                             $this->refinery->int()->isLessThan(count($all_conditions))
-                                         ]
-                                     )
-                                 );
+            $subset_limit['num_compulsory'] = $this->ui_factory->input()->field()
+                ->numeric(
+                    $this->lng->txt('precondition_num_obligatory'),
+                    $this->lng->txt('precondition_num_optional_info')
+                )
+                ->withValue($num_required > 0 ? $num_required : null)
+                // check if the number of required materials is bigger than compulsory conditions in subset mode
+                ->withAdditionalTransformation(
+                    $this->refinery->custom()->constraint(
+                        function ($val) use ($is_subset_mode, $compulsory_count) {
+                            if ($is_subset_mode) {
+                                return $val >= $compulsory_count + 1;
+                            }
+                            return true;
+                        },
+                        $this->lng->txt('precondition_number_of_required_materials_lower_compulsory_items')
+                    )
+                )
+                // absolute ceilings: from 1 to # of preconditions + 1
+                ->withAdditionalTransformation(
+                    $this->refinery->custom()->constraint(
+                        fn($val) => $val >= 1,
+                        $this->lng->txt('precondition_number_of_required_materials_lower_than_one')
+                    )
+                )
+                ->withAdditionalTransformation(
+                    $this->refinery->custom()->constraint(
+                        fn($val) => $val <= $all_conditions_number - 1,
+                        $this->lng->txt('precondition_number_of_required_materials_bigger_preconditions_number')
+
+                    )
+                );
         }
         if (count($all_conditions) > 1) {
             $condition_mode_subset = $this->ui_factory->input()->field()->group(

--- a/components/ILIAS/Conditions/classes/class.ilConditionHandlerGUI.php
+++ b/components/ILIAS/Conditions/classes/class.ilConditionHandlerGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\Refinery\Factory;
 use ILIAS\HTTP\GlobalHttpState;
@@ -914,7 +914,9 @@ class ilConditionHandlerGUI
         $subset_limit = [];
         $compulsory_count = 0;
         foreach ($all_conditions as $condition) {
-            if ($condition['obligatory']) $compulsory_count++;
+            if ($condition['obligatory']) {
+                $compulsory_count++;
+            }
         }
 
         $all_conditions_number = count($all_conditions) - 1;
@@ -930,6 +932,13 @@ class ilConditionHandlerGUI
                     $this->lng->txt('precondition_num_optional_info')
                 )
                 ->withValue($num_required > 0 ? $num_required : null)
+                // absolute ceilings: from 1 to # of preconditions + 1
+                ->withAdditionalTransformation(
+                    $this->refinery->custom()->constraint(
+                        fn($val) => $val >= 1,
+                        $this->lng->txt('precondition_number_of_required_materials_lower_than_one')
+                    )
+                )
                 // check if the number of required materials is bigger than compulsory conditions in subset mode
                 ->withAdditionalTransformation(
                     $this->refinery->custom()->constraint(
@@ -942,18 +951,10 @@ class ilConditionHandlerGUI
                         $this->lng->txt('precondition_number_of_required_materials_lower_compulsory_items')
                     )
                 )
-                // absolute ceilings: from 1 to # of preconditions + 1
-                ->withAdditionalTransformation(
-                    $this->refinery->custom()->constraint(
-                        fn($val) => $val >= 1,
-                        $this->lng->txt('precondition_number_of_required_materials_lower_than_one')
-                    )
-                )
                 ->withAdditionalTransformation(
                     $this->refinery->custom()->constraint(
                         fn($val) => $val <= $all_conditions_number - 1,
                         $this->lng->txt('precondition_number_of_required_materials_bigger_preconditions_number')
-
                     )
                 );
         }

--- a/components/ILIAS/Conditions/classes/class.ilConditionHandlerGUI.php
+++ b/components/ILIAS/Conditions/classes/class.ilConditionHandlerGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\Refinery\Factory;
 use ILIAS\HTTP\GlobalHttpState;
@@ -956,8 +956,6 @@ class ilConditionHandlerGUI
                         $this->lng->txt('precondition_number_of_required_materials_bigger_preconditions_number')
                     )
                 );
-        }
-        if (count($all_conditions) > 1) {
             $condition_mode_subset = $this->ui_factory->input()->field()->group(
                 $subset_limit,
                 $this->lng->txt('rbac_precondition_mode_subset'),

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -14516,6 +14516,9 @@ rbac#:#positions_override_operations#:#Globale Einstellungen überschreiben
 rbac#:#precondition_not_obligatory_alt#:#Die Vorbedingung ist optional
 rbac#:#precondition_num_obligatory#:#Geforderte Anzahl Materialien
 rbac#:#precondition_num_optional_info#:#Anzahl von Materialien, die bis zum festgelegten Status / Ergebnis zu bearbeiten sind
+rbac#:#precondition_number_of_required_materials_bigger_preconditions_number#:#Die Anzahl der geforderten Materialien muss kleiner als die Gesamtzahl der verfügbaren Vorbedingungen sein.
+rbac#:#precondition_number_of_required_materials_lower_compulsory_items#:#Die Anzahl der erforderlichen Materialien muss größer als die Anzahl der verpflichtenden Vorbedingungen sein.
+rbac#:#precondition_number_of_required_materials_lower_than_one#:#Sie müssen mindestens 1 Material angeben.
 rbac#:#precondition_obligatory#:#Verpflichtend
 rbac#:#precondition_obligatory_alt#:#Die Vorbedingung muss erfüllt werden
 rbac#:#precondition_obligatory_info#:#Verpflichtende Vorbedingungen müssen erfüllt werden, um Zugriff zu erhalten.

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -14516,9 +14516,9 @@ rbac#:#positions_override_operations#:#Globale Einstellungen überschreiben
 rbac#:#precondition_not_obligatory_alt#:#Die Vorbedingung ist optional
 rbac#:#precondition_num_obligatory#:#Geforderte Anzahl Materialien
 rbac#:#precondition_num_optional_info#:#Anzahl von Materialien, die bis zum festgelegten Status / Ergebnis zu bearbeiten sind
-rbac#:#precondition_number_of_required_materials_bigger_preconditions_number#:#Die Anzahl der geforderten Materialien muss kleiner als die Gesamtzahl der verfügbaren Vorbedingungen sein.
-rbac#:#precondition_number_of_required_materials_lower_compulsory_items#:#Die Anzahl der erforderlichen Materialien muss größer als die Anzahl der verpflichtenden Vorbedingungen sein.
-rbac#:#precondition_number_of_required_materials_lower_than_one#:#Sie müssen mindestens 1 Material angeben.
+rbac#:#precondition_number_of_required_materials_bigger_preconditions_number#:#Die Anzahl der geforderten Materialien muss kleiner sein, als die Anzahl der Vorbedingungen.
+rbac#:#precondition_number_of_required_materials_lower_compulsory_items#:#Die Anzahl der geforderten Materialien muss größer sein, als die Anzahl der verpflichtenden Vorbedingungen.
+rbac#:#precondition_number_of_required_materials_lower_than_one#:#Die Anzahl der geforderten Materialien muss mindestens 1 sein.
 rbac#:#precondition_obligatory#:#Verpflichtend
 rbac#:#precondition_obligatory_alt#:#Die Vorbedingung muss erfüllt werden
 rbac#:#precondition_obligatory_info#:#Verpflichtende Vorbedingungen müssen erfüllt werden, um Zugriff zu erhalten.

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -14516,8 +14516,8 @@ rbac#:#positions_override_operations#:#Globale Einstellungen überschreiben
 rbac#:#precondition_not_obligatory_alt#:#Die Vorbedingung ist optional
 rbac#:#precondition_num_obligatory#:#Geforderte Anzahl Materialien
 rbac#:#precondition_num_optional_info#:#Anzahl von Materialien, die bis zum festgelegten Status / Ergebnis zu bearbeiten sind
-rbac#:#precondition_number_of_required_materials_bigger_preconditions_number#:#Die Anzahl der geforderten Materialien muss kleiner sein, als die Anzahl der Vorbedingungen.
-rbac#:#precondition_number_of_required_materials_lower_compulsory_items#:#Die Anzahl der geforderten Materialien muss größer sein, als die Anzahl der verpflichtenden Vorbedingungen.
+rbac#:#precondition_number_of_required_materials_bigger_preconditions_number#:#Die Anzahl der geforderten Materialien muss kleiner sein als die Anzahl der Vorbedingungen.
+rbac#:#precondition_number_of_required_materials_lower_compulsory_items#:#Die Anzahl der geforderten Materialien muss größer sein als die Anzahl der verpflichtenden Vorbedingungen.
 rbac#:#precondition_number_of_required_materials_lower_than_one#:#Die Anzahl der geforderten Materialien muss mindestens 1 sein.
 rbac#:#precondition_obligatory#:#Verpflichtend
 rbac#:#precondition_obligatory_alt#:#Die Vorbedingung muss erfüllt werden

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -14517,9 +14517,9 @@ rbac#:#positions_override_operations#:#Override global Settings
 rbac#:#precondition_not_obligatory_alt#:#Precondition is optional
 rbac#:#precondition_num_obligatory#:#Number of Required Materials
 rbac#:#precondition_num_optional_info#:#Please enter the minimum number of materials required to fulfill this precondition.
-rbac#:#precondition_number_of_required_materials_bigger_preconditions_number#:#Number of required materials should be less than the total number of available preconditions.
-rbac#:#precondition_number_of_required_materials_lower_compulsory_items#:#The number of required materials should be greater than the number of compulsory preconditions.
-rbac#:#precondition_number_of_required_materials_lower_than_one#:#You must require at least 1 material.
+rbac#:#precondition_number_of_required_materials_bigger_preconditions_number#:#The number of required materials must be less than the total number of preconditions.
+rbac#:#precondition_number_of_required_materials_lower_compulsory_items#:#The number of required materials must be greater than the number of compulsory preconditions.
+rbac#:#precondition_number_of_required_materials_lower_than_one#:#The number of required materials must be at least 1.
 rbac#:#precondition_obligatory#:#Compulsory
 rbac#:#precondition_obligatory_alt#:#Precondition must be fulfilled
 rbac#:#precondition_obligatory_info#:#Compulsory preconditions must be fulfilled, for having access.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -14517,6 +14517,9 @@ rbac#:#positions_override_operations#:#Override global Settings
 rbac#:#precondition_not_obligatory_alt#:#Precondition is optional
 rbac#:#precondition_num_obligatory#:#Number of Required Materials
 rbac#:#precondition_num_optional_info#:#Please enter the minimum number of materials required to fulfill this precondition.
+rbac#:#precondition_number_of_required_materials_bigger_preconditions_number#:#Number of required materials should be less than the total number of available preconditions.
+rbac#:#precondition_number_of_required_materials_lower_compulsory_items#:#The number of required materials should be greater than the number of compulsory preconditions.
+rbac#:#precondition_number_of_required_materials_lower_than_one#:#You must require at least 1 material.
 rbac#:#precondition_obligatory#:#Compulsory
 rbac#:#precondition_obligatory_alt#:#Precondition must be fulfilled
 rbac#:#precondition_obligatory_info#:#Compulsory preconditions must be fulfilled, for having access.


### PR DESCRIPTION
Fixed the [bug 39967](https://mantis.ilias.de/view.php?id=39967) (number of required materials can be less than number of the compulsory preconditions) by adding additional boundary checks based on mode and number of compulsory preconditions for the number of required materials.