### PR TITLE
Add jstree as npm Dependency for ILIAS 12

### DIFF
--- a/package_new.json
+++ b/package_new.json
@@ -11,6 +11,7 @@
     "npm": "^10.9.3 || ^11.3"
   },
   "dependencies": {
+    "jstree": "^3.3.17"
   },
   "devDependencies": {
   },


### PR DESCRIPTION
Usage: Legacy explorer tree in UIComponent

Wrapped by: UIComponent

Reasoning: Currently the code still relies on this for the legacy explorer component, esp. the async mode being used by repository tree, org tree, and others

Maintenance: Last release is two years ago. Code seems to be pretty stable.

NPM: https://www.npmjs.com/package/jstree