### PR TITLE
[FIX] 47844: Objects askew – scope dropzone flex styling out of object list rows

### DIFF
--- a/templates/default/070-components/UI-framework/Dropzone/_ui-component_dropzone.scss
+++ b/templates/default/070-components/UI-framework/Dropzone/_ui-component_dropzone.scss
@@ -23,7 +23,7 @@
 	}
 }
 
-.ui-dropzone-container {
+.ui-dropzone-container:not(.ilObjListRow .ui-dropzone-container) {
 	display: flex;
 	flex-direction: row-reverse;
 	justify-content: space-between;	

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -4865,7 +4865,7 @@ hr.il-divider-with-label {
   padding: 15px 12px;
 }
 
-.ui-dropzone-container {
+.ui-dropzone-container:not(.ilObjListRow .ui-dropzone-container) {
   display: flex;
   flex-direction: row-reverse;
   justify-content: space-between;


### PR DESCRIPTION
Forward-port of the `release_11` fix for Mantis [#47844](https://mantis.ilias.de/view.php?id=47844) ("Objects askew") to `trunk`.

## Problem
The `.ui-dropzone-container` flex styling (`flex-direction: row-reverse`) was also applied to dropzone containers inside object list rows (`.ilObjListRow`), making list items render askew / reordered.

## Fix
Scope the rule so it no longer matches dropzone containers within `.ilObjListRow`:

```diff
-.ui-dropzone-container {
+.ui-dropzone-container:not(.ilObjListRow .ui-dropzone-container) {
```

Applied to the SCSS source and the compiled `delos.css`.

## Provenance
Cherry-picked from `release_11` (already resolved there), authored by Bettina Solzbacher:
- `823355364f5` — SCSS source (`_ui-component_dropzone.scss`)
- `3a820d9ecbe` — compiled `delos.css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
