### PR TITLE
[FIX] LTI: Return context for active launch ref id

### DIFF
--- a/components/ILIAS/LTIProvider/classes/class.ilLTIViewGUI.php
+++ b/components/ILIAS/LTIProvider/classes/class.ilLTIViewGUI.php
@@ -175,7 +175,7 @@ class ilLTIViewGUI
         // context_id = ref_id in request
         if (ilSession::has('lti_' . $ref_id . '_post_data')) {
             $this->log->debug("lti context session exists for " . $ref_id);
-            //            return $ref_id;
+            return $ref_id;
         }
         // sub item request
         $this->log->debug("ref_id not exists as context_id, walking tree backwards to find a valid context_id");


### PR DESCRIPTION
Return the effective ref id directly when matching LTI post data exists in the session.

This prevents LTI requests for the launched object from falling through to the locator/referer fallback, which can make UIHook tabs on courses or groups ineffective or redirect back to the object view.