### PR TITLE
Chatroom: Fix typo in server: createChatroomSession (ILIAS 11)

### DIFF
--- a/components/ILIAS/Chatroom/chat/Persistence/Database.js
+++ b/components/ILIAS/Chatroom/chat/Persistence/Database.js
@@ -124,7 +124,7 @@ var Database = function Database(config) {
 			};
 
 			sync.toPromise(fetchChatroomUsers)()
-				.then(sync.toPromise(createChatroomSession.bind(null, time)))
+				.then(sync.toPromise(createChatRoomSession.bind(null, time)))
 				.then(() => sync.toPromise(deleteChatroomUsers)());
 		}
 	};


### PR DESCRIPTION
Related to: https://mantis.ilias.de/view.php?id=47816

Not applicable to ILIAS 10, this is caused by a refactoring from:
```sh
$ grep -i createchatroomsession ILIAS10/components/ILIAS/Chatroom/chat/Persistence/Database.js
		function createChatRoomSession(result, next)
				createChatRoomSession,
			function createChatroomSession(result, next)
                                        createChatroomSession,

```

This bug causes users never being considered `disconnected` from the chatroom.