### PR TITLE
TestQuestionPool: Apply PHP CS Fixer Rules to Question Pool

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.assClozeGap.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assClozeGap.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.

--- a/components/ILIAS/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacExpressionInterface.php
+++ b/components/ILIAS/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacExpressionInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.

--- a/components/ILIAS/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacNumericResultExpression.php
+++ b/components/ILIAS/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacNumericResultExpression.php
@@ -106,7 +106,7 @@ class ilAssLacNumericResultExpression extends ilAssLacAbstractExpression impleme
             }
         } else {
             $solution = $result->getSolutionForKey($index);
-            if($solution !== null) {
+            if ($solution !== null) {
                 $isTrue = $this->compare($comperator, $solution["value"] ?? "");
             }
         }

--- a/components/ILIAS/TestQuestionPool/classes/tables/class.assFileUploadFileTableGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/tables/class.assFileUploadFileTableGUI.php
@@ -101,9 +101,9 @@ class assFileUploadFileTableGUI extends ilTable2GUI
     protected function buildFileItemContent(array $a_set): string
     {
         $value = $a_set['value2'];
-        if($value === 'rid') {
+        if ($value === 'rid') {
             $rid = $this->irss->manage()->find($a_set['value1']);
-            if($rid === null) {
+            if ($rid === null) {
                 return ilLegacyFormElementsUtil::prepareFormOutput($value);
             }
             $value = $this->irss->manage()->getCurrentRevision($rid)->getTitle();

--- a/components/ILIAS/TestQuestionPool/interfaces/interface.iQuestionCondition.php
+++ b/components/ILIAS/TestQuestionPool/interfaces/interface.iQuestionCondition.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.

--- a/components/ILIAS/TestQuestionPool/interfaces/interface.ilQuestionHeaderBlockBuilder.php
+++ b/components/ILIAS/TestQuestionPool/interfaces/interface.ilQuestionHeaderBlockBuilder.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.

--- a/components/ILIAS/TestQuestionPool/src/Questions/Question.php
+++ b/components/ILIAS/TestQuestionPool/src/Questions/Question.php
@@ -22,7 +22,6 @@ use ILIAS\Test\Logging\TestParticipantInteraction;
 use ILIAS\Test\Logging\TestParticipantInteractionTypes;
 use ILIAS\Test\Logging\TestQuestionAdministrationInteraction;
 use ILIAS\Test\Logging\TestQuestionAdministrationInteractionTypes;
-
 use ILIAS\Test\Logging\AdditionalInformationGenerator;
 
 interface Question

--- a/components/ILIAS/TestQuestionPool/tests/assKprimChoiceTest.php
+++ b/components/ILIAS/TestQuestionPool/tests/assKprimChoiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.


### PR DESCRIPTION
Applied PHP-CS-Fixer cleanups across `TestQuestionPool`: insert a blank line after the opening `<?php` tag where required, add spacing after `if` keywords, and remove an extra blank line between grouped `use` imports in `Question.php`.

/cc @thojou 