### PR TITLE
fix: preserve blocked status of course members in updateCourse SOAP call (0040575)

### DIFF
--- a/components/ILIAS/Course/classes/class.ilCourseXMLParser.php
+++ b/components/ILIAS/Course/classes/class.ilCourseXMLParser.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=0);
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -15,8 +16,6 @@
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
-
-declare(strict_types=0);
 
 /**
  * Course XML Parser
@@ -55,12 +54,6 @@ class ilCourseXMLParser extends ilMDSaxParser implements ilSaxSubsetParser
     protected ilCourseWaitingList $course_waiting_list;
     protected ?ilAdvancedMDValueParser $adv_md_handler = null;
     protected array $course_members_array = [];
-    protected array $xml_mentioned_member_ids = [];
-
-    public function getProcessedMemberIds(): array
-    {
-        return $this->xml_mentioned_member_ids;
-    }
 
     public function __construct(ilObjCourse $a_course_obj, string $a_xml_file = '')
     {
@@ -447,9 +440,6 @@ class ilCourseXMLParser extends ilMDSaxParser implements ilSaxSubsetParser
      */
     private function handleMember(array $a_attribs, array $id_data): void
     {
-        if (!empty($id_data['usr_id'])) {
-            $this->xml_mentioned_member_ids[] = $id_data['usr_id'];
-        }
         if (!isset($a_attribs['action']) || $a_attribs['action'] == 'Attach') {
             // if action not set, or set and attach
             if (!array_key_exists($id_data['usr_id'], $this->course_members_array)) {

--- a/components/ILIAS/Course/classes/class.ilCourseXMLParser.php
+++ b/components/ILIAS/Course/classes/class.ilCourseXMLParser.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=0);
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -16,6 +15,8 @@ declare(strict_types=0);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=0);
 
 /**
  * Course XML Parser
@@ -54,6 +55,12 @@ class ilCourseXMLParser extends ilMDSaxParser implements ilSaxSubsetParser
     protected ilCourseWaitingList $course_waiting_list;
     protected ?ilAdvancedMDValueParser $adv_md_handler = null;
     protected array $course_members_array = [];
+    protected array $xml_mentioned_member_ids = [];
+
+    public function getProcessedMemberIds(): array
+    {
+        return $this->xml_mentioned_member_ids;
+    }
 
     public function __construct(ilObjCourse $a_course_obj, string $a_xml_file = '')
     {
@@ -440,6 +447,9 @@ class ilCourseXMLParser extends ilMDSaxParser implements ilSaxSubsetParser
      */
     private function handleMember(array $a_attribs, array $id_data): void
     {
+        if (!empty($id_data['usr_id'])) {
+            $this->xml_mentioned_member_ids[] = $id_data['usr_id'];
+        }
         if (!isset($a_attribs['action']) || $a_attribs['action'] == 'Attach') {
             // if action not set, or set and attach
             if (!array_key_exists($id_data['usr_id'], $this->course_members_array)) {

--- a/components/ILIAS/soap/classes/class.ilSoapCourseAdministration.php
+++ b/components/ILIAS/soap/classes/class.ilSoapCourseAdministration.php
@@ -1,25 +1,20 @@
 <?php
-/*
- +-----------------------------------------------------------------------------+
- | ILIAS open source                                                           |
- +-----------------------------------------------------------------------------+
- | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
- |                                                                             |
- | This program is free software; you can redistribute it and/or               |
- | modify it under the terms of the GNU General Public License                 |
- | as published by the Free Software Foundation; either version 2              |
- | of the License, or (at your option) any later version.                      |
- |                                                                             |
- | This program is distributed in the hope that it will be useful,             |
- | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
- | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
- | GNU General Public License for more details.                                |
- |                                                                             |
- | You should have received a copy of the GNU General Public License           |
- | along with this program; if not, write to the Free Software                 |
- | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
- +-----------------------------------------------------------------------------+
-*/
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Soap course administration methods
@@ -375,10 +370,7 @@ class ilSoapCourseAdministration extends ilSoapAdministration
         $md = new ilMD($tmp_course->getId(), 0, 'crs');
         $md->deleteAll();
 
-        ilCourseParticipants::_deleteAllEntries($tmp_course->getId());
-
         ilCourseWaitingList::_deleteAll($tmp_course->getId());
-
 
         $xml_parser = new ilCourseXMLParser($tmp_course);
         $xml_parser->setMode(ilCourseXMLParser::MODE_SOAP);

--- a/components/ILIAS/soap/classes/class.ilSoapCourseAdministration.php
+++ b/components/ILIAS/soap/classes/class.ilSoapCourseAdministration.php
@@ -1,20 +1,32 @@
 <?php
+/*
+ +-----------------------------------------------------------------------------+
+ | ILIAS open source                                                           |
+ +-----------------------------------------------------------------------------+
+ | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
+ |                                                                             |
+ | This program is free software; you can redistribute it and/or               |
+ | modify it under the terms of the GNU General Public License                 |
+ | as published by the Free Software Foundation; either version 2              |
+ | of the License, or (at your option) any later version.                      |
+ |                                                                             |
+ | This program is distributed in the hope that it will be useful,             |
+ | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
+ | GNU General Public License for more details.                                |
+ |                                                                             |
+ | You should have received a copy of the GNU General Public License           |
+ | along with this program; if not, write to the Free Software                 |
+ | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
+ +-----------------------------------------------------------------------------+
+*/
 
 /**
- * This file is part of ILIAS, a powerful learning management system
- * published by ILIAS open source e-Learning e.V.
- *
- * ILIAS is licensed with the GPL-3.0,
- * see https://www.gnu.org/licenses/gpl-3.0.en.html
- * You should have received a copy of said license along with the
- * source code, too.
- *
- * If this is not the case or you just want to try ILIAS, you'll find
- * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- *
- *********************************************************************/
+ * Soap course administration methods
+ * @author  Stefan Meyer <smeyer.ilias@gmx.de>
+ * @version $Id$
+ * @package ilias
+ */
 
 class ilSoapCourseAdministration extends ilSoapAdministration
 {
@@ -363,15 +375,6 @@ class ilSoapCourseAdministration extends ilSoapAdministration
         $md = new ilMD($tmp_course->getId(), 0, 'crs');
         $md->deleteAll();
 
-        $course_participants = ilCourseParticipants::_getInstanceByObjId($tmp_course->getId());
-        $all_members = $course_participants->getParticipants();
-        $blocked_users = [];
-        foreach ($all_members as $usr_id) {
-            if ($course_participants->isBlocked($usr_id)) {
-                $blocked_users[] = $usr_id;
-            }
-        }
-
         ilCourseParticipants::_deleteAllEntries($tmp_course->getId());
 
         ilCourseWaitingList::_deleteAll($tmp_course->getId());
@@ -381,15 +384,6 @@ class ilSoapCourseAdministration extends ilSoapAdministration
         $xml_parser->setMode(ilCourseXMLParser::MODE_SOAP);
         $xml_parser->setXMLContent($xml);
         $xml_parser->startParsing();
-
-        $xml_processed_members = $xml_parser->getProcessedMemberIds();
-        $xml_lookup = array_flip($xml_processed_members);
-        $fresh_participants = ilCourseParticipants::_getInstanceByObjId($tmp_course->getId());
-        foreach ($blocked_users as $usr_id) {
-            if (!isset($xml_lookup[$usr_id]) && $fresh_participants->isMember($usr_id)) {
-                $fresh_participants->updateBlocked($usr_id, true);
-            }
-        }
         $tmp_course->MDUpdateListener('General');
 
         return true;

--- a/components/ILIAS/soap/classes/class.ilSoapCourseAdministration.php
+++ b/components/ILIAS/soap/classes/class.ilSoapCourseAdministration.php
@@ -1,32 +1,20 @@
 <?php
-/*
- +-----------------------------------------------------------------------------+
- | ILIAS open source                                                           |
- +-----------------------------------------------------------------------------+
- | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
- |                                                                             |
- | This program is free software; you can redistribute it and/or               |
- | modify it under the terms of the GNU General Public License                 |
- | as published by the Free Software Foundation; either version 2              |
- | of the License, or (at your option) any later version.                      |
- |                                                                             |
- | This program is distributed in the hope that it will be useful,             |
- | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
- | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
- | GNU General Public License for more details.                                |
- |                                                                             |
- | You should have received a copy of the GNU General Public License           |
- | along with this program; if not, write to the Free Software                 |
- | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
- +-----------------------------------------------------------------------------+
-*/
 
 /**
- * Soap course administration methods
- * @author  Stefan Meyer <smeyer.ilias@gmx.de>
- * @version $Id$
- * @package ilias
- */
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 class ilSoapCourseAdministration extends ilSoapAdministration
 {
@@ -375,6 +363,15 @@ class ilSoapCourseAdministration extends ilSoapAdministration
         $md = new ilMD($tmp_course->getId(), 0, 'crs');
         $md->deleteAll();
 
+        $course_participants = ilCourseParticipants::_getInstanceByObjId($tmp_course->getId());
+        $all_members = $course_participants->getParticipants();
+        $blocked_users = [];
+        foreach ($all_members as $usr_id) {
+            if ($course_participants->isBlocked($usr_id)) {
+                $blocked_users[] = $usr_id;
+            }
+        }
+
         ilCourseParticipants::_deleteAllEntries($tmp_course->getId());
 
         ilCourseWaitingList::_deleteAll($tmp_course->getId());
@@ -384,6 +381,15 @@ class ilSoapCourseAdministration extends ilSoapAdministration
         $xml_parser->setMode(ilCourseXMLParser::MODE_SOAP);
         $xml_parser->setXMLContent($xml);
         $xml_parser->startParsing();
+
+        $xml_processed_members = $xml_parser->getProcessedMemberIds();
+        $xml_lookup = array_flip($xml_processed_members);
+        $fresh_participants = ilCourseParticipants::_getInstanceByObjId($tmp_course->getId());
+        foreach ($blocked_users as $usr_id) {
+            if (!isset($xml_lookup[$usr_id]) && $fresh_participants->isMember($usr_id)) {
+                $fresh_participants->updateBlocked($usr_id, true);
+            }
+        }
         $tmp_course->MDUpdateListener('General');
 
         return true;


### PR DESCRIPTION
This PR addresses the issue outlined in [Mantis #0040575](https://mantis.ilias.de/view.php?id=40575), where blocked course members were silently unblocked after a `updateCourse` SOAP call.

### Steps to Reproduce

1. Create a course (manually or via `addCourse` SOAP call)
2. Add some students to the course
3. In the **Members** tab, activate **"Access Refused"** (blocked) for one or more students
4. Call `updateCourse` via SOAP using the XML in Scenario 1 below
5. Refresh the Members tab in your browser
6. The **"Access Refused"** checkbox is now unchecked — members silently unblocked

### Test Scenarios

> Replace `<SID>::<CLIENT_NAME>`, `<COURSE_REF_ID>`, and `<USR_ID>` with your values.

#### Scenario 1: Settings-only XML (no `<Members>` block) 

```xml
<soapenv:Body>
    <urn:updateCourse>
        <sid><SID>::<CLIENT_NAME></sid>
        <course_id><COURSE_REF_ID></course_id>
        <xml>
            <![CDATA[
                <Course importId="test_course_010">
                    <MetaData>
                        <General Structure="Hierarchical">
                            <Title Language="en">Sample Course</Title>
                            <Language Language="en" />
                            <Description Language="en">Updated description.</Description>
                        </General>
                    </MetaData>
                    <Settings>
                        <Availability><Unlimited /></Availability>
                    </Settings>
                </Course>
            ]]>
        </xml>
    </urn:updateCourse>
</soapenv:Body>
```

**Expected:** Blocked user remains blocked after update.


#### Scenario 2: XML explicitly sends `blocked="No"`

```xml
<soapenv:Body>
    <urn:updateCourse>
        <sid><SID>::<CLIENT_NAME></sid>
        <course_id><COURSE_REF_ID></course_id>
        <xml>
            <![CDATA[
                <Course importId="test_course_010">
                    <MetaData>
                        <General Structure="Hierarchical">
                            <Title Language="en">Sample Course</Title>
                            <Language Language="en" />
                        </General>
                    </MetaData>
                    <Settings>
                        <Availability><Unlimited /></Availability>
                    </Settings>
                    <Members>
                        <Member id="il_0_usr_<USR_ID>" blocked="No" passed="No" action="Attach" />
                    </Members>
                </Course>
            ]]>
        </xml>
    </urn:updateCourse>
</soapenv:Body>
```

**Expected:** User is unblocked


#### Scenario 3: XML sends `action="Detach"` (user removed, not re-blocked)

```xml
<soapenv:Body>
    <urn:updateCourse>
        <sid><SID>::<CLIENT_NAME></sid>
        <course_id><COURSE_REF_ID></course_id>
        <xml>
            <![CDATA[
                <Course importId="test_course_010">
                    <MetaData>
                        <General Structure="Hierarchical">
                            <Title Language="en">Sample Course</Title>
                            <Language Language="en" />
                        </General>
                    </MetaData>
                    <Settings>
                        <Availability><Unlimited /></Availability>
                    </Settings>
                    <Members>
                        <Member id="il_0_usr_<USR_ID>" action="Detach" />
                    </Members>
                </Course>
            ]]>
        </xml>
    </urn:updateCourse>
</soapenv:Body>
```

**Expected:** User is removed from course


If approved, must be picked for 11 and trunk.