### PR TITLE
[Fix] Mail 0047926: Add Notifications for scheduled mails moved to Draft from Outbox

### DIFF
--- a/components/ILIAS/Mail/classes/class.ilMailFolderGUI.php
+++ b/components/ILIAS/Mail/classes/class.ilMailFolderGUI.php
@@ -236,6 +236,12 @@ class ilMailFolderGUI implements ilCtrlSecurityInterface
                 $this->ctrl->setParameterByClass(ilMailFormGUI::class, self::PARAM_MAIL_ID, (string) $mail_ids[0]);
                 if ($this->folder->isOutbox()) {
                     $this->umail->moveMailsToFolder($mail_ids, $this->mbox->getDraftsFolder());
+                    ilSession::set('mail_scheduled_edit_from_outbox', true);
+                    $this->tpl->setOnScreenMessage(
+                        ilGlobalTemplateInterface::MESSAGE_TYPE_INFO,
+                        $this->lng->txt('mail_scheduled_edit_moved_info'),
+                        true
+                    );
                 }
                 $this->ctrl->setParameterByClass(
                     ilMailFormGUI::class,
@@ -490,6 +496,12 @@ class ilMailFolderGUI implements ilCtrlSecurityInterface
             $this->user->getTimeFormat(),
             new DateTimeZone($this->user->getTimeZone())
         );
+
+        if ($this->folder->isOutbox()) {
+            $components[] = $this->ui_factory->messageBox()->info(
+                $this->lng->txt('mail_message_scheduled_info')
+            );
+        }
 
         $components[] = $this->getFilterUI()->getComponent();
         $components[] = $table->getComponent();

--- a/components/ILIAS/Mail/classes/class.ilMailFolderGUI.php
+++ b/components/ILIAS/Mail/classes/class.ilMailFolderGUI.php
@@ -233,10 +233,15 @@ class ilMailFolderGUI implements ilCtrlSecurityInterface
                 return;
 
             case MailFolderTableUI::ACTION_EDIT:
+                $drafts_folder_id = $this->mbox->getDraftsFolder();
                 $this->ctrl->setParameterByClass(ilMailFormGUI::class, self::PARAM_MAIL_ID, (string) $mail_ids[0]);
                 if ($this->folder->isOutbox()) {
-                    $this->umail->moveMailsToFolder($mail_ids, $this->mbox->getDraftsFolder());
-                    ilSession::set('mail_scheduled_edit_from_outbox', true);
+                    $this->umail->moveMailsToFolder($mail_ids, $drafts_folder_id);
+                    $this->ctrl->setParameterByClass(
+                        ilMailFormGUI::class,
+                        ilMailFormGUI::PARAM_SCHEDULED_EDIT_FROM_OUTBOX,
+                        '1'
+                    );
                     $this->tpl->setOnScreenMessage(
                         ilGlobalTemplateInterface::MESSAGE_TYPE_INFO,
                         $this->lng->txt('mail_scheduled_edit_moved_info'),
@@ -246,7 +251,12 @@ class ilMailFolderGUI implements ilCtrlSecurityInterface
                 $this->ctrl->setParameterByClass(
                     ilMailFormGUI::class,
                     self::PARAM_FOLDER_ID,
-                    (string) $this->mbox->getDraftsFolder()
+                    (string) $drafts_folder_id
+                );
+                $this->ctrl->setParameterByClass(
+                    ilMailFolderGUI::class,
+                    self::PARAM_FOLDER_ID,
+                    (string) $drafts_folder_id
                 );
                 $this->ctrl->setParameterByClass(ilMailFormGUI::class, 'type', ilMailFormGUI::MAIL_FORM_TYPE_DRAFT);
                 $this->ctrl->redirectByClass(ilMailFormGUI::class);

--- a/components/ILIAS/Mail/classes/class.ilMailFormGUI.php
+++ b/components/ILIAS/Mail/classes/class.ilMailFormGUI.php
@@ -847,6 +847,19 @@ class ilMailFormGUI
                 break;
         }
 
+        if (
+            $type === self::MAIL_FORM_TYPE_DRAFT
+            && !empty($mail_data['schedule_datetime'])
+            && !ilSession::get('mail_scheduled_edit_from_outbox')
+        ) {
+            $this->tpl->setOnScreenMessage(
+                ilGlobalTemplateInterface::MESSAGE_TYPE_INFO,
+                $this->lng->txt('mail_scheduled_edit_compose_info'),
+                true
+            );
+        }
+        ilSession::clear('mail_scheduled_edit_from_outbox');
+
         $this->tpl->parseCurrentBlock();
 
         $form ??= $this->buildForm($mail_data);

--- a/components/ILIAS/Mail/classes/class.ilMailFormGUI.php
+++ b/components/ILIAS/Mail/classes/class.ilMailFormGUI.php
@@ -55,6 +55,7 @@ class ilMailFormGUI
     final public const string MAIL_FORM_TYPE_FORWARD = 'forward';
     final public const string MAIL_FORM_TYPE_DRAFT = 'draft';
     final public const string MAIL_FORM_TYPE_OUTBOX = 'outbox';
+    final public const string PARAM_SCHEDULED_EDIT_FROM_OUTBOX = 'scheduled_edit_from_outbox';
     final public const string MAIL_FORM_MODE_REGULAR_MAIL = 'regular_mail';
     final public const string MAIL_FORM_MODE_SERIAL_LETTER = 'serial_letter';
 
@@ -850,7 +851,13 @@ class ilMailFormGUI
         if (
             $type === self::MAIL_FORM_TYPE_DRAFT
             && !empty($mail_data['schedule_datetime'])
-            && !ilSession::get('mail_scheduled_edit_from_outbox')
+            && !(
+                $this->http->wrapper()->query()->has(self::PARAM_SCHEDULED_EDIT_FROM_OUTBOX)
+                && $this->http->wrapper()->query()->retrieve(
+                    self::PARAM_SCHEDULED_EDIT_FROM_OUTBOX,
+                    $this->refinery->kindlyTo()->int()
+                ) === 1
+            )
         ) {
             $this->tpl->setOnScreenMessage(
                 ilGlobalTemplateInterface::MESSAGE_TYPE_INFO,
@@ -858,7 +865,6 @@ class ilMailFormGUI
                 true
             );
         }
-        ilSession::clear('mail_scheduled_edit_from_outbox');
 
         $this->tpl->parseCurrentBlock();
 

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -4596,7 +4596,9 @@ common#:#mail_maxsize_attach#:#Maximale Größe des Mail-Anhangs
 common#:#mail_member#:#Mail an Mitglied
 common#:#mail_members#:#Mail an Mitglieder
 common#:#mail_message_scheduled#:#Mail planen
-common#:#mail_message_scheduled_info#:#Geplante Mails werden bis zum gewählten Zeitpunkt im Postausgang verbleiben.
+common#:#mail_message_scheduled_info#:#Geplante Mails bleiben bis zum gewählten Versandzeitpunkt im Postausgang. Beim Bearbeiten werden sie vorübergehend in Entwürfe verschoben, damit sie während der Bearbeitung nicht versendet werden. Nach dem erneuten Planen erscheinen sie wieder im Postausgang.
+common#:#mail_scheduled_edit_compose_info#:#Sie bearbeiten eine geplante Mail. Der Versand ist pausiert, bis Sie die Mail erneut planen..
+common#:#mail_scheduled_edit_moved_info#:#Diese geplante Mail wurde vorübergehend in Entwürfe verschoben, damit sie während der Bearbeitung nicht versendet wird. Nach dem erneuten Planen erscheint sie wieder im Postausgang.
 common#:#mail_not_sent#:#Ihre Mail konnte nicht verschickt werden
 common#:#mail_schedule_error_no_datetime#:#Das Planen einer Mail erfordert ein Datum und eine Uhrzeit.
 common#:#mail_schedule_error_past_datetime#:#Mails können nicht in der Vergangenheit geplant werden.

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -4597,13 +4597,13 @@ common#:#mail_member#:#Mail an Mitglied
 common#:#mail_members#:#Mail an Mitglieder
 common#:#mail_message_scheduled#:#Mail planen
 common#:#mail_message_scheduled_info#:#Geplante Mails bleiben bis zum gewählten Versandzeitpunkt im Postausgang. Beim Bearbeiten werden sie vorübergehend in Entwürfe verschoben, damit sie während der Bearbeitung nicht versendet werden. Nach dem erneuten Planen erscheinen sie wieder im Postausgang.
-common#:#mail_scheduled_edit_compose_info#:#Sie bearbeiten eine geplante Mail. Der Versand ist pausiert, bis Sie die Mail erneut planen..
-common#:#mail_scheduled_edit_moved_info#:#Diese geplante Mail wurde vorübergehend in Entwürfe verschoben, damit sie während der Bearbeitung nicht versendet wird. Nach dem erneuten Planen erscheint sie wieder im Postausgang.
 common#:#mail_not_sent#:#Ihre Mail konnte nicht verschickt werden
 common#:#mail_schedule_error_no_datetime#:#Das Planen einer Mail erfordert ein Datum und eine Uhrzeit.
 common#:#mail_schedule_error_past_datetime#:#Mails können nicht in der Vergangenheit geplant werden.
 common#:#mail_schedule_scheduled_datetime#:#Geplanter Versandzeitpunkt
 common#:#mail_scheduled#:#Mail zur späteren Zustellung im Postausgang abgelegt.
+common#:#mail_scheduled_edit_compose_info#:#Sie bearbeiten eine geplante Mail. Der Versand ist pausiert, bis Sie die Mail erneut planen..
+common#:#mail_scheduled_edit_moved_info#:#Diese geplante Mail wurde vorübergehend in Entwürfe verschoben, damit sie während der Bearbeitung nicht versendet wird. Nach dem erneuten Planen erscheint sie wieder im Postausgang.
 common#:#mail_search_no#:#Es wurden keine passenden Ergebnisse gefunden
 common#:#mail_select_one#:#Sie müssen mindestens eine Mail auswählen
 common#:#mail_send_error#:#Fehler beim Verschicken der Mail

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -4598,13 +4598,13 @@ common#:#mail_member#:#Mail to Member
 common#:#mail_members#:#Mail to Members
 common#:#mail_message_scheduled#:#Scheduled mail
 common#:#mail_message_scheduled_info#:#Scheduled mails remain in the outbox until the chosen sending time. When editing, they are temporarily moved to drafts so they are not sent while you are editing. After scheduling again, they reappear in the outbox.
-common#:#mail_scheduled_edit_compose_info#:#You are editing a scheduled mail. Sending is paused until you schedule the mail again.
-common#:#mail_scheduled_edit_moved_info#:#This scheduled mail was temporarily moved to drafts so it will not be sent while you are editing it. After scheduling again, it will reappear in the outbox.
 common#:#mail_not_sent#:#Mail not sent!
 common#:#mail_schedule_error_no_datetime#:#To schedule a mail, a delivery date and time must be specified.
 common#:#mail_schedule_error_past_datetime#:#You cannot schedule emails in the past.
 common#:#mail_schedule_scheduled_datetime#:#Scheduled Send Time
 common#:#mail_scheduled#:#Mail stored in outbox for later delivery.
+common#:#mail_scheduled_edit_compose_info#:#You are editing a scheduled mail. Sending is paused until you schedule the mail again.
+common#:#mail_scheduled_edit_moved_info#:#This scheduled mail was temporarily moved to drafts so it will not be sent while you are editing it. After scheduling again, it will reappear in the outbox.
 common#:#mail_search_no#:#No entries found.
 common#:#mail_select_one#:#You must select one mail
 common#:#mail_send_error#:#Error sending mail

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -4597,7 +4597,9 @@ common#:#mail_maxsize_attach#:#Max. attachment size
 common#:#mail_member#:#Mail to Member
 common#:#mail_members#:#Mail to Members
 common#:#mail_message_scheduled#:#Scheduled mail
-common#:#mail_message_scheduled_info#:#Mails remain in the outbox until the scheduled sending time.
+common#:#mail_message_scheduled_info#:#Scheduled mails remain in the outbox until the chosen sending time. When editing, they are temporarily moved to drafts so they are not sent while you are editing. After scheduling again, they reappear in the outbox.
+common#:#mail_scheduled_edit_compose_info#:#You are editing a scheduled mail. Sending is paused until you schedule the mail again.
+common#:#mail_scheduled_edit_moved_info#:#This scheduled mail was temporarily moved to drafts so it will not be sent while you are editing it. After scheduling again, it will reappear in the outbox.
 common#:#mail_not_sent#:#Mail not sent!
 common#:#mail_schedule_error_no_datetime#:#To schedule a mail, a delivery date and time must be specified.
 common#:#mail_schedule_error_past_datetime#:#You cannot schedule emails in the past.


### PR DESCRIPTION
Added:

* Info message when editing a scheduled mail from the outbox, explaining that it was temporarily moved to drafts to prevent sending during editing
* Info panel in the outbox describing the scheduled-mail lifecycle (outbox → drafts on edit → outbox after rescheduling)
* Info message in the compose form when editing a scheduled draft, indicating that sending is paused until the mail is scheduled again
* Language variables mail_scheduled_edit_moved_info and mail_scheduled_edit_compose_info (DE/EN)
Extended mail_message_scheduled_info to document the edit/move behavior (DE/EN)