### PR TITLE
[FIX] #46020 UI: accept null for `Field\HasDynamicInputs`

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Checkbox.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Checkbox.php
@@ -53,11 +53,7 @@ class Checkbox extends FormInput implements C\Input\Field\Checkbox, C\Changeable
      */
     protected function isClientSideValueOk($value): bool
     {
-        if ($value == "checked" || $value === "" || is_bool($value)) {
-            return true;
-        } else {
-            return false;
-        }
+        return $value === "checked" || $value === "" || is_bool($value);
     }
 
 
@@ -66,15 +62,7 @@ class Checkbox extends FormInput implements C\Input\Field\Checkbox, C\Changeable
      */
     public function withValue($value): self
     {
-        $value = $value ?? false;
-
-        if (!is_bool($value)) {
-            throw new InvalidArgumentException(
-                "Unknown value type for checkbox: " . gettype($value)
-            );
-        }
-
-        return parent::withValue($value);
+        return parent::withValue($value ?? false);
     }
 
 

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/ColorSelect.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/ColorSelect.php
@@ -58,7 +58,7 @@ class ColorSelect extends FormInput implements C\Input\Field\ColorSelect
     /**
      * @inheritdoc
      */
-    public function isClientSideValueOk($value): bool
+    protected function isClientSideValueOk($value): bool
     {
         return is_string($value);
     }

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/DateTime.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/DateTime.php
@@ -176,7 +176,7 @@ class DateTime extends FormInput implements C\Input\Field\DateTime
 
     protected function isClientSideValueOk($value): bool
     {
-        if ($value instanceof \DateTimeImmutable || is_null($value)) {
+        if ($value instanceof \DateTimeImmutable) {
             return true;
         }
 

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/File.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/File.php
@@ -127,34 +127,6 @@ class File extends HasDynamicInputs implements C\Input\Field\File
     // END IMPLEMENTATION OF FileUpload
     // ===============================================
 
-    // ===============================================
-    // BEGIN OVERWRITTEN METHODS OF HasDynamicInputs
-    // ===============================================
-
-    /**
-     * Maps generated dynamic inputs to their file-id, which must be
-     * provided in or as $value.
-     */
-    public function withValue($value): HasDynamicInputs
-    {
-        $this->checkArg("value", $this->isClientSideValueOk($value), "Display value does not match input type.");
-
-        $clone = clone $this;
-        foreach ($value as $data) {
-            $file_id = ($clone->hasMetadataInputs()) ? $data[0] : $data;
-
-            // that was not implicitly intended, but mapping dynamic inputs
-            // to the file-id is also a duplicate protection.
-            $clone->generated_dynamic_inputs[$file_id] = $clone->getTemplateForDynamicInputs()->withValue($data);
-        }
-
-        return $clone;
-    }
-
-    // ===============================================
-    // END OVERWRITTEN METHODS OF HasDynamicInputs
-    // ===============================================
-
     public function hasMetadataInputs(): bool
     {
         return $this->has_metadata_inputs;
@@ -200,20 +172,14 @@ class File extends HasDynamicInputs implements C\Input\Field\File
         if (!is_array($value)) {
             return false;
         }
-
         foreach ($value as $data) {
-            // if no dynamic input template was provided, the values
-            // must all be strings (possibly file-ids).
-            if (!is_string($data) && !$this->hasMetadataInputs()) {
+            if (!$this->hasMetadataInputs() && !is_string($data)) {
                 return false;
             }
-            // if a dynamic input template was provided, the values
-            // must be valid for the template input.
-            if ($this->hasMetadataInputs() && !$this->dynamic_input_template->isClientSideValueOk($data)) {
+            if ($this->hasMetadataInputs() && !is_string($data[0])) {
                 return false;
             }
         }
-
         return true;
     }
 

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/File.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/File.php
@@ -140,14 +140,12 @@ class File extends HasDynamicInputs implements C\Input\Field\File
         $this->checkArg("value", $this->isClientSideValueOk($value), "Display value does not match input type.");
 
         $clone = clone $this;
-        if (is_array($value)) {
-            foreach ($value as $data) {
-                $file_id = ($clone->hasMetadataInputs()) ? $data[0] : $data;
+        foreach ($value as $data) {
+            $file_id = ($clone->hasMetadataInputs()) ? $data[0] : $data;
 
-                // that was not implicitly intended, but mapping dynamic inputs
-                // to the file-id is also a duplicate protection.
-                $clone->generated_dynamic_inputs[$file_id] = $clone->getTemplateForDynamicInputs()->withValue($data);
-            }
+            // that was not implicitly intended, but mapping dynamic inputs
+            // to the file-id is also a duplicate protection.
+            $clone->generated_dynamic_inputs[$file_id] = $clone->getTemplateForDynamicInputs()->withValue($data);
         }
 
         return $clone;

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/HasDynamicInputs.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/HasDynamicInputs.php
@@ -92,8 +92,13 @@ abstract class HasDynamicInputs extends FormInput
      */
     public function withValue($value): self
     {
-        $this->checkArg('value', $this->isClientSideValueOk($value), "Display value does not match input(-template) type.");
+        $this->checkArg('value', null === $value || $this->isClientSideValueOk($value), "Display value does not match input(-template) type.");
         $clone = clone $this;
+
+        if (null === $value) {
+            $clone->generated_dynamic_inputs = [];
+            return $clone;
+        }
 
         if (!is_array($value)) {
             $clone->generated_dynamic_inputs[] = $clone->getTemplateForDynamicInputs()->withValue($value);

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/HasDynamicInputs.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/HasDynamicInputs.php
@@ -95,13 +95,13 @@ abstract class HasDynamicInputs extends FormInput
         $this->checkArg('value', $this->isClientSideValueOk($value), "Display value does not match input(-template) type.");
         $clone = clone $this;
 
-        if (is_array($value)) {
-            foreach ($value as $input_name => $input_value) {
-                $clone->generated_dynamic_inputs[$input_name] = $clone->getTemplateForDynamicInputs()->withValue($input_value);
-            }
-        } elseif ($value !== null) {
+        if (!is_array($value)) {
             $clone->generated_dynamic_inputs[] = $clone->getTemplateForDynamicInputs()->withValue($value);
             return $clone;
+        }
+
+        foreach ($value as $input_name => $input_value) {
+            $clone->generated_dynamic_inputs[$input_name] = $clone->getTemplateForDynamicInputs()->withValue($input_value);
         }
 
         return $clone;

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/MultiSelect.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/MultiSelect.php
@@ -51,9 +51,6 @@ class MultiSelect extends FormInput implements C\Input\Field\MultiSelect, HasOpt
      */
     protected function isClientSideValueOk($value): bool
     {
-        if (is_null($value)) {
-            return true;
-        }
         if (is_array($value)) {
             foreach ($value as $v) {
                 if (!array_key_exists($v, $this->options)) {

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Numeric.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Numeric.php
@@ -49,7 +49,7 @@ class Numeric extends FormInput implements C\Input\Field\Numeric
      */
     protected function isClientSideValueOk($value): bool
     {
-        return is_numeric($value) || $value === "" || $value === null;
+        return is_numeric($value) || $value === "";
     }
 
     /**

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/OptionalGroup.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/OptionalGroup.php
@@ -22,6 +22,7 @@ namespace ILIAS\UI\Implementation\Component\Input\Field;
 
 use ILIAS\Refinery\Constraint;
 use ILIAS\UI\Implementation\Component\JavaScriptBindable;
+use ILIAS\UI\Implementation\Component\Input\Input;
 use ILIAS\UI\Implementation\Component\Triggerer;
 use ILIAS\UI\Component\Input\InputData;
 use ILIAS\UI\Component\Input\Field as I;
@@ -49,17 +50,6 @@ class OptionalGroup extends Group implements I\OptionalGroup
         return null;
     }
 
-    /**
-     * @inheritdoc
-     */
-    protected function isClientSideValueOk($value): bool
-    {
-        if ($value === null) {
-            return true;
-        }
-        return parent::isClientSideValueOk($value);
-    }
-
     public function withRequired($is_required, ?Constraint $requirement_constraint = null): self
     {
         /** @noinspection PhpIncompatibleReturnTypeInspection */
@@ -77,8 +67,7 @@ class OptionalGroup extends Group implements I\OptionalGroup
     public function withValue($value): self
     {
         if ($value === null) {
-            $clone = clone $this;
-            $clone->value = $value;
+            $clone = Input::withValue($value);
             $clone->null_value_was_explicitly_set = true;
             return $clone;
         }

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Radio.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Radio.php
@@ -47,7 +47,7 @@ class Radio extends FormInput implements C\Input\Field\Radio, HasOptionFilterInt
      */
     protected function isClientSideValueOk($value): bool
     {
-        return ($value === null || array_key_exists($value, $this->getOptions()));
+        return array_key_exists($value, $this->getOptions());
     }
 
     /**

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Rating.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Rating.php
@@ -45,10 +45,10 @@ class Rating extends FormInput implements C\Input\Field\Rating
     {
         return $this->refinery->custom()->transformation(
             static function ($v): ?FiveStarRatingScale {
-                if(is_null($v) || $v instanceof FiveStarRatingScale) {
+                if (is_null($v) || $v instanceof FiveStarRatingScale) {
                     return $v;
                 }
-                return FiveStarRatingScale::from((int)$v);
+                return FiveStarRatingScale::from((int) $v);
             }
         );
     }
@@ -67,15 +67,15 @@ class Rating extends FormInput implements C\Input\Field\Rating
 
     public function withValue($value): self
     {
-        if(!$value instanceof FiveStarRatingScale) {
+        if (!$value instanceof FiveStarRatingScale) {
             $value = $this->getFiveStarRatingScaleTransformation()->transform($value);
         }
         return parent::withValue($value);
     }
 
-    public function isClientSideValueOk($value): bool
+    protected function isClientSideValueOk($value): bool
     {
-        return is_null($value) || is_numeric($value) || $value instanceof FiveStarRatingScale;
+        return is_numeric($value) || $value instanceof FiveStarRatingScale;
     }
 
     protected function getConstraintForRequirement(): ?Constraint
@@ -100,7 +100,7 @@ class Rating extends FormInput implements C\Input\Field\Rating
     public function withCurrentAverage(?float $current_average): static
     {
         $max = count(FiveStarRatingScale::cases()) - 1;
-        if($current_average < 0 || $current_average > $max) {
+        if ($current_average < 0 || $current_average > $max) {
             throw new \InvalidArgumentException('current_average must be between 0 and ' . $max);
         }
         $clone = clone $this;

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/SwitchableGroup.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/SwitchableGroup.php
@@ -23,6 +23,7 @@ namespace ILIAS\UI\Implementation\Component\Input\Field;
 use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Refinery\Constraint;
 use ILIAS\UI\Implementation\Component\JavaScriptBindable;
+use ILIAS\UI\Implementation\Component\Input\Input;
 use ILIAS\UI\Implementation\Component\Triggerer;
 use ILIAS\UI\Component\Input\InputData;
 use ILIAS\UI\Component\Input\Field as I;
@@ -94,14 +95,14 @@ class SwitchableGroup extends Group implements I\SwitchableGroup
      */
     public function withValue($value): self
     {
-        $this->checkArg('value', $this->isClientSideValueOk($value), 'Display value does not match input type.');
-        if (is_string($value) || is_int($value)) {
+        $this->checkArg('value', null === $value || $this->isClientSideValueOk($value), 'Display value does not match input type.');
+        if (null === $value || is_string($value) || is_int($value)) {
             /** @noinspection PhpIncompatibleReturnTypeInspection */
-            return FormInput::withValue($value);
+            return Input::withValue($value);
         }
         [$key, $group_value] = $value;
         /** @var $clone self */
-        $clone = FormInput::withValue($key);
+        $clone = Input::withValue($key);
         $clone->setInputs($clone->getInputsWithOperationForKey($key, fn($i) => $i->withValue($group_value)));
         return $clone;
     }
@@ -111,7 +112,7 @@ class SwitchableGroup extends Group implements I\SwitchableGroup
      */
     public function getValue()
     {
-        $key = FormInput::getValue();
+        $key = Input::getValue();
         if (is_null($key)) {
             return null;
         }

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Tag.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Tag.php
@@ -176,7 +176,7 @@ class Tag extends FormInput implements C\Input\Field\Tag
             ->applyTo(new Ok($value))
             ->isOK();
 
-        return ($this->refinery->null()->accepts($value) || $valueCanBeAddedAsStringToList);
+        return $valueCanBeAddedAsStringToList;
     }
 
 

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/TreeSelect.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/TreeSelect.php
@@ -73,9 +73,6 @@ class TreeSelect extends HasDynamicInputs implements C\Input\Field\TreeSelect
 
     protected function isClientSideValueOk($value): bool
     {
-        if (is_null($value)) {
-            return parent::isClientSideValueOk($value);
-        }
         if (!is_string($value) && !is_int($value)) {
             return false;
         }

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Group.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Group.php
@@ -60,10 +60,12 @@ trait Group
      */
     public function withValue($value): self
     {
-        $this->checkArg("value", $this->isClientSideValueOk($value), "Display value does not match input type.");
+        $this->checkArg("value", null === $value || $this->isClientSideValueOk($value), "Display value does not match input type.");
         $clone = clone $this;
         foreach ($this->getInputs() as $k => $i) {
-            $clone->inputs[$k] = $i->withValue($value[$k]);
+            // note isClientSideValueOk() verifies the structure, there
+            // are no false-positives due to coalescing
+            $clone->inputs[$k] = $i->withValue($value[$k] ?? null);
         }
         return $clone;
     }

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Input.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Input.php
@@ -95,12 +95,12 @@ abstract class Input implements InputInternal
      * Get an input like this with another value displayed on the
      * client side.
      *
-     * @param   mixed $value
-     * @throws  InvalidArgumentException    if value does not fit client side input
+     * @param mixed $value              provide null to set the inputs default value (may not be null!)
+     * @throws InvalidArgumentException if value does not fit client side input
      */
     public function withValue($value): self
     {
-        $this->checkArg("value", $this->isClientSideValueOk($value), "Display value does not match input type.");
+        $this->checkArg("value", null === $value || $this->isClientSideValueOk($value), "Display value does not match input type.");
         $clone = clone $this;
         $clone->value = $value;
         return $clone;
@@ -108,6 +108,9 @@ abstract class Input implements InputInternal
 
     /**
      * Check if the value is good to be displayed client side.
+     *
+     * Do not handle null, as this is a special case which is
+     * already handled by {@see Input::withValue()}.
      *
      * @param mixed $value
      */

--- a/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/FieldSelection.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/FieldSelection.php
@@ -45,7 +45,7 @@ class FieldSelection extends ViewControlInput implements VCInterface\FieldSelect
 
     protected function isClientSideValueOk($value): bool
     {
-        return is_null($value) || is_array($value);
+        return is_array($value);
     }
 
     public function getInternalSignal(): Signal

--- a/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/Mode.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/Mode.php
@@ -51,7 +51,7 @@ class Mode extends ViewControlInput implements VCInterface\Mode
 
     protected function isClientSideValueOk($value): bool
     {
-        return is_null($value) || is_string($value);
+        return is_string($value);
     }
 
     public function getOptions(): array

--- a/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/NullControl.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/NullControl.php
@@ -25,7 +25,7 @@ use ILIAS\Data\Result;
 
 class NullControl extends ViewControlInput implements VCInterface\NullControl
 {
-    public function isClientSideValueOk($value): bool
+    protected function isClientSideValueOk($value): bool
     {
         return true;
     }

--- a/components/ILIAS/UI/tests/Component/Input/Field/ColorSelectTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/ColorSelectTest.php
@@ -125,7 +125,7 @@ class ColorSelectTest extends ILIAS_UI_TestBase
     {
         $f = $this->getFieldFactory();
         $color_select = $f->colorSelect("label", "byline");
-        $this->expectException(\InvalidArgumentException::class);
         $color_select->withValue(null);
+        $this->assertEquals(null, $color_select->getValue());
     }
 }

--- a/components/ILIAS/UI/tests/Component/Input/Field/SwitchableGroupInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/SwitchableGroupInputTest.php
@@ -205,12 +205,6 @@ class SwitchableGroupInputTest extends ILIAS_UI_TestBase
         $this->assertNotSame($this->switchable_group, $new_group);
     }
 
-    public function testGroupOnlyDoesNotAcceptNonArrayValue(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->switchable_group->withValue(null);
-    }
-
     public function testGroupOnlyDoesNoAcceptArrayValuesWithWrongLength(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/components/ILIAS/UI/tests/Component/Input/Field/TreeSelectTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/TreeSelectTest.php
@@ -148,20 +148,12 @@ class TreeSelectTest extends \ILIAS_UI_TestBase
     }
 
     /** @dataProvider getValidArgumentsForWithValue */
-    public function testWithValueForValidArguments(string|int $value): void
+    public function testWithValueForValidArguments(string|int|null $value): void
     {
         $node_retrieval = $this->getNodeRetrieval();
         $component = $this->getFieldFactory()->treeSelect($node_retrieval, '');
         $component = $component->withValue($value);
         $this->assertEquals([$value], $component->getValue());
-    }
-
-    public function testWithValueForEmptyValidArguments(): void
-    {
-        $node_retrieval = $this->getNodeRetrieval();
-        $component = $this->getFieldFactory()->treeSelect($node_retrieval, '');
-        $component = $component->withValue(null);
-        $this->assertEquals([], $component->getValue());
     }
 
     public function testRenderWithValue(): void
@@ -340,6 +332,7 @@ HTML;
             ['1'],
             [''],
             [' '],
+            [null],
         ];
     }
 

--- a/components/ILIAS/UI/tests/Component/Input/Field/TreeSelectTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/TreeSelectTest.php
@@ -148,12 +148,20 @@ class TreeSelectTest extends \ILIAS_UI_TestBase
     }
 
     /** @dataProvider getValidArgumentsForWithValue */
-    public function testWithValueForValidArguments(string|int|null $value): void
+    public function testWithValueForValidArguments(string|int $value): void
     {
         $node_retrieval = $this->getNodeRetrieval();
         $component = $this->getFieldFactory()->treeSelect($node_retrieval, '');
         $component = $component->withValue($value);
         $this->assertEquals([$value], $component->getValue());
+    }
+
+    public function testWithValueForNull(): void
+    {
+        $node_retrieval = $this->getNodeRetrieval();
+        $component = $this->getFieldFactory()->treeSelect($node_retrieval, '');
+        $component = $component->withValue(null);
+        $this->assertEquals([], $component->getValue());
     }
 
     public function testRenderWithValue(): void
@@ -332,7 +340,6 @@ HTML;
             ['1'],
             [''],
             [' '],
-            [null],
         ];
     }
 


### PR DESCRIPTION
Hi @iszmais,

I noticed we may not have solved https://mantis.ilias.de/view.php?id=46020 correctly with #11351, because I began to think `withValue()` should reset the generated inputs in case of previous values. But this brought up the question of how `null` should be treated in general. IMO we can go two ways here: a) treat the value in a sense of not processing, or b) treat the value in a sense of resetting values. So before I continue I would like to discuss this topic here, because the `Image` and `File` input both use a `Group`, which means that I would have to fully implement the `null` behaviour consistently over all inputs already.

This PR therefore reverts your initial fix and replaces it with my own approach. I streamlined the derived classes so most of this logic can now be handled by the base class (as it should have in the first place).

Since you are still familiar with the topic, may I ask you to shepherd this PR? Please note that this PR is not finished, because I did not implement the "resetting behaviour" for groups yet.

Thx and kind regards,
@thibsy