### PR TITLE
fix: persist group owner from XML in addGroup SOAP call (#0032223)

### DIFF
--- a/components/ILIAS/Group/classes/class.ilGroupXMLParser.php
+++ b/components/ILIAS/Group/classes/class.ilGroupXMLParser.php
@@ -517,6 +517,9 @@ class ilGroupXMLParser extends ilSaxParser implements ilSaxSubsetParser
          */
         $this->group_obj->readContainerSettings();
         $this->group_obj->update();
+        if ($ownerChanged) {
+            $this->group_obj->updateOwner();
+        }
 
         // ASSIGN ADMINS/MEMBERS
         $this->assignMembers();


### PR DESCRIPTION
Sister PR: https://github.com/ILIAS-eLearning/ILIAS/pull/11603