### PR TITLE
Additional code authority for bib items, org units and study programme

### DIFF
--- a/docs/development/maintenance.md
+++ b/docs/development/maintenance.md
@@ -259,8 +259,8 @@ of ILIAS. The file contains the following fields:
 
 * **Bibliographic List Item**
     * Authority to Sign off on Conceptual Changes: [lschmidt-tf](https://docu.ilias.de/go/usr/120143)
-    * Authority to Sign off on Code Changes: [fschmid](https://docu.ilias.de/go/usr/21087), [maalers](https://docu.ilias.de/go/usr/119188), [mhomann](https://docu.ilias.de/go/usr/120211)
-    * Authority to Curate Test Cases: [maalers](https://docu.ilias.de/go/usr/119188), [mhomann](https://docu.ilias.de/go/usr/120211)
+    * Authority to Sign off on Code Changes: [fschmid](https://docu.ilias.de/go/usr/21087), [maalers](https://docu.ilias.de/go/usr/119188), [mhomann-tf](https://docu.ilias.de/go/usr/120211)
+    * Authority to Curate Test Cases: [maalers](https://docu.ilias.de/go/usr/119188), [mhomann-tf](https://docu.ilias.de/go/usr/120211)
     * Authority to (De-)Assign Authorities: [maalers](https://docu.ilias.de/go/usr/119188)
     * Assignee for Issues: [maalers](https://docu.ilias.de/go/usr/119188)
     * Assignee for Security Reports: [maalers](https://docu.ilias.de/go/usr/119188)
@@ -1176,7 +1176,7 @@ of ILIAS. The file contains the following fields:
 
 * **Organisational Units**
     * Authority to Sign off on Conceptual Changes: [fschmid](https://docu.ilias.de/go/usr/21087), [lschmidt-tf](https://docu.ilias.de/go/usr/120143)
-    * Authority to Sign off on Code Changes: [fschmid](https://docu.ilias.de/go/usr/21087), [maalers](https://docu.ilias.de/go/usr/119188), [mhomann](https://docu.ilias.de/go/usr/120211)
+    * Authority to Sign off on Code Changes: [fschmid](https://docu.ilias.de/go/usr/21087), [maalers](https://docu.ilias.de/go/usr/119188), [mhomann-tf](https://docu.ilias.de/go/usr/120211)
     * Authority to Curate Test Cases: [wischniak](https://docu.ilias.de/go/usr/21896)
     * Authority to (De-)Assign Authorities: [maalers](https://docu.ilias.de/go/usr/119188)
     * Assignee for Issues: [maalers](https://docu.ilias.de/go/usr/119188) 
@@ -1385,8 +1385,8 @@ of ILIAS. The file contains the following fields:
 
 * **Study Programme**
     * Authority to Sign off on Conceptual Changes: [lschmidt-tf](https://docu.ilias.de/go/usr/120143)
-    * Authority to Sign off on Code Changes: [maalers](https://docu.ilias.de/go/usr/119188), [mhomann](https://docu.ilias.de/go/usr/120211)
-    * Authority to Curate Test Cases: [maalers](https://docu.ilias.de/go/usr/119188), [mhomann](https://docu.ilias.de/go/usr/120211)
+    * Authority to Sign off on Code Changes: [maalers](https://docu.ilias.de/go/usr/119188), [mhomann-tf](https://docu.ilias.de/go/usr/120211)
+    * Authority to Curate Test Cases: [maalers](https://docu.ilias.de/go/usr/119188), [mhomann-tf](https://docu.ilias.de/go/usr/120211)
     * Authority to (De-)Assign Authorities: [maalers](https://docu.ilias.de/go/usr/119188)
     * Assignee for Issues: [maalers](https://docu.ilias.de/go/usr/119188)
     * Assignee for Security Reports: [maalers](https://docu.ilias.de/go/usr/119188)

--- a/docs/development/maintenance.md
+++ b/docs/development/maintenance.md
@@ -259,8 +259,8 @@ of ILIAS. The file contains the following fields:
 
 * **Bibliographic List Item**
     * Authority to Sign off on Conceptual Changes: [lschmidt-tf](https://docu.ilias.de/go/usr/120143)
-    * Authority to Sign off on Code Changes: [fschmid](https://docu.ilias.de/go/usr/21087), [maalers](https://docu.ilias.de/go/usr/119188)
-    * Authority to Curate Test Cases: [maalers](https://docu.ilias.de/go/usr/119188)
+    * Authority to Sign off on Code Changes: [fschmid](https://docu.ilias.de/go/usr/21087), [maalers](https://docu.ilias.de/go/usr/119188), [mhomann](https://docu.ilias.de/go/usr/120211)
+    * Authority to Curate Test Cases: [maalers](https://docu.ilias.de/go/usr/119188), [mhomann](https://docu.ilias.de/go/usr/120211)
     * Authority to (De-)Assign Authorities: [maalers](https://docu.ilias.de/go/usr/119188)
     * Assignee for Issues: [maalers](https://docu.ilias.de/go/usr/119188)
     * Assignee for Security Reports: [maalers](https://docu.ilias.de/go/usr/119188)
@@ -1176,7 +1176,7 @@ of ILIAS. The file contains the following fields:
 
 * **Organisational Units**
     * Authority to Sign off on Conceptual Changes: [fschmid](https://docu.ilias.de/go/usr/21087), [lschmidt-tf](https://docu.ilias.de/go/usr/120143)
-    * Authority to Sign off on Code Changes: [fschmid](https://docu.ilias.de/go/usr/21087), [maalers](https://docu.ilias.de/go/usr/119188)
+    * Authority to Sign off on Code Changes: [fschmid](https://docu.ilias.de/go/usr/21087), [maalers](https://docu.ilias.de/go/usr/119188), [mhomann](https://docu.ilias.de/go/usr/120211)
     * Authority to Curate Test Cases: [wischniak](https://docu.ilias.de/go/usr/21896)
     * Authority to (De-)Assign Authorities: [maalers](https://docu.ilias.de/go/usr/119188)
     * Assignee for Issues: [maalers](https://docu.ilias.de/go/usr/119188) 
@@ -1385,8 +1385,8 @@ of ILIAS. The file contains the following fields:
 
 * **Study Programme**
     * Authority to Sign off on Conceptual Changes: [lschmidt-tf](https://docu.ilias.de/go/usr/120143)
-    * Authority to Sign off on Code Changes: [maalers](https://docu.ilias.de/go/usr/119188)
-    * Authority to Curate Test Cases: [maalers](https://docu.ilias.de/go/usr/119188)
+    * Authority to Sign off on Code Changes: [maalers](https://docu.ilias.de/go/usr/119188), [mhomann](https://docu.ilias.de/go/usr/120211)
+    * Authority to Curate Test Cases: [maalers](https://docu.ilias.de/go/usr/119188), [mhomann](https://docu.ilias.de/go/usr/120211)
     * Authority to (De-)Assign Authorities: [maalers](https://docu.ilias.de/go/usr/119188)
     * Assignee for Issues: [maalers](https://docu.ilias.de/go/usr/119188)
     * Assignee for Security Reports: [maalers](https://docu.ilias.de/go/usr/119188)


### PR DESCRIPTION
Add Maria Homann as second code authority for bib items, org units and study programme to support Marcel Alers