### PR TITLE
User: skip broken users in gallery (47791)

### DIFF
--- a/components/ILIAS/User/classes/Gallery/class.ilUsersGalleryParticipants.php
+++ b/components/ILIAS/User/classes/Gallery/class.ilUsersGalleryParticipants.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Class ilUsersGalleryParticipants

--- a/components/ILIAS/User/classes/Gallery/class.ilUsersGalleryParticipants.php
+++ b/components/ILIAS/User/classes/Gallery/class.ilUsersGalleryParticipants.php
@@ -43,6 +43,10 @@ class ilUsersGalleryParticipants extends ilAbstractUsersGalleryCollectionProvide
                 continue;
             }
 
+            if (!ilObjUser::userExists([$usr_id])) {
+                continue;
+            }
+
             if (!($user = ilObjectFactory::getInstanceByObjId($usr_id, false)) || !($user instanceof ilObjUser)) {
                 continue;
             }


### PR DESCRIPTION
This PR fixes [47791](https://mantis.ilias.de/view.php?id=47791) by checking whether users exist in `usr_data` before instantiating them in `ilUsersGalleryParticipants::getUsers`.