### PR TITLE
Removing code style violations reported for system styles in trunk

### DIFF
--- a/components/ILIAS/Style/System/classes/Documentation/class.ilKSDocumentationGotoLink.php
+++ b/components/ILIAS/Style/System/classes/Documentation/class.ilKSDocumentationGotoLink.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.

--- a/components/ILIAS/Style/System/classes/Overview/class.ilSystemStyleOverviewGUI.php
+++ b/components/ILIAS/Style/System/classes/Overview/class.ilSystemStyleOverviewGUI.php
@@ -131,7 +131,7 @@ class ilSystemStyleOverviewGUI
     protected function view(): void
     {
         $table = new ilSystemStylesTableGUI($this, 'edit');
-        $this->tpl->setContent($table->getHTML().$table->getModalsHtml());
+        $this->tpl->setContent($table->getHTML() . $table->getModalsHtml());
     }
 
     public function getAssignmentCreationModal(string $style_name = ""): ?\ILIAS\UI\Component\Modal\RoundTrip
@@ -152,10 +152,10 @@ class ilSystemStyleOverviewGUI
             return null;
         }
 
-        $txt = $this->lng->txt('sty_move_user_styles').' '.$this->lng->txt('sty_to');
+        $txt = $this->lng->txt('sty_move_user_styles') . ' ' . $this->lng->txt('sty_to');
 
         $byline = $this->lng->txt('sty_move_user_styles') . ' ' .
-            $this->lng->txt('sty_from')  . ' ' . $style_name;
+            $this->lng->txt('sty_from') . ' ' . $style_name;
 
         $select = $this->ui_factory->input()->field()
                                             ->select($txt, $options, $byline)
@@ -180,7 +180,7 @@ class ilSystemStyleOverviewGUI
     {
         $table = new ilSystemStylesTableGUI($this, 'edit');
         $table->addActions($this->isManagementEnabled());
-        $this->tpl->setContent($table->getHTML().$table->getModalsHtml());
+        $this->tpl->setContent($table->getHTML() . $table->getModalsHtml());
     }
 
     public function saveStyleSettings(): void

--- a/components/ILIAS/Style/System/classes/Style/class.ilSkinStyleContainer.php
+++ b/components/ILIAS/Style/System/classes/Style/class.ilSkinStyleContainer.php
@@ -108,17 +108,17 @@ class ilSkinStyleContainer
 
     public function getCSSFilePath(string $style_id): string
     {
-        return $this->getSkinDirectory() . $style_id . "/".$this->getSkin()->getStyle($style_id)->getCssFile() . '.css';
+        return $this->getSkinDirectory() . $style_id . "/" . $this->getSkin()->getStyle($style_id)->getCssFile() . '.css';
     }
 
     public function getScssFilePath(string $style_id): string
     {
-        return $this->getSkinDirectory() . $style_id . "/".$this->getSkin()->getStyle($style_id)->getCssFile() . '.scss';
+        return $this->getSkinDirectory() . $style_id . "/" . $this->getSkin()->getStyle($style_id)->getCssFile() . '.scss';
     }
 
     public function getScssSettingsPath(string $style_id): string
     {
-        return $this->getSkinDirectory() . $style_id . "/".$this->getScssSettingsFolderName();
+        return $this->getSkinDirectory() . $style_id . "/" . $this->getScssSettingsFolderName();
     }
 
     public function getScssSettingsFolderName(): string
@@ -128,17 +128,17 @@ class ilSkinStyleContainer
 
     public function getImagesStylePath(string $style_id): string
     {
-        return $this->getSkinDirectory().$style_id."/".$this->getSkin()->getStyle($style_id)->getImageDirectory();
+        return $this->getSkinDirectory() . $style_id . "/" . $this->getSkin()->getStyle($style_id)->getImageDirectory();
     }
 
     public function getSoundsStylePath(string $style_id): string
     {
-        return $this->getSkinDirectory().$style_id."/".$this->getSkin()->getStyle($style_id)->getSoundDirectory();
+        return $this->getSkinDirectory() . $style_id . "/" . $this->getSkin()->getStyle($style_id)->getSoundDirectory();
     }
 
     public function getFontsStylePath(string $style_id): string
     {
-        return $this->getSkinDirectory().$style_id."/".$this->getSkin()->getStyle($style_id)->getFontDirectory();
+        return $this->getSkinDirectory() . $style_id . "/" . $this->getSkin()->getStyle($style_id)->getFontDirectory();
     }
 
     public function getMessageStack(): ilSystemStyleMessageStack

--- a/components/ILIAS/Style/System/classes/class.ilSystemStyleMainGUI.php
+++ b/components/ILIAS/Style/System/classes/class.ilSystemStyleMainGUI.php
@@ -231,19 +231,22 @@ class ilSystemStyleMainGUI
         return true;
     }
 
-    protected function setTabs(string $skin_id, string $style_id, string $active = '') {
+    protected function setTabs(string $skin_id, string $style_id, string $active = '')
+    {
         $this->ctrl->setParameterByClass(ilSystemStyleDocumentationGUI::class, 'skin_id', $skin_id);
         $this->ctrl->setParameterByClass(ilSystemStyleDocumentationGUI::class, 'style_id', $style_id);
 
         $this->tabs->addSubTab(
             'overview',
             $this->lng->txt('overview'),
-            $this->ctrl->getLinkTargetByClass(self::class), 'documentation');
-        $this->tabs->addSubTab('documentation',
+            $this->ctrl->getLinkTargetByClass(self::class),
+            'documentation'
+        );
+        $this->tabs->addSubTab(
+            'documentation',
             $this->lng->txt('documentation'),
             $this->ctrl->getLinkTargetByClass(ilSystemStyleDocumentationGUI::class, 'entries')
         );
-
     }
     /**
      * Sets the tab correctly if one system style is open (navigational underworld opened)

--- a/components/ILIAS/Style/System/test/Documentation/ilKSDocumentationEntryGUITest.php
+++ b/components/ILIAS/Style/System/test/Documentation/ilKSDocumentationEntryGUITest.php
@@ -22,7 +22,6 @@ require_once('vendor/composer/vendor/autoload.php');
 include_once('./components/ILIAS/UI/tests/UITestHelper.php');
 
 use PHPUnit\Framework\TestCase;
-
 use ILIAS\UI\Implementation\Crawler\Entry\ComponentEntries as Entries;
 use ILIAS\UI\Implementation\Component\Panel\Report;
 

--- a/components/ILIAS/Style/System/test/Provider/KSDocumentationTreeRecursionTest.php
+++ b/components/ILIAS/Style/System/test/Provider/KSDocumentationTreeRecursionTest.php
@@ -22,7 +22,6 @@ require_once('vendor/composer/vendor/autoload.php');
 include_once('./components/ILIAS/UI/tests/UITestHelper.php');
 
 use PHPUnit\Framework\TestCase;
-
 use ILIAS\UI\Implementation\Crawler\Entry\ComponentEntry as Entry;
 use ILIAS\UI\Implementation\Crawler\Entry\ComponentEntries as Entries;
 use ILIAS\Data\URI;

--- a/components/ILIAS/Style/System/test/Provider/SystemStylesGlobalScreenToolProviderTest.php
+++ b/components/ILIAS/Style/System/test/Provider/SystemStylesGlobalScreenToolProviderTest.php
@@ -22,7 +22,6 @@ require_once('vendor/composer/vendor/autoload.php');
 include_once('./components/ILIAS/UI/tests/UITestHelper.php');
 
 use PHPUnit\Framework\TestCase;
-
 use ILIAS\UI\Implementation\Crawler\Entry\ComponentEntry as Entry;
 use ILIAS\UI\Implementation\Crawler\Entry\ComponentEntries as Entries;
 use ILIAS\Data\URI;


### PR DESCRIPTION
Reported in JF on 2026-05-18 (https://docu.ilias.de/go/wiki/wpage_8934_1357)

Updated Files:
- components/ILIAS/Style/System/test/Documentation/ilKSDocumentationEntryGUITest.php
- components/ILIAS/Style/System/classes/Style/class.ilSkinStyleContainer.php
- components/ILIAS/Style/System/test/Provider/KSDocumentationTreeRecursionTest.php
- components/ILIAS/Style/System/test/Provider/SystemStylesGlobalScreenToolProviderTest.php
- components/ILIAS/Style/System/classes/Overview/class.ilSystemStyleOverviewGUI.php
- components/ILIAS/Style/System/classes/Documentation/class.ilKSDocumentationGotoLink.php
- components/ILIAS/Style/System/classes/class.ilSystemStyleMainGUI.php
