### PR TITLE
Improvement: refine UI input method contracts & component documentation

### DIFF
--- a/components/ILIAS/UI/src/Component/Component.php
+++ b/components/ILIAS/UI/src/Component/Component.php
@@ -34,7 +34,7 @@ interface Component
     /**
      * The scheme starts at the leaves of the structure and applies the function
      * to each leave and moves up the tree recursively.
-     * @param Closure(Component, array): mixed $fn
+     * @param \Closure(Component, array): mixed $fn
      */
     public function reduceWith(\Closure $fn): mixed;
 

--- a/components/ILIAS/UI/src/Component/Input/Field/Numeric.php
+++ b/components/ILIAS/UI/src/Component/Input/Field/Numeric.php
@@ -28,6 +28,15 @@ use ILIAS\UI\Component\Input\Container\Filter\FilterInput;
 interface Numeric extends FilterInput
 {
     /**
+     * Returns the step size used for this numeric input field.
+     * This value specifies the step size used when incrementing or decrementing the field's value
+     * via arrow controls, or during validation checks.
+     *
+     * @return int|float The configured step size of the input field.
+     */
+    public function getStepSize(): int|float;
+
+    /**
      * This will not only set the steps for the input's arrow controls,
      * but will also alter the field's transformation.
      * The value will be the same type as the parameter given here,

--- a/components/ILIAS/UI/src/Component/Input/Input.php
+++ b/components/ILIAS/UI/src/Component/Input/Input.php
@@ -69,6 +69,17 @@ interface Input extends Component
     public function withAdditionalTransformation(Transformation $trafo);
 
     /**
+     * Retrieves the dedicated name for this input component.
+     * This name, if set via {@see Input::withDedicatedName(string $dedicated_name)},
+     * is used in the NAME attribute of the rendered input (instead of the auto-generated 'input_x').
+     * If no dedicated name was set, it returns null.
+     * The dedicated name can be useful for customizing how inputs are submitted or referenced programmatically.
+     *
+     * @return string|null The optional dedicated name assigned to this input, or null if none is set.
+     */
+    public function getDedicatedName(): ?string;
+
+    /**
      * Sets an optional dedicated name for this input which is used in the NAME
      * attribute of the rendered input (instead of the auto-generated 'input_x').
      * If the same dedicated name is used more than once, a counter will be

--- a/components/ILIAS/UI/tests/Component/Input/Container/Filter/FilterTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Filter/FilterTest.php
@@ -452,6 +452,7 @@ class FilterTest extends ILIAS_UI_TestBase
             ->getMockBuilder(Input\Field\FormInputInternal::class)
             ->onlyMethods([
                 "getName",
+                "getDedicatedName",
                 "withDedicatedName",
                 "withNameFrom",
                 "withInput",

--- a/components/ILIAS/UI/tests/Component/Input/Container/Form/FormTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Form/FormTest.php
@@ -437,6 +437,7 @@ class FormTest extends ILIAS_UI_TestBase
             ->getMockBuilder(Input\Field\FormInputInternal::class)
             ->onlyMethods([
                 "getName",
+                "getDedicatedName",
                 "withDedicatedName",
                 "withNameFrom",
                 "withInput",


### PR DESCRIPTION
This PR enhances method signatures in the UI component Input interfaces.

The changes include:

- `getStepSize()`: Added contract definition to `Numeric` interface.
- `getDedicatedName()`: Added contract definition to `Input` interface.
- Corrected dockblock in `UI\Component\Component`.

_Note: declared methods already exist in related implementations._


## Why are these methods needed in the public contracts?

`ILIAS\Component\Activities\Activity::getInputDescription()` exposes the UI input description that serves as a machine-readable schema for activity input validation. [[L](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/components/ILIAS/Component/src/Activities/Activity.php)]

As part of the new ILIAS Webservices component, we plan to consume the input description from the activities in REST endpoints. We currently want to use this schema in two places:

### `getDedicatedName()`

`getDedicatedName()` is used to reconstruct the input mapping and validate incoming webservice requests against the expected form input names.

Example:

```php
/**
 * @var \ILIAS\UI\Factory $factory
 * @var \ILIAS\Component\Activities\Activity $activity
 * @var \ILIAS\UI\Component\Input\Container\Form\FormInput $inputDescription
 * @var array<\ILIAS\UI\Component\Input\Container\Form\FormInput> $inputs
 */
$inputDescription = $activity->getInputDescription();
$inputs = $inputDescription->getInputs();

// Reconstruct associative array using dedicated names to ensure form mapping works correctly.
$namedInputs = [];

foreach ($inputs as $input) {
    $dedicatedName = $input->getDedicatedName();
    $key = ($dedicatedName !== null && $dedicatedName !== '')
        ? $dedicatedName
        : $input->getLabel();

    $namedInputs[$key] = $input;
}

$form = $factory->input()
    ->container()
    ->form()
    ->standard('', $namedInputs);
```

### `getStepSize()`

`getStepSize()` is used to determine the appropriate OpenAPI numeric type (`integer` or `number`) when generating the API specification.

See: https://swagger.io/docs/specification/v3_0/data-models/data-types/#numbers

Example:

```php
/** @var \ILIAS\UI\Component\Input\Input $input */
$stepSize = (float) $input->getStepSize();
$hasPrecision = (floor($stepSize) !== $stepSize);

$type = $hasPrecision ? 'number' : 'integer';
$format = $hasPrecision ? 'double' : '';
```

## Existing public implementations

The proposed methods are already declared `public` in their corresponding implementation classes:

- `ILIAS\UI\Implementation\Component\Input\Input::getDedicatedName()` (also has `@inheritdoc`)
- `ILIAS\UI\Implementation\Component\Input\Field\Numeric::getStepSize()`

This change adds them to the corresponding interfaces so consumers of `getInputDescription()` can rely on the public contracts instead of concrete implementation classes.