### PR TITLE
User: fix ids passed to filters in autocomplete (47829)

### DIFF
--- a/components/ILIAS/User/classes/class.ilUserAutoComplete.php
+++ b/components/ILIAS/User/classes/class.ilUserAutoComplete.php
@@ -241,7 +241,7 @@ class ilUserAutoComplete
 
         while (count($usr_ids) <= $max) {
             $next_records = $this->fetchNextRecords($res, $max);
-            $records = array_merge($records, $next_records);
+            $records = array_replace($records, $next_records);
             $usr_ids = array_keys($records);
 
             $callable_name = null;


### PR DESCRIPTION
This PR fixes the user autocomplete in EmployeeTalk, see also [47829](https://mantis.ilias.de/view.php?id=47829), but the problem should apply to all usages of `ilUserAutoComplete::getList` where a user filter is set.

The underlying issue is that `array_merge` re-indexes arrays with numerical keys, so when using `array_keys` to build the list of user IDs that is then passed to the filter, you always get `[0, 1, 2, ...]`. Using `array_replace` instead of `array_merge` fixes that.