### PR TITLE
News: Fix ilCtrl Property Declaration Typo

### DIFF
--- a/components/ILIAS/News/classes/class.ilNewsDefaultRendererGUI.php
+++ b/components/ILIAS/News/classes/class.ilNewsDefaultRendererGUI.php
@@ -26,7 +26,7 @@ class ilNewsDefaultRendererGUI implements ilNewsRendererGUI
     protected \ILIAS\DI\UIServices $ui;
     protected \ILIAS\Refinery\Factory $refinery;
     protected string $lng_key;
-    protected ilCtrl$ctrl;
+    protected ilCtrl $ctrl;
     protected ilLanguage $lng;
     protected ilNewsItem $news_item;
     protected int $news_ref_id;


### PR DESCRIPTION
The `ilCtrl$ctrl` property declaration was missing a space between the type name and the variable. Updated it to `ilCtrl $ctrl`.

/cc @thojou 