### PR TITLE
Fix mantis #47790: Data too long for column 'pattern' in table 'cmi_correct_response'

### DIFF
--- a/components/ILIAS/Scorm2004/classes/Setup/class.ilScorm2004DatabaseUpdateSteps.php
+++ b/components/ILIAS/Scorm2004/classes/Setup/class.ilScorm2004DatabaseUpdateSteps.php
@@ -43,4 +43,10 @@ class ilScorm2004DatabaseUpdateSteps implements ilDatabaseUpdateSteps
             $this->db->addIndex('sahs_user', ['user_id'], 'i1');
         }
     }
+
+    public function step_4(): void
+    {
+        $this->db->modifyTableColumn("cmi_correct_response", "pattern", array("type" => "text", "length" => 4000, "notnull" => false, 'default' => null));
+    }
+
 }


### PR DESCRIPTION
Mantis: https://mantis.ilias.de/view.php?id=47790

Added new Scorm2004 DB Step:

- Increasing max length of column 'pattern' in table 'cmi_correct_response' to varchar(4000)

PR for ILIAS 10 + 11 + TRUNK