### PR TITLE
Chatroom: Show username selection after logout but still subscribed (11)

### DIFF
--- a/components/ILIAS/Chatroom/classes/gui/class.ilChatroomViewGUI.php
+++ b/components/ILIAS/Chatroom/classes/gui/class.ilChatroomViewGUI.php
@@ -66,7 +66,7 @@ class ilChatroomViewGUI extends ilChatroomGUIHandler
         }
 
         if (!$failure && trim($username) !== '') {
-            if (!$room->isSubscribed($chat_user->getUserId())) {
+            if (!$room->isSubscribed($chat_user->getUserId()) || !ilSession::get('chat')) {
                 $chat_user->setUsername($chat_user->buildUniqueUsername($username));
                 $chat_user->setProfilePictureVisible(!$custom_username);
             }
@@ -222,8 +222,8 @@ class ilChatroomViewGUI extends ilChatroomGUIHandler
         $auto_scroll = $register('auto-scroll-toggle', $toggle($txt('auto_scroll'), true));
         $messages = $register('system-messages-toggle', $toggle($txt('chat_show_auto_messages'), $show_auto_messages));
 
-        $invite = $bind('invite-modal', $this->uiFactory->modal()->roundtrip($txt('chat_invite'), $this->legacy($txt('invite_to_private_room')), [
-            $this->uiFactory->input()->field()->text($txt('chat_invite')),
+        $invite = $bind('invite-modal', $this->uiFactory->modal()->roundtrip($txt('chat_invitation_modal_headline'), $this->legacy($txt('chat_invitation_modal_section')), [
+            $this->uiFactory->input()->field()->text($txt('chat_invitation_username_input_label')),
         ])->withSubmitLabel($txt('chat_invite')));
 
         $buttons = [];
@@ -355,7 +355,7 @@ class ilChatroomViewGUI extends ilChatroomGUIHandler
         $chat_user = new ilChatroomUser($this->ilUser, $room);
 
         if ($room->getSetting('allow_custom_usernames')) {
-            if ($room->isSubscribed($chat_user->getUserId())) {
+            if ($room->isSubscribed($chat_user->getUserId()) && ilSession::get('chat')) {
                 $chat_user->setUsername($chat_user->getUsername());
                 $this->showRoom($room, $chat_user);
             } else {

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -2925,9 +2925,12 @@ chatroom#:#chat_https_dhparam_info#:#Bitte geben Sie hier den absoluten Serverpf
 chatroom#:#chat_https_key_info#:#Bitte geben Sie den absoluten Serverpfad zum privaten Schlüssel an (bspw.: /etc/ssl/private/server.key).
 chatroom#:#chat_invitation#:#"[INVITER_NAME]" lädt ein in Chatraum "[ROOM_NAME]"
 chatroom#:#chat_invitation_long#:#[SALUTATION][BR][BR]Sie wurden in einen Chatraum eingeladen:[BR]Titel des Chatraums: [ROOM_NAME][BR]Eingeladen von: [INVITER_NAME][BR]URL: [LINK][BR][BR]Zum Betreten des Chatraums folgen Sie bitte der angegebenen URL.
+chatroom#:#chat_invitation_modal_headline#:#Chatraum Einladung
+chatroom#:#chat_invitation_modal_section#:#Benutzer einladen
 chatroom#:#chat_invitation_nc_inv_x#:#Sie haben %s Chateinladungen.
 chatroom#:#chat_invitation_nc_no_inv#:#Sie haben keine Chateinaldungen.
 chatroom#:#chat_invitation_short#:#Klicken Sie auf den Link, um den Chatraum zu betreten.
+chatroom#:#chat_invitation_username_input_label#:#Benutzer eingeben:
 chatroom#:#chat_invitations#:#Chateinladungen
 chatroom#:#chat_invite#:#Einladen
 chatroom#:#chat_join#:#Betreten

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -2926,9 +2926,12 @@ chatroom#:#chat_https_dhparam_info#:#Please define an absolute server path to a 
 chatroom#:#chat_https_key_info#:#Please define an absolute server path to the private key file (e.g..: /etc/ssl/private/server.key).
 chatroom#:#chat_invitation#:#"[INVITER_NAME]" invites you into chat room "[ROOM_NAME]"
 chatroom#:#chat_invitation_long#:#[SALUTATION][BR][BR]You have been invited to a chat room:[BR]Chat Room Title: [ROOM_NAME][BR]Invited by: [INVITER_NAME][BR]URL: [LINK][BR][BR]To join the chat room, please follow the given URL.
+chatroom#:#chat_invitation_modal_headline#:#Invitation to Chat Room
+chatroom#:#chat_invitation_modal_section#:#Invite User
 chatroom#:#chat_invitation_nc_inv_x#:#You have %s chat invitations.
 chatroom#:#chat_invitation_nc_no_inv#:#You have no chat invitations.
 chatroom#:#chat_invitation_short#:#Please click the link to enter the chat room.
+chatroom#:#chat_invitation_username_input_label#:#Enter Username:
 chatroom#:#chat_invitations#:#Chat invitations
 chatroom#:#chat_invite#:#Invite
 chatroom#:#chat_join#:#Join


### PR DESCRIPTION
This PR fixes Mantis Bug:
https://mantis.ilias.de/view.php?id=47816
Show "Select Custom Username" dialog after logout & login even if the user is still considered "connected" to the chatroom.

and

https://mantis.ilias.de/view.php?id=47815
For the "Invite User" Modal new language variables have been added:
- chat_invitation_modal_headline
- chat_invitation_modal_section
- chat_invitation_username_input_label