### PR TITLE
[LSO]  Streamlining of Permission Handling (remove JOIN/LEAVE, migrate to READ)

### DIFF
--- a/components/ILIAS/LearningSequence/classes/Player/class.ilLSLaunchlinksBuilder.php
+++ b/components/ILIAS/LearningSequence/classes/Player/class.ilLSLaunchlinksBuilder.php
@@ -25,9 +25,6 @@ declare(strict_types=1);
  */
 class ilLSLaunchlinksBuilder
 {
-    public const PERM_PARTICIPATE = 'participate';
-    public const PERM_UNPARTICIPATE = 'unparticipate';
-
     public const CMD_STANDARD = ilObjLearningSequenceLearnerGUI::CMD_STANDARD;
     public const CMD_EXTRO = ilObjLearningSequenceLearnerGUI::CMD_EXTRO;
     public const CMD_START = ilObjLearningSequenceLearnerGUI::CMD_START;
@@ -49,7 +46,7 @@ class ilLSLaunchlinksBuilder
 
     protected function mayJoin(): bool
     {
-        return $this->access->checkAccess(self::PERM_PARTICIPATE, '', $this->lso_ref_id);
+        return $this->access->checkAccess('read', '', $this->lso_ref_id);
     }
 
     public function currentUserMayUnparticipate(): bool
@@ -59,7 +56,7 @@ class ilLSLaunchlinksBuilder
 
     protected function mayUnparticipate(): bool
     {
-        return $this->access->checkAccess(self::PERM_UNPARTICIPATE, '', $this->lso_ref_id);
+        return $this->isMember() && $this->access->checkAccess('read', '', $this->lso_ref_id);
     }
 
     protected function isMember(): bool

--- a/components/ILIAS/LearningSequence/classes/Setup/class.ilLearningSequenceSetupAgent.php
+++ b/components/ILIAS/LearningSequence/classes/Setup/class.ilLearningSequenceSetupAgent.php
@@ -69,6 +69,9 @@ class ilLearningSequenceSetupAgent implements Setup\Agent
             new ilDatabaseUpdateStepsExecutedObjective(
                 new LSODropActivationDBUpdateSteps()
             ),
+            new ilDatabaseUpdateStepsExecutedObjective(
+                new ilLearningSequenceStreamlinePermissionsDBUpdateSteps()
+            ),
         );
     }
 
@@ -89,7 +92,8 @@ class ilLearningSequenceSetupAgent implements Setup\Agent
             'Component LearningSequence',
             true,
             new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilLearningSequenceRectifyPostConditionsTableDBUpdateSteps()),
-            new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilLearningSequenceRegisterNotificationType())
+            new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilLearningSequenceRegisterNotificationType()),
+            new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilLearningSequenceStreamlinePermissionsDBUpdateSteps())
         );
     }
 

--- a/components/ILIAS/LearningSequence/classes/Setup/class.ilLearningSequenceStreamlinePermissionsDBUpdateSteps.php
+++ b/components/ILIAS/LearningSequence/classes/Setup/class.ilLearningSequenceStreamlinePermissionsDBUpdateSteps.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+class ilLearningSequenceStreamlinePermissionsDBUpdateSteps implements \ilDatabaseUpdateSteps
+{
+    private const TYPE_TITLE = 'lso';
+
+    protected \ilDBInterface $db;
+
+    public function prepare(\ilDBInterface $db): void
+    {
+        $this->db = $db;
+    }
+
+    public function step_1(): void
+    {
+        $read_ops_id = $this->getOperationId('read');
+        $participate_ops_id = $this->getOperationId('participate');
+        $unparticipate_ops_id = $this->getOperationId('unparticipate');
+
+        if ($read_ops_id === null || $participate_ops_id === null || $unparticipate_ops_id === null) {
+            return;
+        }
+
+        $res = $this->db->query(
+            "SELECT pa.rol_id, pa.ref_id, pa.ops_id " .
+            "FROM rbac_pa pa " .
+            "JOIN object_reference ref ON ref.ref_id = pa.ref_id " .
+            "JOIN object_data obj ON obj.obj_id = ref.obj_id " .
+            "WHERE obj.type = '" . self::TYPE_TITLE . "'"
+        );
+
+        while ($row = $this->db->fetchAssoc($res)) {
+            $serialized = $row['ops_id'] ?? null;
+            if (!is_string($serialized) || $serialized === '') {
+                continue;
+            }
+
+            $ops = @unserialize($serialized, ['allowed_classes' => false]);
+            if (!is_array($ops)) {
+                continue;
+            }
+
+            $ops = array_map('intval', $ops);
+            $has_old = in_array($participate_ops_id, $ops, true) || in_array($unparticipate_ops_id, $ops, true);
+            if (!$has_old) {
+                continue;
+            }
+
+            $ops[] = $read_ops_id;
+            $ops = array_values(array_unique(array_diff($ops, [$participate_ops_id, $unparticipate_ops_id])));
+            sort($ops);
+
+            $this->db->manipulateF(
+                'UPDATE rbac_pa SET ops_id = %s WHERE rol_id = %s AND ref_id = %s',
+                [\ilDBConstants::T_TEXT, \ilDBConstants::T_INTEGER, \ilDBConstants::T_INTEGER],
+                [serialize($ops), (int) $row['rol_id'], (int) $row['ref_id']]
+            );
+        }
+    }
+
+    public function step_2(): void
+    {
+        $participate_ops_id = $this->getOperationId('participate');
+        $unparticipate_ops_id = $this->getOperationId('unparticipate');
+
+        if ($participate_ops_id === null && $unparticipate_ops_id === null) {
+            return;
+        }
+
+        $ops_ids = array_values(array_filter([(int) $participate_ops_id, (int) $unparticipate_ops_id]));
+        if ($ops_ids === []) {
+            return;
+        }
+
+        $in = implode(',', array_map('intval', $ops_ids));
+        $sql =
+            "DELETE FROM rbac_ta " .
+            "WHERE typ_id IN (" .
+                "SELECT obj_id FROM object_data " .
+                "WHERE type = 'typ' AND title = '" . self::TYPE_TITLE . "'" .
+            ") " .
+            "AND ops_id IN (" . $in . ")";
+
+        $this->db->manipulate($sql);
+    }
+
+    private function getOperationId(string $operation): ?int
+    {
+        $res = $this->db->queryF(
+            'SELECT ops_id FROM rbac_operations WHERE operation = %s',
+            [\ilDBConstants::T_TEXT],
+            [$operation]
+        );
+        $row = $this->db->fetchAssoc($res);
+        if (!is_array($row) || !isset($row['ops_id'])) {
+            return null;
+        }
+        return (int) $row['ops_id'];
+    }
+}

--- a/components/ILIAS/LearningSequence/classes/Setup/class.ilLearningSequenceStreamlinePermissionsDBUpdateSteps.php
+++ b/components/ILIAS/LearningSequence/classes/Setup/class.ilLearningSequenceStreamlinePermissionsDBUpdateSteps.php
@@ -20,7 +20,7 @@ declare(strict_types=1);
 
 class ilLearningSequenceStreamlinePermissionsDBUpdateSteps implements \ilDatabaseUpdateSteps
 {
-    private const TYPE_TITLE = 'lso';
+    private const string TYPE_TITLE = 'lso';
 
     protected \ilDBInterface $db;
 

--- a/components/ILIAS/LearningSequence/classes/Setup/class.ilLearningSequenceStreamlinePermissionsDBUpdateSteps.php
+++ b/components/ILIAS/LearningSequence/classes/Setup/class.ilLearningSequenceStreamlinePermissionsDBUpdateSteps.php
@@ -35,7 +35,17 @@ class ilLearningSequenceStreamlinePermissionsDBUpdateSteps implements \ilDatabas
         $participate_ops_id = $this->getOperationId('participate');
         $unparticipate_ops_id = $this->getOperationId('unparticipate');
 
-        if ($read_ops_id === null || $participate_ops_id === null || $unparticipate_ops_id === null) {
+        if ($read_ops_id === null) {
+            throw new \RuntimeException('Cannot migrate learning sequence permissions: RBAC operation "read" not found.');
+        }
+
+        $old_ops_ids = array_values(
+            array_filter([
+                $participate_ops_id,
+                $unparticipate_ops_id
+            ])
+        );
+        if ($old_ops_ids === []) {
             return;
         }
 
@@ -59,13 +69,19 @@ class ilLearningSequenceStreamlinePermissionsDBUpdateSteps implements \ilDatabas
             }
 
             $ops = array_map('intval', $ops);
-            $has_old = in_array($participate_ops_id, $ops, true) || in_array($unparticipate_ops_id, $ops, true);
+            $has_old = false;
+            foreach ($old_ops_ids as $old_ops_id) {
+                if (in_array((int) $old_ops_id, $ops, true)) {
+                    $has_old = true;
+                    break;
+                }
+            }
             if (!$has_old) {
                 continue;
             }
 
             $ops[] = $read_ops_id;
-            $ops = array_values(array_unique(array_diff($ops, [$participate_ops_id, $unparticipate_ops_id])));
+            $ops = array_values(array_unique(array_diff($ops, array_map('intval', $old_ops_ids))));
             sort($ops);
 
             $this->db->manipulateF(

--- a/components/ILIAS/LearningSequence/classes/class.ilObjLearningSequenceAccess.php
+++ b/components/ILIAS/LearningSequence/classes/class.ilObjLearningSequenceAccess.php
@@ -48,11 +48,6 @@ class ilObjLearningSequenceAccess extends ilObjectAccess
                 'cmd' => ilObjLearningSequenceGUI::CMD_SETTINGS,
                 'permission' => 'write',
                 'lang_var' => 'settings'
-            ],
-            [
-                'cmd' => ilObjLearningSequenceGUI::CMD_UNPARTICIPATE,
-                'permission' => 'unparticipate',
-                'lang_var' => 'unparticipate'
             ]
         );
     }

--- a/components/ILIAS/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
+++ b/components/ILIAS/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
@@ -659,9 +659,11 @@ class ilObjLearningSequenceGUI extends ilContainerGUI implements ilCtrlBaseClass
 
     public function unparticipate(): void
     {
-        if ($this->checkAccess('unparticipate')) {
+        if ($this->checkAccess('read')) {
             $usr_id = $this->user->getId();
-            $this->getObject()->getLSRoles()->leave($usr_id);
+            if ($this->getObject()->getLSRoles()->isMember($usr_id)) {
+                $this->getObject()->getLSRoles()->leave($usr_id);
+            }
         }
         $this->ctrl->redirectByClass('ilObjLearningSequenceLearnerGUI', self::CMD_LEARNER_VIEW);
     }
@@ -880,6 +882,7 @@ class ilObjLearningSequenceGUI extends ilContainerGUI implements ilCtrlBaseClass
                     $field_id = $field->getIdentifier();
                     $c[$v->getId()]['udf_' . $field_id] = (string) $v->getAdditionalFieldByIdentifier($field_id);
                 }
+                return $c;
             },
             []
         );


### PR DESCRIPTION
#### Context / Feature request
This PR implements the JourFixe decision (18 MAY 2026) according to the feature wiki entry:
- https://docu.ilias.de/go/wiki/wpage_6707_1357

JourFixe, ILIAS (18 MAY 2026) clarified:
- This request **removes** the permissions `JOIN` and `LEAVE` (shown as `Subscribe`/`Unsubscribe` in the permission tab).
- The **membership service stays** (users can still be added/removed manually as participants).
- **Migration**: roles with `JOIN` and/or `LEAVE` permission will receive `READ` permission.

---

#### Problem
The Learning Sequence (`lso`) previously used `participate`/`unparticipate` (JOIN/LEAVE) for starting/finishing, leading to confusing and error-prone permission setups compared to other ILIAS objects.

---

#### Changes

##### 1) Unify access handling to `read`
- Removed reliance on RBAC operations `participate` and `unparticipate` for launching/starting.
- Launch/start permissions are now based on `checkAccess('read', ...)`.
- Leaving (`unparticipate`) is no longer controlled by RBAC `unparticipate`, but by:
  - user is a **member** (`isMember()`), and
  - user has `read`.
- `ilObjLearningSequenceGUI::unparticipate()` now checks `read` and only calls `leave()` if the user is actually a member.

##### 2) Clean up permission/command offering
- Removed the `unparticipate` permission command from `ilObjLearningSequenceAccess::_getCommands()`.
- This ensures there is no remaining code path that expects `unparticipate` as a configurable permission for `lso`.

##### 3) DB migration + remove legacy ops from the `lso` type
- Added setup DB update steps for the Learning Sequence component:
  - Migrate `rbac_pa` entries for `lso`: convert `participate` and/or `unparticipate` permissions to `read`.
  - Remove `participate` and `unparticipate` from the type operation assignment (`rbac_ta`) for `lso` so `Subscribe`/`Unsubscribe` no longer appear in the permission tab.

#### Migration / upgrade behavior
- After upgrade, any role that previously had `participate` and/or `unparticipate` on Learning Sequences will have `read`.
- The legacy operations `participate`/`unparticipate` are no longer available for `lso` in the permission tab.
- Membership service unchanged