### PR TITLE
[FIX] Content Style: delete image from IRSS container (47832)

### DIFF
--- a/components/ILIAS/Style/Content/Images/class.ImageFileRepo.php
+++ b/components/ILIAS/Style/Content/Images/class.ImageFileRepo.php
@@ -198,10 +198,15 @@ class ImageFileRepo
     }
 
     // delete image
-    public function deleteImageByFilename(int $style_id, string $filename): void
+    public function deleteImageByFilename(int $style_id, string $rid, string $filename): void
     {
-        $dir = $this->dir($style_id);
-        $this->web_files->delete($dir . "/" . $filename);
+        if ($rid !== "") {
+            $this->irss->removePathFromContainer($rid, "images/" . $filename);
+        }
+        $legacy_path = $this->dir($style_id) . "/" . $filename;
+        if ($this->web_files->has($legacy_path)) {
+            $this->web_files->delete($legacy_path);
+        }
     }
 
     public function importFromUploadResult(

--- a/components/ILIAS/Style/Content/Images/class.ImageManager.php
+++ b/components/ILIAS/Style/Content/Images/class.ImageManager.php
@@ -151,7 +151,8 @@ class ImageManager
 
     public function deleteByFilename(string $filename): void
     {
-        $this->repo->deleteImageByFilename($this->style_id, $filename);
+        $rid = $this->style_repo->readRid($this->style_id);
+        $this->repo->deleteImageByFilename($this->style_id, $rid, $filename);
     }
 
     public function importFromUploadResult(


### PR DESCRIPTION
## Summary
- Images of content styles are stored in the IRSS container since the IRSS migration. Upload and listing already use IRSS, but `ImageFileRepo::deleteImageByFilename()` still removed the file from the legacy web directory `sty/sty_<id>/images`, which does not exist for migrated styles — so the delete button in the Style Editor had no effect.
- This change deletes the entry from the IRSS container via `IRSSWrapper::removePathFromContainer()` and keeps the legacy delete as a fallback for non-migrated styles.

Mantis: [#47832](https://mantis.ilias.de/view.php?id=47832)

## Test plan
- [ ] Administration > Content Styles > edit any style > Images tab
- [ ] Upload an image, then delete it via the checkbox + Delete button
- [ ] Image is removed from the list and from the IRSS container
- [ ] Repeat with a style that still has a legacy `sty/sty_<id>/images` directory and confirm deletion still works there