### PR TITLE
[FIX]: fix #43204 by migrating Google Maps markers to the new API so …

### DIFF
--- a/components/ILIAS/Maps/classes/class.ilGoogleMapGUI.php
+++ b/components/ILIAS/Maps/classes/class.ilGoogleMapGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * User interface class for Google Maps

--- a/components/ILIAS/Maps/classes/class.ilGoogleMapGUI.php
+++ b/components/ILIAS/Maps/classes/class.ilGoogleMapGUI.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
  */
 class ilGoogleMapGUI extends ilMapGUI
 {
+    protected const GOOGLE_MAP_ID = "DEMO_MAP_ID";
     protected static bool $google_maps_api_added = false;
     protected string $css_row = "";
 
@@ -54,7 +55,7 @@ class ilGoogleMapGUI extends ilMapGUI
             $html_tpl->setCurrentBlock("google_maps_api");
             $html_tpl->setVariable(
                 "GOOGLE_MAPS_API_SRC",
-                "https://maps.googleapis.com/maps/api/js?key=" . rawurlencode($api_key)
+                "https://maps.googleapis.com/maps/api/js?key=" . rawurlencode($api_key) . "&libraries=marker"
             );
             $html_tpl->parseCurrentBlock();
             self::$google_maps_api_added = true;
@@ -119,6 +120,7 @@ class ilGoogleMapGUI extends ilMapGUI
         $html_tpl->setVariable("HEIGHT", $this->getHeight());
 
         $js_tpl->setVariable("MAP_ID", $this->getMapId());
+        $js_tpl->setVariable("GOOGLE_MAP_ID", self::GOOGLE_MAP_ID);
         $js_tpl->setVariable("LAT", $this->getLatitude());
         $js_tpl->setVariable("LONG", $this->getLongitude());
         $js_tpl->setVariable("ZOOM", (int) $this->getZoom());

--- a/components/ILIAS/Maps/templates/default/tpl.google_map.js
+++ b/components/ILIAS/Maps/templates/default/tpl.google_map.js
@@ -24,16 +24,15 @@ ilMapUserMarker["{MAP_ID}"] = Array();
 ilMapUserMarker["{UMAP_ID}"][{CNT}] = new Array({ULAT},{ULONG}, "<div style='width:220px;'><img style='float:right; margin-right:10px;' className='ilUserXXSmall' src='{IMG_USER}'\/><span className='small'>{USER_INFO}<\/span><\/div>");
 <!-- END user_marker -->
 
-if (google.maps)
+var ilAdvancedMarkerElement = null;
+if (typeof google !== "undefined" && google.maps)
 {
-    var ilMarkerImage = new google.maps.MarkerImage(
-        "./assets/images/standard/icon_mapm.svg",
-        new google.maps.Size(12, 20),
-        new google.maps.Point(0,0),
-        new google.maps.Point(6, 20));
+    ilAdvancedMarkerElement = google.maps.marker && google.maps.marker.AdvancedMarkerElement
+        ? google.maps.marker.AdvancedMarkerElement
+        : null;
 }
 
-if (google.maps)
+if (typeof google !== "undefined" && google.maps)
 {
 	ilInitMaps();
 }
@@ -75,7 +74,8 @@ function ilInitMap(id, latitude, longitude, zoom, type_control,
         streetViewControl: false,
         mapTypeControl: type_control,
         scaleControl: true,
-        panControl: (nav_control || large_map_control)
+        panControl: (nav_control || large_map_control),
+        mapId: "{GOOGLE_MAP_ID}"
     }
     var map = new google.maps.Map(document.getElementById(id), mapOptions);
 
@@ -138,7 +138,7 @@ function ilUpdateLocationInput(id, map, loc, address)
 
     if (ilCM[id])
     {
-        ilCM[id].setPosition(loc);
+        ilSetMarkerPosition(ilCM[id], loc);
     }
 }
 
@@ -193,19 +193,53 @@ function ilUpdateMap(id)
 
     if (ilCM[id])
     {
-        ilCM[id].setPosition(loc);
+        ilSetMarkerPosition(ilCM[id], loc);
     }
+}
+
+function ilCreateMarkerContent()
+{
+    var markerContent = document.createElement("img");
+    markerContent.src = "./assets/images/standard/icon_mapm.svg";
+    markerContent.width = 24;
+    markerContent.height = 40;
+    markerContent.alt = "";
+    return markerContent;
 }
 
 function ilCreateMarker(map, latitude, longitude)
 {
     var point = new google.maps.LatLng(latitude, longitude);
-    var marker = new google.maps.Marker({
+    if (ilAdvancedMarkerElement)
+    {
+        return new ilAdvancedMarkerElement({
+            position: point,
+            map: map,
+            content: ilCreateMarkerContent(),
+            anchorLeft: "-50%",
+            anchorTop: "-100%"
+        });
+    }
+
+    return new google.maps.Marker({
         position: point,
-        icon: ilMarkerImage,
+        icon: {
+            url: "./assets/images/standard/icon_mapm.svg",
+            scaledSize: new google.maps.Size(48, 80),
+            anchor: new google.maps.Point(24, 80)
+        },
         map: map
     });
-    return marker;
+}
+
+function ilSetMarkerPosition(marker, loc)
+{
+    if (typeof marker.setPosition === "function")
+    {
+        marker.setPosition(loc);
+        return;
+    }
+    marker.position = loc;
 }
 
 /**
@@ -234,7 +268,10 @@ function ilMapOpenInfoWindow(id, map, marker, j)
     var infowindow = new google.maps.InfoWindow({
         content: ilMapUserMarker[id][j][2]
     });
-    infowindow.open(map, marker);
+    infowindow.open({
+        anchor: marker,
+        map: map
+    });
 }
 
 function ilShowUserMarker(id, j)
@@ -245,7 +282,10 @@ function ilShowUserMarker(id, j)
     var infowindow = new google.maps.InfoWindow({
         content: ilMapUserMarker[id][j][2]
     });
-    infowindow.open(ilMap[id], ilMapUserMarker[id][j][3]);
+    infowindow.open({
+        anchor: ilMapUserMarker[id][j][3],
+        map: ilMap[id]
+    });
 
     return false;
 }


### PR DESCRIPTION
…the location marker is visible again

Mitigate the deprecated google.maps.Marker usage by switching the map integration to google.maps.marker.AdvancedMarkerElement and loading the required marker library. This adapts the Maps component to the current Google Maps API and restores the visibility of the location marker.