### PR TITLE
fix: replace deprecated DIC->ilErr() with DIC['ilErr'] in ilAuthPageE…

### DIFF
--- a/components/ILIAS/Authentication/classes/class.ilAuthPageEditorGUI.php
+++ b/components/ILIAS/Authentication/classes/class.ilAuthPageEditorGUI.php
@@ -58,7 +58,7 @@ class ilAuthPageEditorGUI implements ilCtrlSecurityInterface
         $this->tabs = $DIC->tabs();
 
         $this->http = $DIC->http();
-        $this->ilErr = $DIC->ilErr();
+        $this->ilErr = $DIC['ilErr'];
         $this->refinery = $DIC->refinery();
         $this->ui_factory = $DIC->ui()->factory();
         $this->ui_renderer = $DIC->ui()->renderer();


### PR DESCRIPTION
…ditorGUI

### Version
ILIAS 11.0 php 8.4 node 24 mariadb 10.11

### Steps to reproduce
1. Go to Administration → Authentication and Registration
2. Try to access the 'Design Login-Page' Editor

### Error
Call to undefined method ILIAS\DI\Container::ilErr() in components/ILIAS/Authentication/classes/class.ilAuthPageEditorGUI.php:61

### Stacktrace
Stacktrace:
#6 Error in /appsrv/www/ilias-11.0/components/ILIAS/Authentication/classes/class.ilAuthPageEditorGUI.php:61 #5 ilAuthPageEditorGUI:__construct in /appsrv/www/ilias-11.0/components/ILIAS/Authentication/classes/class.ilObjAuthSettingsGUI.php:967 #4 ilObjAuthSettingsGUI:executeCommand in /appsrv/www/ilias-11.0/components/ILIAS/UICore/classes/class.ilCtrl.php:119 #3 ilCtrl:forwardCommand in /appsrv/www/ilias-11.0/components/ILIAS/Administration/classes/class.ilAdministrationGUI.php:229 #2 ilAdministrationGUI:executeCommand in /appsrv/www/ilias-11.0/components/ILIAS/UICore/classes/class.ilCtrl.php:119 #1 ilCtrl:forwardCommand in /appsrv/www/ilias-11.0/components/ILIAS/UICore/classes/class.ilCtrl.php:92 #0 ilCtrl:callBaseClass in /appsrv/www/ilias-11.0/public/ilias.php:39

### Fix
Line 61: replace
  $this->ilErr = $DIC->ilErr();
with
  $this->ilErr = $DIC['ilErr'];