### PR TITLE
Add chart.js as npm Dependency for ILIAS 12

### DIFF
--- a/package_new.json
+++ b/package_new.json
@@ -11,6 +11,7 @@
     "npm": "^10.9.3 || ^11.3"
   },
   "dependencies": {
+    "chart.js": "^4.5.1"
   },
   "devDependencies": {
   },


### PR DESCRIPTION
This PR suggests adding `chart.js` (v. 4.5.1) as npm package.

General Information:
* [X] this dependency was already used in ILIAS.
* [X] MIT license

Usage:
* `components/ILIAS/Poll`
* `components/ILIAS/Skill`

Wrapped By:
* `ILIAS\UI\Implementation\Component\Chart\Bar`

Reasoning:
* `chart.js` provides a set of frequently used chart types (like bar charts, line charts, pie charts,...). The charts are responsive, animated, interactive and HTML5-based.
* Among [many charting libraries ](https://awesome.cube.dev/?tools=charts&ref=eco-chartjs) for JavaScript application developers, Chart.js is currently the most popular one according to [GitHub stars ](https://github.com/chartjs/Chart.js)(~67,500) and [npm downloads ](https://www.npmjs.com/package/chart.js)(~11,600,000 weekly).

Maintenance:
* `chart.js` is actively maintained by multiple contributors. New releases are published every few weeks/months.

Links:
* NPM: https://www.npmjs.com/package/chart.js
* GitHub: https://github.com/chartjs/Chart.js
* Documentation: https://www.chartjs.org/docs/latest/