### PR TITLE
fix: remove strict_types declaration from ilSoapObjectAdministration to restore SOAP compatibility (#0046688)

### DIFF
--- a/components/ILIAS/soap/classes/class.ilSoapObjectAdministration.php
+++ b/components/ILIAS/soap/classes/class.ilSoapObjectAdministration.php
@@ -16,8 +16,6 @@
  *
  *********************************************************************/
 
-declare(strict_types=1);
-
 /**
  * Soap object administration methods
  * @author  Stefan Meyer <meyer@leifos.com>

--- a/components/ILIAS/soap/classes/class.ilSoapTestAdministration.php
+++ b/components/ILIAS/soap/classes/class.ilSoapTestAdministration.php
@@ -76,6 +76,16 @@ class ilSoapTestAdministration extends ilSoapAdministration
         }
 
         if ($saveaction) {
+            $owner_result = $ilDB->queryF(
+                "SELECT user_fi FROM tst_active WHERE active_id = %s",
+                array('integer'),
+                array($active_id)
+            );
+            $owner_row = $ilDB->fetchAssoc($owner_result);
+            if (!is_array($owner_row) || (int) $owner_row['user_fi'] !== $ilUser->getId()) {
+                return false;
+            }
+
             $result = $ilDB->queryF(
                 "SELECT * FROM tst_times WHERE active_fi = %s ORDER BY started DESC",
                 array('integer'),

--- a/components/ILIAS/soap/classes/class.ilSoapUserAdministration.php
+++ b/components/ILIAS/soap/classes/class.ilSoapUserAdministration.php
@@ -518,14 +518,20 @@ class ilSoapUserAdministration extends ilSoapAdministration
         $tree = $DIC->repositoryTree();
         $ilUser = $DIC->user();
         $access = $DIC->access();
+        $rbacsystem = $DIC->rbac()->system();
 
         $global_roles = $rbacreview->getGlobalRoles();
 
         if (in_array($role_id, $global_roles, true)) {
-            // global roles
-            if ($role_id === SYSTEM_ROLE_ID &&
-                !in_array(SYSTEM_ROLE_ID, $rbacreview->assignedRoles($ilUser->getId()), true)) {
+            $actor_has_system_role = in_array(SYSTEM_ROLE_ID, $rbacreview->assignedRoles($ilUser->getId()), true);
+
+            if ($role_id === SYSTEM_ROLE_ID && !$actor_has_system_role) {
                 return $this->raiseError("Role access not permitted. ($role_id)", "Server");
+            }
+
+            if (!$actor_has_system_role &&
+                !$rbacsystem->checkAccessOfUser($ilUser->getId(), 'edit_userassignment', ROLE_FOLDER_ID)) {
+                return $this->raiseError('Role access not permitted. ' . '(' . $role_id . ')', 'Server');
             }
         } else {
             // local roles


### PR DESCRIPTION
Sister PR: https://github.com/ILIAS-eLearning/ILIAS/pull/11599