### PR TITLE
Chatroom: Change section for autogenerated chat names. Add lang vars (ILIAS 11)

### DIFF
--- a/components/ILIAS/Chatroom/classes/class.ilChatroomFormFactory.php
+++ b/components/ILIAS/Chatroom/classes/class.ilChatroomFormFactory.php
@@ -137,21 +137,17 @@ class ilChatroomFormFactory
         ];
 
         $function_fields = [
-            self::PROP_ALLOW_ANONYMOUS => $field_factory->checkbox(
-                $this->lng->txt('allow_anonymous'),
-                $this->lng->txt('anonymous_hint')
-            )->withValue((bool) ($values['allow_anonymous'] ?? false)),
-            self::PROP_ALLOW_CUSTOM_NAMES => $field_factory->optionalGroup(
-                [
-                    self::PROP_AUTOGEN_USERNAMES => $field_factory->text(
-                        $this->lng->txt('autogen_usernames'),
-                        $this->lng->txt('autogen_usernames_info')
-                    )->withRequired(true),
-                ],
-                $this->lng->txt('allow_custom_usernames')
-            )->withValue(
-                ($values['allow_custom_usernames'] ?? false) ? [self::PROP_AUTOGEN_USERNAMES => $values['autogen_usernames'] ?? ''] : null
-            ),
+            self::PROP_ALLOW_ANONYMOUS => $field_factory->optionalGroup([
+                self::PROP_AUTOGEN_USERNAMES => $field_factory->text(
+                    $this->lng->txt('autogen_usernames'),
+                    $this->lng->txt('autogen_usernames_info')
+                )->withRequired(true)->withValue($this->lng->txt('chatroom_anonymous_default'))
+            ], $this->lng->txt('allow_anonymous'), $this->lng->txt('anonymous_hint'))
+                ->withValue(($values['allow_anonymous'] ?? false) ? [self::PROP_AUTOGEN_USERNAMES => $values['autogen_usernames'] ?? ''] : null),
+            self::PROP_ALLOW_CUSTOM_NAMES => $field_factory->checkbox(
+                $this->lng->txt('allow_custom_usernames'),
+                $this->lng->txt('allow_custom_usernames_info')
+            )->withValue((bool) ($values['allow_custom_usernames'] ?? false)),
         ];
 
         $sections = [

--- a/components/ILIAS/Chatroom/classes/class.ilChatroomUser.php
+++ b/components/ILIAS/Chatroom/classes/class.ilChatroomUser.php
@@ -131,11 +131,11 @@ class ilChatroomUser
 
     public function buildAnonymousName(): string
     {
-        return str_replace(
-            '#',
-            (string) random_int(0, 10000),
-            $this->room->getSetting('autogen_usernames')
-        );
+        $template = $this->room->getSetting('autogen_usernames');
+        $rand = (string) random_int(0, 10000);
+        return str_contains($template, '#') ?
+            str_replace('#', $rand, $template) :
+            $template . '#' . $rand;
     }
 
     public function buildFullname(): string

--- a/components/ILIAS/Chatroom/classes/gui/class.ilChatroomSettingsGUI.php
+++ b/components/ILIAS/Chatroom/classes/gui/class.ilChatroomSettingsGUI.php
@@ -42,19 +42,18 @@ class ilChatroomSettingsGUI extends ilChatroomGUIHandler
             true
         );
 
-        $result = (new \ILIAS\Data\Factory())->error($this->ilLng->txt('form_input_not_valid'));
+        $values = null;
         if ($this->http->request()->getMethod() === 'POST') {
             $settingsForm = $settingsForm->withRequest($this->http->request());
-            $result = $settingsForm->getInputGroup()->getContent();
+            $values = $settingsForm->getData();
+        } else {
+            $this->mainTpl->setOnScreenMessage('failure', $this->ilLng->txt('form_input_not_valid'));
         }
 
-        if (!$result->isOK()) {
-            $this->mainTpl->setOnScreenMessage('failure', $result->error());
+        if ($values === null) {
             $this->general($settingsForm);
             return;
         }
-
-        $values = $result->value();
 
         $this->gui->getObject()->getObjectProperties()->storePropertyTitleAndDescription(
             $values[ilChatroomFormFactory::PROP_TITLE_AND_DESC]
@@ -74,10 +73,10 @@ class ilChatroomSettingsGUI extends ilChatroomGUIHandler
         }
 
         foreach ($mutated_settings as $setting => &$value) {
-            if ($setting === ilChatroomFormFactory::PROP_ALLOW_CUSTOM_NAMES) {
-                $value = is_array($values[$setting] ?? null);
+            if ($setting === ilChatroomFormFactory::PROP_ALLOW_ANONYMOUS) {
+                $value = isset($values[$setting]);
             } elseif ($setting === ilChatroomFormFactory::PROP_AUTOGEN_USERNAMES) {
-                $value = $values[ilChatroomFormFactory::PROP_ALLOW_CUSTOM_NAMES][ilChatroomFormFactory::PROP_AUTOGEN_USERNAMES] ?? '';
+                $value = $values[ilChatroomFormFactory::PROP_ALLOW_ANONYMOUS][ilChatroomFormFactory::PROP_AUTOGEN_USERNAMES] ?? '';
             } elseif (array_key_exists($setting, $values)) {
                 $value = $values[$setting];
             }

--- a/components/ILIAS/Chatroom/classes/gui/class.ilChatroomViewGUI.php
+++ b/components/ILIAS/Chatroom/classes/gui/class.ilChatroomViewGUI.php
@@ -362,7 +362,7 @@ class ilChatroomViewGUI extends ilChatroomGUIHandler
                 $this->showNameSelection($chat_user);
             }
         } else {
-            $chat_user->setUsername($this->ilUser->getPublicName());
+            $chat_user->setUsername($this->ilUser->isAnonymous() ? $chat_user->buildAnonymousName() : $this->ilUser->getPublicName());
             $chat_user->setProfilePictureVisible(true);
             $this->showRoom($room, $chat_user);
         }

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -2890,6 +2890,7 @@ certificate#:#persistent_certificate_mode_instant#:#Direkt
 certificate#:#persistent_certificate_mode_instant_info#:#Diese Option wird für Systeme mit geringer bis zu mittelgroßer Benutzerinteraktion empfohlen. Für Systeme, die zu hoher Last während der Zertifikatserstellung neigen, wird die Option "Cron-Job" empfohlen.
 chatroom#:#allow_anonymous#:#Anonyme Anmeldung erlauben
 chatroom#:#allow_custom_usernames#:#Frei wählbare Chat-Namen
+chatroom#:#allow_custom_usernames_info#:#Erlaube Benutzern einen eigenen Namen innerhalb des Chatraums zu wählen. Falls diese Option nicht selektiert ist, wird der Benutzernamen des Users verwendet.
 chatroom#:#anonymous_hint#:#Bitte beachten Sie, dass für den Zugriff von anonymen Benutzer die entsprechenden Berechtigungen im "Berechtigungen"-Reiter gesetzt sein müssen.
 chatroom#:#auto_scroll#:#Automatisch an das Ende scrollen
 chatroom#:#autogen_usernames#:#Chat-Namen für anonyme Teilnahme
@@ -2988,6 +2989,7 @@ chatroom#:#chat_user_action_invite_public_room#:#In öffentlichen Chatraum einla
 chatroom#:#chat_user_x_is_typing#:#Benutzer %s tippt gerade ...
 chatroom#:#chat_users_are_typing#:#Mehrere Benutzer tippen gerade ...
 chatroom#:#chat_whisper#:#Flüstern
+chatroom#:#chatroom_anonymous_default#:#Anonym #
 chatroom#:#chatroom_auth#:#Authentifikation
 chatroom#:#chatroom_auth_btn_txt#:#Schlüssel generieren
 chatroom#:#chatroom_auth_key#:#Authentifikation-Schlüssel

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -2891,6 +2891,7 @@ certificate#:#persistent_certificate_mode_instant#:#Instant
 certificate#:#persistent_certificate_mode_instant_info#:#This option is recommended for systems with low up to medium levels of user interaction. Systems that tend towards longer loading times during the creation of multiple user certificates should switch to the ‘Cron Job’ option.
 chatroom#:#allow_anonymous#:#Allow Anonymous Login
 chatroom#:#allow_custom_usernames#:#Allow Custom User Names
+chatroom#:#allow_custom_usernames_info#:#Allow users to enter their own unique session name to use within the chat room. If this option is not selected, users are automatically identified using their usernames (login) when in the chat room.
 chatroom#:#anonymous_hint#:#Make sure to set the proper permissions in the ‘Permissions’ tab to allow anonymous user access to this repository item.
 chatroom#:#auto_scroll#:#Scroll to Bottom
 chatroom#:#autogen_usernames#:#Auto Generated User Names
@@ -2989,6 +2990,7 @@ chatroom#:#chat_user_action_invite_public_room#:#Invite to Public Room
 chatroom#:#chat_user_x_is_typing#:#User %s is typing ...
 chatroom#:#chat_users_are_typing#:#Multiple users are typing ...
 chatroom#:#chat_whisper#:#Whisper
+chatroom#:#chatroom_anonymous_default#:#Anonymous #
 chatroom#:#chatroom_auth#:#Authentication
 chatroom#:#chatroom_auth_btn_txt#:#Generate Keys
 chatroom#:#chatroom_auth_key#:#Authentication-Key


### PR DESCRIPTION
Fix Mantis issues
- https://mantis.ilias.de/view.php?id=47824
- https://mantis.ilias.de/view.php?id=47813

This also adds the new lang vars `allow_custom_usernames_info` and `chatroom_anonymous_default`.