### PR TITLE
TestQuestionPool 47939: Fix choice answer legacy UI

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
@@ -915,7 +915,7 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
         }
 
         if ($answer->getAnswertext() !== '') {
-            $answer_elements[] = $this->ui->factory()->legacy()->content(
+            $answer_elements[] = $this->ui->factory()->legacy(
                 $answer_text . $answer->getAnswertext()
             );
         }

--- a/components/ILIAS/TestQuestionPool/classes/class.assSingleChoiceGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assSingleChoiceGUI.php
@@ -756,7 +756,7 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
         }
 
         if ($answer->getAnswertext() !== '') {
-            $answer_elements[] = $this->ui->factory()->legacy()->content(
+            $answer_elements[] = $this->ui->factory()->legacy(
                 $answer_text . $answer->getAnswertext()
             );
         }


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=47939

Single- and multiple-choice answer rendering called `legacy()->content(...)`, which is not a valid UI factory API and broke answer output. `assSingleChoiceGUI` and `assMultipleChoiceGUI` now pass answer HTML through `legacy(...)` directly when building answer elements.

/cc @thojou 