### PR TITLE
Test: Apply PHP CS Fixer Rules to Sources

### DIFF
--- a/components/ILIAS/Test/classes/PassPresentedVariablesRepo.php
+++ b/components/ILIAS/Test/classes/PassPresentedVariablesRepo.php
@@ -47,7 +47,7 @@ class PassPresentedVariablesRepo
             [$question_id, $active_id, $pass]
         );
 
-        if($result->numRows() === 0) {
+        if ($result->numRows() === 0) {
             return null;
         }
 

--- a/components/ILIAS/Test/classes/class.ilTestProcessLockFileStorage.php
+++ b/components/ILIAS/Test/classes/class.ilTestProcessLockFileStorage.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.

--- a/components/ILIAS/Test/src/Logging/TestAdministrationInteraction.php
+++ b/components/ILIAS/Test/src/Logging/TestAdministrationInteraction.php
@@ -21,7 +21,6 @@ declare(strict_types=1);
 namespace ILIAS\Test\Logging;
 
 use ILIAS\Test\Utilities\TitleColumnsBuilder;
-
 use ILIAS\UI\Factory as UIFactory;
 use ILIAS\UI\Component\Listing\Descriptive as DescriptiveListing;
 use ILIAS\UI\Component\Table\DataRowBuilder;

--- a/components/ILIAS/Test/src/Logging/TestLogger.php
+++ b/components/ILIAS/Test/src/Logging/TestLogger.php
@@ -21,7 +21,6 @@ declare(strict_types=1);
 namespace ILIAS\Test\Logging;
 
 use Psr\Log\LoggerInterface;
-
 use ILIAS\Test\Settings\GlobalSettings\TestLoggingSettings;
 
 class TestLogger implements LoggerInterface

--- a/components/ILIAS/Test/src/Logging/TestScoringInteraction.php
+++ b/components/ILIAS/Test/src/Logging/TestScoringInteraction.php
@@ -21,9 +21,7 @@ declare(strict_types=1);
 namespace ILIAS\Test\Logging;
 
 use ILIAS\Test\Utilities\TitleColumnsBuilder;
-
 use ILIAS\TestQuestionPool\Questions\GeneralQuestionPropertiesRepository;
-
 use ILIAS\UI\Factory as UIFactory;
 use ILIAS\UI\Component\Listing\Descriptive as DescriptiveListing;
 use ILIAS\StaticURL\Services as StaticURLServices;

--- a/components/ILIAS/Test/src/Settings/Templates/PersonalSettingsTableApplyAction.php
+++ b/components/ILIAS/Test/src/Settings/Templates/PersonalSettingsTableApplyAction.php
@@ -47,7 +47,6 @@ class PersonalSettingsTableApplyAction implements TableAction
         private readonly MainSettingsRepository $main_settings_repository,
         private readonly ScoreSettingsRepository $score_settings_repository,
         private readonly MarksRepository $marks_repository,
-
     ) {
     }
 

--- a/components/ILIAS/Test/src/Settings/Templates/PersonalSettingsTableDeleteAction.php
+++ b/components/ILIAS/Test/src/Settings/Templates/PersonalSettingsTableDeleteAction.php
@@ -74,10 +74,11 @@ class PersonalSettingsTableDeleteAction implements TableAction
             $url_builder->buildURI()->__toString()
         )->withAffectedItems(
             array_map(
-                 fn(PersonalSettingsTemplate $v) => $this->ui_factory->modal()->interruptiveItem()->standard(
-                     (string) $v->getId(), $v->getName()
-                 ),
-                 $selected_templates
+                fn(PersonalSettingsTemplate $v) => $this->ui_factory->modal()->interruptiveItem()->standard(
+                    (string) $v->getId(),
+                    $v->getName()
+                ),
+                $selected_templates
             )
         )->withActionButtonLabel($this->lng->txt('delete'));
     }

--- a/components/ILIAS/Test/src/Settings/TestSettings.php
+++ b/components/ILIAS/Test/src/Settings/TestSettings.php
@@ -21,7 +21,6 @@ declare(strict_types=1);
 namespace ILIAS\Test\Settings;
 
 use ILIAS\Test\Logging\AdditionalInformationGenerator;
-
 use ILIAS\UI\Component\Input\Field\Factory as FieldFactory;
 use ILIAS\UI\Component\Input\Container\Form\FormInput;
 use ILIAS\Refinery\Factory as Refinery;

--- a/components/ILIAS/Test/tests/Setup/SetupAgentTest.php
+++ b/components/ILIAS/Test/tests/Setup/SetupAgentTest.php
@@ -19,7 +19,6 @@
 namespace ILIAS\Test\test;
 
 use ILIAS\Test\Setup\TestSetupAgent;
-
 use ILIAS\Setup\ObjectiveCollection;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\Setup\Objective\NullObjective;


### PR DESCRIPTION
Aligned several `Test` component files with PHP-CS-Fixer output, including
spacing after the `if` keyword, a blank line after the file header in
`class.ilTestProcessLockFileStorage.php`, removal of redundant blank lines
between `use` imports, cleanup of constructor parameter lists, and
formatting of the `interruptiveItem` mapping in
`PersonalSettingsTableDeleteAction`.

/cc @thojou 