### PR TITLE
fix: persist group owner from XML in addGroup SOAP call (#0032223)

### DIFF
--- a/components/ILIAS/Group/classes/class.ilGroupXMLParser.php
+++ b/components/ILIAS/Group/classes/class.ilGroupXMLParser.php
@@ -571,6 +571,9 @@ class ilGroupXMLParser extends ilMDSaxParser implements ilSaxSubsetParser
          */
         $this->group_obj->readContainerSettings();
         $this->group_obj->update();
+        if ($ownerChanged) {
+            $this->group_obj->updateOwner();
+        }
 
         // ASSIGN ADMINS/MEMBERS
         $this->assignMembers();


### PR DESCRIPTION
This PR addresses [Mantis #0032223](https://mantis.ilias.de/view.php?id=32223), where the `<owner>` tag in the XML passed to the `addGroup` SOAP method was silently ignored.

### Test Scenarios

#### Scenario 1 — Owner tag with valid user

```xml
<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
                  xmlns:urn="urn:ilUserAdministration">
   <soapenv:Header/>
   <soapenv:Body>
      <urn:addGroup>
         <sid><SID>::<CLIENT></sid>
         <target_id><TARGET_REF_ID></target_id>
         <group_xml>
            <![CDATA[
            <group id="<GROUP_ID>" type="open">
               <title><GROUP_TITLE></title>
               <owner id="il_0_usr_<OWNER_ID>"/>
               <description><GROUP_DESCRIPTION></description>

               <Registration waitingList="No">
               </Registration>

               <information><GROUP_INFORMATION></information>

               <admin id="il_0_usr_<ADMIN_ID>"/>
               <member id="il_0_usr_<MEMBER_ID_1>"/>
               <member id="il_0_usr_<MEMBER_ID_2>"/>
            </group>
            ]]>
         </group_xml>
      </urn:addGroup>
   </soapenv:Body>
</soapenv:Envelope>
```

**Expected:** Group owner is set to the specified user, not root.