### PR TITLE
[36631] Remove “Download Multiple Objects” from Learning Sequence (LSO)

### DIFF
--- a/components/ILIAS/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
+++ b/components/ILIAS/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
@@ -663,6 +663,15 @@ class ilObjLearningSequenceGUI extends ilContainerGUI implements ilCtrlBaseClass
         }
         $this->ctrl->redirectByClass('ilObjLearningSequenceLearnerGUI', self::CMD_LEARNER_VIEW);
     }
+
+    /**
+     * Initializes the header action for the object list GUI with optional subtype and sub-ID.
+     * Disables multi-download functionality for the object list GUI if initialized.
+     *
+     * @param string|null $sub_type Optional subtype identifier.
+     * @param int|null    $sub_id   Optional sub-ID.
+     * @return ilObjectListGUI|null Returns the initialized object list GUI instance or null.
+     */
     protected function initHeaderAction(?string $sub_type = null, ?int $sub_id = null): ?ilObjectListGUI
     {
         $lg = parent::initHeaderAction($sub_type, $sub_id);

--- a/components/ILIAS/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
+++ b/components/ILIAS/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
@@ -663,6 +663,15 @@ class ilObjLearningSequenceGUI extends ilContainerGUI implements ilCtrlBaseClass
         }
         $this->ctrl->redirectByClass('ilObjLearningSequenceLearnerGUI', self::CMD_LEARNER_VIEW);
     }
+    protected function initHeaderAction(?string $sub_type = null, ?int $sub_id = null): ?ilObjectListGUI
+    {
+        $lg = parent::initHeaderAction($sub_type, $sub_id);
+        if (is_object($lg)) {
+            $lg->enableMultiDownload(false);
+        }
+        return $lg;
+    }
+
 
     protected function getTabs(): void
     {
@@ -878,6 +887,7 @@ class ilObjLearningSequenceGUI extends ilContainerGUI implements ilCtrlBaseClass
                     $field_id = $field->getIdentifier();
                     $c[$v->getId()]['udf_' . $field_id] = (string) $v->getAdditionalFieldByIdentifier($field_id);
                 }
+                return $c;
             },
             []
         );


### PR DESCRIPTION
Mantis Ticket #36631 reports that using “Download Multiple Objects” in a Learning Sequence leads to an exception 

This PR disables the multi-download action for LSOs by disabling multi-download on the object list GUI used in the header action.

Concretely:
Override initHeaderAction() in ilObjLearningSequenceGUI.
Call enableMultiDownload(false) on the returned ilObjectListGUI instance.

While touching the same class, this PR also fixes addCustomData() by returning the accumulator $c inside the array_reduce() callback. Without returning $c, the reduce operation cannot reliably accumulate data.

This PR intentionally follows the JF decision to remove/disable the feature for LSO.