### PR TITLE
Support OIDC registration prompt

### DIFF
--- a/components/ILIAS/OpenIdConnect/classes/class.ilAuthFrontendCredentialsOpenIdConnect.php
+++ b/components/ILIAS/OpenIdConnect/classes/class.ilAuthFrontendCredentialsOpenIdConnect.php
@@ -22,9 +22,11 @@ class ilAuthFrontendCredentialsOpenIdConnect extends ilAuthFrontendCredentials
 {
     private const SESSION_TARGET = 'oidc_target';
     private const QUERY_PARAM_TARGET = 'target';
+    private const QUERY_PARAM_REGISTER = 'register';
 
     private readonly ilOpenIdConnectSettings $settings;
     private ?string $target = null;
+    private bool $registration_requested = false;
 
     public function __construct()
     {
@@ -37,6 +39,12 @@ class ilAuthFrontendCredentialsOpenIdConnect extends ilAuthFrontendCredentials
         if ($httpquery->has(self::QUERY_PARAM_TARGET)) {
             $this->target = $httpquery->retrieve(self::QUERY_PARAM_TARGET, $DIC->refinery()->to()->string());
         }
+        if ($httpquery->has(self::QUERY_PARAM_REGISTER)) {
+            $this->registration_requested = $httpquery->retrieve(
+                self::QUERY_PARAM_REGISTER,
+                $DIC->refinery()->kindlyTo()->bool()
+            );
+        }
     }
 
     protected function getSettings(): ilOpenIdConnectSettings
@@ -47,6 +55,11 @@ class ilAuthFrontendCredentialsOpenIdConnect extends ilAuthFrontendCredentials
     public function getRedirectionTarget(): ?string
     {
         return $this->target;
+    }
+
+    public function isRegistrationRequested(): bool
+    {
+        return $this->registration_requested;
     }
 
     public function initFromRequest(): void

--- a/components/ILIAS/OpenIdConnect/classes/class.ilAuthProviderOpenIdConnect.php
+++ b/components/ILIAS/OpenIdConnect/classes/class.ilAuthProviderOpenIdConnect.php
@@ -95,7 +95,14 @@ class ilAuthProviderOpenIdConnect extends ilAuthProvider
             );
 
             $oidc->addScope($this->settings->getAllScopes());
-            if ($this->settings->getLoginPromptType() === ilOpenIdConnectSettings::LOGIN_ENFORCE) {
+
+            $credentials = $this->getCredentials();
+            if (
+                $credentials instanceof ilAuthFrontendCredentialsOpenIdConnect &&
+                $credentials->isRegistrationRequested()
+            ) {
+                $oidc->addAuthParam(['prompt' => 'create']);
+            } elseif ($this->settings->getLoginPromptType() === ilOpenIdConnectSettings::LOGIN_ENFORCE) {
                 $oidc->addAuthParam(['prompt' => 'login']);
             }
 


### PR DESCRIPTION
Allow the OpenID Connect login endpoint to receive a register flag and carry that intent through the OIDC credentials object. When registration is requested, send prompt=create to the provider instead of the regular forced login prompt.

This lets ILIAS initiate the OIDC request itself, preserving state handling while delegating account registration to the identity provider.

https://openid.net/specs/openid-connect-prompt-create-1_0.html