### PR TITLE
[FIX] LTI: Derive status lists from outcomes

### DIFF
--- a/components/ILIAS/Tracking/classes/status/class.ilLPStatusLtiOutcome.php
+++ b/components/ILIAS/Tracking/classes/status/class.ilLPStatusLtiOutcome.php
@@ -28,20 +28,44 @@ class ilLPStatusLtiOutcome extends ilLPStatus
 {
     private static array $userResultCache = array();
 
-    private static function getUsersByStatus(int $a_obj_id, int $a_status): array
+    private static function getUsersWithLtiData(int $a_obj_id): array
     {
         global $DIC;
 
         $ilDB = $DIC['ilDB'];
 
         $usr_ids = array();
-        $query = 'SELECT DISTINCT usr_id FROM ut_lp_marks'
-            . ' WHERE obj_id = ' . $ilDB->quote($a_obj_id, 'integer')
-            . ' AND status = ' . $ilDB->quote($a_status, 'integer');
+        $query = 'SELECT DISTINCT usr_id FROM lti_consumer_results'
+            . ' WHERE obj_id = ' . $ilDB->quote($a_obj_id, 'integer');
 
         $res = $ilDB->query($query);
         while ($row = $ilDB->fetchAssoc($res)) {
             $usr_ids[] = (int) $row['usr_id'];
+        }
+
+        if ($ilDB->tableExists('lti_consumer_grades')) {
+            $query = 'SELECT DISTINCT usr_id FROM lti_consumer_grades'
+                . ' WHERE obj_id = ' . $ilDB->quote($a_obj_id, 'integer');
+
+            $res = $ilDB->query($query);
+            while ($row = $ilDB->fetchAssoc($res)) {
+                $usr_ids[] = (int) $row['usr_id'];
+            }
+        }
+
+        return array_values(array_unique($usr_ids));
+    }
+
+    private static function getUsersByStatus(int $a_obj_id, int $a_status): array
+    {
+        $usr_ids = array();
+        $lp_status = new self($a_obj_id);
+        $object = ilObjectFactory::getInstanceByObjId($a_obj_id);
+
+        foreach (self::getUsersWithLtiData($a_obj_id) as $usr_id) {
+            if ($lp_status->determineStatus($a_obj_id, $usr_id, $object) === $a_status) {
+                $usr_ids[] = $usr_id;
+            }
         }
 
         return $usr_ids;
@@ -128,7 +152,7 @@ class ilLPStatusLtiOutcome extends ilLPStatus
         $ltiResult = $this->getLtiUserResult($a_obj_id, $a_usr_id);
 
         if ($ltiResult instanceof ilLTIConsumerResult) {
-            return (int) $ltiResult->getResult() * 100;
+            return (int) round((float) $ltiResult->getResult() * 100);
         }
 
         return 0;

--- a/components/ILIAS/Tracking/classes/status/class.ilLPStatusLtiOutcome.php
+++ b/components/ILIAS/Tracking/classes/status/class.ilLPStatusLtiOutcome.php
@@ -27,6 +27,7 @@ declare(strict_types=0);
 class ilLPStatusLtiOutcome extends ilLPStatus
 {
     private static array $userResultCache = array();
+    private static array $objectCache = array();
 
     private static function getUsersWithLtiData(int $a_obj_id): array
     {
@@ -60,7 +61,7 @@ class ilLPStatusLtiOutcome extends ilLPStatus
     {
         $usr_ids = array();
         $lp_status = new self($a_obj_id);
-        $object = ilObjectFactory::getInstanceByObjId($a_obj_id);
+        $object = self::getObject($a_obj_id);
 
         foreach (self::getUsersWithLtiData($a_obj_id) as $usr_id) {
             if ($lp_status->determineStatus($a_obj_id, $usr_id, $object) === $a_status) {
@@ -69,6 +70,15 @@ class ilLPStatusLtiOutcome extends ilLPStatus
         }
 
         return $usr_ids;
+    }
+
+    private static function getObject(int $objId): ilObjLTIConsumer
+    {
+        if (!isset(self::$objectCache[$objId])) {
+            self::$objectCache[$objId] = ilObjectFactory::getInstanceByObjId($objId);
+        }
+
+        return self::$objectCache[$objId];
     }
 
     public static function _getInProgress(int $a_obj_id): array
@@ -118,7 +128,7 @@ class ilLPStatusLtiOutcome extends ilLPStatus
     private function ensureObject(int $objId, $object): ilObjLTIConsumer
     {
         if (!($object instanceof ilObjLTIConsumer)) {
-            $object = ilObjectFactory::getInstanceByObjId($objId);
+            $object = self::getObject($objId);
         }
         return $object;
     }


### PR DESCRIPTION
### Description

This follow-up adjusts the LTI outcome learning progress status list methods so they no longer derive their user lists from `ut_lp_marks`.

`_getInProgress()`, `_getCompleted()` and `_getFailed()` now collect users from the underlying LTI outcome data:

- `lti_consumer_results`
- `lti_consumer_grades`, if available

The users are then classified through the existing `determineStatus()` logic.

This keeps parent object / LP collection aggregation working while avoiding a circular dependency during `ilLPStatusWrapper::_refreshStatus()`, where these methods are used to recalculate and persist `ut_lp_marks`.

The existing Basic Outcomes status semantics are preserved.

### Related

Original PR: #11641
Follow-up to the review comment on commit `3beedccc0067c9fbbb9531c0e21845a099a1dc11`.

Mantis: https://mantis.ilias.de/view.php?id=41919