### PR TITLE
[TRUNK] [FIX] TestQuestionPool: Translate plugin question types

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.assQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assQuestionGUI.php
@@ -1068,6 +1068,17 @@ abstract class assQuestionGUI
             }
         }
 
+        return $this->getQuestionTypeTranslation();
+    }
+
+    private function getQuestionTypeTranslation(): string
+    {
+        $question_properties = $this->questionrepository->getForQuestionId($this->object->getId());
+        $type_name = $question_properties?->getTypeName($this->lng);
+        if ($type_name !== null && $type_name !== '') {
+            return $type_name;
+        }
+
         return $this->lng->txt($this->object->getQuestionType());
     }
 

--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionList.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionList.php
@@ -582,7 +582,7 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
             $row['description'] = $tags_trafo->transform($row['description'] ?? '');
             $row['author'] = $tags_trafo->transform($row['author']);
             $row['taxonomies'] = $this->loadTaxonomyAssignmentData($row['obj_fi'], $row['question_id']);
-            $row['question_type'] = $this->lng->txt($row['question_type']);
+            $row['question_type'] = $this->getQuestionTypeTranslation($row);
             $row['feedback'] = $row['feedback'] === 1;
             $row['comments'] = $this->getNumberOfCommentsForQuestion($row['question_id']);
 
@@ -702,6 +702,22 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
             ->getPluginSlotById('qst')
             ->getPluginByName($questionData['plugin_name'])
             ->isActive();
+    }
+
+    private function getQuestionTypeTranslation(array $questionData): string
+    {
+        if (!($questionData['plugin'] ?? false)) {
+            return $this->lng->txt($questionData['question_type']);
+        }
+
+        global $DIC;
+        foreach ($DIC['component.factory']->getActivePluginsInSlot('qst') as $plugin) {
+            if ($plugin->getQuestionType() === $questionData['question_type']) {
+                return $plugin->getQuestionTypeTranslation();
+            }
+        }
+
+        return $this->lng->txt($questionData['question_type']);
     }
 
     public function getDataArrayForQuestionId(int $questionId): array


### PR DESCRIPTION
## Fix: Plugin question type is not translated in question pool

**Mantis:** [#0047758](https://mantis.ilias.de/view.php?id=47758)

### Problem
The question list in a question pool was not translating the type name of plugin questions. The `ilAssQuestionList::load` function was calling `$this->lng->txt($row['question_type'])` directly, bypassing the plugin's own translation mechanism. The same issue existed in `assQuestionGUI::outQuestionType()`, used by `ilTestCorrectionsGUI::populatePageTitleAndDescription`.

### Solution
Added a `getQuestionTypeTranslation()` helper method in both `ilAssQuestionList` and `assQuestionGUI` that checks whether the question belongs to a plugin and, if so, delegates to `$plugin->getQuestionTypeTranslation()`. Otherwise it falls back to the standard language translation.

### Files changed
- `components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionList.php`
- `components/ILIAS/TestQuestionPool/classes/class.assQuestionGUI.php`

### How to test
1. Install a question type plugin.
2. Add a question of that plugin to a question pool.
3. Open the question list in the pool — the type column should now show the plugin's translated type name.
4. Also verify the question type label in the test corrections view (`ilTestCorrectionsGUI`).