### PR TITLE
Remove moving plugin and data directory to public/

### DIFF
--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -560,15 +560,6 @@ sudo -uwww-data rsync -av --exclude='/public/' --exclude='/Customizing/' --exclu
 rm -rf /tmp/ilias_update
 ```
 </details>
-After upgrading the code from ILIAS 10 to ILIAS 11 due to structural changes, you need to move the `/Customizing/global/plugins`
-and `/data` folder to its new destination. Both are now located in the newly created `public` folder.
-
-```shell
-sudo -uwww-data mkdir -p public/Customizing/plugins
-mv data public/
-mv Customizing/global/plugins/Services/* public/Customizing/plugins/
-mv Customizing/global/plugins/Modules/* public/Customizing/plugins/
-```
 
 Then update the code of your plugins according to their documentation to ensure they are compatible with the new ILIAS version.
 If you are **not** using the tar.gz archive to upgrade your release, update your javascript and php dependencies. If you


### PR DESCRIPTION
This step has to be done when upgrading from ILIAS 9 to 10 and it seems that this section was copied from the release_10, but when upgrading from ILIAS 10 to 11 it was already done before and therefore is not needed.

In addition it is not possible to skip a major upgrade, so you always have to do this with ILIAS 10 when upgrading from 9 to 10 to 11.