### PR TITLE
LegalDocuments: Fix UnitTest deprecations

### DIFF
--- a/components/ILIAS/DataProtection/tests/ConsumerTest.php
+++ b/components/ILIAS/DataProtection/tests/ConsumerTest.php
@@ -56,14 +56,14 @@ class ConsumerTest extends TestCase
             'settings' => $settings,
             'refinery' => ['byTrying' => $by_trying],
         ]);
-        $container->method('offsetGet')->with('ilObjDataCache')->willReturn($this->mock(ilObjectDataCache::class));
+        $container->expects($this->once())->method('offsetGet')->with('ilObjDataCache')->willReturn($this->mock(ilObjectDataCache::class));
 
         $slot = $this->mock(UseSlot::class);
-        $slot->expects(self::once())->method('hasDocuments')->willReturn($slot);
-        $slot->expects(self::once())->method('hasHistory')->willReturn($slot);
-        $slot->expects(self::once())->method('hasPublicApi')->willReturn($slot);
-        $slot->expects(self::once())->method('hasPublicPage')->willReturn($slot);
-        $slot->expects(self::once())->method('showInFooter')->willReturn($slot);
+        $slot->expects($this->once())->method('hasDocuments')->willReturn($slot);
+        $slot->expects($this->once())->method('hasHistory')->willReturn($slot);
+        $slot->expects($this->once())->method('hasPublicApi')->willReturn($slot);
+        $slot->expects($this->once())->method('hasPublicPage')->willReturn($slot);
+        $slot->expects($this->once())->method('showInFooter')->willReturn($slot);
 
         $instance = new Consumer($container);
 
@@ -75,7 +75,7 @@ class ConsumerTest extends TestCase
         $by_trying = $this->mockTree(ByTrying::class, ['transform' => true]);
         $settings = $this->mock(ilSetting::class);
         $consecutive = ['dpro_enabled', 'dpro_no_acceptance'];
-        $settings->method('get')->with(
+        $settings->expects($this->exactly(2))->method('get')->with(
             $this->callback(function ($value) use (&$consecutive) {
                 $this->assertSame(array_shift($consecutive), $value);
                 return true;
@@ -88,15 +88,15 @@ class ConsumerTest extends TestCase
             'refinery' => ['byTrying' => $by_trying],
             'ctrl' => $this->mock(ilCtrl::class),
         ]);
-        $container->method('offsetGet')->with('ilObjDataCache')->willReturn($this->mock(ilObjectDataCache::class));
+        $container->expects($this->once())->method('offsetGet')->with('ilObjDataCache')->willReturn($this->mock(ilObjectDataCache::class));
 
         $slot = $this->mock(UseSlot::class);
-        $slot->expects(self::once())->method('hasDocuments')->willReturn($slot);
-        $slot->expects(self::once())->method('hasHistory')->willReturn($slot);
-        $slot->expects(self::once())->method('showOnLoginPage')->willReturn($slot);
-        $slot->expects(self::once())->method('showInFooter')->willReturn($slot);
-        $slot->expects(self::once())->method('hasPublicPage')->willReturn($slot);
-        $slot->expects(self::once())->method('hasPublicApi')->willReturn($slot);
+        $slot->expects($this->once())->method('hasDocuments')->willReturn($slot);
+        $slot->expects($this->once())->method('hasHistory')->willReturn($slot);
+        $slot->expects($this->once())->method('showOnLoginPage')->willReturn($slot);
+        $slot->expects($this->once())->method('showInFooter')->willReturn($slot);
+        $slot->expects($this->once())->method('hasPublicPage')->willReturn($slot);
+        $slot->expects($this->once())->method('hasPublicApi')->willReturn($slot);
 
         $instance = new Consumer($container);
 
@@ -110,7 +110,7 @@ class ConsumerTest extends TestCase
 
         $settings = $this->mock(ilSetting::class);
         $consecutive = ['dpro_enabled', 'dpro_no_acceptance'];
-        $settings->method('get')->with(
+        $settings->expects($this->exactly(2))->method('get')->with(
             $this->callback(function ($value) use (&$consecutive) {
                 $this->assertSame(array_shift($consecutive), $value);
                 return true;
@@ -123,21 +123,21 @@ class ConsumerTest extends TestCase
             'refinery' => ['byTrying' => $by_trying],
             'ctrl' => $this->mock(ilCtrl::class),
         ]);
-        $container->method('offsetGet')->with('ilObjDataCache')->willReturn($this->mock(ilObjectDataCache::class));
+        $container->expects($this->once())->method('offsetGet')->with('ilObjDataCache')->willReturn($this->mock(ilObjectDataCache::class));
 
         $slot = $this->mock(UseSlot::class);
-        $slot->expects(self::once())->method('hasDocuments')->willReturn($slot);
-        $slot->expects(self::once())->method('hasHistory')->willReturn($slot);
-        $slot->expects(self::once())->method('showOnLoginPage')->willReturn($slot);
-        $slot->expects(self::once())->method('canWithdraw')->willReturn($slot);
-        $slot->expects(self::once())->method('hasAgreement')->willReturn($slot);
-        $slot->expects(self::once())->method('showInFooter')->willReturn($slot);
-        $slot->expects(self::once())->method('onSelfRegistration')->willReturn($slot);
-        $slot->expects(self::once())->method('hasOnlineStatusFilter')->willReturn($slot);
-        $slot->expects(self::once())->method('hasUserManagementFields')->willReturn($slot);
-        $slot->expects(self::once())->method('hasPublicApi')->willReturn($slot);
-        $slot->expects(self::once())->method('canReadInternalMails')->willReturn($slot);
-        $slot->expects(self::once())->method('canUseSoapApi')->willReturn($slot);
+        $slot->expects($this->once())->method('hasDocuments')->willReturn($slot);
+        $slot->expects($this->once())->method('hasHistory')->willReturn($slot);
+        $slot->expects($this->once())->method('showOnLoginPage')->willReturn($slot);
+        $slot->expects($this->once())->method('canWithdraw')->willReturn($slot);
+        $slot->expects($this->once())->method('hasAgreement')->willReturn($slot);
+        $slot->expects($this->once())->method('showInFooter')->willReturn($slot);
+        $slot->expects($this->once())->method('onSelfRegistration')->willReturn($slot);
+        $slot->expects($this->once())->method('hasOnlineStatusFilter')->willReturn($slot);
+        $slot->expects($this->once())->method('hasUserManagementFields')->willReturn($slot);
+        $slot->expects($this->once())->method('hasPublicApi')->willReturn($slot);
+        $slot->expects($this->once())->method('canReadInternalMails')->willReturn($slot);
+        $slot->expects($this->once())->method('canUseSoapApi')->willReturn($slot);
 
         $instance = new Consumer($container);
 

--- a/components/ILIAS/DataProtection/tests/SettingsTest.php
+++ b/components/ILIAS/DataProtection/tests/SettingsTest.php
@@ -82,7 +82,7 @@ class SettingsTest extends TestCase
         $marshal = $this->mockMethod(Marshal::class, $type, [], $convert);
 
         $settings = $this->mock(SelectSetting::class);
-        $settings->expects(self::once())->method('typed')->willReturnCallback(function (string $k, callable $select) use ($marshal, $convert, $setting, $key) {
+        $settings->expects($this->once())->method('typed')->willReturnCallback(function (string $k, callable $select) use ($marshal, $convert, $setting, $key) {
             $this->assertSame($key, $k);
             $this->assertSame($convert, $select($marshal));
             return $setting;

--- a/components/ILIAS/DataProtection/tests/UserSettingsTest.php
+++ b/components/ILIAS/DataProtection/tests/UserSettingsTest.php
@@ -47,7 +47,7 @@ class UserSettingsTest extends TestCase
         $marshal = $this->mockMethod(Marshal::class, 'boolean', [], $convert);
 
         $settings = $this->mock(SelectSetting::class);
-        $settings->expects(self::once())->method('typed')->willReturnCallback(function (string $key, callable $select) use ($marshal, $convert, $setting) {
+        $settings->expects($this->once())->method('typed')->willReturnCallback(function (string $key, callable $select) use ($marshal, $convert, $setting) {
             $this->assertSame('dpro_withdrawal_requested', $key);
             $this->assertSame($convert, $select($marshal));
             return $setting;
@@ -64,10 +64,10 @@ class UserSettingsTest extends TestCase
         $date = $this->mock(Convert::class);
 
         $marshal = $this->mockMethod(Marshal::class, 'nullable', [$date], $convert);
-        $marshal->expects(self::once())->method('dateTime')->willReturn($date);
+        $marshal->expects($this->once())->method('dateTime')->willReturn($date);
 
         $settings = $this->mock(SelectSetting::class);
-        $settings->expects(self::once())->method('typed')->willReturnCallback(function (string $key, callable $select) use ($marshal, $convert, $setting) {
+        $settings->expects($this->once())->method('typed')->willReturnCallback(function (string $key, callable $select) use ($marshal, $convert, $setting) {
             $this->assertSame('dpro_agree_date', $key);
             $this->assertSame($convert, $select($marshal));
             return $setting;

--- a/components/ILIAS/LegalDocuments/tests/AdministrationEditLinksTest.php
+++ b/components/ILIAS/LegalDocuments/tests/AdministrationEditLinksTest.php
@@ -50,7 +50,7 @@ class AdministrationEditLinksTest extends TestCase
 
         $args = array_slice($args, 0, $argc);
 
-        $admin->expects(self::once())->method($target)->with($gui, ...[...$args, $method])->willReturn('my-link');
+        $admin->expects($this->once())->method($target)->with($gui, ...[...$args, $method])->willReturn('my-link');
 
         $instance = new AdministrationEditLinks($gui, $admin);
         $this->assertSame('my-link', $instance->$method(...$args));

--- a/components/ILIAS/LegalDocuments/tests/AdministrationTest.php
+++ b/components/ILIAS/LegalDocuments/tests/AdministrationTest.php
@@ -95,7 +95,7 @@ class AdministrationTest extends TestCase
         $repository = $this->getMockBuilder(DocumentRepository::class)->getMock();
 
         $consecutive = $documents;
-        $repository->expects(self::exactly(count($documents)))->method('deleteDocument')->with(
+        $repository->expects($this->exactly(count($documents)))->method('deleteDocument')->with(
             $this->callback(function ($value) use (&$consecutive) {
                 $this->assertSame(array_shift($consecutive), $value);
                 return true;
@@ -153,8 +153,8 @@ class AdministrationTest extends TestCase
             'getQueryParams',
             [],
             $query_params,
-            self::exactly(1)
-        ), self::exactly(1));
+            $this->exactly(1)
+        ), $this->exactly(1));
         $http->method('wrapper')->willReturn($httpWrapper);
 
         $refinery = $this->mockMethod(Refinery::class, 'kindlyTo', [], $this->mockMethod(KindlyToGroup::class, 'int', [], $this->mockMethod(
@@ -180,8 +180,8 @@ class AdministrationTest extends TestCase
     private function doc(int $id, string $title): Document
     {
         $document = $this->getMockBuilder(Document::class)->disableOriginalConstructor()->getMock();
-        $document->expects(self::once())->method('id')->willReturn($id);
-        $document->expects(self::once())->method('content')->willReturn(
+        $document->expects($this->once())->method('id')->willReturn($id);
+        $document->expects($this->once())->method('content')->willReturn(
             $this->mockMethod(DocumentContent::class, 'title', [], $title)
         );
 

--- a/components/ILIAS/LegalDocuments/tests/ConductorTest.php
+++ b/components/ILIAS/LegalDocuments/tests/ConductorTest.php
@@ -141,7 +141,7 @@ class ConductorTest extends TestCase
     public function testAgree(string $gui, string $key): void
     {
         $main_template = $this->mock(ilGlobalTemplateInterface::class);
-        $main_template->expects(self::once())->method('setContent')->with('rendered');
+        $main_template->expects($this->once())->method('setContent')->with('rendered');
         $this->agreement('agree', $gui, $key, $main_template);
     }
 
@@ -155,7 +155,7 @@ class ConductorTest extends TestCase
     {
         $this->expectExceptionMessage('Not available.');
         $routing = $this->mock(Routing::class);
-        $routing->expects(self::once())->method('redirectToOriginalTarget');
+        $routing->expects($this->once())->method('redirectToOriginalTarget');
         $constraint = $this->mock(Constraint::class);
         $container = $this->mockTree(Container::class, [
             'refinery' => ['to' => ['string' => $constraint]],
@@ -172,7 +172,7 @@ class ConductorTest extends TestCase
     public function testWithdraw(): void
     {
         $main_template = $this->mock(ilGlobalTemplateInterface::class);
-        $main_template->expects(self::once())->method('setContent')->with('rendered');
+        $main_template->expects($this->once())->method('setContent')->with('rendered');
         $this->agreement('withdraw', 'foo', 'withdraw', $main_template);
     }
 
@@ -320,7 +320,7 @@ class ConductorTest extends TestCase
         $constraint = $this->mock(Constraint::class);
 
         $ctrl = $this->mock(ilCtrl::class);
-        $ctrl->expects(self::once())->method('setParameterByClass')->with($gui, 'id', 'foo');
+        $ctrl->expects($this->once())->method('setParameterByClass')->with($gui, 'id', 'foo');
 
         $container = $this->mockTree(Container::class, [
             'refinery' => ['to' => ['string' => $constraint]],

--- a/components/ILIAS/LegalDocuments/tests/ConfigTest.php
+++ b/components/ILIAS/LegalDocuments/tests/ConfigTest.php
@@ -55,7 +55,7 @@ class ConfigTest extends TestCase
 
     public function testNonEditableLegalDocuments(): void
     {
-        $provide = $this->mockMethod(Provide::class, 'allowEditing', [], $this->mock(Provide::class), self::never());
+        $provide = $this->mockMethod(Provide::class, 'allowEditing', [], $this->mock(Provide::class), $this->never());
         $this->assertSame($provide, (new Config($provide))->legalDocuments());
     }
 }

--- a/components/ILIAS/LegalDocuments/tests/ConsumerSlots/SelfRegistration/BundleTest.php
+++ b/components/ILIAS/LegalDocuments/tests/ConsumerSlots/SelfRegistration/BundleTest.php
@@ -68,7 +68,7 @@ class BundleTest extends TestCase
     {
         $user = $this->mock(ilObjUser::class);
         $self_registration = $this->mock(SelfRegistration::class);
-        $self_registration->expects(self::exactly(2))->method('userCreation')->with($user);
+        $self_registration->expects($this->exactly(2))->method('userCreation')->with($user);
 
         $bundle = new Bundle([
             $self_registration,

--- a/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/BlocksTest.php
+++ b/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/BlocksTest.php
@@ -94,8 +94,8 @@ class BlocksTest extends TestCase
     public function testUi(): void
     {
         $container = $this->mock(Container::class);
-        $container->expects(self::once())->method('ui')->willReturn($this->mock(UIServices::class));
-        $container->expects(self::once())->method('language')->willReturn($this->mock(ilLanguage::class));
+        $container->expects($this->once())->method('ui')->willReturn($this->mock(UIServices::class));
+        $container->expects($this->once())->method('language')->willReturn($this->mock(ilLanguage::class));
 
         $instance = new Blocks(
             'foo',
@@ -145,8 +145,8 @@ class BlocksTest extends TestCase
     public function testUserManagementAgreeDateField(): void
     {
         $result = $this->mockTree(Result::class, ['value' => 'dummy']);
-        $result->expects(self::once())->method('map')->willReturn($result);
-        $result->expects(self::once())->method('except')->willReturn($result);
+        $result->expects($this->once())->method('map')->willReturn($result);
+        $result->expects($this->once())->method('except')->willReturn($result);
         $user = $this->mock(ilObjUser::class);
         $date = new DateTimeImmutable();
         $ldoc_user = $this->mockTree(User::class, [
@@ -156,7 +156,7 @@ class BlocksTest extends TestCase
 
         $language = $this->mock(ilLanguage::class);
         $consecutive = ['dummy lang', 'ldoc'];
-        $language->expects(self::exactly(2))->method('loadLanguageModule')->with(
+        $language->expects($this->exactly(2))->method('loadLanguageModule')->with(
             $this->callback(function ($value) use (&$consecutive) {
                 $this->assertSame(array_shift($consecutive), $value);
                 return true;
@@ -190,8 +190,8 @@ class BlocksTest extends TestCase
         ]);
 
         $form = $this->mock(Form::class);
-        $form->expects(self::once())->method('withRequest')->with($container->http()->request())->willReturn($form);
-        $form->expects(self::once())->method('getData')->willReturn($data);
+        $form->expects($this->once())->method('withRequest')->with($container->http()->request())->willReturn($form);
+        $form->expects($this->once())->method('getData')->willReturn($data);
 
         $instance = new Blocks('foo', $container, $this->mock(Provide::class));
         $this->assertSame($form, $instance->withRequest($form, function ($x) use ($data, &$called) {

--- a/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/ConsumerSlots/ModifyFooterTest.php
+++ b/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/ConsumerSlots/ModifyFooterTest.php
@@ -110,8 +110,8 @@ class ModifyFooterTest extends TestCase
     public function testWithdrawalButton(): void
     {
         $template = $this->mock(ilTemplate::class);
-        $template->expects(self::exactly(3))->method('setVariable');
-        $template->expects(self::once())->method('get');
+        $template->expects($this->exactly(3))->method('setVariable');
+        $template->expects($this->once())->method('get');
 
         $instance = new ModifyFooter(
             $this->mock(UI::class),

--- a/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/ConsumerSlots/SelfRegistrationTest.php
+++ b/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/ConsumerSlots/SelfRegistrationTest.php
@@ -93,10 +93,10 @@ class SelfRegistrationTest extends TestCase
         );
 
         $checkbox = $this->mock(ilCheckboxInputGUI::class);
-        $checkbox->expects(self::once())->method('setAlert');
+        $checkbox->expects($this->once())->method('setAlert');
 
         $form = $this->mockTree(ilPropertyFormGUI::class, ['getInput' => false]);
-        $form->expects(self::once())->method('getItemByPostVar')->with('accept_foo')->willReturn($checkbox);
+        $form->expects($this->once())->method('getItemByPostVar')->with('accept_foo')->willReturn($checkbox);
 
         $this->assertFalse($instance->saveLegacyForm($form));
     }
@@ -105,7 +105,7 @@ class SelfRegistrationTest extends TestCase
     {
         $user = $this->mock(ilObjUser::class);
         $ldoc_user = $this->mock(User::class);
-        $ldoc_user->expects(self::once())->method('acceptMatchingDocument');
+        $ldoc_user->expects($this->once())->method('acceptMatchingDocument');
 
         $instance = new SelfRegistration(
             'foo',
@@ -127,11 +127,11 @@ class SelfRegistrationTest extends TestCase
     {
         $user = $this->mock(ilObjUser::class);
         $ldoc_user = $this->mock(User::class);
-        $ldoc_user->expects(self::once())->method('acceptMatchingDocument')->willReturnCallback(function () {
+        $ldoc_user->expects($this->once())->method('acceptMatchingDocument')->willReturnCallback(function () {
             throw new \ILIAS\Data\NotOKException('This is not ok.');
         });
 
-        $ldoc_user->expects(self::once())->method('acceptAnyDocument');
+        $ldoc_user->expects($this->once())->method('acceptAnyDocument');
 
         $instance = new SelfRegistration(
             'foo',

--- a/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/ConsumerSlots/ShowOnLoginPageTest.php
+++ b/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/ConsumerSlots/ShowOnLoginPageTest.php
@@ -67,7 +67,7 @@ class ShowOnLoginPageTest extends TestCase
             ['HREF', $url]
         ];
         $template
-            ->expects(self::exactly(2))
+            ->expects($this->exactly(2))
             ->method('setVariable')
             ->willReturnCallback(
                 function (string $k, string $v) use (&$expected) {
@@ -77,7 +77,7 @@ class ShowOnLoginPageTest extends TestCase
                 }
             );
 
-        $template->expects(self::once())->method('get')->willReturn('Rendered');
+        $template->expects($this->once())->method('get')->willReturn('Rendered');
 
         $instance = new ShowOnLoginPage($this->mockTree(Provide::class, [
             'document' => ['repository' => ['countAll' => 1]],

--- a/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/ConsumerSlots/WithdrawProcessTest.php
+++ b/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/ConsumerSlots/WithdrawProcessTest.php
@@ -87,7 +87,7 @@ class WithdrawProcessTest extends TestCase
     public function testWithdrawalRequested(): void
     {
         $setting = $this->mock(Setting::class);
-        $setting->expects(self::once())->method('update')->with(true);
+        $setting->expects($this->once())->method('update')->with(true);
 
         $instance = new WithdrawProcess(
             $this->mockTree(User::class, ['cannotAgree' => false, 'neverAgreed' => false, 'withdrawalRequested' => $setting]),
@@ -125,7 +125,7 @@ class WithdrawProcessTest extends TestCase
     public function testWithdrawalFinished(): void
     {
         $main_template = $this->mock(ilGlobalTemplateInterface::class);
-        $main_template->expects(self::once())->method('setOnScreenMessage');
+        $main_template->expects($this->once())->method('setOnScreenMessage');
 
         $instance = new WithdrawProcess(
             $this->mock(User::class),

--- a/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/KeyValueStore/ILIASSettingStoreTest.php
+++ b/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/KeyValueStore/ILIASSettingStoreTest.php
@@ -46,7 +46,7 @@ class ILIASSettingStoreTest extends TestCase
     public function testUpdate(): void
     {
         $settings = $this->mock(ilSetting::class);
-        $settings->expects(self::once())->method('set')->with('foo', 'bar');
+        $settings->expects($this->once())->method('set')->with('foo', 'bar');
 
         $instance = new ILIASSettingStore($settings);
 

--- a/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/KeyValueStore/UserPreferenceStoreTest.php
+++ b/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/KeyValueStore/UserPreferenceStoreTest.php
@@ -49,7 +49,7 @@ class UserPreferenceStoreTest extends TestCase
     public function testUpdate(): void
     {
         $user = $this->mock(ilObjUser::class);
-        $user->expects(self::once())->method('writePref')->with('foo', 'bar');
+        $user->expects($this->once())->method('writePref')->with('foo', 'bar');
 
         (new UserPreferenceStore($user))->update('foo', 'bar');
     }

--- a/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/MarshalTest.php
+++ b/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/MarshalTest.php
@@ -69,7 +69,7 @@ class MarshalTest extends TestCase
             'custom' => ['transformation' => $custom],
             'kindlyTo' => ['string' => $to, 'bool' => $bool],
         ]);
-        $refinery->expects(self::once())->method('byTrying')->with([$bool, $custom])->willReturn($from);
+        $refinery->expects($this->once())->method('byTrying')->with([$bool, $custom])->willReturn($from);
 
         $convert = (new Marshal($refinery))->boolean();
         $this->assertSame($from, $convert->fromString());
@@ -96,7 +96,7 @@ class MarshalTest extends TestCase
             'null' => $null,
         ]);
         $consecutive = [[$nice_null, $decorate->fromString()], [$series, $decorate->toString()]];
-        $refinery->expects(self::exactly(2))->method('byTrying')->with(
+        $refinery->expects($this->exactly(2))->method('byTrying')->with(
             $this->callback(function ($value) use (&$consecutive) {
                 $this->assertSame(array_shift($consecutive), $value);
                 return true;

--- a/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/RoutingTest.php
+++ b/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/RoutingTest.php
@@ -64,7 +64,7 @@ class RoutingTest extends TestCase
         $called = false;
 
         $session = $this->mock(SelectSetting::class);
-        $session->expects(self::once())->method('typed')->willReturnCallback(function (string $key, callable $proc) {
+        $session->expects($this->once())->method('typed')->willReturnCallback(function (string $key, callable $proc) {
             $this->assertSame('orig_request_target', $key);
             return $this->mockTree(Setting::class, ['value' => null]);
         });
@@ -85,7 +85,7 @@ class RoutingTest extends TestCase
     {
         $setting = $this->mock(Setting::class);
         $setting->method('value')->willReturn('some url');
-        $setting->expects(self::once())->method('update')->with(null);
+        $setting->expects($this->once())->method('update')->with(null);
 
         $session = $this->mock(SelectSetting::class);
         $session->method('typed')->willReturnCallback(function (string $key, callable $proc) use ($setting) {
@@ -95,7 +95,7 @@ class RoutingTest extends TestCase
         });
 
         $ctrl = $this->mock(ilCtrl::class);
-        $ctrl->expects(self::once())->method('redirectToURL')->with('some url');
+        $ctrl->expects($this->once())->method('redirectToURL')->with('some url');
 
         (new Routing(
             $ctrl,

--- a/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/SelectSettingTest.php
+++ b/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/SelectSettingTest.php
@@ -54,8 +54,8 @@ class SelectSettingTest extends TestCase
         ]);
 
         $store = $this->mock(KeyValueStore::class);
-        $store->expects(self::once())->method('value')->with('foo')->willReturn($read_value);
-        $store->expects(self::once())->method('update')->with('foo', $write_value);
+        $store->expects($this->once())->method('value')->with('foo')->willReturn($read_value);
+        $store->expects($this->once())->method('update')->with('foo', $write_value);
 
         $instance = new SelectSetting($store, $marshal);
         $setting = $instance->typed('foo', function (Marshal $m) use ($marshal, $convert): Convert {

--- a/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/UITest.php
+++ b/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/UITest.php
@@ -59,7 +59,7 @@ class UITest extends TestCase
             ['ldoc_foo', true]
         ];
         $language
-            ->expects(self::exactly(2))
+            ->expects($this->exactly(2))
             ->method('exists')
             ->willReturnCallback(
                 function (string $txt) use (&$consecutive) {
@@ -77,7 +77,7 @@ class UITest extends TestCase
         $consecutive = ['bar_foo', 'ldoc_foo'];
         $language = $this->mockMethod(ilLanguage::class, 'txt', ['foo'], 'baz');
         $language
-            ->expects(self::exactly(2))
+            ->expects($this->exactly(2))
             ->method('exists')
             ->willReturnCallback(
                 function (string $txt) use (&$consecutive) {

--- a/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/UserTest.php
+++ b/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/UserTest.php
@@ -61,7 +61,7 @@ class UserTest extends TestCase
         $this->ensureDefined('ANONYMOUS_USER_ID', 13);
 
         $user = $this->mock(ilObjUser::class);
-        $user->expects(self::exactly(5))->method('getId')->willReturnOnConsecutiveCalls(0, ANONYMOUS_USER_ID, 9, 1, 68);
+        $user->expects($this->exactly(5))->method('getId')->willReturnOnConsecutiveCalls(0, ANONYMOUS_USER_ID, 9, 1, 68);
 
         $instance = new User(
             $user,
@@ -84,7 +84,7 @@ class UserTest extends TestCase
         $this->ensureDefined('SYSTEM_USER_ID', 9);
 
         $user = $this->mock(ilObjUser::class);
-        $user->expects(self::exactly(5))->method('getId')->willReturnOnConsecutiveCalls(0, ANONYMOUS_USER_ID, SYSTEM_USER_ID, 1, 68);
+        $user->expects($this->exactly(5))->method('getId')->willReturnOnConsecutiveCalls(0, ANONYMOUS_USER_ID, SYSTEM_USER_ID, 1, 68);
 
         $instance = new User(
             $user,
@@ -104,10 +104,10 @@ class UserTest extends TestCase
     public function testNeverAgreed(): void
     {
         $setting = $this->mock(Setting::class);
-        $setting->expects(self::exactly(2))->method('value')->willReturnOnConsecutiveCalls(null, new DateTimeImmutable());
+        $setting->expects($this->exactly(2))->method('value')->willReturnOnConsecutiveCalls(null, new DateTimeImmutable());
 
         $user_settings = $this->mock(UserSettings::class);
-        $user_settings->expects(self::exactly(2))->method('agreeDate')->willReturn($setting);
+        $user_settings->expects($this->exactly(2))->method('agreeDate')->willReturn($setting);
 
         $instance = new User(
             $this->mock(ilObjUser::class),
@@ -302,10 +302,10 @@ class UserTest extends TestCase
         $date = new DateTimeImmutable();
 
         $history = $this->mock(ProvideHistory::class);
-        $history->expects(self::once())->method('acceptDocument')->with($user, $document);
+        $history->expects($this->once())->method('acceptDocument')->with($user, $document);
 
         $setting = $this->mock(Setting::class);
-        $setting->expects(self::once())->method('update')->with($date);
+        $setting->expects($this->once())->method('update')->with($date);
 
         $instance = new User(
             $user,
@@ -386,7 +386,7 @@ class UserTest extends TestCase
         $user = $this->mock(ilObjUser::class);
         $history = $this->mock(ProvideHistory::class);
         $doc = $this->mock(Document::class);
-        $history->expects(self::once())->method('acceptDocument')->with($user, $doc);
+        $history->expects($this->once())->method('acceptDocument')->with($user, $doc);
 
         $instance = new User(
             $user,

--- a/components/ILIAS/LegalDocuments/tests/ContainerMock.php
+++ b/components/ILIAS/LegalDocuments/tests/ContainerMock.php
@@ -31,7 +31,7 @@ trait ContainerMock
 
     private function mockMethod(string $class, string $method, array $args, $return, $times = null)
     {
-        $times ??= self::once();
+        $times ??= $this->once();
         $mock = $this->mock($class);
         $mock->expects($times)->method($method)->with(...$args)->willReturn($return);
 

--- a/components/ILIAS/LegalDocuments/tests/DefaultMappingsTest.php
+++ b/components/ILIAS/LegalDocuments/tests/DefaultMappingsTest.php
@@ -57,7 +57,7 @@ class DefaultMappingsTest extends TestCase
             'language' => $this->mockMethod(ilLanguage::class, 'getInstalledLanguages', [], []),
             'rbac' => $this->mockMethod(RBACServices::class, 'review', [], $this->mock(ilRbacReview::class)),
         ]);
-        $container->method('offsetGet')->with('ilObjDataCache')->willReturn($this->mock(ilObjectDataCache::class));
+        $container->expects($this->once())->method('offsetGet')->with('ilObjDataCache')->willReturn($this->mock(ilObjectDataCache::class));
 
         $instance = new DefaultMappings('foo', $container);
         $result = $instance->conditionDefinitions();

--- a/components/ILIAS/LegalDocuments/tests/Legacy/ConfirmationTest.php
+++ b/components/ILIAS/LegalDocuments/tests/Legacy/ConfirmationTest.php
@@ -40,7 +40,7 @@ class ConfirmationTest extends TestCase
     {
         $confirmation = $this->confirmationGUIReplacement();
         $language = $this->mock(ilLanguage::class);
-        $language->expects(self::exactly(2))->method('txt')->willReturnCallback(static fn(string $key): string => 'translated ' . $key);
+        $language->expects($this->exactly(2))->method('txt')->willReturnCallback(static fn(string $key): string => 'translated ' . $key);
 
         $instance = new Confirmation($language, static fn() => $confirmation);
         $this->assertSame('rendered string', $instance->render('dummy link', 'submit', 'cancel', 'Hi', [

--- a/components/ILIAS/LegalDocuments/tests/PageFragment/PageContentTest.php
+++ b/components/ILIAS/LegalDocuments/tests/PageFragment/PageContentTest.php
@@ -42,7 +42,7 @@ class PageContentTest extends TestCase
     public function testRender(): void
     {
         $template = $this->mock(ilGlobalTemplateInterface::class);
-        $template->expects(self::once())->method('setTitle')->with('foo');
+        $template->expects($this->once())->method('setTitle')->with('foo');
         $components = [$this->mock(Component::class), $this->mock(Component::class)];
         $renderer = $this->mockMethod(Renderer::class, 'render', [$components], 'rendered');
 

--- a/components/ILIAS/LegalDocuments/tests/PageFragment/ShowOnScreenMessageTest.php
+++ b/components/ILIAS/LegalDocuments/tests/PageFragment/ShowOnScreenMessageTest.php
@@ -41,7 +41,7 @@ class ShowOnScreenMessageTest extends TestCase
     public function testRender(): void
     {
         $template = $this->mock(ilGlobalTemplateInterface::class);
-        $template->expects(self::once())->method('setOnScreenMessage')->with('foo', 'bar', true);
+        $template->expects($this->once())->method('setOnScreenMessage')->with('foo', 'bar', true);
         $renderer = $this->mock(Renderer::class);
         $page = $this->mockMethod(PageFragment::class, 'render', [$template, $renderer], 'rendered');
 

--- a/components/ILIAS/LegalDocuments/tests/Provide/ProvideDocumentTest.php
+++ b/components/ILIAS/LegalDocuments/tests/Provide/ProvideDocumentTest.php
@@ -219,11 +219,11 @@ class ProvideDocumentTest extends TestCase
         $other_existing_content = new CriterionContent('foo', ['baz']);
 
         $condition = $this->mock(Condition::class);
-        $condition->expects(self::exactly(2))->method('knownToNeverMatchWith')->with($condition)->willReturn(false);
+        $condition->expects($this->exactly(2))->method('knownToNeverMatchWith')->with($condition)->willReturn(false);
 
         $definition = $this->mock(ConditionDefinition::class);
         $consecutive = [$content, $other_existing_content, $content];
-        $definition->expects(self::exactly(3))->method('withCriterion')->with(
+        $definition->expects($this->exactly(3))->method('withCriterion')->with(
             $this->callback(function ($value) use (&$consecutive) {
                 $this->assertSame(array_shift($consecutive), $value);
                 return true;
@@ -261,7 +261,7 @@ class ProvideDocumentTest extends TestCase
         $existing_content = new CriterionContent('hoo', ['haz']);
 
         $condition = $this->mock(Condition::class);
-        $condition->expects(self::once())->method('knownToNeverMatchWith')->with($condition)->willReturn(true);
+        $condition->expects($this->once())->method('knownToNeverMatchWith')->with($condition)->willReturn(true);
 
         $instance = new ProvideDocument('foo', $this->mock(DocumentRepository::class), new SelectionMap([
             'hoo' => $this->mockMethod(ConditionDefinition::class, 'withCriterion', [$existing_content], $condition),

--- a/components/ILIAS/LegalDocuments/tests/Provide/ProvideHistoryTest.php
+++ b/components/ILIAS/LegalDocuments/tests/Provide/ProvideHistoryTest.php
@@ -89,7 +89,7 @@ class ProvideHistoryTest extends TestCase
         $document = $this->mock(Document::class);
 
         $repository = $this->mock(HistoryRepository::class);
-        $repository->expects(self::once())->method('acceptDocument')->with($user, $document);
+        $repository->expects($this->once())->method('acceptDocument')->with($user, $document);
 
         $instance = new ProvideHistory('foo', $repository, $this->mock(ProvideDocument::class), $this->mock(Container::class));
         $instance->acceptDocument($user, $document);

--- a/components/ILIAS/LegalDocuments/tests/Provide/ProvidePublicPageTest.php
+++ b/components/ILIAS/LegalDocuments/tests/Provide/ProvidePublicPageTest.php
@@ -41,7 +41,7 @@ class ProvidePublicPageTest extends TestCase
     {
         $ctrl = $this->mock(ilCtrl::class);
         $consecutive = ['foo', ''];
-        $ctrl->expects(self::exactly(2))->method('setParameterByClass')->with(
+        $ctrl->expects($this->exactly(2))->method('setParameterByClass')->with(
             $this->identicalTo(ilStartUpGUI::class),
             $this->identicalTo('id'),
             $this->callback(function ($value) use (&$consecutive) {
@@ -49,7 +49,7 @@ class ProvidePublicPageTest extends TestCase
                 return true;
             })
         );
-        $ctrl->expects(self::once())->method('getLinkTargetByClass')->with(ilStartUpGUI::class, 'showLegalDocuments')->willReturn('url');
+        $ctrl->expects($this->once())->method('getLinkTargetByClass')->with(ilStartUpGUI::class, 'showLegalDocuments')->willReturn('url');
 
         $instance = new ProvidePublicPage('foo', $ctrl);
         $this->assertSame('url', $instance->url());

--- a/components/ILIAS/LegalDocuments/tests/Provide/ProvideWithdrawalTest.php
+++ b/components/ILIAS/LegalDocuments/tests/Provide/ProvideWithdrawalTest.php
@@ -62,10 +62,10 @@ class ProvideWithdrawalTest extends TestCase
         $called = false;
 
         $auth_session = $this->mock(ilAuthSession::class);
-        $auth_session->expects(self::once())->method('logout');
+        $auth_session->expects($this->once())->method('logout');
 
         $ctrl = $this->mock(ilCtrl::class);
-        $ctrl->expects(self::once())->method('redirectToURL')->with('login.php?bar=baz&withdrawal_finished=foo&cmd=force_login');
+        $ctrl->expects($this->once())->method('redirectToURL')->with('login.php?bar=baz&withdrawal_finished=foo&cmd=force_login');
 
         $instance = new ProvideWithdrawal(
             'foo',

--- a/components/ILIAS/LegalDocuments/tests/ProvideTest.php
+++ b/components/ILIAS/LegalDocuments/tests/ProvideTest.php
@@ -46,7 +46,7 @@ class ProvideTest extends TestCase
     public function testWithdrawal(): void
     {
         $container = $this->mockTree(Container::class, ['ctrl' => $this->mock(ilCtrl::class)]);
-        $container->expects(self::once())->method('offsetGet')->with('ilAuthSession')->willReturn($this->mock(ilAuthSession::class));
+        $container->expects($this->once())->method('offsetGet')->with('ilAuthSession')->willReturn($this->mock(ilAuthSession::class));
 
         $instance = new Provide('foo', $this->mockMethod(Internal::class, 'get', ['withdraw'], 'foo'), $container);
 
@@ -93,7 +93,7 @@ class ProvideTest extends TestCase
             ['writable-document', 'foo']
         ];
         $internal
-            ->expects(self::exactly(2))
+            ->expects($this->exactly(2))
             ->method('get')
             ->willReturnCallback(
                 function ($a, $b) use (&$consecutive, $document) {

--- a/components/ILIAS/LegalDocuments/tests/StartUpStepTest.php
+++ b/components/ILIAS/LegalDocuments/tests/StartUpStepTest.php
@@ -56,9 +56,9 @@ class StartUpStepTest extends TestCase
     public function testExecute(): void
     {
         $ctrl = $this->mock(ilCtrl::class);
-        $ctrl->expects(self::once())->method('setParameterByClass')->with('foo', 'id', 'baz');
-        $ctrl->expects(self::once())->method('getLinkTargetByClass')->with(['foo'], 'bar')->willReturn('link');
-        $ctrl->expects(self::once())->method('redirectToURL')->with('link');
+        $ctrl->expects($this->once())->method('setParameterByClass')->with('foo', 'id', 'baz');
+        $ctrl->expects($this->once())->method('getLinkTargetByClass')->with(['foo'], 'bar')->willReturn('link');
+        $ctrl->expects($this->once())->method('redirectToURL')->with('link');
 
         $instance = new StartUpStep($ctrl, $this->mockTree(Conductor::class, ['intercepting' => [
             $this->mockTree(Intercept::class, ['intercept' => false, 'id' => 'ho', 'target' => ['guiName' => 'dummy', 'guiPath' => ['dummy'], 'command' => 'hej']]),

--- a/components/ILIAS/LegalDocuments/tests/Table/DocumentModalTest.php
+++ b/components/ILIAS/LegalDocuments/tests/Table/DocumentModalTest.php
@@ -52,13 +52,13 @@ class DocumentModalTest extends TestCase
         $signal = $this->mock(Signal::class);
         $modal_component = $this->mockTree(Lightbox::class, ['getShowSignal' => $signal]);
         $button_component = $this->mock(Shy::class);
-        $button_component->expects(self::once())->method('withOnClick')->with($signal)->willReturn($button_component);
+        $button_component->expects($this->once())->method('withOnClick')->with($signal)->willReturn($button_component);
 
         $text_page = $this->mock(LightboxTextPage::class);
 
         $modal = $this->mock(ModalFactory::class);
-        $modal->expects(self::once())->method('lightboxTextPage')->with('rendered', 'foo')->willReturn($text_page);
-        $modal->expects(self::once())->method('lightbox')->with([$text_page])->willReturn($modal_component);
+        $modal->expects($this->once())->method('lightboxTextPage')->with('rendered', 'foo')->willReturn($text_page);
+        $modal->expects($this->once())->method('lightbox')->with([$text_page])->willReturn($modal_component);
 
         $instance = new DocumentModal($this->mockTree(UIServices::class, [
             'renderer' => $this->mockMethod(Renderer::class, 'render', [$component], 'rendered'),

--- a/components/ILIAS/LegalDocuments/tests/Table/HistoryTableTest.php
+++ b/components/ILIAS/LegalDocuments/tests/Table/HistoryTableTest.php
@@ -56,7 +56,7 @@ class HistoryTableTest extends TestCase
     public function testColumns(): void
     {
         $ui = $this->mock(UI::class);
-        $ui->expects(self::exactly(6))->method('txt')->willReturnCallback(fn($key) => 'txt: ' . $key);
+        $ui->expects($this->exactly(6))->method('txt')->willReturnCallback(fn($key) => 'txt: ' . $key);
 
         $instance = new HistoryTable(
             $this->mock(HistoryRepository::class),
@@ -82,14 +82,14 @@ class HistoryTableTest extends TestCase
     {
         class_exists(ilDateTime::class, true); // Trigger autoload to ensure IL_CAL_UNIX is defined.
         $filter = $this->mock(TableFilter::class);
-        $filter->expects(self::exactly(2))->method('addFilterItem');
+        $filter->expects($this->exactly(2))->method('addFilterItem');
 
         $config = $this->mock(TableConfig::class);
-        $config->expects(self::once())->method('setTitle')->with('txt: acceptance_history');
-        $config->expects(self::once())->method('setDefaultOrderField')->with('created');
-        $config->expects(self::once())->method('setDefaultOrderDirection')->with('DESC');
-        $config->expects(self::once())->method('setSelectableColumns')->with('firstname', 'lastname', 'criteria');
-        $config->expects(self::once())->method('asFilter')->with('reset command')->willReturn($filter);
+        $config->expects($this->once())->method('setTitle')->with('txt: acceptance_history');
+        $config->expects($this->once())->method('setDefaultOrderField')->with('created');
+        $config->expects($this->once())->method('setDefaultOrderDirection')->with('DESC');
+        $config->expects($this->once())->method('setSelectableColumns')->with('firstname', 'lastname', 'criteria');
+        $config->expects($this->once())->method('asFilter')->with('reset command')->willReturn($filter);
 
         $ui = $this->mock(UI::class);
         $ui->method('txt')->willReturnCallback(fn($key) => 'txt: ' . $key);
@@ -111,8 +111,8 @@ class HistoryTableTest extends TestCase
     {
         $expected_filter = ['a' => 'b', 'start' => 'x', 'end' => 'y', 'c' => 'd'];
         $repository = $this->mock(HistoryRepository::class);
-        $repository->expects(self::once())->method('countAll')->with($expected_filter)->willReturn(2);
-        $repository->expects(self::once())->method('all')->with(
+        $repository->expects($this->once())->method('countAll')->with($expected_filter)->willReturn(2);
+        $repository->expects($this->once())->method('all')->with(
             $expected_filter,
             ['foo' => 'bar'],
             4,
@@ -129,7 +129,7 @@ class HistoryTableTest extends TestCase
             'getOffset' => 4,
             'getLimit' => 34,
         ]);
-        $selection->expects(self::once())->method('setMaxCount')->with(2);
+        $selection->expects($this->once())->method('setMaxCount')->with(2);
 
         $instance = new HistoryTable(
             $repository,

--- a/components/ILIAS/LegalDocuments/tests/WiringTest.php
+++ b/components/ILIAS/LegalDocuments/tests/WiringTest.php
@@ -115,7 +115,7 @@ class WiringTest extends TestCase
         $slot = $this->mockMethod(SlotConstructor::class, 'history', [$document], $history);
         $slot->method('id')->willReturn('foo');
         $map = $this->mockTree(Map::class, ['value' => ['document' => ['foo' => $document]]]);
-        $map->expects(self::once())->method('set')->with('history', 'foo', $history)->willReturn($map);
+        $map->expects($this->once())->method('set')->with('history', 'foo', $history)->willReturn($map);
 
         $instance = new Wiring($slot, $map);
         $this->assertSame($map, $instance->hasHistory()->map());

--- a/components/ILIAS/TermsOfService/tests/ConsumerTest.php
+++ b/components/ILIAS/TermsOfService/tests/ConsumerTest.php
@@ -56,14 +56,14 @@ class ConsumerTest extends TestCase
             'settings' => $settings,
             'refinery' => ['byTrying' => $by_trying],
         ]);
-        $container->method('offsetGet')->with('ilObjDataCache')->willReturn($this->mock(ilObjectDataCache::class));
+        $container->expects($this->once())->method('offsetGet')->with('ilObjDataCache')->willReturn($this->mock(ilObjectDataCache::class));
 
         $slot = $this->mock(UseSlot::class);
-        $slot->expects(self::once())->method('hasDocuments')->willReturn($slot);
-        $slot->expects(self::once())->method('hasHistory')->willReturn($slot);
-        $slot->expects(self::once())->method('hasPublicApi')->willReturn($slot);
-        $slot->expects(self::once())->method('hasPublicPage')->willReturn($slot);
-        $slot->expects(self::once())->method('showInFooter')->willReturn($slot);
+        $slot->expects($this->once())->method('hasDocuments')->willReturn($slot);
+        $slot->expects($this->once())->method('hasHistory')->willReturn($slot);
+        $slot->expects($this->once())->method('hasPublicApi')->willReturn($slot);
+        $slot->expects($this->once())->method('hasPublicPage')->willReturn($slot);
+        $slot->expects($this->once())->method('showInFooter')->willReturn($slot);
 
         $instance = new Consumer($container);
 
@@ -80,21 +80,21 @@ class ConsumerTest extends TestCase
             'refinery' => ['byTrying' => $by_trying],
             'ctrl' => $this->mock(ilCtrl::class),
         ]);
-        $container->method('offsetGet')->with('ilObjDataCache')->willReturn($this->mock(ilObjectDataCache::class));
+        $container->expects($this->once())->method('offsetGet')->with('ilObjDataCache')->willReturn($this->mock(ilObjectDataCache::class));
 
         $slot = $this->mock(UseSlot::class);
-        $slot->expects(self::once())->method('hasDocuments')->willReturn($slot);
-        $slot->expects(self::once())->method('hasHistory')->willReturn($slot);
-        $slot->expects(self::once())->method('canWithdraw')->willReturn($slot);
-        $slot->expects(self::once())->method('hasAgreement')->willReturn($slot);
-        $slot->expects(self::once())->method('showInFooter')->willReturn($slot);
-        $slot->expects(self::once())->method('showOnLoginPage')->willReturn($slot);
-        $slot->expects(self::once())->method('onSelfRegistration')->willReturn($slot);
-        $slot->expects(self::once())->method('hasOnlineStatusFilter')->willReturn($slot);
-        $slot->expects(self::once())->method('hasUserManagementFields')->willReturn($slot);
-        $slot->expects(self::once())->method('hasPublicApi')->willReturn($slot);
-        $slot->expects(self::once())->method('canReadInternalMails')->willReturn($slot);
-        $slot->expects(self::once())->method('canUseSoapApi')->willReturn($slot);
+        $slot->expects($this->once())->method('hasDocuments')->willReturn($slot);
+        $slot->expects($this->once())->method('hasHistory')->willReturn($slot);
+        $slot->expects($this->once())->method('canWithdraw')->willReturn($slot);
+        $slot->expects($this->once())->method('hasAgreement')->willReturn($slot);
+        $slot->expects($this->once())->method('showInFooter')->willReturn($slot);
+        $slot->expects($this->once())->method('showOnLoginPage')->willReturn($slot);
+        $slot->expects($this->once())->method('onSelfRegistration')->willReturn($slot);
+        $slot->expects($this->once())->method('hasOnlineStatusFilter')->willReturn($slot);
+        $slot->expects($this->once())->method('hasUserManagementFields')->willReturn($slot);
+        $slot->expects($this->once())->method('hasPublicApi')->willReturn($slot);
+        $slot->expects($this->once())->method('canReadInternalMails')->willReturn($slot);
+        $slot->expects($this->once())->method('canUseSoapApi')->willReturn($slot);
 
         $instance = new Consumer($container);
 

--- a/components/ILIAS/TermsOfService/tests/SettingsTest.php
+++ b/components/ILIAS/TermsOfService/tests/SettingsTest.php
@@ -77,7 +77,7 @@ class SettingsTest extends TestCase
         $marshal = $this->mockMethod(Marshal::class, $type, [], $convert);
 
         $settings = $this->mock(SelectSetting::class);
-        $settings->expects(self::once())->method('typed')->willReturnCallback(function (string $k, callable $select) use ($marshal, $convert, $setting, $key) {
+        $settings->expects($this->once())->method('typed')->willReturnCallback(function (string $k, callable $select) use ($marshal, $convert, $setting, $key) {
             $this->assertSame($key, $k);
             $this->assertSame($convert, $select($marshal));
             return $setting;

--- a/components/ILIAS/TermsOfService/tests/UserSettingsTest.php
+++ b/components/ILIAS/TermsOfService/tests/UserSettingsTest.php
@@ -55,7 +55,7 @@ class UserSettingsTest extends TestCase
         $marshal = $this->mockMethod(Marshal::class, 'boolean', [], $convert);
 
         $settings = $this->mock(SelectSetting::class);
-        $settings->expects(self::once())->method('typed')->willReturnCallback(function (string $key, callable $select) use ($marshal, $convert, $setting) {
+        $settings->expects($this->once())->method('typed')->willReturnCallback(function (string $key, callable $select) use ($marshal, $convert, $setting) {
             $this->assertSame('consent_withdrawal_requested', $key);
             $this->assertSame($convert, $select($marshal));
             return $setting;
@@ -80,7 +80,7 @@ class UserSettingsTest extends TestCase
             ['agree date', $return_date],
             [$date, 'another date']
         ];
-        $by_trying->expects(self::exactly(2))
+        $by_trying->expects($this->exactly(2))
             ->method('transform')
             ->willReturnCallback(
                 function ($in) use (&$consecutive) {
@@ -91,9 +91,9 @@ class UserSettingsTest extends TestCase
             );
 
         $user = $this->mock(ilObjUser::class);
-        $user->expects(self::once())->method('getAgreeDate')->willReturn('agree date');
-        $user->expects(self::once())->method('setAgreeDate')->with('another date');
-        $user->expects(self::once())->method('update');
+        $user->expects($this->once())->method('getAgreeDate')->willReturn('agree date');
+        $user->expects($this->once())->method('setAgreeDate')->with('another date');
+        $user->expects($this->once())->method('update');
 
         $refinery = $this->mockTree(Refinery::class, ['byTrying' => $by_trying]);
 


### PR DESCRIPTION
This PR fixes the PHPUnit deprecation:
```
Using with*() without expects() is deprecated and will no longer be possible in PHPUnit 14.
```

and replaces static calls to non-static ones for `once`, `never` & `exactly`

in the components `LegalDocuments`, `TermsOfService` and `DataProtection`.