### PR TITLE
patch for older composer versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,7 @@
 		},
 		"audit": {
 			"ignore": {
-				"PKSA-ns3q-qtk3-d35r": {
-					"apply": "block",
-					"reasons": "We need to keep Geshi, since Phiki (alternative) needs PHP 8.2. We remove the contrib directory via composer hooks. See #46938."
-				}
+				"PKSA-ns3q-qtk3-d35r": "We need to keep Geshi, since Phiki (alternative) needs PHP 8.2. We remove the contrib directory via composer hooks. See #46938."
 			}
 		}
 	},


### PR DESCRIPTION
This makes the composer ignore function compatible with older composer versions for release_9 (only this is needed).