### PR TITLE
fix: remove strict_types declaration from ilSoapObjectAdministration to restore SOAP compatibility (#0046688)

### DIFF
--- a/components/ILIAS/soap/classes/class.ilSoapObjectAdministration.php
+++ b/components/ILIAS/soap/classes/class.ilSoapObjectAdministration.php
@@ -16,8 +16,6 @@
  *
  *********************************************************************/
 
-declare(strict_types=1);
-
 /**
  * Soap object administration methods
  * @author  Stefan Meyer <meyer@leifos.com>
@@ -1047,7 +1045,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
             return $this->raiseError('No valid target given.', 'Client');
         }
 
-        if(!$rbacsystem->checkAccess('move', $ref_id)) {
+        if (!$rbacsystem->checkAccess('move', $ref_id)) {
             return $this->raiseError("No permission to move object with id: $ref_id", 'Client');
         }
 


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=46688

Removes declare(strict_types=1) from ilSoapObjectAdministration.

Discussed on Mantis: https://mantis.ilias.de/view.php?id=46688, the conclusion was to revert, since a proper strict-type check would break several soap functions at this point and such changes should come through a development version in future releases.

There is inconsistency among versions. Currently, version 11 does not have the strict check. However, trunk has. I will provide the PR for trunk as well.