### PR TITLE
[FIX] LTI: Provide outcome status lists

### DIFF
--- a/components/ILIAS/Tracking/classes/status/class.ilLPStatusLtiOutcome.php
+++ b/components/ILIAS/Tracking/classes/status/class.ilLPStatusLtiOutcome.php
@@ -27,6 +27,88 @@ declare(strict_types=1);
 class ilLPStatusLtiOutcome extends ilLPStatus
 {
     private static array $userResultCache = array();
+    private static array $objectCache = array();
+
+    private static function getUsersWithLtiData(int $a_obj_id): array
+    {
+        global $DIC;
+
+        $ilDB = $DIC['ilDB'];
+
+        $usr_ids = array();
+        $query = 'SELECT DISTINCT usr_id FROM lti_consumer_results'
+            . ' WHERE obj_id = ' . $ilDB->quote($a_obj_id, 'integer');
+
+        $res = $ilDB->query($query);
+        while ($row = $ilDB->fetchAssoc($res)) {
+            $usr_ids[] = (int) $row['usr_id'];
+        }
+
+        if ($ilDB->tableExists('lti_consumer_grades')) {
+            $query = 'SELECT DISTINCT usr_id FROM lti_consumer_grades'
+                . ' WHERE obj_id = ' . $ilDB->quote($a_obj_id, 'integer');
+
+            $res = $ilDB->query($query);
+            while ($row = $ilDB->fetchAssoc($res)) {
+                $usr_ids[] = (int) $row['usr_id'];
+            }
+        }
+
+        return array_values(array_unique($usr_ids));
+    }
+
+    private static function getUsersByStatus(int $a_obj_id, int $a_status): array
+    {
+        $usr_ids = array();
+        $lp_status = new self($a_obj_id);
+        $object = self::getObject($a_obj_id);
+
+        foreach (self::getUsersWithLtiData($a_obj_id) as $usr_id) {
+            if ($lp_status->determineStatus($a_obj_id, $usr_id, $object) === $a_status) {
+                $usr_ids[] = $usr_id;
+            }
+        }
+
+        return $usr_ids;
+    }
+
+    private static function getObject(int $objId): ilObjLTIConsumer
+    {
+        if (!isset(self::$objectCache[$objId])) {
+            self::$objectCache[$objId] = ilObjectFactory::getInstanceByObjId($objId);
+        }
+
+        return self::$objectCache[$objId];
+    }
+
+    public static function _getInProgress(int $a_obj_id): array
+    {
+        return self::getUsersByStatus($a_obj_id, self::LP_STATUS_IN_PROGRESS_NUM);
+    }
+
+    public static function _getCompleted(int $a_obj_id): array
+    {
+        return self::getUsersByStatus($a_obj_id, self::LP_STATUS_COMPLETED_NUM);
+    }
+
+    public static function _getFailed(int $a_obj_id): array
+    {
+        return self::getUsersByStatus($a_obj_id, self::LP_STATUS_FAILED_NUM);
+    }
+
+    public static function _getNotAttempted(int $a_obj_id): array
+    {
+        $members = ilObjectLP::getInstance($a_obj_id)->getMembers();
+        if (!$members) {
+            return array();
+        }
+
+        $users = array_diff((array) $members, self::_getInProgress($a_obj_id));
+        $users = array_diff($users, self::_getCompleted($a_obj_id));
+        $users = array_diff($users, self::_getFailed($a_obj_id));
+
+        return $users;
+    }
 
     private function getLtiUserResult(
         int $objId,
@@ -46,7 +128,7 @@ class ilLPStatusLtiOutcome extends ilLPStatus
     private function ensureObject(int $objId, $object): ilObjLTIConsumer
     {
         if (!($object instanceof ilObjLTIConsumer)) {
-            $object = ilObjectFactory::getInstanceByObjId($objId);
+            $object = self::getObject($objId);
         }
         return $object;
     }
@@ -88,7 +170,7 @@ class ilLPStatusLtiOutcome extends ilLPStatus
         $ltiResult = $this->getLtiUserResult($a_obj_id, $a_usr_id);
 
         if ($ltiResult instanceof ilLTIConsumerResult) {
-            return (int) $ltiResult->getResult() * 100;
+            return (int) round((float) $ltiResult->getResult() * 100);
         }
 
         return 0;


### PR DESCRIPTION
### Description

This backports the LTI outcome learning progress status list fix to ILIAS 10.

It combines the changes from #11641 and #11667 in one PR:

- Adds `_getInProgress()`, `_getCompleted()`, `_getFailed()` and `_getNotAttempted()` for LTI outcome LP status.
- Derives the status lists from the underlying LTI outcome data instead of `ut_lp_marks`.
- Uses the existing `determineStatus()` logic to classify users.
- Caches the LTI consumer object per request while calculating the lists.

This keeps parent object / LP collection aggregation working while avoiding a circular dependency during `ilLPStatusWrapper::_refreshStatus()`.

### Related

Backport of:
- #11641
- #11667

Mantis: https://mantis.ilias.de/view.php?id=41919