### PR TITLE
Test 47625: Fix unit handling in advanced rating evaluation

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.assFormulaQuestion.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assFormulaQuestion.php
@@ -834,8 +834,7 @@ class assFormulaQuestion extends assQuestion implements iQuestionCondition, Ques
                 $this->getVariables(),
                 $this->getResults(),
                 $user_solution[$result->getResult()]['value'] ?? '',
-                $user_solution[$result->getResult()]['unit'] ?? null,
-                $this->unitrepository->getUnits()
+                $user_solution[$result->getResult()]['unit'] ?? null
             );
         }
 
@@ -849,7 +848,7 @@ class assFormulaQuestion extends assQuestion implements iQuestionCondition, Ques
         $points = 0;
         foreach ($this->getResults() as $result) {
             $result_unit = "{$result->getResult()}_unit";
-            $unit_id = isset($user_solution[$result_unit]) && is_numeric($user_solution[$result_unit])
+            $answer_unit_id = isset($user_solution[$result_unit]) && is_numeric($user_solution[$result_unit])
                 ? (int) $user_solution[$result_unit]
                 : null;
 
@@ -857,8 +856,7 @@ class assFormulaQuestion extends assQuestion implements iQuestionCondition, Ques
                 $this->getVariables(),
                 $this->getResults(),
                 $user_solution[$result->getResult()] ?? '',
-                $unit_id !== null ? $this->unitrepository->getUnit($unit_id) : null,
-                $this->unitrepository->getUnits()
+                $answer_unit_id !== null ? $this->unitrepository->getUnit($answer_unit_id) : null
             );
         }
         return $this->ensureNonNegativePoints($points);

--- a/components/ILIAS/TestQuestionPool/classes/class.assFormulaQuestionResult.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assFormulaQuestionResult.php
@@ -411,15 +411,11 @@ class assFormulaQuestionResult
         return ($v1 >= 0.0 && $v2 >= 0.0) || ($v1 <= 0.0 && $v2 <= 0.0);
     }
 
-    /**
-     * @param assFormulaQuestionUnit[] $units
-     */
     public function getReachedPoints(
         array $variables,
         array $results,
         string $answer_value,
-        ?assFormulaQuestionUnit $answer_unit,
-        array $units
+        ?assFormulaQuestionUnit $answer_unit
     ): float {
         if ($this->getRatingSimple()) {
             return $this->isCorrect($variables, $results, $answer_value, $answer_unit)
@@ -431,16 +427,12 @@ class assFormulaQuestionResult
         $float_value = $this->transformAnswerValueAccordingToType($answer_value, $answer_unit);
 
         $points = 0.0;
-        if ($answer_unit instanceof assFormulaQuestionUnit && $answer_unit instanceof assFormulaQuestionUnit) {
-            $base1 = $units[$answer_unit->getBaseUnit()] ?? null;
-            $base2 = $units[$answer_unit->getBaseUnit()] ?? null;
-            if (
-                $base1 instanceof assFormulaQuestionUnit
-                && $base2 instanceof assFormulaQuestionUnit
-                && $base1->getId() === $base2->getId()
-            ) {
-                $points += ilMath::_mul($this->getPoints(), ilMath::_div($this->getRatingUnit(), 100));
-            }
+        if (
+            $this->unit instanceof assFormulaQuestionUnit
+            && $answer_unit instanceof assFormulaQuestionUnit
+            && $this->unit->getBaseUnit() === $answer_unit->getBaseUnit()
+        ) {
+            $points += ilMath::_mul($this->getPoints(), ilMath::_div($this->getRatingUnit(), 100));
         }
 
         if ($float_value === null) {

--- a/components/ILIAS/TestQuestionPool/classes/questions/LogicalAnswerCompare/ilAssLacCompositeEvaluator.php
+++ b/components/ILIAS/TestQuestionPool/classes/questions/LogicalAnswerCompare/ilAssLacCompositeEvaluator.php
@@ -181,8 +181,7 @@ class ilAssLacCompositeEvaluator
                     $question->getVariables(),
                     $question->getResults(),
                     $result["value"] ?? "",
-                    $key,
-                    $unit_repository->getUnits()
+                    $key
                 );
 
                 $percentage = 0;


### PR DESCRIPTION
Hi everyone,

This PR relates to Mantis ticket [47625](https://mantis.ilias.de/view.php?id=47625). The behaviour can only be reproduced if the ‘Advanced rating’ mode has been enabled for the formula question.

It seems to me that the issue has been addressed in commit c5c9537 by @matheuszych. However in 723a7c8, some operands were swapped, which, in my POV, leads to the problem described in the ticket. In the `getReachedPoints` method, `answer_unit` was compared with `answer_unit` to verify the result. Consequently, this always returned true, and the result was awarded the full marks for the correct unit.

As always, I look forward to your feedback and comments on these changes.

Best,
@lukas-heinrich 

/cc @thojou 