### PR TITLE
[Survey] Update XML schema validation structure

### DIFF
--- a/components/ILIAS/Survey/Setup/class.Agent.php
+++ b/components/ILIAS/Survey/Setup/class.Agent.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Survey\Setup;
+
+use ILIAS\Setup;
+
+class Agent extends Setup\Agent\NullAgent
+{
+    public function getMigrations(): array
+    {
+        return [new InitLOMForSurveyMigration()];
+    }
+}

--- a/components/ILIAS/Survey/Setup/class.InitLOMForSurveyMigration.php
+++ b/components/ILIAS/Survey/Setup/class.InitLOMForSurveyMigration.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Survey\Setup;
+
+use ILIAS\MetaData\Setup\InitLOMForObjectTypeMigration;
+
+class InitLOMForSurveyMigration extends InitLOMForObjectTypeMigration
+{
+    protected function objectType(): string
+    {
+        return 'svy';
+    }
+
+    public function getLabel(): string
+    {
+        return 'Creates LOM sets for pre-existing Surveys.';
+    }
+}

--- a/components/ILIAS/Survey/Survey.php
+++ b/components/ILIAS/Survey/Survey.php
@@ -34,5 +34,6 @@ class Survey implements Component\Component
     ): void {
         $contribute[Component\Resource\PublicAsset::class] = fn() =>
             new Component\Resource\ComponentCSS($this, "survey.css");
+        $contribute[\ILIAS\Setup\Agent::class] = static fn() => new \ILIAS\Survey\Setup\Agent();
     }
 }

--- a/components/ILIAS/Survey/Survey.php
+++ b/components/ILIAS/Survey/Survey.php
@@ -34,6 +34,8 @@ class Survey implements Component\Component
     ): void {
         $contribute[Component\Resource\PublicAsset::class] = fn() =>
             new Component\Resource\ComponentCSS($this, "survey.css");
-        $contribute[\ILIAS\Setup\Agent::class] = static fn() => new \ILIAS\Survey\Setup\Agent();
+        $contribute[\ILIAS\Setup\Agent::class] = static fn() => new \ILIAS\Survey\Setup\Agent(
+            $pull[\ILIAS\Refinery\Factory::class]
+        );
     }
 }

--- a/components/ILIAS/SurveyQuestionPool/Export/class.ilSurveyQuestionPoolExporter.php
+++ b/components/ILIAS/SurveyQuestionPool/Export/class.ilSurveyQuestionPoolExporter.php
@@ -45,7 +45,7 @@ class ilSurveyQuestionPoolExporter extends ilXmlExporter
         $dependencies = [];
 
         // service settings
-        $deps[] = [
+        $dependencies[] = [
             "component" => "components/ILIAS/ILIASObject",
             "entity" => "common",
             "ids" => $a_ids

--- a/components/ILIAS/SurveyQuestionPool/Setup/class.Agent.php
+++ b/components/ILIAS/SurveyQuestionPool/Setup/class.Agent.php
@@ -31,6 +31,11 @@ class Agent extends Setup\Agent\NullAgent
         return new \ilDatabaseUpdateStepsExecutedObjective(new SurveyQuestionPoolDBUpdateSteps());
     }
 
+    public function getMigrations(): array
+    {
+        return [new InitLOMForSurveyQuestionPoolMigration()];
+    }
+
     public function getStatusObjective(Metrics\Storage $storage): Objective
     {
         return new \ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new SurveyQuestionPoolDBUpdateSteps());

--- a/components/ILIAS/SurveyQuestionPool/Setup/class.InitLOMForSurveyQuestionPoolMigration.php
+++ b/components/ILIAS/SurveyQuestionPool/Setup/class.InitLOMForSurveyQuestionPoolMigration.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\SurveyQuestionPool\Setup;
+
+use ILIAS\MetaData\Setup\InitLOMForObjectTypeMigration;
+
+class InitLOMForSurveyQuestionPoolMigration extends InitLOMForObjectTypeMigration
+{
+    protected function objectType(): string
+    {
+        return 'spl';
+    }
+
+    public function getLabel(): string
+    {
+        return 'Creates LOM sets for pre-existing Survey Question Pools.';
+    }
+}


### PR DESCRIPTION
This PR fixes an issue detected in Testrail test T85968 and reported in Mantis 47144.

When importing a Survey Question Pool, the import could fail during XML schema validation of the LOM metadata export. The failing package contained a `rights` element where the schema expected the mandatory `general` element first.

## Changes

* Add component-level LOM initialization for Survey objects (`svy`).
* Add component-level LOM initialization for Survey Question Pool objects (`spl`).
* Register the corresponding setup migrations in the Survey and Survey Question Pool setup agents.
* Fix the Survey Question Pool export dependencies so the common ILIAS object data is included correctly.

## Related

* Mantis: [https://mantis.ilias.de/view.php?id=47144](https://mantis.ilias.de/view.php?id=47144)
* Testrail: [https://testrail.ilias.de/index.php?/tests/view/85968](https://testrail.ilias.de/index.php?/tests/view/85968)