### PR TITLE
Improvement: add UNPROCESSABLE_ENTITY status code (422)

### DIFF
--- a/components/ILIAS/HTTP/src/StatusCode.php
+++ b/components/ILIAS/HTTP/src/StatusCode.php
@@ -71,6 +71,7 @@ interface StatusCode
     public const HTTP_UNSUPPORTED_MEDIA_TYPE = 415;
     public const HTTP_REQUESTED_RANGE_NOT_SATISFIABLE = 416;
     public const HTTP_EXPECTATION_FAILED = 417;
+    public const HTTP_UNPROCESSABLE_ENTITY = 422;
     public const HTTP_TOO_MANY_REQUESTS = 429;
     // [Server Error 5xx]
 


### PR DESCRIPTION
This PR introduces the standard HTTP 422 Unprocessable Entity status code constant. This allows services to return precise error responses when client input fails validation or cannot be processed by the server logic.