### PR TITLE
[FIX]: Ensure Google Maps API Key is added to the template (Mantis #4…

### DIFF
--- a/components/ILIAS/Maps/classes/class.ilGoogleMapGUI.php
+++ b/components/ILIAS/Maps/classes/class.ilGoogleMapGUI.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
  */
 class ilGoogleMapGUI extends ilMapGUI
 {
+    protected static bool $google_maps_api_added = false;
     protected string $css_row = "";
 
     public function __construct()
@@ -48,7 +49,16 @@ class ilGoogleMapGUI extends ilMapGUI
             "components/ILIAS/Maps"
         );
 
-        $this->tpl->addJavaScript("//maps.google.com/maps/api/js?key=" . ilMapUtil::getApiKey(), false);
+        $api_key = trim(ilMapUtil::getApiKey());
+        if ($api_key !== "" && !self::$google_maps_api_added) {
+            $html_tpl->setCurrentBlock("google_maps_api");
+            $html_tpl->setVariable(
+                "GOOGLE_MAPS_API_SRC",
+                "https://maps.googleapis.com/maps/api/js?key=" . rawurlencode($api_key)
+            );
+            $html_tpl->parseCurrentBlock();
+            self::$google_maps_api_added = true;
+        }
 
         // add user markers
         $cnt = 0;

--- a/components/ILIAS/Maps/classes/class.ilGoogleMapGUI.php
+++ b/components/ILIAS/Maps/classes/class.ilGoogleMapGUI.php
@@ -49,7 +49,7 @@ class ilGoogleMapGUI extends ilMapGUI
             "components/ILIAS/Maps"
         );
 
-        $api_key = trim(ilMapUtil::getApiKey());
+        $api_key = trim(ilMapUtil::getApiKey() ?? '');
         if ($api_key !== "" && !self::$google_maps_api_added) {
             $html_tpl->setCurrentBlock("google_maps_api");
             $html_tpl->setVariable(

--- a/components/ILIAS/Maps/templates/default/tpl.google_map.html
+++ b/components/ILIAS/Maps/templates/default/tpl.google_map.html
@@ -1,1 +1,4 @@
+<!-- BEGIN google_maps_api -->
+<script src="{GOOGLE_MAPS_API_SRC}"></script>
+<!-- END google_maps_api -->
 <div id="{MAP_ID}" class="ilGoogleMap" style="width: 100%; max-width: {WIDTH}; height: {HEIGHT};"></div>


### PR DESCRIPTION
…6761)

->addJavaScript had truncated the API Key. So now it is included directly in the template, which makes Google Maps usable again.