### PR TITLE
Fixes German language file variable typo

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -7373,7 +7373,7 @@ copg#:#copg_cron_keep_entries_info#:#Diese Anzahl an Einträgen wird im Verlauf 
 copg#:#copg_days#:#Tage
 copg#:#copg_details#:#Details
 copg#:#copg_edit_iframe_title#:#Text bearbeiten im Seiteneditor
-copg#:#copg_edit_style_class#:Style-Klasse bearbeiten
+copg#:#copg_edit_style_class#:#Style-Klasse bearbeiten
 copg#:#copg_entries#:#Einträge
 copg#:#copg_error#:#Problem
 copg#:#copg_error_occured_modal#:#Es ist leider ein Fehler aufgetreten. Bitte drücken Sie "Seite neu laden" um zum zuletzt gespeicherten Inhalt zu gelangen.


### PR DESCRIPTION
You are currently unable to refresh the German language file. 

<img width="1007" height="256" alt="Screenshot from 2026-05-29 13-20-22" src="https://github.com/user-attachments/assets/520ba2f7-d088-4ec6-8d75-e1ee297fa978" />

/cc @thojou 