### PR TITLE
[FIX] #47810 UI: Fix Ordering Table Dialog Open and Close

### DIFF
--- a/components/ILIAS/UI/src/templates/default/Table/tpl.orderingtable.html
+++ b/components/ILIAS/UI/src/templates/default/Table/tpl.orderingtable.html
@@ -76,16 +76,16 @@
 
 	<div class="c-table-data__async_modal_container"></div>
 
-	<div class="c-table-data__async_message modal" role="dialog" id="{ID}_msgmodal">
+	<dialog class="c-table-data__async_message c-modal" id="{ID}_msgmodal">
 		<div class="modal-dialog" role="document">
 			<div class="modal-content">
 				<div class="modal-header">
-					<button type="button" class="close" data-dismiss="modal" aria-label="close"><span aria-hidden="true">&times;</span></button>
+					<form><button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button></form>
 				</div>
 				<div class="c-table-data__async_messageresponse modal-body"></div>
 			</div>
 		</div>
-	</div>
+	</dialog>
 	<!-- BEGIN warning_dialog -->
 	<dialog class="c-modal c-table-data__multiaction-warning" id="{ID}_warningmodal">
 		<div class="modal-dialog" role="document">

--- a/components/ILIAS/UI/tests/Component/Table/OrderingRendererTest.php
+++ b/components/ILIAS/UI/tests/Component/Table/OrderingRendererTest.php
@@ -109,17 +109,16 @@ class OrderingRendererTest extends TableRendererTestBase
         </table>
     </form>
     <div class="c-table-data__async_modal_container"></div>
-    <div class="c-table-data__async_message modal" role="dialog" id="id_1_msgmodal">
+    <dialog class="c-table-data__async_message c-modal" id="id_1_msgmodal">
         <div class="modal-dialog" role="document">
             <div class="modal-content">
                 <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="close">
-                        <span aria-hidden="true">&times;</span></button>
+                    <form><button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button></form>
                 </div>
                 <div class="c-table-data__async_messageresponse modal-body"></div>
             </div>
         </div>
-    </div>
+    </dialog>
 </div>
 EOT;
         $this->assertEquals($this->brutallyTrimHTML($expected), $this->brutallyTrimHTML($actual));


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=47810

The ordering table’s async message layer used a Bootstrap-style `div.modal` close control, which interfered with showing and dismissing the overlay. It now uses a native `<dialog class="c-modal">` and a `formmethod="dialog"` close button, consistent with the multi-action warning dialog. The table title is emitted as a fixed `<h2 class="ilHeader">` for reliable semantics. `OrderingRendererTest` expected markup was updated accordingly.

/cc @oliversamoila @thojou 