### PR TITLE
fix: remove strict_types declaration from ilSoapObjectAdministration to restore SOAP compatibility (#0046688)

### DIFF
--- a/components/ILIAS/soap/classes/class.ilSoapObjectAdministration.php
+++ b/components/ILIAS/soap/classes/class.ilSoapObjectAdministration.php
@@ -16,8 +16,6 @@
  *
  *********************************************************************/
 
-declare(strict_types=1);
-
 /**
  * Soap object administration methods
  * @author  Stefan Meyer <meyer@leifos.com>


### PR DESCRIPTION
Sister PR: https://github.com/ILIAS-eLearning/ILIAS/pull/11599