### PR TITLE
Legacy Explorer2: public dir typo fix

### DIFF
--- a/components/ILIAS/UIComponent/Explorer2/classes/class.ilExplorerSelectInputGUI.php
+++ b/components/ILIAS/UIComponent/Explorer2/classes/class.ilExplorerSelectInputGUI.php
@@ -170,7 +170,7 @@ abstract class ilExplorerSelectInputGUI extends ilFormPropertyGUI implements ilT
         $on_load_code = $this->getInitializationOnLoadCode();
 
         $this->global_tpl->addJavascript("assets/js/Explorer2.js");
-        $this->global_tpl->addJavascript("asserts/js/LegacyModal.js");
+        $this->global_tpl->addJavascript("assets/js/LegacyModal.js");
         $this->global_tpl->addOnLoadCode($on_load_code);
 
         $tpl = new ilTemplate("tpl.prop_expl_select.html", true, true, "components/ILIAS/UIComponent/Explorer2");


### PR DESCRIPTION
Typo in public assets directory name.
Has to be picked to 11 & trunk.