### PR TITLE
[ILIAS 10] [FIX] TestQuestionPool: Translate plugin question types

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.assQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assQuestionGUI.php
@@ -1063,6 +1063,17 @@ abstract class assQuestionGUI
             }
         }
 
+        return $this->getQuestionTypeTranslation();
+    }
+
+    private function getQuestionTypeTranslation(): string
+    {
+        $question_properties = $this->questionrepository->getForQuestionId($this->object->getId());
+        $type_name = $question_properties?->getTypeName($this->lng);
+        if ($type_name !== null && $type_name !== '') {
+            return $type_name;
+        }
+
         return $this->lng->txt($this->object->getQuestionType());
     }
 

--- a/components/ILIAS/TestQuestionPool/classes/class.assQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assQuestionGUI.php
@@ -109,6 +109,7 @@ abstract class assQuestionGUI
     private ilDBInterface $db;
     protected ilLogger $logger;
     private ilComponentRepository $component_repository;
+    private ilComponentFactory $component_factory;
     protected GeneralQuestionPropertiesRepository $questionrepository;
     protected GUIService $notes_gui;
     protected ilCtrl $ctrl;
@@ -177,6 +178,7 @@ abstract class assQuestionGUI
         $this->db = $DIC->database();
         $this->logger = $DIC['ilLog'];
         $this->component_repository = $DIC['component.repository'];
+        $this->component_factory = $DIC['component.factory'];
         $this->refinery = $DIC['refinery'];
 
         $local_dic = QuestionPoolDIC::dic();
@@ -1068,10 +1070,10 @@ abstract class assQuestionGUI
 
     private function getQuestionTypeTranslation(): string
     {
-        $question_properties = $this->questionrepository->getForQuestionId($this->object->getId());
-        $type_name = $question_properties?->getTypeName($this->lng);
-        if ($type_name !== null && $type_name !== '') {
-            return $type_name;
+        foreach ($this->component_factory->getActivePluginsInSlot('qst') as $plugin) {
+            if ($plugin->getQuestionType() === $this->object->getQuestionType()) {
+                return $plugin->getQuestionTypeTranslation();
+            }
         }
 
         return $this->lng->txt($this->object->getQuestionType());

--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionList.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionList.php
@@ -603,7 +603,7 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
             $row['description'] = $tags_trafo->transform($row['description'] ?? '');
             $row['author'] = $tags_trafo->transform($row['author']);
             $row['taxonomies'] = $this->loadTaxonomyAssignmentData($row['obj_fi'], $row['question_id']);
-            $row['ttype'] = $this->lng->txt($row['type_tag']);
+            $row['ttype'] = $this->getQuestionTypeTranslation($row);
             $row['feedback'] = $row['feedback'] === 1;
             $row['hints'] = $row['hints'] === 1;
             $row['comments'] = $this->getNumberOfCommentsForQuestion($row['question_id']);
@@ -697,6 +697,22 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
             ->getPluginSlotById('qst')
             ->getPluginByName($questionData['plugin_name'])
             ->isActive();
+    }
+
+    private function getQuestionTypeTranslation(array $questionData): string
+    {
+        if (!($questionData['plugin'] ?? false)) {
+            return $this->lng->txt($questionData['type_tag']);
+        }
+
+        global $DIC;
+        foreach ($DIC['component.factory']->getActivePluginsInSlot('qst') as $plugin) {
+            if ($plugin->getQuestionType() === $questionData['type_tag']) {
+                return $plugin->getQuestionTypeTranslation();
+            }
+        }
+
+        return $this->lng->txt($questionData['type_tag']);
     }
 
     public function getDataArrayForQuestionId(int $questionId)

--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionList.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionList.php
@@ -74,6 +74,8 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
     private ?Order $order = null;
     private ?Range $range = null;
 
+    private ilComponentFactory $component_factory;
+
     public function __construct(
         private ilDBInterface $db,
         private ilLanguage $lng,
@@ -81,6 +83,8 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         private ilComponentRepository $component_repository,
         private ?NotesService $notes_service = null
     ) {
+        global $DIC;
+        $this->component_factory = $DIC['component.factory'];
     }
 
     public function setOrder(?Order $order = null): void
@@ -699,20 +703,19 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
             ->isActive();
     }
 
-    private function getQuestionTypeTranslation(array $questionData): string
+    private function getQuestionTypeTranslation(array $question_data): string
     {
-        if (!($questionData['plugin'] ?? false)) {
-            return $this->lng->txt($questionData['type_tag']);
+        if (!($question_data['plugin'] ?? false)) {
+            return $this->lng->txt($question_data['type_tag']);
         }
 
-        global $DIC;
-        foreach ($DIC['component.factory']->getActivePluginsInSlot('qst') as $plugin) {
-            if ($plugin->getQuestionType() === $questionData['type_tag']) {
+        foreach ($this->component_factory->getActivePluginsInSlot('qst') as $plugin) {
+            if ($plugin->getQuestionType() === $question_data['type_tag']) {
                 return $plugin->getQuestionTypeTranslation();
             }
         }
 
-        return $this->lng->txt($questionData['type_tag']);
+        return $this->lng->txt($question_data['type_tag']);
     }
 
     public function getDataArrayForQuestionId(int $questionId)


### PR DESCRIPTION
## Fix: Plugin question type is not translated in question pool

**Mantis:** [#0047758](https://mantis.ilias.de/view.php?id=47758)

### Problem
The question list in a question pool was not translating the type name of plugin questions. The `ilAssQuestionList::load` function was calling `$this->lng->txt($row['question_type'])` directly, bypassing the plugin's own translation mechanism. The same issue existed in `assQuestionGUI::outQuestionType()`, used by `ilTestCorrectionsGUI::populatePageTitleAndDescription`.

### Solution
Added a `getQuestionTypeTranslation()` helper method in both `ilAssQuestionList` and `assQuestionGUI` that checks whether the question belongs to a plugin and, if so, delegates to `$plugin->getQuestionTypeTranslation()`. Otherwise it falls back to the standard language translation.

### Files changed
- `components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionList.php`
- `components/ILIAS/TestQuestionPool/classes/class.assQuestionGUI.php`

### How to test
1. Install a question type plugin.
2. Add a question of that plugin to a question pool.
3. Open the question list in the pool — the type column should now show the plugin's translated type name.
4. Also verify the question type label in the test corrections view (`ilTestCorrectionsGUI`).