### PR TITLE
[FIX] Remove orphaned ilStyleIRSSMigration reference in setup agent

### DIFF
--- a/components/ILIAS/Style/classes/Setup/class.ilStyleSetupAgent.php
+++ b/components/ILIAS/Style/classes/Setup/class.ilStyleSetupAgent.php
@@ -98,7 +98,7 @@ class ilStyleSetupAgent implements Setup\Agent
     public function getMigrations(): array
     {
         return [
-            new ilStyleIRSSMigration()
+
         ];
     }
 


### PR DESCRIPTION
## Problem

`ilStyleSetupAgent::getMigrations()` instantiates `new ilStyleIRSSMigration()`, but that class was deleted in commit f8a0199625 ("content style: removed migration"). The dangling reference causes a **class-not-found fatal during setup**.

## Fix

Remove the orphaned `new ilStyleIRSSMigration()` entry, leaving an empty migrations array.

## Notes

cc @alex40724 — this completes the cleanup from f8a0199625, which removed the migration class file but left its instantiation behind.