### PR TITLE
Fix mantis #47789: Data too long for column 'id' in table 'cmi_interaction'

### DIFF
--- a/components/ILIAS/Scorm2004/classes/Setup/class.ilScorm2004DatabaseUpdateSteps.php
+++ b/components/ILIAS/Scorm2004/classes/Setup/class.ilScorm2004DatabaseUpdateSteps.php
@@ -49,4 +49,9 @@ class ilScorm2004DatabaseUpdateSteps implements ilDatabaseUpdateSteps
         $this->db->modifyTableColumn("cmi_correct_response", "pattern", array("type" => "text", "length" => 4000, "notnull" => false, 'default' => null));
     }
 
+    public function step_5(): void
+    {
+        $this->db->modifyTableColumn("cmi_interaction", "id", array("type" => "text", "length" => 4000, "notnull" => false, 'default' => null));
+    }
+
 }


### PR DESCRIPTION
Mantis: https://mantis.ilias.de/view.php?id=47789 and https://mantis.ilias.de/view.php?id=44728

Added new Scorm2004 DB Step:

- Increasing max length of column 'id' in table 'cmi_interaction' to varchar(4000)

PR for ILIAS 10 + 11 + TRUNK