### PR TITLE
Container: fix parameters for page editor action (47845)

### DIFF
--- a/components/ILIAS/Container/classes/class.ilContainerGUI.php
+++ b/components/ILIAS/Container/classes/class.ilContainerGUI.php
@@ -441,6 +441,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                         !$this->isActiveOrdering() &&
                         $this->supportsPageEditor()
                     ) {
+                        $this->ctrl->setParameter($this, "ref_id", $this->object->getRefId());
                         $toolbar->addButton(
                             $lng->txt("cntr_text_media_editor"),
                             $ilCtrl->getLinkTarget($this, "editPageFrame")


### PR DESCRIPTION
This PR fixes [47845](https://mantis.ilias.de/view.php?id=47845): depending on the configuration of the container, the `ref_id` parameter can be set to the last object rendered in the object list, presumably because the object list isn't cleaning up the parameters properly.