### PR TITLE
[Survey] fix: Include display title and calculate sum at export

### DIFF
--- a/components/ILIAS/Survey/classes/class.ilObjSurvey.php
+++ b/components/ILIAS/Survey/classes/class.ilObjSurvey.php
@@ -3017,8 +3017,8 @@ class ilObjSurvey extends ilObject
         $custom_properties = array();
         $custom_properties["evaluation_access"] = $this->getEvaluationAccess();
         $custom_properties["status"] = !$this->getOfflineStatus();
-        $custom_properties["display_question_titles"] = (int)$this->getShowQuestionTitles();
-        $custom_properties["calculate_sum_score"] = (int)$this->getCalculateSumScore();
+        $custom_properties["display_question_titles"] = (int) $this->getShowQuestionTitles();
+        $custom_properties["calculate_sum_score"] = (int) $this->getCalculateSumScore();
 
         $custom_properties["own_results_view"] = (int) $this->hasViewOwnResults();
         $custom_properties["own_results_mail"] = (int) $this->hasMailOwnResults();

--- a/components/ILIAS/Survey/classes/class.ilObjSurvey.php
+++ b/components/ILIAS/Survey/classes/class.ilObjSurvey.php
@@ -3017,7 +3017,8 @@ class ilObjSurvey extends ilObject
         $custom_properties = array();
         $custom_properties["evaluation_access"] = $this->getEvaluationAccess();
         $custom_properties["status"] = !$this->getOfflineStatus();
-        $custom_properties["display_question_titles"] = $this->getShowQuestionTitles();
+        $custom_properties["display_question_titles"] = (int)$this->getShowQuestionTitles();
+        $custom_properties["calculate_sum_score"] = (int)$this->getCalculateSumScore();
 
         $custom_properties["own_results_view"] = (int) $this->hasViewOwnResults();
         $custom_properties["own_results_mail"] = (int) $this->hasMailOwnResults();
@@ -3031,7 +3032,6 @@ class ilObjSurvey extends ilObject
         $custom_properties["mode_360_results"] = $this->get360Results();
         $custom_properties["mode_skill_service"] = (int) $this->getSkillService();
         $custom_properties["mode_self_eval_results"] = $this->getSelfEvaluationResults();
-
 
         // :TODO: skills?
 

--- a/components/ILIAS/SurveyQuestionPool/Export/class.SurveyImportParser.php
+++ b/components/ILIAS/SurveyQuestionPool/Export/class.SurveyImportParser.php
@@ -611,6 +611,9 @@ class SurveyImportParser extends ilSaxParser
                             case "evaluation_access":
                                 $this->survey->setEvaluationAccess($value["entry"]);
                                 break;
+                            case "calculate_sum_score":
+                                $this->survey->setCalculateSumScore($value["entry"]);
+                                break;
                             case "pool_usage":
                                 $this->survey->setPoolUsage($value["entry"]);
                                 break;

--- a/components/ILIAS/SurveyQuestionPool/Export/class.SurveyImportParser.php
+++ b/components/ILIAS/SurveyQuestionPool/Export/class.SurveyImportParser.php
@@ -612,7 +612,7 @@ class SurveyImportParser extends ilSaxParser
                                 $this->survey->setEvaluationAccess($value["entry"]);
                                 break;
                             case "calculate_sum_score":
-                                $this->survey->setCalculateSumScore($value["entry"]);
+                                $this->survey->setCalculateSumScore((bool) $value["entry"]);
                                 break;
                             case "pool_usage":
                                 $this->survey->setPoolUsage($value["entry"]);


### PR DESCRIPTION
### Fix display question title and sum score export

This fixes the display of the question title and ensures the calculated sum score is exported successfully.

Related ticket: https://mantis.ilias.de/view.php?id=47147