### PR TITLE
[FIX/11] News 47631: Fixes News Context Filter

### DIFF
--- a/components/ILIAS/News/Dashboard/class.DashboardNewsManager.php
+++ b/components/ILIAS/News/Dashboard/class.DashboardNewsManager.php
@@ -110,11 +110,9 @@ class DashboardNewsManager
      */
     public function getContextOptions(): array
     {
-        $context_count = $this->repo->news()->countByContextsBatch(
-            $this->domain->resolver()->getAccessibleContexts(
-                $this->domain->user(),
-                new NewsCriteria(period: $this->getDashboardNewsPeriod(), only_public: false)
-            )
+        $context_count = $this->domain->collection()->countNewsByContext(
+            $this->domain->user(),
+            new NewsCriteria(period: $this->getDashboardNewsPeriod(), only_public: false)
         );
 
         $options = [];

--- a/components/ILIAS/News/Dashboard/class.DashboardNewsManager.php
+++ b/components/ILIAS/News/Dashboard/class.DashboardNewsManager.php
@@ -74,35 +74,18 @@ class DashboardNewsManager
      */
     public function getPeriodOptions(): array
     {
-        $lng = $this->domain->lng();
-        $news_set = new \ilSetting("news");
-        $allow_shorter_periods = $news_set->get("allow_shorter_periods");
-        $allow_longer_periods = $news_set->get("allow_longer_periods");
-        $default_per = \ilNewsItem::_lookupDefaultPDPeriod();
-
         $options = [
-            "7" => $lng->txt("news_period_1_week"),
-            "30" => $lng->txt("news_period_1_month"),
-            "366" => $lng->txt("news_period_1_year")
+            7 => $this->domain->lng()->txt('news_period_1_week'),
+            30 => $this->domain->lng()->txt('news_period_1_month'),
+            366 => $this->domain->lng()->txt('news_period_1_year')
         ];
 
+        $dash_period = $this->getDashboardNewsPeriod();
+        if (!isset($options[$dash_period])) {
+            $options[$dash_period] = sprintf($this->domain->lng()->txt('news_period_x_days'), $dash_period);
+        }
+
         return $options;
-
-        /*
-        $unset = [];
-        foreach ($options as $k => $opt) {
-            if (!$allow_shorter_periods && ($k < $default_per)) {
-                $unset[$k] = $k;
-            }
-            if (!$allow_longer_periods && ($k > $default_per)) {
-                $unset[$k] = $k;
-            }
-        }
-        foreach ($unset as $k) {
-            unset($options[$k]);
-        }
-
-        return $options;*/
     }
 
     /**

--- a/components/ILIAS/News/Dashboard/class.InternalGUIService.php
+++ b/components/ILIAS/News/Dashboard/class.InternalGUIService.php
@@ -71,7 +71,7 @@ class InternalGUIService
                     (string) $this->manager->getDashboardNewsPeriod(),
                     true
                 )
-                ->select("news_ref_id", $lng->txt("context"), $context_options, true, null, true);
+                ->select("news_ref_id", $lng->txt("context"), $context_options, true, "0", true);
         }
         return $this->filter;
     }
@@ -79,7 +79,7 @@ class InternalGUIService
     public function getTimelineGUI(): \ilNewsTimelineGUI
     {
         $ctrl = $this->gui->ctrl();
-        if ($ctrl->isAsynch() && ! $this->gui->standardRequest()->getFilterOff()) {
+        if ($ctrl->isAsynch() && !$this->gui->standardRequest()->getFilterOff()) {
             $period = $this->manager->getDashboardNewsPeriod();
             $news_ref_id = $this->manager->getDashboardSelectedRefId();
         } else {

--- a/components/ILIAS/News/classes/class.ilNewsTimelineGUI.php
+++ b/components/ILIAS/News/classes/class.ilNewsTimelineGUI.php
@@ -45,6 +45,7 @@ class ilNewsTimelineGUI
     protected ilToolbarGUI $toolbar;
     protected ilObjUser $user;
     protected ilAccessHandler $access;
+    protected ilObjectDataCache $object_data_cache;
     protected static int $items_per_load = 20;
     protected bool $user_edit_all = false;
     protected StandardGUIRequest $std_request;
@@ -67,6 +68,7 @@ class ilNewsTimelineGUI
         $this->access = $DIC->access();
         $this->http = $DIC->http();
         $this->notes = $DIC->notes();
+        $this->object_data_cache = $DIC['ilObjDataCache'];
 
         $this->std_request = $DIC->news()
             ->internal()
@@ -182,15 +184,17 @@ class ilNewsTimelineGUI
 
     protected function readNewsData($excluded = []): void
     {
+        $context_obj_id = $this->object_data_cache->lookupObjId($this->ref_id);
+
         $this->news_collection = $this->manager->getNewsData(
             $this->ref_id,
-            $this->ctrl->getContextObjId(),
-            $this->ctrl->getContextObjType(),
+            $context_obj_id,
+            $this->object_data_cache->lookupType($context_obj_id),
             $this->period,
             $this->include_auto_entries,
             self::$items_per_load,
             $excluded
-        );
+        )->orderByDate();
     }
 
     public function getHTML(?ilPropertyFormGUI $form = null): string

--- a/components/ILIAS/News/src/Data/LazyNewsCollection.php
+++ b/components/ILIAS/News/src/Data/LazyNewsCollection.php
@@ -248,4 +248,9 @@ class LazyNewsCollection extends NewsCollection
     {
         return parent::limit($limit)->withFetchCallback($this->fetch_callback);
     }
+
+    public function orderByDate(): static
+    {
+        return parent::orderByDate()->withFetchCallback($this->fetch_callback);
+    }
 }

--- a/components/ILIAS/News/src/Data/NewsCollection.php
+++ b/components/ILIAS/News/src/Data/NewsCollection.php
@@ -432,6 +432,22 @@ class NewsCollection implements \Countable, \IteratorAggregate, \JsonSerializabl
         return $filtered;
     }
 
+    /**
+     * Returns a new collection with news items ordered by creation date
+     */
+    public function orderByDate(): static
+    {
+        $ordered = new static();
+        $ordered->addNewsItems($this->news_items);
+
+        uasort(
+            $ordered->news_items,
+            fn(NewsItem $a, NewsItem $b): int => $a->getCreationDate() <=> $b->getCreationDate()
+        );
+
+        return $ordered;
+    }
+
     public function load(array $news_ids = []): static
     {
         return $this;

--- a/components/ILIAS/News/src/Domain/NewsCollectionService.php
+++ b/components/ILIAS/News/src/Domain/NewsCollectionService.php
@@ -91,6 +91,16 @@ class NewsCollectionService
         return $this->applyFinalProcessing($this->getNewsForContexts([$context], $criteria, $user_id, $lazy), $criteria);
     }
 
+    /**
+     * @return list<array{0: NewsContext, 1: int}>
+     */
+    public function countNewsByContext(\ilObjUser $user_id, NewsCriteria $criteria): array
+    {
+        $contexts = $this->user_context_resolver->getAccessibleContexts($user_id, $criteria);
+        $contexts = $this->fetchContextData($contexts);
+        return $this->repository->countByContextsBatch($contexts);
+    }
+
     public function invalidateCache(int $user_id): void
     {
         $this->cache->invalidateNewsForUser($user_id);


### PR DESCRIPTION
Hi everyone,

this PR is the adapted version of #11481 for `release_11` and addresses the issues described in ticket 47631.

The second commit in this PR is a follow-up fix. The issue from the ticket can still be reproduced when enabling custom time ranges on the dashboard besides the default range (1 week, 1 month, 1 year). For this, the global news setting “Allow shorter/longer time ranges” must be enabled. This commit also needs to be backported to `release_10`.

Best
@lukas-heinrich 