### PR TITLE
fix UI Mantis 47772 -  fix alignment of dropdown menu im Slate/Page Editor

### DIFF
--- a/templates/default/070-components/UI-framework/Dropdown/_ui-component_dropdown.scss
+++ b/templates/default/070-components/UI-framework/Dropdown/_ui-component_dropdown.scss
@@ -309,7 +309,7 @@ $cursor-disabled: not-allowed !default;
 //Note, this is a rather nasty fix for #27751
 //Should be removed in upcoming version
 .il-maincontrols-slate-content{
-	.dropdown-menu{
+	.ilFloatRight .dropdown-menu{
 		right: 0;
 		left: inherit;
 	}

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -264,7 +264,7 @@
   cursor: pointer;
 }
 .bootstrap-datetimepicker-widget table thead tr:first-child th:hover {
-  background: #e2e8ef;
+  background: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   color: black;
 }
 .bootstrap-datetimepicker-widget table td {
@@ -284,7 +284,7 @@
   width: 20px;
 }
 .bootstrap-datetimepicker-widget table td.day:hover, .bootstrap-datetimepicker-widget table td.hour:hover, .bootstrap-datetimepicker-widget table td.minute:hover, .bootstrap-datetimepicker-widget table td.second:hover {
-  background: #e2e8ef;
+  background: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   color: black;
   cursor: pointer;
 }
@@ -299,14 +299,14 @@
   display: inline-block;
   border: solid transparent;
   border-width: 0 0 7px 7px;
-  border-bottom-color: #557b2e;
+  border-bottom-color: rgb(84.5, 122.9090909091, 46.0909090909);
   border-top-color: rgba(0, 0, 0, 0.2);
   position: absolute;
   bottom: 4px;
   right: 4px;
 }
 .bootstrap-datetimepicker-widget table td.active, .bootstrap-datetimepicker-widget table td.active:hover {
-  background-color: #557b2e;
+  background-color: rgb(84.5, 122.9090909091, 46.0909090909);
   color: white;
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
 }
@@ -328,11 +328,11 @@
   border-radius: 0px;
 }
 .bootstrap-datetimepicker-widget table td span:hover {
-  background: #e2e8ef;
+  background: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   color: black;
 }
 .bootstrap-datetimepicker-widget table td span.active {
-  background-color: #557b2e;
+  background-color: rgb(84.5, 122.9090909091, 46.0909090909);
   color: white;
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
 }
@@ -538,7 +538,7 @@
 .dropdown-menu li .btn-link:hover,
 .dropdown-menu li .btn-link:focus {
   color: black;
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   text-decoration: none;
 }
 .dropdown-menu li a[disabled],
@@ -571,7 +571,7 @@
   margin: 3px 0;
 }
 
-.il-maincontrols-slate-content .dropdown-menu {
+.il-maincontrols-slate-content .ilFloatRight .dropdown-menu {
   right: 0;
   left: inherit;
 }
@@ -607,7 +607,7 @@
   background-color: transparent;
 }
 .ui-menu .ui-menu-item > *:hover, .ui-menu .ui-menu-item > *.ui-state-hover, .ui-menu .ui-menu-item > *.ui-state-active {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   color: #161616;
 }
 .ui-menu .ui-menu-item a {
@@ -2326,7 +2326,7 @@ a {
   /* END WebDAV: Enable links with AnchorClick behavior for Internet Explorer. */
 }
 a:hover, a:focus {
-  color: #3a4c65;
+  color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
   text-decoration: underline;
 }
 a:focus-visible {
@@ -2452,15 +2452,15 @@ strong, b {
 code {
   font-family: Pragmata, Menlo, "DejaVu LGC Sans Mono", "DejaVu Sans Mono", Consolas, "Everson Mono", "Lucida Console", "Andale Mono", "Nimbus Mono L", "Liberation Mono", FreeMono, "Osaka Monospaced", Courier, "New Courier", monospace;
   font-size: 0.75rem;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
 }
 
 ::selection {
-  background: #e2e8ef;
+  background: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 
 ::-moz-selection {
-  background: #e2e8ef;
+  background: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 
 @media print {
@@ -2571,7 +2571,7 @@ code {
   color: #4c6586;
 }
 .breadcrumb-wrapper .breadcrumb div.breadcrumb-crumb a:hover {
-  color: #3a4c65;
+  color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
 }
 .breadcrumb-wrapper .breadcrumb div.breadcrumb-crumb a:focus {
   border: inherit;
@@ -2640,22 +2640,6 @@ ol.breadcrumb > li + li:before {
 .il-drilldown .menulevel, .navbar-form > a {
   display: inline-flex;
   vertical-align: middle;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  user-select: none;
-  touch-action: manipulation;
-  font-family: "Open Sans", Verdana, Arial, Helvetica, sans-serif;
-  text-align: center;
-  line-height: inherit;
-  font-size: inherit;
-  font-weight: 400;
-  text-decoration: none;
-  min-height: 28px;
-  min-width: 28px;
-  font-size: 0.75rem;
-  padding: 3px 6px;
-  gap: 6px;
 }
 .btn + .btn, .il-link.link-bulky + .btn,
 .il-drilldown .menulevel + .btn, .btn + .il-link.link-bulky, .il-link.link-bulky + .il-link.link-bulky,
@@ -2667,10 +2651,32 @@ ol.breadcrumb > li + li:before {
 .il-drilldown .navbar-form > .menulevel + a, .navbar-form > a + a {
   margin-left: 3px;
 }
+.btn, .il-link.link-bulky,
+.il-drilldown .menulevel, .navbar-form > a {
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  user-select: none;
+  touch-action: manipulation;
+  font-family: "Open Sans", Verdana, Arial, Helvetica, sans-serif;
+  text-align: center;
+  line-height: inherit;
+  font-size: inherit;
+  font-weight: 400;
+  text-decoration: none;
+}
 .btn:focus-visible, .il-link.link-bulky:focus-visible,
 .il-drilldown .menulevel:focus-visible, .navbar-form > a:focus-visible {
   outline: 3px solid #0078D7;
   box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 5px #FFFFFF;
+}
+.btn, .il-link.link-bulky,
+.il-drilldown .menulevel, .navbar-form > a {
+  min-height: 28px;
+  min-width: 28px;
+  font-size: 0.75rem;
+  padding: 3px 6px;
+  gap: 6px;
 }
 .btn .glyph, .il-link.link-bulky .glyph,
 .il-drilldown .menulevel .glyph, .navbar-form > a .glyph,
@@ -2714,19 +2720,19 @@ input.btn, input.il-link.link-bulky,
 }
 .btn-default:hover, .navbar-form > a:hover {
   text-decoration: none;
-  background-color: #3a4c65;
+  background-color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
   color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #3a4c65;
+  border-color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
 }
 .btn-default:active, .navbar-form > a:active {
   transform: none;
-  background-color: #273445;
+  background-color: rgb(39.0857142857, 51.9428571429, 68.9142857143);
   color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #273445;
+  border-color: rgb(39.0857142857, 51.9428571429, 68.9142857143);
 }
 .btn-default:focus, .navbar-form > a:focus {
   color: white;
@@ -2757,28 +2763,28 @@ input.btn, input.il-link.link-bulky,
   font-size: 0.75rem;
   padding: 3px 6px;
   gap: 6px;
-  background-color: #557b2e;
+  background-color: rgb(84.5, 122.9090909091, 46.0909090909);
   color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #557b2e;
+  border-color: rgb(84.5, 122.9090909091, 46.0909090909);
   border-radius: 0px;
 }
 .btn-primary:hover {
   text-decoration: none;
-  background-color: #3b5620;
+  background-color: rgb(59, 85.8181818182, 32.1818181818);
   color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #3b5620;
+  border-color: rgb(59, 85.8181818182, 32.1818181818);
 }
 .btn-primary:active {
   transform: none;
-  background-color: #223112;
+  background-color: rgb(33.5, 48.7272727273, 18.2727272727);
   color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #223112;
+  border-color: rgb(33.5, 48.7272727273, 18.2727272727);
 }
 .btn-primary:focus {
   color: white;
@@ -2798,7 +2804,7 @@ input.btn, input.il-link.link-bulky,
   background-color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #557b2e;
+  border-color: rgb(84.5, 122.9090909091, 46.0909090909);
   color: #161616;
 }
 
@@ -2822,31 +2828,9 @@ input.btn, input.il-link.link-bulky,
 .il-viewcontrol-sortation .dropdown > .btn-default.btn,
 .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link,
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
   display: inline-flex;
   vertical-align: middle;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  user-select: none;
-  touch-action: manipulation;
-  font-family: "Open Sans", Verdana, Arial, Helvetica, sans-serif;
-  text-align: center;
-  line-height: inherit;
-  font-size: inherit;
-  font-weight: 400;
-  text-decoration: none;
-  min-height: 2.2rem;
-  min-width: 2.2rem;
-  font-size: 0.75rem;
-  padding: 3px 6px;
-  gap: 6px;
-  background-color: #e2e8ef;
-  color: #4c6586;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e2e8ef;
-  border-radius: 10px;
 }
 .btn-ctrl + .btn-ctrl, .il-viewcontrol-sortation > .btn-default + .btn-ctrl, .il-viewcontrol-sortation > .btn-link + .btn-ctrl,
 .il-viewcontrol-section > .btn-default + .btn-ctrl,
@@ -2864,188 +2848,667 @@ input.btn, input.il-link.link-bulky,
 .il-viewcontrol-pagination .last > .btn-default + .btn-ctrl,
 .il-viewcontrol-pagination .last > .btn-link + .btn-ctrl,
 .il-viewcontrol-mode > .btn-default + .btn-ctrl,
-.il-viewcontrol-mode > .btn-link + .btn-ctrl,
+.il-viewcontrol-mode > .btn-link + .btn-ctrl, .il-viewcontrol-sortation > .btn-default.btn + .btn-ctrl,
 .il-viewcontrol-sortation .dropdown > .btn-default.btn + .btn-ctrl,
 .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn + .btn-ctrl, .il-viewcontrol-sortation > .btn-ctrl + .btn-default, .il-viewcontrol-sortation > .btn-default + .btn-default, .il-viewcontrol-sortation > .btn-link + .btn-default,
-.il-viewcontrol-sortation .il-viewcontrol-sortation.dropdown > .btn-default.btn + .btn-default,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-sortation.l-bar__element > .btn-default.btn + .btn-default, .il-viewcontrol-sortation > .btn-ctrl + .btn-link, .il-viewcontrol-sortation > .btn-default + .btn-link, .il-viewcontrol-sortation > .btn-link + .btn-link,
-.il-viewcontrol-sortation .il-viewcontrol-sortation.dropdown > .btn-default.btn + .btn-link,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-sortation.l-bar__element > .btn-default.btn + .btn-link,
+.il-viewcontrol-section.il-viewcontrol-sortation > .btn-default + .btn-default,
+.il-viewcontrol-section.il-viewcontrol-sortation > .btn-link + .btn-default,
+.il-viewcontrol-section .btn-group.il-viewcontrol-sortation > .btn-default + .btn-default,
+.il-viewcontrol-section .btn-group.il-viewcontrol-sortation > .btn-link + .btn-default,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-sortation > .btn-default + .btn-default,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-sortation > .btn-link + .btn-default,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-sortation > .btn-default + .btn-default,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-sortation > .btn-link + .btn-default,
+.il-viewcontrol-pagination.il-viewcontrol-sortation > .btn-default + .btn-default,
+.il-viewcontrol-pagination.il-viewcontrol-sortation > .btn-link + .btn-default,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-sortation > .btn-default + .btn-default,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-sortation > .btn-link + .btn-default,
+.il-viewcontrol-pagination .last.il-viewcontrol-sortation > .btn-default + .btn-default,
+.il-viewcontrol-pagination .last.il-viewcontrol-sortation > .btn-link + .btn-default,
+.il-viewcontrol-mode.il-viewcontrol-sortation > .btn-default + .btn-default,
+.il-viewcontrol-mode.il-viewcontrol-sortation > .btn-link + .btn-default, .il-viewcontrol-sortation > .btn-default.btn + .btn-default,
+.il-viewcontrol-sortation .dropdown.il-viewcontrol-sortation > .btn-default.btn + .btn-default,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-sortation > .btn-default.btn + .btn-default, .il-viewcontrol-sortation > .btn-ctrl + .btn-link, .il-viewcontrol-sortation > .btn-default + .btn-link, .il-viewcontrol-sortation > .btn-link + .btn-link,
+.il-viewcontrol-section.il-viewcontrol-sortation > .btn-default + .btn-link,
+.il-viewcontrol-section.il-viewcontrol-sortation > .btn-link + .btn-link,
+.il-viewcontrol-section .btn-group.il-viewcontrol-sortation > .btn-default + .btn-link,
+.il-viewcontrol-section .btn-group.il-viewcontrol-sortation > .btn-link + .btn-link,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-sortation > .btn-default + .btn-link,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-sortation > .btn-link + .btn-link,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-sortation > .btn-default + .btn-link,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-sortation > .btn-link + .btn-link,
+.il-viewcontrol-pagination.il-viewcontrol-sortation > .btn-default + .btn-link,
+.il-viewcontrol-pagination.il-viewcontrol-sortation > .btn-link + .btn-link,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-sortation > .btn-default + .btn-link,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-sortation > .btn-link + .btn-link,
+.il-viewcontrol-pagination .last.il-viewcontrol-sortation > .btn-default + .btn-link,
+.il-viewcontrol-pagination .last.il-viewcontrol-sortation > .btn-link + .btn-link,
+.il-viewcontrol-mode.il-viewcontrol-sortation > .btn-default + .btn-link,
+.il-viewcontrol-mode.il-viewcontrol-sortation > .btn-link + .btn-link, .il-viewcontrol-sortation > .btn-default.btn + .btn-link,
+.il-viewcontrol-sortation .dropdown.il-viewcontrol-sortation > .btn-default.btn + .btn-link,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-sortation > .btn-default.btn + .btn-link,
 .il-viewcontrol-section > .btn-ctrl + .btn-default,
+.il-viewcontrol-sortation.il-viewcontrol-section > .btn-default + .btn-default,
+.il-viewcontrol-sortation.il-viewcontrol-section > .btn-link + .btn-default,
 .il-viewcontrol-section > .btn-default + .btn-default,
 .il-viewcontrol-section > .btn-link + .btn-default,
-.il-viewcontrol-sortation .il-viewcontrol-section.dropdown > .btn-default.btn + .btn-default,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section.l-bar__element > .btn-default.btn + .btn-default,
+.il-viewcontrol-section .btn-group.il-viewcontrol-section > .btn-default + .btn-default,
+.il-viewcontrol-section .btn-group.il-viewcontrol-section > .btn-link + .btn-default,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-section > .btn-default + .btn-default,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-section > .btn-link + .btn-default,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-section > .btn-default + .btn-default,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-section > .btn-link + .btn-default,
+.il-viewcontrol-pagination.il-viewcontrol-section > .btn-default + .btn-default,
+.il-viewcontrol-pagination.il-viewcontrol-section > .btn-link + .btn-default,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-section > .btn-default + .btn-default,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-section > .btn-link + .btn-default,
+.il-viewcontrol-pagination .last.il-viewcontrol-section > .btn-default + .btn-default,
+.il-viewcontrol-pagination .last.il-viewcontrol-section > .btn-link + .btn-default,
+.il-viewcontrol-mode.il-viewcontrol-section > .btn-default + .btn-default,
+.il-viewcontrol-mode.il-viewcontrol-section > .btn-link + .btn-default,
+.il-viewcontrol-sortation.il-viewcontrol-section > .btn-default.btn + .btn-default,
+.il-viewcontrol-sortation .dropdown.il-viewcontrol-section > .btn-default.btn + .btn-default,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-section > .btn-default.btn + .btn-default,
 .il-viewcontrol-section > .btn-ctrl + .btn-link,
+.il-viewcontrol-sortation.il-viewcontrol-section > .btn-default + .btn-link,
+.il-viewcontrol-sortation.il-viewcontrol-section > .btn-link + .btn-link,
 .il-viewcontrol-section > .btn-default + .btn-link,
 .il-viewcontrol-section > .btn-link + .btn-link,
-.il-viewcontrol-sortation .il-viewcontrol-section.dropdown > .btn-default.btn + .btn-link,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section.l-bar__element > .btn-default.btn + .btn-link,
+.il-viewcontrol-section .btn-group.il-viewcontrol-section > .btn-default + .btn-link,
+.il-viewcontrol-section .btn-group.il-viewcontrol-section > .btn-link + .btn-link,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-section > .btn-default + .btn-link,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-section > .btn-link + .btn-link,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-section > .btn-default + .btn-link,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-section > .btn-link + .btn-link,
+.il-viewcontrol-pagination.il-viewcontrol-section > .btn-default + .btn-link,
+.il-viewcontrol-pagination.il-viewcontrol-section > .btn-link + .btn-link,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-section > .btn-default + .btn-link,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-section > .btn-link + .btn-link,
+.il-viewcontrol-pagination .last.il-viewcontrol-section > .btn-default + .btn-link,
+.il-viewcontrol-pagination .last.il-viewcontrol-section > .btn-link + .btn-link,
+.il-viewcontrol-mode.il-viewcontrol-section > .btn-default + .btn-link,
+.il-viewcontrol-mode.il-viewcontrol-section > .btn-link + .btn-link,
+.il-viewcontrol-sortation.il-viewcontrol-section > .btn-default.btn + .btn-link,
+.il-viewcontrol-sortation .dropdown.il-viewcontrol-section > .btn-default.btn + .btn-link,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-section > .btn-default.btn + .btn-link,
 .il-viewcontrol-section .btn-group > .btn-ctrl + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-sortation.btn-group > .btn-default + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-sortation.btn-group > .btn-link + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-section.btn-group > .btn-default + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-section.btn-group > .btn-link + .btn-default,
 .il-viewcontrol-section .btn-group > .btn-default + .btn-default,
 .il-viewcontrol-section .btn-group > .btn-link + .btn-default,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .btn-group.l-bar__element > .btn-default.btn + .btn-default,
-.il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .btn-group.l-bar__element > .btn-default.btn + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination__sectioncontrol.btn-group > .btn-default + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination__sectioncontrol.btn-group > .btn-link + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination__num-of-items.btn-group > .btn-default + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination__num-of-items.btn-group > .btn-link + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination.btn-group > .btn-default + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination.btn-group > .btn-link + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown.btn-group > .btn-default + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown.btn-group > .btn-default + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown.btn-group > .btn-link + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown.btn-group > .btn-link + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-section .last.btn-group > .btn-default + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination .last.btn-group > .btn-default + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-section .last.btn-group > .btn-link + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination .last.btn-group > .btn-link + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-mode.btn-group > .btn-default + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-mode.btn-group > .btn-link + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-sortation.btn-group > .btn-default.btn + .btn-default,
+.il-viewcontrol-sortation .il-viewcontrol-section .dropdown.btn-group > .btn-default.btn + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-sortation .dropdown.btn-group > .btn-default.btn + .btn-default,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .l-bar__element.btn-group > .btn-default.btn + .btn-default,
+.il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.btn-group > .btn-default.btn + .btn-default,
 .il-viewcontrol-section .btn-group > .btn-ctrl + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-sortation.btn-group > .btn-default + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-sortation.btn-group > .btn-link + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-section.btn-group > .btn-default + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-section.btn-group > .btn-link + .btn-link,
 .il-viewcontrol-section .btn-group > .btn-default + .btn-link,
 .il-viewcontrol-section .btn-group > .btn-link + .btn-link,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .btn-group.l-bar__element > .btn-default.btn + .btn-link,
-.il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .btn-group.l-bar__element > .btn-default.btn + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination__sectioncontrol.btn-group > .btn-default + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination__sectioncontrol.btn-group > .btn-link + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination__num-of-items.btn-group > .btn-default + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination__num-of-items.btn-group > .btn-link + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination.btn-group > .btn-default + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination.btn-group > .btn-link + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown.btn-group > .btn-default + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown.btn-group > .btn-default + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown.btn-group > .btn-link + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown.btn-group > .btn-link + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-section .last.btn-group > .btn-default + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination .last.btn-group > .btn-default + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-section .last.btn-group > .btn-link + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination .last.btn-group > .btn-link + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-mode.btn-group > .btn-default + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-mode.btn-group > .btn-link + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-sortation.btn-group > .btn-default.btn + .btn-link,
+.il-viewcontrol-sortation .il-viewcontrol-section .dropdown.btn-group > .btn-default.btn + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-sortation .dropdown.btn-group > .btn-default.btn + .btn-link,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .l-bar__element.btn-group > .btn-default.btn + .btn-link,
+.il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.btn-group > .btn-default.btn + .btn-link,
 .il-viewcontrol-pagination__sectioncontrol > .btn-ctrl + .btn-default,
+.il-viewcontrol-sortation.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-default,
+.il-viewcontrol-sortation.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-default,
+.il-viewcontrol-section.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-default,
+.il-viewcontrol-section.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-default,
+.il-viewcontrol-section .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-default,
+.il-viewcontrol-section .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-default,
 .il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-default,
 .il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-default,
-.il-viewcontrol-sortation .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-default.btn + .btn-default,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination__sectioncontrol.l-bar__element > .btn-default.btn + .btn-default,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-default,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-default,
+.il-viewcontrol-pagination.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-default,
+.il-viewcontrol-pagination.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-default,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-default,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-default,
+.il-viewcontrol-pagination .last.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-default,
+.il-viewcontrol-pagination .last.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-default,
+.il-viewcontrol-mode.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-default,
+.il-viewcontrol-mode.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-default,
+.il-viewcontrol-sortation.il-viewcontrol-pagination__sectioncontrol > .btn-default.btn + .btn-default,
+.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-default.btn + .btn-default,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination__sectioncontrol > .btn-default.btn + .btn-default,
 .il-viewcontrol-pagination__sectioncontrol > .btn-ctrl + .btn-link,
+.il-viewcontrol-sortation.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-link,
+.il-viewcontrol-sortation.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-link,
+.il-viewcontrol-section.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-link,
+.il-viewcontrol-section.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-link,
+.il-viewcontrol-section .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-link,
+.il-viewcontrol-section .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-link,
 .il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-link,
 .il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-link,
-.il-viewcontrol-sortation .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-default.btn + .btn-link,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination__sectioncontrol.l-bar__element > .btn-default.btn + .btn-link,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-link,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-link,
+.il-viewcontrol-pagination.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-link,
+.il-viewcontrol-pagination.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-link,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-link,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-link,
+.il-viewcontrol-pagination .last.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-link,
+.il-viewcontrol-pagination .last.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-link,
+.il-viewcontrol-mode.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-link,
+.il-viewcontrol-mode.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-link,
+.il-viewcontrol-sortation.il-viewcontrol-pagination__sectioncontrol > .btn-default.btn + .btn-link,
+.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-default.btn + .btn-link,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination__sectioncontrol > .btn-default.btn + .btn-link,
 .il-viewcontrol-pagination__num-of-items > .btn-ctrl + .btn-default,
+.il-viewcontrol-sortation.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-default,
+.il-viewcontrol-sortation.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-default,
+.il-viewcontrol-section.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-default,
+.il-viewcontrol-section.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-default,
+.il-viewcontrol-section .btn-group.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-default,
+.il-viewcontrol-section .btn-group.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-default,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-default,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-default,
 .il-viewcontrol-pagination__num-of-items > .btn-default + .btn-default,
 .il-viewcontrol-pagination__num-of-items > .btn-link + .btn-default,
-.il-viewcontrol-sortation .il-viewcontrol-pagination__num-of-items.dropdown > .btn-default.btn + .btn-default,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination__num-of-items.l-bar__element > .btn-default.btn + .btn-default,
+.il-viewcontrol-pagination.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-default,
+.il-viewcontrol-pagination.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-default,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-default,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-default,
+.il-viewcontrol-pagination .last.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-default,
+.il-viewcontrol-pagination .last.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-default,
+.il-viewcontrol-mode.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-default,
+.il-viewcontrol-mode.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-default,
+.il-viewcontrol-sortation.il-viewcontrol-pagination__num-of-items > .btn-default.btn + .btn-default,
+.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination__num-of-items > .btn-default.btn + .btn-default,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination__num-of-items > .btn-default.btn + .btn-default,
 .il-viewcontrol-pagination__num-of-items > .btn-ctrl + .btn-link,
+.il-viewcontrol-sortation.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-link,
+.il-viewcontrol-sortation.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-link,
+.il-viewcontrol-section.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-link,
+.il-viewcontrol-section.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-link,
+.il-viewcontrol-section .btn-group.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-link,
+.il-viewcontrol-section .btn-group.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-link,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-link,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-link,
 .il-viewcontrol-pagination__num-of-items > .btn-default + .btn-link,
 .il-viewcontrol-pagination__num-of-items > .btn-link + .btn-link,
-.il-viewcontrol-sortation .il-viewcontrol-pagination__num-of-items.dropdown > .btn-default.btn + .btn-link,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination__num-of-items.l-bar__element > .btn-default.btn + .btn-link,
+.il-viewcontrol-pagination.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-link,
+.il-viewcontrol-pagination.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-link,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-link,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-link,
+.il-viewcontrol-pagination .last.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-link,
+.il-viewcontrol-pagination .last.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-link,
+.il-viewcontrol-mode.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-link,
+.il-viewcontrol-mode.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-link,
+.il-viewcontrol-sortation.il-viewcontrol-pagination__num-of-items > .btn-default.btn + .btn-link,
+.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination__num-of-items > .btn-default.btn + .btn-link,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination__num-of-items > .btn-default.btn + .btn-link,
 .il-viewcontrol-pagination > .btn-ctrl + .btn-default,
+.il-viewcontrol-sortation.il-viewcontrol-pagination > .btn-default + .btn-default,
+.il-viewcontrol-sortation.il-viewcontrol-pagination > .btn-link + .btn-default,
+.il-viewcontrol-section.il-viewcontrol-pagination > .btn-default + .btn-default,
+.il-viewcontrol-section.il-viewcontrol-pagination > .btn-link + .btn-default,
+.il-viewcontrol-section .btn-group.il-viewcontrol-pagination > .btn-default + .btn-default,
+.il-viewcontrol-section .btn-group.il-viewcontrol-pagination > .btn-link + .btn-default,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination > .btn-default + .btn-default,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination > .btn-link + .btn-default,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination > .btn-default + .btn-default,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination > .btn-link + .btn-default,
 .il-viewcontrol-pagination > .btn-default + .btn-default,
 .il-viewcontrol-pagination > .btn-link + .btn-default,
-.il-viewcontrol-sortation .il-viewcontrol-pagination.dropdown > .btn-default.btn + .btn-default,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination.l-bar__element > .btn-default.btn + .btn-default,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination > .btn-default + .btn-default,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination > .btn-link + .btn-default,
+.il-viewcontrol-pagination .last.il-viewcontrol-pagination > .btn-default + .btn-default,
+.il-viewcontrol-pagination .last.il-viewcontrol-pagination > .btn-link + .btn-default,
+.il-viewcontrol-mode.il-viewcontrol-pagination > .btn-default + .btn-default,
+.il-viewcontrol-mode.il-viewcontrol-pagination > .btn-link + .btn-default,
+.il-viewcontrol-sortation.il-viewcontrol-pagination > .btn-default.btn + .btn-default,
+.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination > .btn-default.btn + .btn-default,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination > .btn-default.btn + .btn-default,
 .il-viewcontrol-pagination > .btn-ctrl + .btn-link,
+.il-viewcontrol-sortation.il-viewcontrol-pagination > .btn-default + .btn-link,
+.il-viewcontrol-sortation.il-viewcontrol-pagination > .btn-link + .btn-link,
+.il-viewcontrol-section.il-viewcontrol-pagination > .btn-default + .btn-link,
+.il-viewcontrol-section.il-viewcontrol-pagination > .btn-link + .btn-link,
+.il-viewcontrol-section .btn-group.il-viewcontrol-pagination > .btn-default + .btn-link,
+.il-viewcontrol-section .btn-group.il-viewcontrol-pagination > .btn-link + .btn-link,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination > .btn-default + .btn-link,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination > .btn-link + .btn-link,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination > .btn-default + .btn-link,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination > .btn-link + .btn-link,
 .il-viewcontrol-pagination > .btn-default + .btn-link,
 .il-viewcontrol-pagination > .btn-link + .btn-link,
-.il-viewcontrol-sortation .il-viewcontrol-pagination.dropdown > .btn-default.btn + .btn-link,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination.l-bar__element > .btn-default.btn + .btn-link,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination > .btn-default + .btn-link,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination > .btn-link + .btn-link,
+.il-viewcontrol-pagination .last.il-viewcontrol-pagination > .btn-default + .btn-link,
+.il-viewcontrol-pagination .last.il-viewcontrol-pagination > .btn-link + .btn-link,
+.il-viewcontrol-mode.il-viewcontrol-pagination > .btn-default + .btn-link,
+.il-viewcontrol-mode.il-viewcontrol-pagination > .btn-link + .btn-link,
+.il-viewcontrol-sortation.il-viewcontrol-pagination > .btn-default.btn + .btn-link,
+.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination > .btn-default.btn + .btn-link,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination > .btn-default.btn + .btn-link,
 .il-viewcontrol-pagination .dropdown > .btn-ctrl + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-sortation.dropdown > .btn-default + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-sortation.dropdown > .btn-link + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-section.dropdown > .btn-default + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-section.dropdown > .btn-link + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination .btn-group.dropdown > .btn-default + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-section .btn-group.dropdown > .btn-default + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination .btn-group.dropdown > .btn-link + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-section .btn-group.dropdown > .btn-link + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-default + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-link + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.dropdown > .btn-default + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.dropdown > .btn-link + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-pagination.dropdown > .btn-default + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-pagination.dropdown > .btn-link + .btn-default,
 .il-viewcontrol-pagination .dropdown > .btn-default + .btn-default,
 .il-viewcontrol-pagination .dropdown > .btn-link + .btn-default,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .dropdown.l-bar__element > .btn-default.btn + .btn-default,
-.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .dropdown.l-bar__element > .btn-default.btn + .btn-default,
+.il-viewcontrol-pagination .last.dropdown > .btn-default + .btn-default,
+.il-viewcontrol-pagination .last.dropdown > .btn-link + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-mode.dropdown > .btn-default + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-mode.dropdown > .btn-link + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-sortation.dropdown > .btn-default.btn + .btn-default,
+.il-viewcontrol-sortation .il-viewcontrol-pagination .dropdown > .btn-default.btn + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-sortation .dropdown > .btn-default.btn + .btn-default,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .l-bar__element.dropdown > .btn-default.btn + .btn-default,
+.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.dropdown > .btn-default.btn + .btn-default,
 .il-viewcontrol-pagination .dropdown > .btn-ctrl + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-sortation.dropdown > .btn-default + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-sortation.dropdown > .btn-link + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-section.dropdown > .btn-default + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-section.dropdown > .btn-link + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination .btn-group.dropdown > .btn-default + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-section .btn-group.dropdown > .btn-default + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination .btn-group.dropdown > .btn-link + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-section .btn-group.dropdown > .btn-link + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-default + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-link + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.dropdown > .btn-default + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.dropdown > .btn-link + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-pagination.dropdown > .btn-default + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-pagination.dropdown > .btn-link + .btn-link,
 .il-viewcontrol-pagination .dropdown > .btn-default + .btn-link,
 .il-viewcontrol-pagination .dropdown > .btn-link + .btn-link,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .dropdown.l-bar__element > .btn-default.btn + .btn-link,
-.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .dropdown.l-bar__element > .btn-default.btn + .btn-link,
+.il-viewcontrol-pagination .last.dropdown > .btn-default + .btn-link,
+.il-viewcontrol-pagination .last.dropdown > .btn-link + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-mode.dropdown > .btn-default + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-mode.dropdown > .btn-link + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-sortation.dropdown > .btn-default.btn + .btn-link,
+.il-viewcontrol-sortation .il-viewcontrol-pagination .dropdown > .btn-default.btn + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-sortation .dropdown > .btn-default.btn + .btn-link,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .l-bar__element.dropdown > .btn-default.btn + .btn-link,
+.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.dropdown > .btn-default.btn + .btn-link,
 .il-viewcontrol-pagination .last > .btn-ctrl + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-sortation.last > .btn-default + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-sortation.last > .btn-link + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-section.last > .btn-default + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-section.last > .btn-link + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination .btn-group.last > .btn-default + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-section .btn-group.last > .btn-default + .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination .btn-group.last > .btn-link + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-section .btn-group.last > .btn-link + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.last > .btn-default + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.last > .btn-link + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.last > .btn-default + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.last > .btn-link + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-pagination.last > .btn-default + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-pagination.last > .btn-link + .btn-default,
+.il-viewcontrol-pagination .dropdown.last > .btn-default + .btn-default,
+.il-viewcontrol-pagination .dropdown.last > .btn-link + .btn-default,
 .il-viewcontrol-pagination .last > .btn-default + .btn-default,
 .il-viewcontrol-pagination .last > .btn-link + .btn-default,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .last.l-bar__element > .btn-default.btn + .btn-default,
-.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .last.l-bar__element > .btn-default.btn + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-mode.last > .btn-default + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-mode.last > .btn-link + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-sortation.last > .btn-default.btn + .btn-default,
+.il-viewcontrol-sortation .il-viewcontrol-pagination .dropdown.last > .btn-default.btn + .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-sortation .dropdown.last > .btn-default.btn + .btn-default,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .l-bar__element.last > .btn-default.btn + .btn-default,
+.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.last > .btn-default.btn + .btn-default,
 .il-viewcontrol-pagination .last > .btn-ctrl + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-sortation.last > .btn-default + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-sortation.last > .btn-link + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-section.last > .btn-default + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-section.last > .btn-link + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination .btn-group.last > .btn-default + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-section .btn-group.last > .btn-default + .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination .btn-group.last > .btn-link + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-section .btn-group.last > .btn-link + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.last > .btn-default + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.last > .btn-link + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.last > .btn-default + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.last > .btn-link + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-pagination.last > .btn-default + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-pagination.last > .btn-link + .btn-link,
+.il-viewcontrol-pagination .dropdown.last > .btn-default + .btn-link,
+.il-viewcontrol-pagination .dropdown.last > .btn-link + .btn-link,
 .il-viewcontrol-pagination .last > .btn-default + .btn-link,
 .il-viewcontrol-pagination .last > .btn-link + .btn-link,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .last.l-bar__element > .btn-default.btn + .btn-link,
-.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .last.l-bar__element > .btn-default.btn + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-mode.last > .btn-default + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-mode.last > .btn-link + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-sortation.last > .btn-default.btn + .btn-link,
+.il-viewcontrol-sortation .il-viewcontrol-pagination .dropdown.last > .btn-default.btn + .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-sortation .dropdown.last > .btn-default.btn + .btn-link,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .l-bar__element.last > .btn-default.btn + .btn-link,
+.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.last > .btn-default.btn + .btn-link,
 .il-viewcontrol-mode > .btn-ctrl + .btn-default,
+.il-viewcontrol-sortation.il-viewcontrol-mode > .btn-default + .btn-default,
+.il-viewcontrol-sortation.il-viewcontrol-mode > .btn-link + .btn-default,
+.il-viewcontrol-section.il-viewcontrol-mode > .btn-default + .btn-default,
+.il-viewcontrol-section.il-viewcontrol-mode > .btn-link + .btn-default,
+.il-viewcontrol-section .btn-group.il-viewcontrol-mode > .btn-default + .btn-default,
+.il-viewcontrol-section .btn-group.il-viewcontrol-mode > .btn-link + .btn-default,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-mode > .btn-default + .btn-default,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-mode > .btn-link + .btn-default,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-mode > .btn-default + .btn-default,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-mode > .btn-link + .btn-default,
+.il-viewcontrol-pagination.il-viewcontrol-mode > .btn-default + .btn-default,
+.il-viewcontrol-pagination.il-viewcontrol-mode > .btn-link + .btn-default,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-mode > .btn-default + .btn-default,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-mode > .btn-link + .btn-default,
+.il-viewcontrol-pagination .last.il-viewcontrol-mode > .btn-default + .btn-default,
+.il-viewcontrol-pagination .last.il-viewcontrol-mode > .btn-link + .btn-default,
 .il-viewcontrol-mode > .btn-default + .btn-default,
 .il-viewcontrol-mode > .btn-link + .btn-default,
-.il-viewcontrol-sortation .il-viewcontrol-mode.dropdown > .btn-default.btn + .btn-default,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-mode.l-bar__element > .btn-default.btn + .btn-default,
+.il-viewcontrol-sortation.il-viewcontrol-mode > .btn-default.btn + .btn-default,
+.il-viewcontrol-sortation .dropdown.il-viewcontrol-mode > .btn-default.btn + .btn-default,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-mode > .btn-default.btn + .btn-default,
 .il-viewcontrol-mode > .btn-ctrl + .btn-link,
+.il-viewcontrol-sortation.il-viewcontrol-mode > .btn-default + .btn-link,
+.il-viewcontrol-sortation.il-viewcontrol-mode > .btn-link + .btn-link,
+.il-viewcontrol-section.il-viewcontrol-mode > .btn-default + .btn-link,
+.il-viewcontrol-section.il-viewcontrol-mode > .btn-link + .btn-link,
+.il-viewcontrol-section .btn-group.il-viewcontrol-mode > .btn-default + .btn-link,
+.il-viewcontrol-section .btn-group.il-viewcontrol-mode > .btn-link + .btn-link,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-mode > .btn-default + .btn-link,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-mode > .btn-link + .btn-link,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-mode > .btn-default + .btn-link,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-mode > .btn-link + .btn-link,
+.il-viewcontrol-pagination.il-viewcontrol-mode > .btn-default + .btn-link,
+.il-viewcontrol-pagination.il-viewcontrol-mode > .btn-link + .btn-link,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-mode > .btn-default + .btn-link,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-mode > .btn-link + .btn-link,
+.il-viewcontrol-pagination .last.il-viewcontrol-mode > .btn-default + .btn-link,
+.il-viewcontrol-pagination .last.il-viewcontrol-mode > .btn-link + .btn-link,
 .il-viewcontrol-mode > .btn-default + .btn-link,
 .il-viewcontrol-mode > .btn-link + .btn-link,
-.il-viewcontrol-sortation .il-viewcontrol-mode.dropdown > .btn-default.btn + .btn-link,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-mode.l-bar__element > .btn-default.btn + .btn-link,
+.il-viewcontrol-sortation.il-viewcontrol-mode > .btn-default.btn + .btn-link,
+.il-viewcontrol-sortation .dropdown.il-viewcontrol-mode > .btn-default.btn + .btn-link,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-mode > .btn-default.btn + .btn-link, .il-viewcontrol-sortation > .btn-ctrl + .btn-default.btn, .il-viewcontrol-sortation > .btn-default + .btn-default.btn, .il-viewcontrol-sortation > .btn-link + .btn-default.btn,
+.il-viewcontrol-section.il-viewcontrol-sortation > .btn-default + .btn-default.btn,
+.il-viewcontrol-section.il-viewcontrol-sortation > .btn-link + .btn-default.btn,
+.il-viewcontrol-section .btn-group.il-viewcontrol-sortation > .btn-default + .btn-default.btn,
+.il-viewcontrol-section .btn-group.il-viewcontrol-sortation > .btn-link + .btn-default.btn,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-sortation > .btn-default + .btn-default.btn,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-sortation > .btn-link + .btn-default.btn,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-sortation > .btn-default + .btn-default.btn,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-sortation > .btn-link + .btn-default.btn,
+.il-viewcontrol-pagination.il-viewcontrol-sortation > .btn-default + .btn-default.btn,
+.il-viewcontrol-pagination.il-viewcontrol-sortation > .btn-link + .btn-default.btn,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-sortation > .btn-default + .btn-default.btn,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-sortation > .btn-link + .btn-default.btn,
+.il-viewcontrol-pagination .last.il-viewcontrol-sortation > .btn-default + .btn-default.btn,
+.il-viewcontrol-pagination .last.il-viewcontrol-sortation > .btn-link + .btn-default.btn,
+.il-viewcontrol-mode.il-viewcontrol-sortation > .btn-default + .btn-default.btn,
+.il-viewcontrol-mode.il-viewcontrol-sortation > .btn-link + .btn-default.btn, .il-viewcontrol-sortation > .btn-default.btn + .btn-default.btn,
+.il-viewcontrol-sortation .dropdown.il-viewcontrol-sortation > .btn-default.btn + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-sortation > .btn-default.btn + .btn-default.btn,
 .il-viewcontrol-sortation .dropdown > .btn-ctrl + .btn-default.btn,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-sortation > .btn-default + .btn-default.btn,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-sortation > .btn-link + .btn-default.btn,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-section > .btn-default + .btn-default.btn,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-section > .btn-link + .btn-default.btn,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-default.btn,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-default.btn,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-default.btn,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-default.btn,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination > .btn-default + .btn-default.btn,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination > .btn-link + .btn-default.btn,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-mode > .btn-default + .btn-default.btn,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-mode > .btn-link + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-sortation.dropdown > .btn-default + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-sortation.dropdown > .btn-link + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-section.dropdown > .btn-default + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-section.dropdown > .btn-link + .btn-default.btn,
+.il-viewcontrol-section .il-viewcontrol-sortation .btn-group.dropdown > .btn-default + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-section .btn-group.dropdown > .btn-default + .btn-default.btn,
+.il-viewcontrol-section .il-viewcontrol-sortation .btn-group.dropdown > .btn-link + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-section .btn-group.dropdown > .btn-link + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-default + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-link + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-pagination__num-of-items.dropdown > .btn-default + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-pagination__num-of-items.dropdown > .btn-link + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-pagination.dropdown > .btn-default + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-pagination.dropdown > .btn-link + .btn-default.btn,
+.il-viewcontrol-pagination .il-viewcontrol-sortation .dropdown > .btn-default + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-pagination .dropdown > .btn-default + .btn-default.btn,
+.il-viewcontrol-pagination .il-viewcontrol-sortation .dropdown > .btn-link + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-pagination .dropdown > .btn-link + .btn-default.btn,
+.il-viewcontrol-pagination .il-viewcontrol-sortation .last.dropdown > .btn-default + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-pagination .last.dropdown > .btn-default + .btn-default.btn,
+.il-viewcontrol-pagination .il-viewcontrol-sortation .last.dropdown > .btn-link + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-pagination .last.dropdown > .btn-link + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-mode.dropdown > .btn-default + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-mode.dropdown > .btn-link + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-sortation.dropdown > .btn-default.btn + .btn-default.btn,
 .il-viewcontrol-sortation .dropdown > .btn-default.btn + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-sortation .l-bar__element.dropdown > .btn-default.btn + .btn-default.btn,
+.il-viewcontrol-sortation .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.dropdown > .btn-default.btn + .btn-default.btn,
 .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-ctrl + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-sortation > .btn-default + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-sortation > .btn-link + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-section > .btn-default + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-section > .btn-link + .btn-default.btn,
-.il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.btn-group > .btn-default + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .l-bar__element.btn-group > .btn-default + .btn-default.btn,
-.il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.btn-group > .btn-link + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .l-bar__element.btn-group > .btn-link + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination > .btn-default + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination > .btn-link + .btn-default.btn,
-.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.dropdown > .btn-default + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .l-bar__element.dropdown > .btn-default + .btn-default.btn,
-.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.dropdown > .btn-link + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .l-bar__element.dropdown > .btn-link + .btn-default.btn,
-.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.last > .btn-default + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .l-bar__element.last > .btn-default + .btn-default.btn,
-.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.last > .btn-link + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .l-bar__element.last > .btn-link + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-mode > .btn-default + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-mode > .btn-link + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn + .btn-default.btn, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link + .btn-ctrl, .ilTableNav > table > tbody > tr > td > .il-viewcontrol-sortation.btn-group > .btn-link + .btn-default,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-section.btn-group > .btn-link + .btn-default,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination__sectioncontrol.btn-group > .btn-link + .btn-default,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination__num-of-items.btn-group > .btn-link + .btn-default,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination.btn-group > .btn-link + .btn-default,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-mode.btn-group > .btn-link + .btn-default,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .ilTableNav > table > tbody > tr > td > .l-bar__element.btn-group > .btn-link + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-sortation.l-bar__element > .btn-default + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-sortation.l-bar__element > .btn-link + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section.l-bar__element > .btn-default + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section.l-bar__element > .btn-link + .btn-default.btn,
+.il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .btn-group.l-bar__element > .btn-default + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .btn-group.l-bar__element > .btn-default + .btn-default.btn,
+.il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .btn-group.l-bar__element > .btn-link + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .btn-group.l-bar__element > .btn-link + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination__sectioncontrol.l-bar__element > .btn-default + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination__sectioncontrol.l-bar__element > .btn-link + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination__num-of-items.l-bar__element > .btn-default + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination__num-of-items.l-bar__element > .btn-link + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination.l-bar__element > .btn-default + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination.l-bar__element > .btn-link + .btn-default.btn,
+.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .dropdown.l-bar__element > .btn-default + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .dropdown.l-bar__element > .btn-default + .btn-default.btn,
+.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .dropdown.l-bar__element > .btn-link + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .dropdown.l-bar__element > .btn-link + .btn-default.btn,
+.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .last.l-bar__element > .btn-default + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .last.l-bar__element > .btn-default + .btn-default.btn,
+.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .last.l-bar__element > .btn-link + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .last.l-bar__element > .btn-link + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-mode.l-bar__element > .btn-default + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-mode.l-bar__element > .btn-link + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-sortation.l-bar__element > .btn-default.btn + .btn-default.btn,
+.il-viewcontrol-sortation .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .dropdown.l-bar__element > .btn-default.btn + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-sortation .dropdown.l-bar__element > .btn-default.btn + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn + .btn-default.btn, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link + .btn-ctrl, .ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-sortation > .btn-link + .btn-default, .ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-sortation > .btn-link + .btn-link,
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-section > .btn-link + .btn-default,
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-section > .btn-link + .btn-link,
+.il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link + .btn-default,
+.il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link + .btn-link,
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-default,
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-link,
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-default,
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-link,
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-pagination > .btn-link + .btn-default,
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-pagination > .btn-link + .btn-link,
+.il-viewcontrol-pagination .ilTableNav > table > tbody > tr > td > .btn-group.dropdown > .btn-link + .btn-default,
+.il-viewcontrol-pagination .ilTableNav > table > tbody > tr > td > .btn-group.dropdown > .btn-link + .btn-link,
+.il-viewcontrol-pagination .ilTableNav > table > tbody > tr > td > .btn-group.last > .btn-link + .btn-default,
+.il-viewcontrol-pagination .ilTableNav > table > tbody > tr > td > .btn-group.last > .btn-link + .btn-link,
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-mode > .btn-link + .btn-default,
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-mode > .btn-link + .btn-link, .ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-sortation > .btn-link + .btn-default.btn,
+.il-viewcontrol-sortation .ilTableNav > table > tbody > tr > td > .btn-group.dropdown > .btn-link + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .ilTableNav > table > tbody > tr > td > .btn-group.l-bar__element > .btn-link + .btn-default.btn,
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default + .btn-ctrl,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-sortation.dropdown > .btn-default + .btn-link,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-section.dropdown > .btn-default + .btn-link,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-default + .btn-link,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination__num-of-items.dropdown > .btn-default + .btn-link,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination.dropdown > .btn-default + .btn-link,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-mode.dropdown > .btn-default + .btn-link,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .ilTableNav > table > tbody > tr > td > .l-bar__element.dropdown > .btn-default + .btn-default.btn,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a + .btn-ctrl,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-sortation.navbar-form.dropdown > a + .btn-link,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-section.navbar-form.dropdown > a + .btn-link,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination__sectioncontrol.navbar-form.dropdown > a + .btn-link,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination__num-of-items.navbar-form.dropdown > a + .btn-link,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination.navbar-form.dropdown > a + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-sortation > .btn-default + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-sortation > .btn-default + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-section > .btn-default + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-section > .btn-default + .btn-link,
+.il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .dropdown.btn-group > .btn-default + .btn-default,
+.il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .dropdown.btn-group > .btn-default + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-pagination > .btn-default + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-pagination > .btn-default + .btn-link,
+.il-viewcontrol-pagination .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default + .btn-default,
+.il-viewcontrol-pagination .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default + .btn-link,
+.il-viewcontrol-pagination .ilTableNav > table > tbody > tr > td > .dropdown.last > .btn-default + .btn-default,
+.il-viewcontrol-pagination .ilTableNav > table > tbody > tr > td > .dropdown.last > .btn-default + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-mode > .btn-default + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-mode > .btn-default + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-sortation > .btn-default + .btn-default.btn,
+.il-viewcontrol-sortation .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .ilTableNav > table > tbody > tr > td > .dropdown.l-bar__element > .btn-default + .btn-default.btn,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a + .btn-ctrl,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-sortation > a + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-sortation > a + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-section > a + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-section > a + .btn-link,
+.il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.btn-group > a + .btn-default,
+.il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.btn-group > a + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-pagination__sectioncontrol > a + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-pagination__sectioncontrol > a + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-pagination__num-of-items > a + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-pagination__num-of-items > a + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-pagination > a + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-pagination > a + .btn-link,
+.il-viewcontrol-pagination .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a + .btn-default,
 .il-viewcontrol-pagination .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a + .btn-link,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-mode.navbar-form.dropdown > a + .btn-link,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .ilTableNav > table > tbody > tr > td > .l-bar__element.navbar-form.dropdown > a + .btn-default.btn, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-ctrl + .btn-link, .ilTableNav > table > tbody > tr > td > .il-viewcontrol-sortation.btn-group > .btn-default + .btn-link,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-section.btn-group > .btn-default + .btn-link,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination__sectioncontrol.btn-group > .btn-default + .btn-link,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination__num-of-items.btn-group > .btn-default + .btn-link,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination.btn-group > .btn-default + .btn-link,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-mode.btn-group > .btn-default + .btn-link,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .ilTableNav > table > tbody > tr > td > .l-bar__element.btn-group > .btn-default.btn + .btn-link, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link + .btn-link,
-.ilTableNav > table > tbody > tr > td > .btn-group.dropdown > .btn-default + .btn-link,
-.ilTableNav > table > tbody > tr > td > .btn-group.navbar-form.dropdown > a + .btn-link,
+.il-viewcontrol-pagination .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.last > a + .btn-default,
+.il-viewcontrol-pagination .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.last > a + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-mode > a + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-mode > a + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-sortation > a + .btn-default.btn,
+.il-viewcontrol-sortation .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.l-bar__element > a + .btn-default.btn, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-ctrl + .btn-link, .ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-sortation > .btn-default + .btn-link, .ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-sortation > .btn-link + .btn-link,
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-section > .btn-default + .btn-link,
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-section > .btn-link + .btn-link,
+.il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .btn-group > .btn-default + .btn-link,
+.il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link + .btn-link,
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-link,
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-link,
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-link,
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-link,
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-pagination > .btn-default + .btn-link,
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-pagination > .btn-link + .btn-link,
+.il-viewcontrol-pagination .ilTableNav > table > tbody > tr > td > .btn-group.dropdown > .btn-default + .btn-link,
+.il-viewcontrol-pagination .ilTableNav > table > tbody > tr > td > .btn-group.dropdown > .btn-link + .btn-link,
+.il-viewcontrol-pagination .ilTableNav > table > tbody > tr > td > .btn-group.last > .btn-default + .btn-link,
+.il-viewcontrol-pagination .ilTableNav > table > tbody > tr > td > .btn-group.last > .btn-link + .btn-link,
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-mode > .btn-default + .btn-link,
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-mode > .btn-link + .btn-link, .ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-sortation > .btn-default.btn + .btn-link,
+.il-viewcontrol-sortation .ilTableNav > table > tbody > tr > td > .btn-group.dropdown > .btn-default.btn + .btn-link,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .ilTableNav > table > tbody > tr > td > .btn-group.l-bar__element > .btn-default.btn + .btn-link, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.btn-group > .btn-default + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.btn-group > a + .btn-link,
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-ctrl + .btn-default,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-sortation.dropdown > .btn-link + .btn-default,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-section.dropdown > .btn-link + .btn-default,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-link + .btn-default,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination__num-of-items.dropdown > .btn-link + .btn-default,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination.dropdown > .btn-link + .btn-default,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-mode.dropdown > .btn-link + .btn-default,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .ilTableNav > table > tbody > tr > td > .l-bar__element.dropdown > .btn-default.btn + .btn-default,
-.ilTableNav > table > tbody > tr > td > .dropdown.btn-group > .btn-link + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-sortation > .btn-default + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-sortation > .btn-link + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-section > .btn-default + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-section > .btn-link + .btn-default,
+.il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .dropdown.btn-group > .btn-default + .btn-default,
+.il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .dropdown.btn-group > .btn-link + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-pagination > .btn-default + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-pagination > .btn-link + .btn-default,
+.il-viewcontrol-pagination .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default + .btn-default,
+.il-viewcontrol-pagination .ilTableNav > table > tbody > tr > td > .dropdown > .btn-link + .btn-default,
+.il-viewcontrol-pagination .ilTableNav > table > tbody > tr > td > .dropdown.last > .btn-default + .btn-default,
+.il-viewcontrol-pagination .ilTableNav > table > tbody > tr > td > .dropdown.last > .btn-link + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-mode > .btn-default + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-mode > .btn-link + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-sortation > .btn-default.btn + .btn-default,
+.il-viewcontrol-sortation .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default.btn + .btn-default,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .ilTableNav > table > tbody > tr > td > .dropdown.l-bar__element > .btn-default.btn + .btn-default,
+.ilTableNav > table > tbody > tr > td > .btn-group.dropdown > .btn-link + .btn-default,
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default + .btn-default,
 .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a + .btn-default,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > .btn-ctrl + a,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-sortation.navbar-form.dropdown > .btn-link + a,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-section.navbar-form.dropdown > .btn-link + a,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination__sectioncontrol.navbar-form.dropdown > .btn-link + a,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination__num-of-items.navbar-form.dropdown > .btn-link + a,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination.navbar-form.dropdown > .btn-link + a,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > .btn-ctrl + a,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-sortation > .btn-default + a,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-sortation > .btn-link + a,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-section > .btn-default + a,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-section > .btn-link + a,
+.il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.btn-group > .btn-default + a,
+.il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.btn-group > .btn-link + a,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-pagination__sectioncontrol > .btn-default + a,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-pagination__sectioncontrol > .btn-link + a,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-pagination__num-of-items > .btn-default + a,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-pagination__num-of-items > .btn-link + a,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-pagination > .btn-default + a,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-pagination > .btn-link + a,
+.il-viewcontrol-pagination .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > .btn-default + a,
 .il-viewcontrol-pagination .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > .btn-link + a,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-mode.navbar-form.dropdown > .btn-link + a,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .ilTableNav > table > tbody > tr > td > .l-bar__element.navbar-form.dropdown > .btn-default.btn + a,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown.btn-group > .btn-link + a,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > .btn-default + a,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a + a {
+.il-viewcontrol-pagination .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.last > .btn-default + a,
+.il-viewcontrol-pagination .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.last > .btn-link + a,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-mode > .btn-default + a,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-mode > .btn-link + a,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-sortation > .btn-default.btn + a,
+.il-viewcontrol-sortation .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > .btn-default.btn + a,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.l-bar__element > .btn-default.btn + a,
+.ilTableNav > table > tbody > tr > td > .btn-group.dropdown.navbar-form > .btn-link + a,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > .btn-default + a,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a + a {
   margin-left: 3px;
+}
+.btn-ctrl, .il-viewcontrol-sortation > .btn-default, .il-viewcontrol-sortation > .btn-link,
+.il-viewcontrol-section > .btn-default,
+.il-viewcontrol-section > .btn-link,
+.il-viewcontrol-section .btn-group > .btn-default,
+.il-viewcontrol-section .btn-group > .btn-link,
+.il-viewcontrol-pagination__sectioncontrol > .btn-default,
+.il-viewcontrol-pagination__sectioncontrol > .btn-link,
+.il-viewcontrol-pagination__num-of-items > .btn-default,
+.il-viewcontrol-pagination__num-of-items > .btn-link,
+.il-viewcontrol-pagination > .btn-default,
+.il-viewcontrol-pagination > .btn-link,
+.il-viewcontrol-pagination .dropdown > .btn-default,
+.il-viewcontrol-pagination .dropdown > .btn-link,
+.il-viewcontrol-pagination .last > .btn-default,
+.il-viewcontrol-pagination .last > .btn-link,
+.il-viewcontrol-mode > .btn-default,
+.il-viewcontrol-mode > .btn-link, .il-viewcontrol-sortation > .btn-default.btn,
+.il-viewcontrol-sortation .dropdown > .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown > .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  user-select: none;
+  touch-action: manipulation;
+  font-family: "Open Sans", Verdana, Arial, Helvetica, sans-serif;
+  text-align: center;
+  line-height: inherit;
+  font-size: inherit;
+  font-weight: 400;
+  text-decoration: none;
 }
 .btn-ctrl:focus-visible, .il-viewcontrol-sortation > .btn-default:focus-visible, .il-viewcontrol-sortation > .btn-link:focus-visible,
 .il-viewcontrol-section > .btn-default:focus-visible,
@@ -3067,9 +3530,42 @@ input.btn, input.il-link.link-bulky,
 .il-viewcontrol-sortation .dropdown > .btn-default.btn:focus-visible,
 .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn:focus-visible, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link:focus-visible,
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default:focus-visible,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a:focus-visible {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a:focus-visible {
   outline: 3px solid #0078D7;
   box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 5px #FFFFFF;
+}
+.btn-ctrl, .il-viewcontrol-sortation > .btn-default, .il-viewcontrol-sortation > .btn-link,
+.il-viewcontrol-section > .btn-default,
+.il-viewcontrol-section > .btn-link,
+.il-viewcontrol-section .btn-group > .btn-default,
+.il-viewcontrol-section .btn-group > .btn-link,
+.il-viewcontrol-pagination__sectioncontrol > .btn-default,
+.il-viewcontrol-pagination__sectioncontrol > .btn-link,
+.il-viewcontrol-pagination__num-of-items > .btn-default,
+.il-viewcontrol-pagination__num-of-items > .btn-link,
+.il-viewcontrol-pagination > .btn-default,
+.il-viewcontrol-pagination > .btn-link,
+.il-viewcontrol-pagination .dropdown > .btn-default,
+.il-viewcontrol-pagination .dropdown > .btn-link,
+.il-viewcontrol-pagination .last > .btn-default,
+.il-viewcontrol-pagination .last > .btn-link,
+.il-viewcontrol-mode > .btn-default,
+.il-viewcontrol-mode > .btn-link, .il-viewcontrol-sortation > .btn-default.btn,
+.il-viewcontrol-sortation .dropdown > .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown > .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
+  min-height: 2.2rem;
+  min-width: 2.2rem;
+  font-size: 0.75rem;
+  padding: 3px 6px;
+  gap: 6px;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
+  color: #4c6586;
+  border-width: 1px;
+  border-style: solid;
+  border-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
+  border-radius: 10px;
 }
 .btn-ctrl:hover, .il-viewcontrol-sortation > .btn-default:hover, .il-viewcontrol-sortation > .btn-link:hover,
 .il-viewcontrol-section > .btn-default:hover,
@@ -3091,7 +3587,7 @@ input.btn, input.il-link.link-bulky,
 .il-viewcontrol-sortation .dropdown > .btn-default.btn:hover,
 .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn:hover, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link:hover,
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default:hover,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a:hover {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a:hover {
   text-decoration: none;
   background-color: white;
   color: #4c6586;
@@ -3119,7 +3615,7 @@ input.btn, input.il-link.link-bulky,
 .il-viewcontrol-sortation .dropdown > .btn-default.btn:active,
 .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn:active, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link:active,
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default:active,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a:active {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a:active {
   transform: none;
   background-color: white;
   color: #4c6586;
@@ -3147,7 +3643,7 @@ input.btn, input.il-link.link-bulky,
 .il-viewcontrol-sortation .dropdown > .btn-default.btn:focus,
 .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn:focus, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link:focus,
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default:focus,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a:focus {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a:focus {
   color: #4c6586;
   text-decoration: none;
 }
@@ -3171,7 +3667,7 @@ input.btn, input.il-link.link-bulky,
 .il-viewcontrol-sortation .dropdown > [disabled].btn-default.btn,
 .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > [disabled].btn-default.btn, .ilTableNav > table > tbody > tr > td > .btn-group > [disabled].btn-link,
 .ilTableNav > table > tbody > tr > td > .dropdown > [disabled].btn-default,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a[disabled],
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a[disabled],
 .btn-ctrl fieldset[disabled],
 .il-viewcontrol-sortation > .btn-default fieldset[disabled],
 .il-viewcontrol-sortation > .btn-link fieldset[disabled],
@@ -3195,7 +3691,7 @@ input.btn, input.il-link.link-bulky,
 .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn fieldset[disabled],
 .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link fieldset[disabled],
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default fieldset[disabled],
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a fieldset[disabled] {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a fieldset[disabled] {
   background-color: #b0b0b0;
   border-width: 1px;
   border-style: solid;
@@ -3224,11 +3720,11 @@ input.btn, input.il-link.link-bulky,
 .il-viewcontrol-sortation .dropdown > .engaged.btn-default.btn,
 .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .engaged.btn-default.btn, .ilTableNav > table > tbody > tr > td > .btn-group > .engaged.btn-link,
 .ilTableNav > table > tbody > tr > td > .dropdown > .engaged.btn-default,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a.engaged {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a.engaged {
   background-color: white;
   border-width: 3px;
   border-style: solid;
-  border-color: #e2e8ef;
+  border-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   color: #000;
 }
 .btn-ctrl.engaged, .il-viewcontrol-sortation > .engaged.btn-default, .il-viewcontrol-sortation > .engaged.btn-link,
@@ -3251,7 +3747,7 @@ input.btn, input.il-link.link-bulky,
 .il-viewcontrol-sortation .dropdown > .engaged.btn-default.btn,
 .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .engaged.btn-default.btn, .ilTableNav > table > tbody > tr > td > .btn-group > .engaged.btn-link,
 .ilTableNav > table > tbody > tr > td > .dropdown > .engaged.btn-default,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a.engaged, .open .btn-ctrl, .open .il-viewcontrol-sortation > .btn-default, .open .il-viewcontrol-sortation > .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a.engaged, .open .btn-ctrl, .open .il-viewcontrol-sortation > .btn-default, .open .il-viewcontrol-sortation > .btn-link,
 .open .il-viewcontrol-section > .btn-default,
 .open .il-viewcontrol-section > .btn-link,
 .open .il-viewcontrol-section .btn-group > .btn-default,
@@ -3279,7 +3775,7 @@ input.btn, input.il-link.link-bulky,
 .open .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn,
 .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .open .l-bar__element > .btn-default.btn, .open .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link,
 .open .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default,
-.open .ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a {
+.open .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
   border: 1px solid #4c6586;
   background-color: white;
 }
@@ -3311,13 +3807,13 @@ input.btn, input.il-link.link-bulky,
 .open .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn,
 .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .open .l-bar__element > .btn-default.btn, .open .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link,
 .open .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default,
-.open .ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a {
+.open .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
   box-shadow: none;
 }
 
 .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link,
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
   margin-left: 3px;
 }
 
@@ -3339,7 +3835,7 @@ input.btn, input.il-link.link-bulky,
   border-color: transparent;
 }
 .btn-link:hover {
-  color: #3a4c65;
+  color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
   text-decoration: underline;
   background-color: transparent;
 }
@@ -3354,7 +3850,7 @@ input.btn, input.il-link.link-bulky,
 }
 .btn-link.engaged {
   color: #161616;
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 
 .btn-bulky, .il-link.link-bulky,
@@ -3374,11 +3870,11 @@ input.btn, input.il-link.link-bulky,
 .btn-bulky:hover, .il-link.link-bulky:hover,
 .il-drilldown .menulevel:hover {
   text-decoration: none;
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   color: #161616;
   border-width: 1px;
   border-style: solid;
-  border-color: #e2e8ef;
+  border-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 .btn-bulky:active, .il-link.link-bulky:active,
 .il-drilldown .menulevel:active {
@@ -3407,7 +3903,7 @@ input.btn, input.il-link.link-bulky,
 }
 .btn-bulky.engaged, .engaged.il-link.link-bulky,
 .il-drilldown .engaged.menulevel {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   border-width: 1px;
   border-style: solid;
   border-color: #f0f0f0;
@@ -3475,13 +3971,15 @@ button > .glyphicon {
   background-image: url("../images/media/loader.svg");
   background-color: #b0b0b0;
   border-color: #b0b0b0;
-  background-repeat: no-repeat;
-  background-position: right center;
-  padding-right: 18px;
 }
 .il-btn-with-loading-animation:hover {
   background-color: #b0b0b0;
   border-color: #b0b0b0;
+}
+.il-btn-with-loading-animation {
+  background-repeat: no-repeat;
+  background-position: right center;
+  padding-right: 18px;
 }
 
 .minimize, .close {
@@ -3512,6 +4010,36 @@ button .minimize, button .close {
   white-space: nowrap;
   padding: 1px 3px;
   margin: 3px 6px 3px 0;
+}
+.btn-tag.btn-tag-inactive {
+  cursor: default !important;
+}
+.btn-tag.btn-tag-relevance-verylow {
+  color: #161616;
+  background-color: rgb(175.5, 175.5, 175.5);
+  border-color: rgb(175.5, 175.5, 175.5);
+}
+.btn-tag.btn-tag-relevance-low {
+  color: #161616;
+  background-color: rgb(164.7, 184.0846153846, 186.3);
+  border-color: rgb(164.7, 184.0846153846, 186.3);
+}
+.btn-tag.btn-tag-relevance-middle {
+  color: #161616;
+  background-color: rgb(148.8, 196.7230769231, 202.2);
+  border-color: rgb(148.8, 196.7230769231, 202.2);
+}
+.btn-tag.btn-tag-relevance-high {
+  color: #161616;
+  background-color: rgb(132.9, 209.3615384615, 218.1);
+  border-color: rgb(132.9, 209.3615384615, 218.1);
+}
+.btn-tag.btn-tag-relevance-veryhigh {
+  color: #161616;
+  background-color: #75deea;
+  border-color: rgb(132.9, 209.3615384615, 218.1);
+}
+.btn-tag {
   min-height: 28px;
   min-width: 28px;
   font-size: 0.75rem;
@@ -3524,49 +4052,21 @@ button .minimize, button .close {
   border-color: #4c6586;
   border-radius: 3px;
 }
-.btn-tag.btn-tag-inactive {
-  cursor: default !important;
-}
-.btn-tag.btn-tag-relevance-verylow {
-  color: #161616;
-  background-color: #b0b0b0;
-  border-color: #b0b0b0;
-}
-.btn-tag.btn-tag-relevance-low {
-  color: #161616;
-  background-color: #a5b8ba;
-  border-color: #a5b8ba;
-}
-.btn-tag.btn-tag-relevance-middle {
-  color: #161616;
-  background-color: #95c5ca;
-  border-color: #95c5ca;
-}
-.btn-tag.btn-tag-relevance-high {
-  color: #161616;
-  background-color: #85d1da;
-  border-color: #85d1da;
-}
-.btn-tag.btn-tag-relevance-veryhigh {
-  color: #161616;
-  background-color: #75deea;
-  border-color: #85d1da;
-}
 .btn-tag:hover {
   text-decoration: none;
-  background-color: #3a4c65;
+  background-color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
   color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #3a4c65;
+  border-color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
 }
 .btn-tag:active {
   transform: none;
-  background-color: #273445;
+  background-color: rgb(39.0857142857, 51.9428571429, 68.9142857143);
   color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #273445;
+  border-color: rgb(39.0857142857, 51.9428571429, 68.9142857143);
 }
 .btn-tag:focus {
   color: white;
@@ -3612,8 +4112,8 @@ button .minimize, button .close {
 }
 
 .il-toggle-button.on {
-  background: #4d6f2a;
-  border: 1px solid #4d6f2a;
+  background: rgb(76.5, 111.2727272727, 41.7272727273);
+  border: 1px solid rgb(76.5, 111.2727272727, 41.7272727273);
 }
 .il-toggle-button.on .il-toggle-label-on {
   position: absolute;
@@ -3675,7 +4175,6 @@ button .minimize, button .close {
   border: 1px solid #dddddd;
   border-radius: 0;
   box-shadow: none;
-  /* see bug #24947 */
 }
 .il-card .il-card-image-container {
   width: 100%;
@@ -3688,6 +4187,9 @@ button .minimize, button .close {
   width: 100%;
   max-height: 100%;
   margin: auto;
+}
+.il-card {
+  /* see bug #24947 */
 }
 .il-card a {
   overflow: hidden;
@@ -3726,7 +4228,7 @@ button .minimize, button .close {
 }
 .il-card .caption dl dt {
   font-weight: 400;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   padding-top: 6px;
 }
 .il-card .il-card-repository-head {
@@ -4091,7 +4593,7 @@ hr.il-divider-with-label {
 }
 
 .ui-dropzone.highlight-current {
-  border: 1px dashed #5c5c5c;
+  border: 1px dashed rgb(91.5, 91.5, 91.5);
   background-color: #FFF9BC;
 }
 
@@ -4133,9 +4635,6 @@ hr.il-divider-with-label {
 .c-entity.__actions .dropdown {
   height: max-content;
 }
-.c-entity.__secondary-identifier {
-  grid-area: second-id;
-}
 .c-entity.__secondary-identifier.--string, .c-entity.__secondary-identifier.--shy, .c-entity.__secondary-identifier.--shylink {
   width: 10rem;
 }
@@ -4144,6 +4643,9 @@ hr.il-divider-with-label {
 }
 .c-entity.__secondary-identifier.--image {
   width: 15rem;
+}
+.c-entity.__secondary-identifier {
+  grid-area: second-id;
 }
 .c-entity.__primary-identifier {
   grid-area: prim-id;
@@ -4442,7 +4944,7 @@ hr.il-divider-with-label {
 }
 
 .il-filter.disabled .il-filter-inputs-active span {
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
 }
 
 .input-group-addon {
@@ -4589,7 +5091,7 @@ hr.il-divider-with-label {
   margin-top: -3px;
   margin-bottom: 0px;
   font-size: 160%;
-  color: #e2e8ef;
+  color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 .il-input-rating .il-input-rating__none {
   float: left;
@@ -4600,14 +5102,14 @@ hr.il-divider-with-label {
   opacity: 100;
 }
 .il-input-rating .il-input-rating-scaleoption:checked ~ .il-input-rating-star {
-  color: #3a4c65;
+  color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
 }
 .il-input-rating .il-input-rating-scaleoption:checked + label + span {
   display: block;
 }
 .il-input-rating .il-input-rating-star:hover,
 .il-input-rating .il-input-rating-star:hover ~ .il-input-rating-star {
-  color: #3a4c65;
+  color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
 }
 .il-input-rating .il-input-rating:not(:hover) .il-input-rating-scaleoption:checked + label + span {
   display: block;
@@ -4624,7 +5126,7 @@ hr.il-divider-with-label {
 .il-input-rating .il-input-rating__average {
   height: 1px;
   width: 100%;
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 .il-input-rating .il-input-rating__average_value {
   height: 1px;
@@ -4670,10 +5172,6 @@ hr.il-divider-with-label {
 .c-form .c-input[data-il-ui-component=switchable-group-field-input] > .c-input__field > .c-input {
   display: grid;
   grid-template-columns: 25% 75%;
-  grid-template-rows: repeat(3, max-content) 1fr;
-  transition-property: grid-template-rows;
-  transition-duration: 0.3s;
-  transition-timing-function: ease-in-out;
 }
 .c-form .c-input[data-il-ui-component=optional-group-field-input] > .c-input__field,
 .c-form .c-input[data-il-ui-component=switchable-group-field-input] > .c-input__field > .c-input > .c-input__field {
@@ -4684,12 +5182,15 @@ hr.il-divider-with-label {
 .c-form .c-input[data-il-ui-component=optional-group-field-input] > .c-input__field > .c-input,
 .c-form .c-input[data-il-ui-component=switchable-group-field-input] > .c-input__field > .c-input > .c-input__field > .c-input {
   margin: 0;
-  padding: 12px 15px;
-  background-color: #f9f9f9;
 }
 .c-form .c-input[data-il-ui-component=optional-group-field-input] > .c-input__field > .c-input:first-child,
 .c-form .c-input[data-il-ui-component=switchable-group-field-input] > .c-input__field > .c-input > .c-input__field > .c-input:first-child {
   margin-top: 6px;
+}
+.c-form .c-input[data-il-ui-component=optional-group-field-input] > .c-input__field > .c-input,
+.c-form .c-input[data-il-ui-component=switchable-group-field-input] > .c-input__field > .c-input > .c-input__field > .c-input {
+  padding: 12px 15px;
+  background-color: #f9f9f9;
 }
 .c-form .c-input[data-il-ui-component=optional-group-field-input] > .c-input__field > .c-input:hover, .c-form .c-input[data-il-ui-component=optional-group-field-input] > .c-input__field > .c-input:has(:focus-visible),
 .c-form .c-input[data-il-ui-component=switchable-group-field-input] > .c-input__field > .c-input > .c-input__field > .c-input:hover,
@@ -4711,6 +5212,13 @@ hr.il-divider-with-label {
 .c-form .c-input[data-il-ui-component=optional-group-field-input] > .c-input__error-msg,
 .c-form .c-input[data-il-ui-component=switchable-group-field-input] > .c-input__field > .c-input > .c-input__error-msg {
   grid-area: error;
+}
+.c-form .c-input[data-il-ui-component=optional-group-field-input],
+.c-form .c-input[data-il-ui-component=switchable-group-field-input] > .c-input__field > .c-input {
+  grid-template-rows: repeat(3, max-content) 1fr;
+  transition-property: grid-template-rows;
+  transition-duration: 0.3s;
+  transition-timing-function: ease-in-out;
 }
 .c-form .c-input[data-il-ui-component=optional-group-field-input] > .c-input__field,
 .c-form .c-input[data-il-ui-component=switchable-group-field-input] > .c-input__field > .c-input > .c-input__field {
@@ -4837,8 +5345,8 @@ hr.il-divider-with-label {
   background-color: #f9f9f9;
 }
 .c-input:not([data-il-ui-component=section-field-input]):has(:focus-visible) {
-  box-shadow: 0px 0px 0px 9px #e2e8ef;
-  background-color: #e2e8ef;
+  box-shadow: 0px 0px 0px 9px rgb(226.2857142857, 231.6428571429, 238.7142857143);
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 
 .c-form .c-form__error-msg {
@@ -4846,8 +5354,8 @@ hr.il-divider-with-label {
   margin-bottom: 0;
 }
 .c-form .c-input[data-il-ui-component] input:invalid {
-  background-color: #ffd7d7;
-  border: 1px solid #ffd7d7;
+  background-color: rgb(255, 214.54, 214.54);
+  border: 1px solid rgb(255, 214.54, 214.54);
 }
 .c-form .c-input__help-byline {
   margin-top: 3px;
@@ -4855,13 +5363,15 @@ hr.il-divider-with-label {
 }
 .c-form .c-input__error-msg {
   margin-top: 3px;
-  margin-bottom: 0;
 }
 .c-form .c-input__error-msg:first-child {
   margin-top: 0;
 }
+.c-form .c-input__error-msg {
+  margin-bottom: 0;
+}
 .c-form .c-input[data-il-ui-component]:not([data-il-ui-component=section-field-input]):has(> .c-input__error-msg) {
-  border-inline-start: 6px solid #ffd7d7;
+  border-inline-start: 6px solid rgb(255, 214.54, 214.54);
   padding-left: 9px;
 }
 .c-form [data-il-ui-component=textarea-field-input] .c-input__field textarea,
@@ -4932,7 +5442,7 @@ hr.il-divider-with-label {
 }
 .il-item .il-item-property-name {
   font-size: 0.75rem;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   overflow: hidden;
 }
 .il-item .il-item-property-name:not(:empty):after {
@@ -5058,30 +5568,28 @@ hr.il-divider-with-label {
   }
 }
 .c-launcher .btn-bulky {
-  background-color: #557b2e;
+  background-color: rgb(84.5, 122.9090909091, 46.0909090909);
   color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #557b2e;
+  border-color: rgb(84.5, 122.9090909091, 46.0909090909);
   border-radius: 10px;
-  min-width: 50%;
-  width: max-content;
 }
 .c-launcher .btn-bulky:hover {
   text-decoration: none;
-  background-color: #3b5620;
+  background-color: rgb(59, 85.8181818182, 32.1818181818);
   color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #3b5620;
+  border-color: rgb(59, 85.8181818182, 32.1818181818);
 }
 .c-launcher .btn-bulky:active {
   transform: none;
-  background-color: #223112;
+  background-color: rgb(33.5, 48.7272727273, 18.2727272727);
   color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #223112;
+  border-color: rgb(33.5, 48.7272727273, 18.2727272727);
 }
 .c-launcher .btn-bulky:focus {
   color: white;
@@ -5101,8 +5609,12 @@ hr.il-divider-with-label {
   background-color: white;
   border-width: 3px;
   border-style: solid;
-  border-color: #557b2e;
+  border-color: rgb(84.5, 122.9090909091, 46.0909090909);
   color: #000;
+}
+.c-launcher .btn-bulky {
+  min-width: 50%;
+  width: max-content;
 }
 .c-launcher .btn-bulky[disabled] {
   cursor: not-allowed;
@@ -5181,16 +5693,16 @@ hr.il-divider-with-label {
 .il-maincontrols-metabar .il-counter {
   font-size: 1.4375rem;
 }
+.il-maincontrols-metabar > li > .btn.btn-bulky:focus-visible, .il-maincontrols-metabar > li > a.il-link.link-bulky:focus-visible {
+  outline: none;
+  border: 3px solid #0078D7;
+  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 2px #FFFFFF;
+}
 .il-maincontrols-metabar > li > .btn.btn-bulky, .il-maincontrols-metabar > li > a.il-link.link-bulky {
   border: none;
   background-color: transparent;
   height: 60px;
   min-width: 60px;
-}
-.il-maincontrols-metabar > li > .btn.btn-bulky:focus-visible, .il-maincontrols-metabar > li > a.il-link.link-bulky:focus-visible {
-  outline: none;
-  border: 3px solid #0078D7;
-  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 2px #FFFFFF;
 }
 @media only screen and (max-width: 991px) {
   .il-maincontrols-metabar > li > .btn.btn-bulky, .il-maincontrols-metabar > li > a.il-link.link-bulky {
@@ -5243,13 +5755,15 @@ hr.il-divider-with-label {
   background-color: #fafafa;
   position: absolute;
   max-width: 500px;
+}
+.il-metabar-slates .il-maincontrols-slate {
+  min-width: 500px;
+}
+.il-metabar-slates {
   max-height: 90vh;
   overflow-y: auto;
   right: 0;
   top: 60px;
-}
-.il-metabar-slates .il-maincontrols-slate {
-  min-width: 500px;
 }
 .il-metabar-slates .bulky-label {
   margin-top: auto;
@@ -5419,13 +5933,13 @@ main {
   display: block;
 }
 
+.il-layout-page-content:focus-visible {
+  outline: none;
+}
 .il-layout-page-content {
   display: flex;
   flex-flow: column;
   overflow: auto;
-}
-.il-layout-page-content:focus-visible {
-  outline: none;
 }
 .il-layout-page-content #mainspacekeeper {
   flex-grow: 1;
@@ -5751,15 +6265,15 @@ a[aria-disabled].il-link.link-bulky:hover {
 }
 
 /* common css for characteristic value listing */
-.il-listing-characteristic-value-row {
-  /* i tried .ilClearFloat, did not work as expected */
-  border-top: solid #dddddd 1px;
-  padding: 12px 0;
-}
 .il-listing-characteristic-value-row::after {
   display: block;
   clear: both;
   content: "";
+}
+.il-listing-characteristic-value-row {
+  /* i tried .ilClearFloat, did not work as expected */
+  border-top: solid #dddddd 1px;
+  padding: 12px 0;
 }
 
 .il-listing-characteristic-value-row:first-child {
@@ -5866,15 +6380,15 @@ a[aria-disabled].il-link.link-bulky:hover {
 }
 .il-workflow-container .not-available.in-progress .text span,
 .il-workflow-container .no-longer-available.in-progress .text span {
-  color: #5c5c5c;
+  color: rgb(91.9, 91.9, 91.9);
 }
 .il-workflow-container .not-available.not-started::before,
 .il-workflow-container .no-longer-available.not-started::before {
-  color: #5c5c5c;
+  color: rgb(91.9, 91.9, 91.9);
 }
 .il-workflow-container .not-available .text,
 .il-workflow-container .no-longer-available .text {
-  color: #5c5c5c;
+  color: rgb(91.9, 91.9, 91.9);
 }
 .il-workflow-container .no-longer-available:before {
   content: "\e023";
@@ -5986,6 +6500,12 @@ a[aria-disabled].il-link.link-bulky:hover {
 .il-maincontrols-slate.il-maincontrols-slate-notification .il-maincontrols-slate-notification-title {
   padding: 12px;
 }
+.il-maincontrols-slate.il-maincontrols-slate-notification .il-maincontrols-slate-notification-title .btn-bulky .glyph :before {
+  content: " \e605";
+  font-family: "il-icons";
+  font-size: 1.0625rem;
+  margin-right: 10px;
+}
 .il-maincontrols-slate.il-maincontrols-slate-notification .il-maincontrols-slate-notification-title .btn-bulky {
   margin: -12px;
   border: none;
@@ -5994,12 +6514,6 @@ a[aria-disabled].il-link.link-bulky:hover {
   padding: 12px;
   background-color: transparent;
   width: 50%;
-}
-.il-maincontrols-slate.il-maincontrols-slate-notification .il-maincontrols-slate-notification-title .btn-bulky .glyph :before {
-  content: " \e605";
-  font-family: "il-icons";
-  font-size: 1.0625rem;
-  margin-right: 10px;
 }
 .il-maincontrols-slate #il-tag-slate-container .btn-bulky .glyph :before, .il-maincontrols-slate #ilHelpPanel .btn-bulky .glyph :before {
   content: " \e605";
@@ -6153,16 +6667,16 @@ a[aria-disabled].il-link.link-bulky:hover {
 .il-maincontrols-metabar .il-counter {
   font-size: 1.4375rem;
 }
+.il-maincontrols-metabar > li > .btn.btn-bulky:focus-visible, .il-maincontrols-metabar > li > a.il-link.link-bulky:focus-visible {
+  outline: none;
+  border: 3px solid #0078D7;
+  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 2px #FFFFFF;
+}
 .il-maincontrols-metabar > li > .btn.btn-bulky, .il-maincontrols-metabar > li > a.il-link.link-bulky {
   border: none;
   background-color: transparent;
   height: 60px;
   min-width: 60px;
-}
-.il-maincontrols-metabar > li > .btn.btn-bulky:focus-visible, .il-maincontrols-metabar > li > a.il-link.link-bulky:focus-visible {
-  outline: none;
-  border: 3px solid #0078D7;
-  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 2px #FFFFFF;
 }
 @media only screen and (max-width: 991px) {
   .il-maincontrols-metabar > li > .btn.btn-bulky, .il-maincontrols-metabar > li > a.il-link.link-bulky {
@@ -6215,13 +6729,15 @@ a[aria-disabled].il-link.link-bulky:hover {
   background-color: #fafafa;
   position: absolute;
   max-width: 500px;
+}
+.il-metabar-slates .il-maincontrols-slate {
+  min-width: 500px;
+}
+.il-metabar-slates {
   max-height: 90vh;
   overflow-y: auto;
   right: 0;
   top: 60px;
-}
-.il-metabar-slates .il-maincontrols-slate {
-  min-width: 500px;
 }
 .il-metabar-slates .bulky-label {
   margin-top: auto;
@@ -6332,20 +6848,6 @@ a[aria-disabled].il-link.link-bulky:hover {
 .il-mainbar-tools-button .il-link.link-bulky .bulky-label,
 .il-mainbar-tool-trigger-item .btn-bulky .bulky-label,
 .il-mainbar-tool-trigger-item .il-link.link-bulky .bulky-label {
-  /* edge, chrome, safari go here... */
-  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
-  word-break: break-word;
-  -ms-hyphens: auto;
-  -moz-hyphens: auto;
-  -webkit-hyphens: auto;
-  hyphens: auto;
-}
-.il-mainbar-triggers .btn-bulky .bulky-label,
-.il-mainbar-triggers .il-link.link-bulky .bulky-label,
-.il-mainbar-tools-button .btn-bulky .bulky-label,
-.il-mainbar-tools-button .il-link.link-bulky .bulky-label,
-.il-mainbar-tool-trigger-item .btn-bulky .bulky-label,
-.il-mainbar-tool-trigger-item .il-link.link-bulky .bulky-label {
   position: relative;
   max-height: 3em;
   overflow: hidden;
@@ -6365,6 +6867,14 @@ a[aria-disabled].il-link.link-bulky:hover {
   width: 30%;
   height: 1.5em;
   background: linear-gradient(to right, rgba(255, 255, 255, 0), rgb(255, 255, 255) 80%);
+}
+.il-mainbar-triggers .btn-bulky .bulky-label,
+.il-mainbar-triggers .il-link.link-bulky .bulky-label,
+.il-mainbar-tools-button .btn-bulky .bulky-label,
+.il-mainbar-tools-button .il-link.link-bulky .bulky-label,
+.il-mainbar-tool-trigger-item .btn-bulky .bulky-label,
+.il-mainbar-tool-trigger-item .il-link.link-bulky .bulky-label {
+  /* edge, chrome, safari go here... */
 }
 @supports (-webkit-line-clamp: 2) {
   .il-mainbar-triggers .btn-bulky .bulky-label,
@@ -6388,6 +6898,14 @@ a[aria-disabled].il-link.link-bulky:hover {
     display: none;
   }
 }
+.il-mainbar-triggers .btn-bulky .bulky-label,
+.il-mainbar-triggers .il-link.link-bulky .bulky-label,
+.il-mainbar-tools-button .btn-bulky .bulky-label,
+.il-mainbar-tools-button .il-link.link-bulky .bulky-label,
+.il-mainbar-tool-trigger-item .btn-bulky .bulky-label,
+.il-mainbar-tool-trigger-item .il-link.link-bulky .bulky-label {
+  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
+}
 @supports (-moz-line-clamp: 2) {
   .il-mainbar-triggers .btn-bulky .bulky-label,
   .il-mainbar-triggers .il-link.link-bulky .bulky-label,
@@ -6409,6 +6927,18 @@ a[aria-disabled].il-link.link-bulky:hover {
   .il-mainbar-tool-trigger-item .il-link.link-bulky .bulky-label:after {
     display: none;
   }
+}
+.il-mainbar-triggers .btn-bulky .bulky-label,
+.il-mainbar-triggers .il-link.link-bulky .bulky-label,
+.il-mainbar-tools-button .btn-bulky .bulky-label,
+.il-mainbar-tools-button .il-link.link-bulky .bulky-label,
+.il-mainbar-tool-trigger-item .btn-bulky .bulky-label,
+.il-mainbar-tool-trigger-item .il-link.link-bulky .bulky-label {
+  word-break: break-word;
+  -ms-hyphens: auto;
+  -moz-hyphens: auto;
+  -webkit-hyphens: auto;
+  hyphens: auto;
 }
 
 .il-mainbar-triggers .il-mainbar-entries {
@@ -6561,7 +7091,7 @@ a[aria-disabled].il-link.link-bulky:hover {
   filter: brightness(0) invert(1);
 }
 .il-mainbar-tools-button .btn-bulky.engaged {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   color: #2c2c2c;
 }
 .il-mainbar-tools-button .btn-bulky.engaged .icon {
@@ -6593,11 +7123,14 @@ a[aria-disabled].il-link.link-bulky:hover {
 .il-mainbar-tools-entries .btn-bulky.engaged, .il-mainbar-tools-entries .btn-bulky.engaged,
 .il-mainbar-tools-entries .il-link.link-bulky.engaged {
   background-color: white;
-  color: #2c2c2c;
 }
 .il-mainbar-tools-entries .btn-bulky.engaged:not(:focus-visible), .il-mainbar-tools-entries .btn-bulky.engaged:not(:focus-visible),
 .il-mainbar-tools-entries .il-link.link-bulky.engaged:not(:focus-visible) {
   border: 0;
+}
+.il-mainbar-tools-entries .btn-bulky.engaged, .il-mainbar-tools-entries .btn-bulky.engaged,
+.il-mainbar-tools-entries .il-link.link-bulky.engaged {
+  color: #2c2c2c;
 }
 .il-mainbar-tools-entries .btn-bulky.engaged .icon, .il-mainbar-tools-entries .btn-bulky.engaged .icon,
 .il-mainbar-tools-entries .il-link.link-bulky.engaged .icon {
@@ -6612,7 +7145,7 @@ a[aria-disabled].il-link.link-bulky:hover {
 }
 
 .il-mainbar-tools-entries-bg {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   display: flex;
   height: 80px;
   width: 100%;
@@ -6673,11 +7206,11 @@ a[aria-disabled].il-link.link-bulky:hover {
   position: relative;
 }
 
-.il-mainbar-slates > .il-maincontrols-slate.engaged > .il-maincontrols-slate-content {
-  height: 0px;
-}
 .il-mainbar-slates > .il-maincontrols-slate.engaged > .il-maincontrols-slate-content > :first-child {
   z-index: 1;
+}
+.il-mainbar-slates > .il-maincontrols-slate.engaged > .il-maincontrols-slate-content {
+  height: 0px;
 }
 .il-mainbar-slates > .il-maincontrols-slate.engaged > .il-maincontrols-slate-content .panel-secondary {
   margin-bottom: 0;
@@ -6840,7 +7373,7 @@ a {
 }
 
 a:hover, a:focus {
-  color: #3a4c65;
+  color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
   text-decoration: underline;
 }
 
@@ -6968,15 +7501,15 @@ strong, b {
 code {
   font-family: Pragmata, Menlo, "DejaVu LGC Sans Mono", "DejaVu Sans Mono", Consolas, "Everson Mono", "Lucida Console", "Andale Mono", "Nimbus Mono L", "Liberation Mono", FreeMono, "Osaka Monospaced", Courier, "New Courier", monospace;
   font-size: 0.75rem;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
 }
 
 ::selection {
-  background: #e2e8ef;
+  background: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 
 ::-moz-selection {
-  background: #e2e8ef;
+  background: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 
 @media print {
@@ -6994,7 +7527,7 @@ code {
   color: #4c6586;
 }
 .c-maincontrols__footer a:hover, .c-maincontrols__footer a:focus, .c-maincontrols__footer .btn-link:hover, .c-maincontrols__footer .btn-link:focus {
-  color: #3a4c65;
+  color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
 }
 .c-maincontrols__footer .btn-link {
   min-height: 0;
@@ -7105,11 +7638,6 @@ code {
   color: white;
 }
 .c-mode-info__label {
-  /* edge, chrome, safari go here... */
-  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
-  flex-grow: 1;
-}
-.c-mode-info__label {
   position: relative;
   max-height: 1.5em;
   overflow: hidden;
@@ -7125,6 +7653,9 @@ code {
   height: 1.5em;
   background: linear-gradient(to right, rgba(255, 255, 255, 0), rgb(255, 255, 255) 80%);
 }
+.c-mode-info__label {
+  /* edge, chrome, safari go here... */
+}
 @supports (-webkit-line-clamp: 2) {
   .c-mode-info__label {
     overflow: hidden;
@@ -7137,6 +7668,9 @@ code {
     display: none;
   }
 }
+.c-mode-info__label {
+  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
+}
 @supports (-moz-line-clamp: 2) {
   .c-mode-info__label {
     overflow: hidden;
@@ -7148,6 +7682,9 @@ code {
   .c-mode-info__label:after {
     display: none;
   }
+}
+.c-mode-info__label {
+  flex-grow: 1;
 }
 @media only screen and (max-width: 991px) {
   .c-mode-info__mobile-padding {
@@ -7177,21 +7714,11 @@ code {
 /** nagtive or positive contrast color for text and glyph **/
 /** contrast threshold for contrast color **/
 /** three color variants for neutral, important, breaking Head Infos **/
-.il-system-info {
-  line-height: 20px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-  height: 32px;
-  display: flex;
-  flex-wrap: nowrap;
-  flex-direction: row;
-  justify-content: flex-start;
-}
 .il-system-info.il-system-info-neutral {
   -webkit-box-shadow: inset 0px -10px 4px -10px rgba(0, 0, 0, 0.25);
   -moz-box-shadow: inset 0px -10px 4px -10px rgba(0, 0, 0, 0.25);
   box-shadow: inset 0px -10px 4px -10px rgba(0, 0, 0, 0.25);
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   border-top: #dddddd none;
   border-bottom: #dddddd none;
   border-left: #dddddd none;
@@ -7233,10 +7760,20 @@ code {
   color: white;
 }
 .il-system-info.il-system-info-breaking a {
-  color: #9f9f9f;
+  color: rgb(159.2662116041, 159.2662116041, 159.2662116041);
 }
 .il-system-info.il-system-info-breaking a.glyph {
   color: white;
+}
+.il-system-info {
+  line-height: 20px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+  height: 32px;
+  display: flex;
+  flex-wrap: nowrap;
+  flex-direction: row;
+  justify-content: flex-start;
 }
 .il-system-info.full {
   height: auto;
@@ -7300,22 +7837,6 @@ code {
 .il-drilldown .menulevel, .navbar-form > a {
   display: inline-flex;
   vertical-align: middle;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  user-select: none;
-  touch-action: manipulation;
-  font-family: "Open Sans", Verdana, Arial, Helvetica, sans-serif;
-  text-align: center;
-  line-height: inherit;
-  font-size: inherit;
-  font-weight: 400;
-  text-decoration: none;
-  min-height: 28px;
-  min-width: 28px;
-  font-size: 0.75rem;
-  padding: 3px 6px;
-  gap: 6px;
 }
 
 .btn + .btn, .c-drilldown .c-drilldown__menulevel--trigger + .btn, .c-drilldown .btn + .c-drilldown__menulevel--trigger, .c-drilldown .c-drilldown__menulevel--trigger + .c-drilldown__menulevel--trigger, .il-link.link-bulky + .btn, .c-drilldown .il-link.link-bulky + .c-drilldown__menulevel--trigger,
@@ -7333,10 +7854,34 @@ code {
   margin-left: 3px;
 }
 
+.btn, .c-drilldown .c-drilldown__menulevel--trigger, .il-link.link-bulky,
+.il-drilldown .menulevel, .navbar-form > a {
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  user-select: none;
+  touch-action: manipulation;
+  font-family: "Open Sans", Verdana, Arial, Helvetica, sans-serif;
+  text-align: center;
+  line-height: inherit;
+  font-size: inherit;
+  font-weight: 400;
+  text-decoration: none;
+}
+
 .btn:focus-visible, .c-drilldown .c-drilldown__menulevel--trigger:focus-visible, .il-link.link-bulky:focus-visible,
 .il-drilldown .menulevel:focus-visible, .navbar-form > a:focus-visible {
   outline: 3px solid #0078D7;
   box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 5px #FFFFFF;
+}
+
+.btn, .c-drilldown .c-drilldown__menulevel--trigger, .il-link.link-bulky,
+.il-drilldown .menulevel, .navbar-form > a {
+  min-height: 28px;
+  min-width: 28px;
+  font-size: 0.75rem;
+  padding: 3px 6px;
+  gap: 6px;
 }
 
 .btn .glyph, .c-drilldown .c-drilldown__menulevel--trigger .glyph, .il-link.link-bulky .glyph,
@@ -7383,20 +7928,20 @@ input.btn, .c-drilldown input.c-drilldown__menulevel--trigger, input.il-link.lin
 
 .btn-default:hover, .navbar-form > a:hover {
   text-decoration: none;
-  background-color: #3a4c65;
+  background-color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
   color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #3a4c65;
+  border-color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
 }
 
 .btn-default:active, .navbar-form > a:active {
   transform: none;
-  background-color: #273445;
+  background-color: rgb(39.0857142857, 51.9428571429, 68.9142857143);
   color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #273445;
+  border-color: rgb(39.0857142857, 51.9428571429, 68.9142857143);
 }
 
 .btn-default:focus, .navbar-form > a:focus {
@@ -7430,30 +7975,30 @@ input.btn, .c-drilldown input.c-drilldown__menulevel--trigger, input.il-link.lin
   font-size: 0.75rem;
   padding: 3px 6px;
   gap: 6px;
-  background-color: #557b2e;
+  background-color: rgb(84.5, 122.9090909091, 46.0909090909);
   color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #557b2e;
+  border-color: rgb(84.5, 122.9090909091, 46.0909090909);
   border-radius: 0px;
 }
 
 .btn-primary:hover {
   text-decoration: none;
-  background-color: #3b5620;
+  background-color: rgb(59, 85.8181818182, 32.1818181818);
   color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #3b5620;
+  border-color: rgb(59, 85.8181818182, 32.1818181818);
 }
 
 .btn-primary:active {
   transform: none;
-  background-color: #223112;
+  background-color: rgb(33.5, 48.7272727273, 18.2727272727);
   color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #223112;
+  border-color: rgb(33.5, 48.7272727273, 18.2727272727);
 }
 
 .btn-primary:focus {
@@ -7476,15 +8021,36 @@ input.btn, .c-drilldown input.c-drilldown__menulevel--trigger, input.il-link.lin
   background-color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #557b2e;
+  border-color: rgb(84.5, 122.9090909091, 46.0909090909);
   color: #161616;
 }
 
 .btn-ctrl, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link,
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
   display: inline-flex;
   vertical-align: middle;
+}
+
+.btn-ctrl + .btn-ctrl, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link + .btn-ctrl,
+.ilTableNav > table > tbody > tr > td > .dropdown > .btn-default + .btn-ctrl,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a + .btn-ctrl, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-ctrl + .btn-link, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.btn-group > .btn-default + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.btn-group > a + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown > .btn-ctrl + .btn-default,
+.ilTableNav > table > tbody > tr > td > .btn-group.dropdown > .btn-link + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown > .btn-default + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > .btn-ctrl + a,
+.ilTableNav > table > tbody > tr > td > .btn-group.dropdown.navbar-form > .btn-link + a,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > .btn-default + a,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a + a {
+  margin-left: 3px;
+}
+
+.btn-ctrl, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown > .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
   align-items: center;
   justify-content: center;
   cursor: pointer;
@@ -7496,45 +8062,34 @@ input.btn, .c-drilldown input.c-drilldown__menulevel--trigger, input.il-link.lin
   font-size: inherit;
   font-weight: 400;
   text-decoration: none;
+}
+
+.btn-ctrl:focus-visible, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link:focus-visible,
+.ilTableNav > table > tbody > tr > td > .dropdown > .btn-default:focus-visible,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a:focus-visible {
+  outline: 3px solid #0078D7;
+  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 5px #FFFFFF;
+}
+
+.btn-ctrl, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown > .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
   min-height: 2.2rem;
   min-width: 2.2rem;
   font-size: 0.75rem;
   padding: 3px 6px;
   gap: 6px;
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   color: #4c6586;
   border-width: 1px;
   border-style: solid;
-  border-color: #e2e8ef;
+  border-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   border-radius: 10px;
-}
-
-.btn-ctrl + .btn-ctrl, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link + .btn-ctrl,
-.ilTableNav > table > tbody > tr > td > .dropdown > .btn-default + .btn-ctrl,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a + .btn-ctrl, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-ctrl + .btn-link, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link + .btn-link,
-.ilTableNav > table > tbody > tr > td > .btn-group.dropdown > .btn-default + .btn-link,
-.ilTableNav > table > tbody > tr > td > .btn-group.navbar-form.dropdown > a + .btn-link,
-.ilTableNav > table > tbody > tr > td > .dropdown > .btn-ctrl + .btn-default,
-.ilTableNav > table > tbody > tr > td > .dropdown.btn-group > .btn-link + .btn-default,
-.ilTableNav > table > tbody > tr > td > .dropdown > .btn-default + .btn-default,
-.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a + .btn-default,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > .btn-ctrl + a,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown.btn-group > .btn-link + a,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > .btn-default + a,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a + a {
-  margin-left: 3px;
-}
-
-.btn-ctrl:focus-visible, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link:focus-visible,
-.ilTableNav > table > tbody > tr > td > .dropdown > .btn-default:focus-visible,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a:focus-visible {
-  outline: 3px solid #0078D7;
-  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 5px #FFFFFF;
 }
 
 .btn-ctrl:hover, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link:hover,
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default:hover,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a:hover {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a:hover {
   text-decoration: none;
   background-color: white;
   color: #4c6586;
@@ -7545,7 +8100,7 @@ input.btn, .c-drilldown input.c-drilldown__menulevel--trigger, input.il-link.lin
 
 .btn-ctrl:active, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link:active,
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default:active,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a:active {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a:active {
   transform: none;
   background-color: white;
   color: #4c6586;
@@ -7556,18 +8111,18 @@ input.btn, .c-drilldown input.c-drilldown__menulevel--trigger, input.il-link.lin
 
 .btn-ctrl:focus, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link:focus,
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default:focus,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a:focus {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a:focus {
   color: #4c6586;
   text-decoration: none;
 }
 
 .btn-ctrl[disabled], .ilTableNav > table > tbody > tr > td > .btn-group > [disabled].btn-link,
 .ilTableNav > table > tbody > tr > td > .dropdown > [disabled].btn-default,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a[disabled],
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a[disabled],
 .btn-ctrl fieldset[disabled],
 .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link fieldset[disabled],
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default fieldset[disabled],
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a fieldset[disabled] {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a fieldset[disabled] {
   background-color: #b0b0b0;
   border-width: 1px;
   border-style: solid;
@@ -7579,32 +8134,32 @@ input.btn, .c-drilldown input.c-drilldown__menulevel--trigger, input.il-link.lin
 
 .btn-ctrl.engaged, .ilTableNav > table > tbody > tr > td > .btn-group > .engaged.btn-link,
 .ilTableNav > table > tbody > tr > td > .dropdown > .engaged.btn-default,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a.engaged {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a.engaged {
   background-color: white;
   border-width: 3px;
   border-style: solid;
-  border-color: #e2e8ef;
+  border-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   color: #000;
 }
 
 .btn-ctrl.engaged, .ilTableNav > table > tbody > tr > td > .btn-group > .engaged.btn-link,
 .ilTableNav > table > tbody > tr > td > .dropdown > .engaged.btn-default,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a.engaged, .open .btn-ctrl, .open .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a.engaged, .open .btn-ctrl, .open .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link,
 .open .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default,
-.open .ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a {
+.open .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
   border: 1px solid #4c6586;
   background-color: white;
 }
 
 .open .btn-ctrl, .open .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link,
 .open .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default,
-.open .ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a {
+.open .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
   box-shadow: none;
 }
 
 .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link,
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
   margin-left: 3px;
 }
 
@@ -7629,7 +8184,7 @@ input.btn, .c-drilldown input.c-drilldown__menulevel--trigger, input.il-link.lin
 }
 
 .btn-link:hover {
-  color: #3a4c65;
+  color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
   text-decoration: underline;
   background-color: transparent;
 }
@@ -7647,7 +8202,7 @@ input.btn, .c-drilldown input.c-drilldown__menulevel--trigger, input.il-link.lin
 
 .btn-link.engaged {
   color: #161616;
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 
 .btn-bulky, .c-drilldown .c-drilldown__menulevel--trigger, .il-link.link-bulky,
@@ -7668,11 +8223,11 @@ input.btn, .c-drilldown input.c-drilldown__menulevel--trigger, input.il-link.lin
 .btn-bulky:hover, .c-drilldown .c-drilldown__menulevel--trigger:hover, .il-link.link-bulky:hover,
 .il-drilldown .menulevel:hover {
   text-decoration: none;
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   color: #161616;
   border-width: 1px;
   border-style: solid;
-  border-color: #e2e8ef;
+  border-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 
 .btn-bulky:active, .c-drilldown .c-drilldown__menulevel--trigger:active, .il-link.link-bulky:active,
@@ -7706,7 +8261,7 @@ input.btn, .c-drilldown input.c-drilldown__menulevel--trigger, input.il-link.lin
 
 .btn-bulky.engaged, .c-drilldown .engaged.c-drilldown__menulevel--trigger, .engaged.il-link.link-bulky,
 .il-drilldown .engaged.menulevel {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   border-width: 1px;
   border-style: solid;
   border-color: #f0f0f0;
@@ -7782,14 +8337,17 @@ button > .glyphicon {
   background-image: url("../images/media/loader.svg");
   background-color: #b0b0b0;
   border-color: #b0b0b0;
-  background-repeat: no-repeat;
-  background-position: right center;
-  padding-right: 18px;
 }
 
 .il-btn-with-loading-animation:hover {
   background-color: #b0b0b0;
   border-color: #b0b0b0;
+}
+
+.il-btn-with-loading-animation {
+  background-repeat: no-repeat;
+  background-position: right center;
+  padding-right: 18px;
 }
 
 .minimize, .close {
@@ -7919,7 +8477,7 @@ button .minimize, button .close {
   display: flex;
 }
 .c-drilldown.c-drilldown--filtered .c-drilldown__menu .c-drilldown__menulevel--trigger {
-  background: #e2e8ef;
+  background: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 .c-drilldown.c-drilldown--filtered .c-drilldown__menu .c-drilldown__menulevel--trigger > .glyphicon-triangle-right {
   display: none;
@@ -7950,7 +8508,7 @@ button .minimize, button .close {
     overflow: visible;
   }
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch > .c-drilldown__menulevel--trigger {
-    background-color: #a1b3ca;
+    background-color: rgb(161.2, 178.7, 201.8);
   }
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch > ul {
     overflow: auto;
@@ -7959,23 +8517,23 @@ button .minimize, button .close {
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch > ul > li > .btn-bulky,
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch > ul > li > .link-bulky {
     display: flex;
-    background-color: #e2e8ef;
+    background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
     position: relative;
     z-index: 40;
   }
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch > ul > li > .c-drilldown__menulevel--trigger:hover,
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch > ul > li > .btn-bulky:hover,
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch > ul > li > .link-bulky:hover {
-    background-color: #a1b3ca;
-    border-color: #a1b3ca;
+    background-color: rgb(161.2, 178.7, 201.8);
+    border-color: rgb(161.2, 178.7, 201.8);
   }
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch ~ .c-drilldown__branch > .c-drilldown__menulevel--trigger {
     background-color: transparent;
     border-color: transparent;
   }
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch ~ .c-drilldown__branch > .c-drilldown__menulevel--trigger:hover {
-    background-color: #a1b3ca;
-    border-color: #a1b3ca;
+    background-color: rgb(161.2, 178.7, 201.8);
+    border-color: rgb(161.2, 178.7, 201.8);
   }
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch ~ .c-drilldown__branch > ul > li > .c-drilldown__menulevel--trigger,
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch ~ .c-drilldown__branch > ul > li > .btn-bulky,
@@ -8007,19 +8565,19 @@ button .minimize, button .close {
     width: 50%;
   }
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent > .c-drilldown__menuitem--engaged > .c-drilldown__menulevel--trigger {
-    background: #a1b3ca;
+    background: rgb(161.2, 178.7, 201.8);
   }
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent .c-drilldown__menulevel--engaged {
     overflow: auto;
   }
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent .c-drilldown__menulevel--engaged ~ .c-drilldown__menulevel--trigger {
-    background: #e2e8ef;
+    background: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   }
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent .c-drilldown__menulevel--engaged > li > .c-drilldown__branch,
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent .c-drilldown__menulevel--engaged > li > .btn-bulky,
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent .c-drilldown__menulevel--engaged > li > .c-drilldown__menulevel--trigger,
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent .c-drilldown__menulevel--engaged > li > .link-bulky {
-    background-color: #e2e8ef;
+    background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
     position: relative;
     z-index: 40;
   }
@@ -8027,8 +8585,8 @@ button .minimize, button .close {
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent .c-drilldown__menulevel--engaged > li > .btn-bulky:hover,
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent .c-drilldown__menulevel--engaged > li > .c-drilldown__menulevel--trigger:hover,
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent .c-drilldown__menulevel--engaged > li > .link-bulky:hover {
-    background-color: #a1b3ca;
-    border-color: #a1b3ca;
+    background-color: rgb(161.2, 178.7, 201.8);
+    border-color: rgb(161.2, 178.7, 201.8);
   }
 }
 .c-drilldown hr {
@@ -8043,8 +8601,8 @@ button .minimize, button .close {
 .c-drilldown .btn-bulky:hover,
 .c-drilldown .link-bulky:hover,
 .c-drilldown .c-drilldown__menulevel--trigger:hover {
-  background-color: #a1b3ca;
-  border-color: #a1b3ca;
+  background-color: rgb(161.2, 178.7, 201.8);
+  border-color: rgb(161.2, 178.7, 201.8);
   color: inherit;
 }
 .c-drilldown .c-drilldown__menu--no-items,
@@ -8074,7 +8632,7 @@ div.alert ul {
   background-color: #f9f9f9;
   padding: 6px 12px;
   font-size: 0.75rem;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   list-style-type: none;
 }
 div.alert ul > li:before {
@@ -8370,7 +8928,7 @@ div.alert ul > li:before {
   overflow: hidden;
   text-overflow: ellipsis;
   font-style: italic;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   padding-left: 6px;
 }
 
@@ -8730,7 +9288,7 @@ div.alert ul > li:before {
   font-weight: bold;
   line-height: 18px;
   background-color: #fff;
-  border-bottom: 1px solid #f2f2f2;
+  border-bottom: 1px solid rgb(242.25, 242.25, 242.25);
   border-radius: 5px 5px 0 0;
 }
 
@@ -8746,7 +9304,7 @@ div.alert ul > li:before {
 }
 .webui-popover-inverse .webui-popover-title {
   background: #333;
-  border-bottom: 1px solid #3b3b3b;
+  border-bottom: 1px solid rgb(58.65, 58.65, 58.65);
   color: #eee;
 }
 
@@ -10114,7 +10672,7 @@ div.alert ul > li:before {
   color: #4c6586;
 }
 .glyph.highlighted {
-  color: #913f00;
+  color: rgb(144.8, 63.2, 0);
 }
 .glyph.highlighted:hover {
   color: #B54F00;
@@ -10124,7 +10682,7 @@ div.alert ul > li:before {
   pointer-events: none;
 }
 .glyph:hover, .glyph:focus {
-  color: #3a4c65;
+  color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
   text-decoration: none;
 }
 .glyph:focus-visible {
@@ -10386,132 +10944,132 @@ div.alert ul > li:before {
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-1 {
   background-color: #0e6252;
-  border-color: #55e7cb;
+  border-color: rgb(85.25, 230.75, 203.0357142857);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-2 {
   background-color: #107360;
-  border-color: #65ead0;
+  border-color: rgb(101.3740458015, 233.6259541985, 208.2442748092);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-3 {
   background-color: #896F06;
-  border-color: #f8db63;
+  border-color: rgb(248.1608391608, 218.5244755245, 98.8391608392);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-4 {
   background-color: #A06608;
-  border-color: #f8c97c;
+  border-color: rgb(248.4285714286, 200.7857142857, 123.5714285714);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-5 {
   background-color: #176437;
-  border-color: #6add9a;
+  border-color: rgb(106.2195121951, 220.7804878049, 153.8292682927);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-6 {
   background-color: #196f3d;
-  border-color: #74e0a1;
+  border-color: rgb(116.25, 223.75, 161.25);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-7 {
   background-color: #B25E15;
-  border-color: #f4c79f;
+  border-color: rgb(243.7085427136, 198.5427135678, 159.2914572864);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-8 {
   background-color: #a04000;
-  border-color: #ffa76d;
+  border-color: rgb(255, 167.4, 109);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-9 {
   background-color: #1d6fa5;
-  border-color: #a0cfee;
+  border-color: rgb(159.7422680412, 207.0824742268, 238.2577319588);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-10 {
   background-color: #1b557a;
-  border-color: #7ebce3;
+  border-color: rgb(126.4496644295, 187.5637583893, 226.5503355705);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-11 {
   background-color: #bf2718;
-  border-color: #f5b5ae;
+  border-color: rgb(244.8418604651, 180.5069767442, 174.1581395349);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-12 {
   background-color: #81261d;
-  border-color: #e48f86;
+  border-color: rgb(227.835443038, 142.5949367089, 134.164556962);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-13 {
   background-color: #713b87;
-  border-color: #d0b1dd;
+  border-color: rgb(208.2371134021, 177.0618556701, 220.9381443299);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-14 {
   background-color: #522764;
-  border-color: #bb87d0;
+  border-color: rgb(186.5179856115, 134.8561151079, 208.1438848921);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-15 {
   background-color: #6A747C;
-  border-color: #d6d9dc;
+  border-color: rgb(214.0260869565, 217.3304347826, 219.9739130435);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-16 {
   background-color: #34495e;
-  border-color: #98afc6;
+  border-color: rgb(151.9863013699, 175, 198.0136986301);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-17 {
   background-color: #2c3e50;
-  border-color: #8aa4be;
+  border-color: rgb(137.5806451613, 164, 190.4193548387);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-18 {
   background-color: #566566;
-  border-color: #bfc8c9;
+  border-color: rgb(190.9787234043, 200.3936170213, 201.0212765957);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-19 {
   background-color: #90175a;
-  border-color: #ec87bf;
+  border-color: rgb(235.8562874251, 135.1437125749, 190.9101796407);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-20 {
   background-color: #9e2b6e;
-  border-color: #e9accf;
+  border-color: rgb(232.5373134328, 172.4626865672, 207.4626865672);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-21 {
   background-color: #d22f10;
-  border-color: #f9c0b5;
+  border-color: rgb(249.3362831858, 191.6371681416, 180.6637168142);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-22 {
   background-color: #666d4e;
-  border-color: #c9cdba;
+  border-color: rgb(200.9090909091, 205.3636363636, 185.6363636364);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-23 {
   background-color: #715a32;
-  border-color: #d3bf9c;
+  border-color: rgb(211.1349693252, 190.9570552147, 155.8650306748);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-24 {
   background-color: #83693a;
-  border-color: #dbcbae;
+  border-color: rgb(219.0952380952, 203, 173.9047619048);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-25 {
   background-color: #963a30;
-  border-color: #e5b3ad;
+  border-color: rgb(228.8181818182, 178.6363636364, 173.1818181818);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-26 {
   background-color: #DE2F1B;
-  border-color: #f9d1cc;
+  border-color: rgb(248.8192771084, 208.7590361446, 204.1807228916);
   color: white;
 }
 
@@ -10618,14 +11176,16 @@ div.alert ul > li:before {
   text-color: white;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
-  min-height: 20px;
-  font-size: 0.75rem;
 }
 .il-table-presentation-row .il-table-presentation-row-expanded .il-table-presentation-details .il-table-presentation-fields blockquote {
   border-color: #dddddd;
 }
+.il-table-presentation-row .il-table-presentation-row-expanded .il-table-presentation-details .il-table-presentation-fields {
+  min-height: 20px;
+  font-size: 0.75rem;
+}
 .il-table-presentation-row .il-table-presentation-row-expanded .il-table-presentation-details .il-table-presentation-fields .il-item-property-name {
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
 }
 
 .c-table-data .viewcontrols,
@@ -10811,7 +11371,7 @@ td.c-table-data__cell--highlighted {
 @media screen and (min-width: 769px) {
   .c-table-data .c-table-data__row:hover td.c-table-data__cell--highlighted,
   .c-table-ordering:not(.dragInProgress) .c-table-data__row:hover td.c-table-data__cell--highlighted {
-    background-color: #dedede;
+    background-color: rgb(222.15, 222.15, 222.15);
   }
 }
 
@@ -11012,14 +11572,14 @@ tr.c-table-data__row.c-table-data__row--drag-settle {
   text-overflow: ellipsis;
   font-style: italic;
   font-size: 0.75rem;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
 }
 .c-tree li.c-tree__node .c-tree__node__line > .c-tree__node__byline {
   padding-left: 4px;
   width: 100%;
 }
 .c-tree li.c-tree__node.highlighted > .c-tree__node__line {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 .c-tree li.c-tree__node.expandable > .c-tree__node__line:before {
   color: #737373;
@@ -11053,276 +11613,454 @@ tr.c-table-data__row.c-table-data__row--drag-settle {
   width: fit-content;
   min-height: 2.2rem;
   min-width: 2.2rem;
-  border: 1px solid #e2e8ef;
+  border: 1px solid rgb(226.2857142857, 231.6428571429, 238.7142857143);
   padding: 3px;
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   border-radius: 10px;
 }
 
 .il-viewcontrol-sortation > .btn-default, .il-viewcontrol-sortation > .btn-link, .il-viewcontrol-sortation > .btn-ctrl, .il-viewcontrol-sortation > .btn-default.btn,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-sortation > .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-sortation > .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-sortation.dropdown > .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-sortation.l-bar__element > .btn-default.btn, .il-viewcontrol-sortation > .btn-default, .il-viewcontrol-sortation > .btn-link,
+.il-viewcontrol-sortation.il-viewcontrol-section > .btn-default,
+.il-viewcontrol-sortation.il-viewcontrol-section > .btn-link,
+.il-viewcontrol-section .il-viewcontrol-sortation.btn-group > .btn-default,
+.il-viewcontrol-section .il-viewcontrol-sortation.btn-group > .btn-link,
+.il-viewcontrol-sortation.il-viewcontrol-pagination__sectioncontrol > .btn-default,
+.il-viewcontrol-sortation.il-viewcontrol-pagination__sectioncontrol > .btn-link,
+.il-viewcontrol-sortation.il-viewcontrol-pagination__num-of-items > .btn-default,
+.il-viewcontrol-sortation.il-viewcontrol-pagination__num-of-items > .btn-link,
+.il-viewcontrol-sortation.il-viewcontrol-pagination > .btn-default,
+.il-viewcontrol-sortation.il-viewcontrol-pagination > .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-sortation.dropdown > .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-sortation.dropdown > .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-sortation.last > .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-sortation.last > .btn-link,
+.il-viewcontrol-sortation.il-viewcontrol-mode > .btn-default,
+.il-viewcontrol-sortation.il-viewcontrol-mode > .btn-link,
 .il-viewcontrol-section > .btn-default,
 .il-viewcontrol-section > .btn-link,
 .il-viewcontrol-section > .btn-ctrl,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-section > .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-section > .btn-default.btn,
+.il-viewcontrol-section.il-viewcontrol-sortation > .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-section.dropdown > .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section.l-bar__element > .btn-default.btn,
+.il-viewcontrol-section.il-viewcontrol-sortation > .btn-default,
+.il-viewcontrol-section.il-viewcontrol-sortation > .btn-link,
+.il-viewcontrol-section > .btn-default,
+.il-viewcontrol-section > .btn-link,
+.il-viewcontrol-section .il-viewcontrol-section.btn-group > .btn-default,
+.il-viewcontrol-section .il-viewcontrol-section.btn-group > .btn-link,
+.il-viewcontrol-section.il-viewcontrol-pagination__sectioncontrol > .btn-default,
+.il-viewcontrol-section.il-viewcontrol-pagination__sectioncontrol > .btn-link,
+.il-viewcontrol-section.il-viewcontrol-pagination__num-of-items > .btn-default,
+.il-viewcontrol-section.il-viewcontrol-pagination__num-of-items > .btn-link,
+.il-viewcontrol-section.il-viewcontrol-pagination > .btn-default,
+.il-viewcontrol-section.il-viewcontrol-pagination > .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-section.dropdown > .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-section.dropdown > .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-section.last > .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-section.last > .btn-link,
+.il-viewcontrol-section.il-viewcontrol-mode > .btn-default,
+.il-viewcontrol-section.il-viewcontrol-mode > .btn-link,
 .il-viewcontrol-section .btn-group > .btn-default,
 .il-viewcontrol-section .btn-group > .btn-link,
 .il-viewcontrol-section .btn-group > .btn-ctrl,
-.il-viewcontrol-section .il-viewcontrol-sortation .dropdown.btn-group > .btn-default.btn,
-.il-viewcontrol-sortation .il-viewcontrol-section .dropdown.btn-group > .btn-default.btn,
-.il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.btn-group > .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .l-bar__element.btn-group > .btn-default.btn,
+.il-viewcontrol-section .btn-group.il-viewcontrol-sortation > .btn-default.btn,
+.il-viewcontrol-section .il-viewcontrol-sortation .btn-group.dropdown > .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-section .btn-group.dropdown > .btn-default.btn,
+.il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .btn-group.l-bar__element > .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .btn-group.l-bar__element > .btn-default.btn,
+.il-viewcontrol-section .btn-group.il-viewcontrol-sortation > .btn-default,
+.il-viewcontrol-section .btn-group.il-viewcontrol-sortation > .btn-link,
+.il-viewcontrol-section .btn-group.il-viewcontrol-section > .btn-default,
+.il-viewcontrol-section .btn-group.il-viewcontrol-section > .btn-link,
+.il-viewcontrol-section .btn-group > .btn-default,
+.il-viewcontrol-section .btn-group > .btn-link,
+.il-viewcontrol-section .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-default,
+.il-viewcontrol-section .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-link,
+.il-viewcontrol-section .btn-group.il-viewcontrol-pagination__num-of-items > .btn-default,
+.il-viewcontrol-section .btn-group.il-viewcontrol-pagination__num-of-items > .btn-link,
+.il-viewcontrol-section .btn-group.il-viewcontrol-pagination > .btn-default,
+.il-viewcontrol-section .btn-group.il-viewcontrol-pagination > .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination .btn-group.dropdown > .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-section .btn-group.dropdown > .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination .btn-group.dropdown > .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-section .btn-group.dropdown > .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination .btn-group.last > .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-section .btn-group.last > .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination .btn-group.last > .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-section .btn-group.last > .btn-link,
+.il-viewcontrol-section .btn-group.il-viewcontrol-mode > .btn-default,
+.il-viewcontrol-section .btn-group.il-viewcontrol-mode > .btn-link,
 .il-viewcontrol-pagination__sectioncontrol > .btn-default,
 .il-viewcontrol-pagination__sectioncontrol > .btn-link,
 .il-viewcontrol-pagination__sectioncontrol > .btn-ctrl,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination__sectioncontrol > .btn-default.btn,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-sortation > .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination__sectioncontrol.l-bar__element > .btn-default.btn,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-sortation > .btn-default,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-sortation > .btn-link,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-section > .btn-default,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-section > .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination__sectioncontrol.btn-group > .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination__sectioncontrol.btn-group > .btn-link,
+.il-viewcontrol-pagination__sectioncontrol > .btn-default,
+.il-viewcontrol-pagination__sectioncontrol > .btn-link,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination__num-of-items > .btn-default,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination__num-of-items > .btn-link,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination > .btn-default,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination > .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.last > .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.last > .btn-link,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-mode > .btn-default,
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-mode > .btn-link,
 .il-viewcontrol-pagination__num-of-items > .btn-default,
 .il-viewcontrol-pagination__num-of-items > .btn-link,
 .il-viewcontrol-pagination__num-of-items > .btn-ctrl,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination__num-of-items > .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination__num-of-items > .btn-default.btn,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-sortation > .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-pagination__num-of-items.dropdown > .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination__num-of-items.l-bar__element > .btn-default.btn,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-sortation > .btn-default,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-sortation > .btn-link,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-section > .btn-default,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-section > .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination__num-of-items.btn-group > .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination__num-of-items.btn-group > .btn-link,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination__sectioncontrol > .btn-default,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination__sectioncontrol > .btn-link,
+.il-viewcontrol-pagination__num-of-items > .btn-default,
+.il-viewcontrol-pagination__num-of-items > .btn-link,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination > .btn-default,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination > .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.dropdown > .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.dropdown > .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.last > .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.last > .btn-link,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-mode > .btn-default,
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-mode > .btn-link,
 .il-viewcontrol-pagination > .btn-default,
 .il-viewcontrol-pagination > .btn-link,
 .il-viewcontrol-pagination > .btn-ctrl,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination > .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination > .btn-default.btn,
+.il-viewcontrol-pagination.il-viewcontrol-sortation > .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-pagination.dropdown > .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination.l-bar__element > .btn-default.btn,
+.il-viewcontrol-pagination.il-viewcontrol-sortation > .btn-default,
+.il-viewcontrol-pagination.il-viewcontrol-sortation > .btn-link,
+.il-viewcontrol-pagination.il-viewcontrol-section > .btn-default,
+.il-viewcontrol-pagination.il-viewcontrol-section > .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination.btn-group > .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination.btn-group > .btn-link,
+.il-viewcontrol-pagination.il-viewcontrol-pagination__sectioncontrol > .btn-default,
+.il-viewcontrol-pagination.il-viewcontrol-pagination__sectioncontrol > .btn-link,
+.il-viewcontrol-pagination.il-viewcontrol-pagination__num-of-items > .btn-default,
+.il-viewcontrol-pagination.il-viewcontrol-pagination__num-of-items > .btn-link,
+.il-viewcontrol-pagination > .btn-default,
+.il-viewcontrol-pagination > .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-pagination.dropdown > .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-pagination.dropdown > .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-pagination.last > .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-pagination.last > .btn-link,
+.il-viewcontrol-pagination.il-viewcontrol-mode > .btn-default,
+.il-viewcontrol-pagination.il-viewcontrol-mode > .btn-link,
 .il-viewcontrol-pagination .dropdown > .btn-default,
 .il-viewcontrol-pagination .dropdown > .btn-link,
 .il-viewcontrol-pagination .dropdown > .btn-ctrl,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-sortation > .btn-default.btn,
 .il-viewcontrol-pagination .il-viewcontrol-sortation .dropdown > .btn-default.btn,
 .il-viewcontrol-sortation .il-viewcontrol-pagination .dropdown > .btn-default.btn,
-.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.dropdown > .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .l-bar__element.dropdown > .btn-default.btn,
+.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .dropdown.l-bar__element > .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .dropdown.l-bar__element > .btn-default.btn,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-sortation > .btn-default,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-sortation > .btn-link,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-section > .btn-default,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-section > .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown.btn-group > .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown.btn-group > .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown.btn-group > .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown.btn-group > .btn-link,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-default,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-link,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__num-of-items > .btn-default,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__num-of-items > .btn-link,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination > .btn-default,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination > .btn-link,
+.il-viewcontrol-pagination .dropdown > .btn-default,
+.il-viewcontrol-pagination .dropdown > .btn-link,
+.il-viewcontrol-pagination .dropdown.last > .btn-default,
+.il-viewcontrol-pagination .dropdown.last > .btn-link,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-mode > .btn-default,
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-mode > .btn-link,
 .il-viewcontrol-pagination .last > .btn-default,
 .il-viewcontrol-pagination .last > .btn-link,
 .il-viewcontrol-pagination .last > .btn-ctrl,
-.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.last > .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .l-bar__element.last > .btn-default.btn,
+.il-viewcontrol-pagination .last.il-viewcontrol-sortation > .btn-default.btn,
+.il-viewcontrol-pagination .il-viewcontrol-sortation .last.dropdown > .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-pagination .last.dropdown > .btn-default.btn,
+.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .last.l-bar__element > .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .last.l-bar__element > .btn-default.btn,
+.il-viewcontrol-pagination .last.il-viewcontrol-sortation > .btn-default,
+.il-viewcontrol-pagination .last.il-viewcontrol-sortation > .btn-link,
+.il-viewcontrol-pagination .last.il-viewcontrol-section > .btn-default,
+.il-viewcontrol-pagination .last.il-viewcontrol-section > .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-section .last.btn-group > .btn-default,
+.il-viewcontrol-section .il-viewcontrol-pagination .last.btn-group > .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-section .last.btn-group > .btn-link,
+.il-viewcontrol-section .il-viewcontrol-pagination .last.btn-group > .btn-link,
+.il-viewcontrol-pagination .last.il-viewcontrol-pagination__sectioncontrol > .btn-default,
+.il-viewcontrol-pagination .last.il-viewcontrol-pagination__sectioncontrol > .btn-link,
+.il-viewcontrol-pagination .last.il-viewcontrol-pagination__num-of-items > .btn-default,
+.il-viewcontrol-pagination .last.il-viewcontrol-pagination__num-of-items > .btn-link,
+.il-viewcontrol-pagination .last.il-viewcontrol-pagination > .btn-default,
+.il-viewcontrol-pagination .last.il-viewcontrol-pagination > .btn-link,
+.il-viewcontrol-pagination .last.dropdown > .btn-default,
+.il-viewcontrol-pagination .last.dropdown > .btn-link,
+.il-viewcontrol-pagination .last > .btn-default,
+.il-viewcontrol-pagination .last > .btn-link,
+.il-viewcontrol-pagination .last.il-viewcontrol-mode > .btn-default,
+.il-viewcontrol-pagination .last.il-viewcontrol-mode > .btn-link,
 .il-viewcontrol-mode > .btn-default,
 .il-viewcontrol-mode > .btn-link,
 .il-viewcontrol-mode > .btn-ctrl,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-mode > .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-mode > .btn-default.btn {
+.il-viewcontrol-mode.il-viewcontrol-sortation > .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-mode.dropdown > .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-mode.l-bar__element > .btn-default.btn,
+.il-viewcontrol-mode.il-viewcontrol-sortation > .btn-default,
+.il-viewcontrol-mode.il-viewcontrol-sortation > .btn-link,
+.il-viewcontrol-mode.il-viewcontrol-section > .btn-default,
+.il-viewcontrol-mode.il-viewcontrol-section > .btn-link,
+.il-viewcontrol-section .il-viewcontrol-mode.btn-group > .btn-default,
+.il-viewcontrol-section .il-viewcontrol-mode.btn-group > .btn-link,
+.il-viewcontrol-mode.il-viewcontrol-pagination__sectioncontrol > .btn-default,
+.il-viewcontrol-mode.il-viewcontrol-pagination__sectioncontrol > .btn-link,
+.il-viewcontrol-mode.il-viewcontrol-pagination__num-of-items > .btn-default,
+.il-viewcontrol-mode.il-viewcontrol-pagination__num-of-items > .btn-link,
+.il-viewcontrol-mode.il-viewcontrol-pagination > .btn-default,
+.il-viewcontrol-mode.il-viewcontrol-pagination > .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-mode.dropdown > .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-mode.dropdown > .btn-link,
+.il-viewcontrol-pagination .il-viewcontrol-mode.last > .btn-default,
+.il-viewcontrol-pagination .il-viewcontrol-mode.last > .btn-link,
+.il-viewcontrol-mode > .btn-default,
+.il-viewcontrol-mode > .btn-link {
   min-height: 1.7rem;
   min-width: 1.7rem;
   border-radius: 10px;
 }
 .il-viewcontrol-sortation > .btn-ctrl:has(> .glyph.disabled), .il-viewcontrol-sortation > .btn-default.btn:has(> .glyph.disabled),
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-sortation > .btn-default.btn:has(> .glyph.disabled),
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-sortation > .btn-default.btn:has(> .glyph.disabled), .il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled), .il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .btn-group.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section .btn-group.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination__num-of-items.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination__num-of-items.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .dropdown.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .dropdown.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .last.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .last.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-mode.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-mode.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section > .btn-ctrl:has(> .glyph.disabled),
-.il-viewcontrol-sortation.il-viewcontrol-section > .btn-default.btn:has(> .glyph.disabled),
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-section > .btn-default.btn:has(> .glyph.disabled),
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-section > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-sortation .il-viewcontrol-sortation.dropdown > .btn-default.btn:has(> .glyph.disabled),
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-sortation.l-bar__element > .btn-default.btn:has(> .glyph.disabled), .il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled), .il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-sortation.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-sortation.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .btn-group.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section .btn-group.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination__num-of-items.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination__num-of-items.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .dropdown.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .dropdown.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .last.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .last.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-mode.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-mode.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .btn-group > .btn-ctrl:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-sortation.btn-group > .btn-default.btn:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-sortation .dropdown.btn-group > .btn-default.btn:has(> .glyph.disabled),
-.il-viewcontrol-sortation .il-viewcontrol-section .dropdown.btn-group > .btn-default.btn:has(> .glyph.disabled),
-.il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.btn-group > .btn-default.btn:has(> .glyph.disabled),
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .l-bar__element.btn-group > .btn-default.btn:has(> .glyph.disabled),
 .il-viewcontrol-section .il-viewcontrol-sortation.btn-group > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-section .il-viewcontrol-sortation.btn-group > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-section.btn-group > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-section.btn-group > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .btn-group > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section .btn-group > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-pagination__sectioncontrol.btn-group > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-pagination__sectioncontrol.btn-group > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-pagination__num-of-items.btn-group > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-pagination__num-of-items.btn-group > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-pagination.btn-group > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-pagination.btn-group > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-pagination .dropdown.btn-group > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-section .dropdown.btn-group > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-pagination .dropdown.btn-group > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-section .dropdown.btn-group > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-pagination .last.btn-group > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-section .last.btn-group > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-pagination .last.btn-group > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-section .last.btn-group > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-mode.btn-group > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-mode.btn-group > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination__sectioncontrol > .btn-ctrl:has(> .glyph.disabled),
-.il-viewcontrol-sortation.il-viewcontrol-pagination__sectioncontrol > .btn-default.btn:has(> .glyph.disabled),
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-default.btn:has(> .glyph.disabled),
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination__sectioncontrol > .btn-default.btn:has(> .glyph.disabled),
 .il-viewcontrol-sortation.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-sortation.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .last.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .last.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-mode.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-mode.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination__num-of-items > .btn-ctrl:has(> .glyph.disabled),
-.il-viewcontrol-sortation.il-viewcontrol-pagination__num-of-items > .btn-default.btn:has(> .glyph.disabled),
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination__num-of-items > .btn-default.btn:has(> .glyph.disabled),
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination__num-of-items > .btn-default.btn:has(> .glyph.disabled),
 .il-viewcontrol-sortation.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-sortation.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .btn-group.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section .btn-group.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .last.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .last.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-mode.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-mode.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination > .btn-ctrl:has(> .glyph.disabled),
-.il-viewcontrol-sortation.il-viewcontrol-pagination > .btn-default.btn:has(> .glyph.disabled),
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination > .btn-default.btn:has(> .glyph.disabled),
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination > .btn-default.btn:has(> .glyph.disabled),
 .il-viewcontrol-sortation.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-sortation.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .btn-group.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section .btn-group.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .last.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .last.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-mode.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-mode.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .dropdown > .btn-ctrl:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-sortation.dropdown > .btn-default.btn:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-sortation .dropdown > .btn-default.btn:has(> .glyph.disabled),
-.il-viewcontrol-sortation .il-viewcontrol-pagination .dropdown > .btn-default.btn:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.dropdown > .btn-default.btn:has(> .glyph.disabled),
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .l-bar__element.dropdown > .btn-default.btn:has(> .glyph.disabled),
 .il-viewcontrol-pagination .il-viewcontrol-sortation.dropdown > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-pagination .il-viewcontrol-sortation.dropdown > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-section.dropdown > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-section.dropdown > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-section .btn-group.dropdown > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-pagination .btn-group.dropdown > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-section .btn-group.dropdown > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-pagination .btn-group.dropdown > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.dropdown > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.dropdown > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-pagination.dropdown > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-pagination.dropdown > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .dropdown > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .dropdown > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .last.dropdown > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .last.dropdown > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-mode.dropdown > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-mode.dropdown > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .last > .btn-ctrl:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-sortation.last > .btn-default.btn:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-sortation .dropdown.last > .btn-default.btn:has(> .glyph.disabled),
-.il-viewcontrol-sortation .il-viewcontrol-pagination .dropdown.last > .btn-default.btn:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.last > .btn-default.btn:has(> .glyph.disabled),
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .l-bar__element.last > .btn-default.btn:has(> .glyph.disabled),
 .il-viewcontrol-pagination .il-viewcontrol-sortation.last > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-pagination .il-viewcontrol-sortation.last > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-section.last > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-section.last > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-section .btn-group.last > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-pagination .btn-group.last > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-section .btn-group.last > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-pagination .btn-group.last > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.last > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.last > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.last > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.last > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-pagination.last > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-pagination.last > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .dropdown.last > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .dropdown.last > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .last > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .last > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-mode.last > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-mode.last > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-mode > .btn-ctrl:has(> .glyph.disabled),
-.il-viewcontrol-sortation.il-viewcontrol-mode > .btn-default.btn:has(> .glyph.disabled),
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-mode > .btn-default.btn:has(> .glyph.disabled),
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-mode > .btn-default.btn:has(> .glyph.disabled),
 .il-viewcontrol-sortation.il-viewcontrol-mode > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-sortation.il-viewcontrol-mode > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section > .btn-ctrl:has(> .glyph.disabled),
+.il-viewcontrol-section.il-viewcontrol-sortation > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-sortation .il-viewcontrol-section.dropdown > .btn-default.btn:has(> .glyph.disabled),
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section.l-bar__element > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-section.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-section.btn-group > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-section.btn-group > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section.dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section.dropdown > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section.last > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section.last > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-section.il-viewcontrol-mode > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-section.il-viewcontrol-mode > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .btn-group > .btn-ctrl:has(> .glyph.disabled),
+.il-viewcontrol-section .btn-group.il-viewcontrol-sortation > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-sortation .btn-group.dropdown > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-sortation .il-viewcontrol-section .btn-group.dropdown > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .btn-group.l-bar__element > .btn-default.btn:has(> .glyph.disabled),
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .btn-group.l-bar__element > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-section .btn-group.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .btn-group.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .btn-group.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .btn-group.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .btn-group > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .btn-group > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .btn-group.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .btn-group.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .btn-group.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .btn-group.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination .btn-group.dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section .btn-group.dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination .btn-group.dropdown > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section .btn-group.dropdown > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination .btn-group.last > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section .btn-group.last > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination .btn-group.last > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section .btn-group.last > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-section .btn-group.il-viewcontrol-mode > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-section .btn-group.il-viewcontrol-mode > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination__sectioncontrol > .btn-ctrl:has(> .glyph.disabled),
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-sortation > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-sortation .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-default.btn:has(> .glyph.disabled),
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination__sectioncontrol.l-bar__element > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination__sectioncontrol.btn-group > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination__sectioncontrol.btn-group > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.last > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.last > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-mode > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-mode > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination__num-of-items > .btn-ctrl:has(> .glyph.disabled),
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-sortation > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-sortation .il-viewcontrol-pagination__num-of-items.dropdown > .btn-default.btn:has(> .glyph.disabled),
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination__num-of-items.l-bar__element > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination__num-of-items.btn-group > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination__num-of-items.btn-group > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.dropdown > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.last > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.last > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-pagination__num-of-items.il-viewcontrol-mode > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-pagination__num-of-items.il-viewcontrol-mode > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination > .btn-ctrl:has(> .glyph.disabled),
+.il-viewcontrol-pagination.il-viewcontrol-sortation > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-sortation .il-viewcontrol-pagination.dropdown > .btn-default.btn:has(> .glyph.disabled),
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination.l-bar__element > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-pagination.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination.btn-group > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination.btn-group > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-pagination.dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-pagination.dropdown > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-pagination.last > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-pagination.last > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-pagination.il-viewcontrol-mode > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-pagination.il-viewcontrol-mode > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown > .btn-ctrl:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-sortation > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-sortation .dropdown > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-sortation .il-viewcontrol-pagination .dropdown > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .dropdown.l-bar__element > .btn-default.btn:has(> .glyph.disabled),
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .dropdown.l-bar__element > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown.btn-group > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown.btn-group > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown.btn-group > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown.btn-group > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown.last > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown.last > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-pagination .dropdown.il-viewcontrol-mode > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-pagination .dropdown.il-viewcontrol-mode > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last > .btn-ctrl:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last.il-viewcontrol-sortation > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-sortation .last.dropdown > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-sortation .il-viewcontrol-pagination .last.dropdown > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .last.l-bar__element > .btn-default.btn:has(> .glyph.disabled),
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .last.l-bar__element > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section .last.btn-group > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination .last.btn-group > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section .last.btn-group > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination .last.btn-group > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last.dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last.dropdown > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-pagination .last.il-viewcontrol-mode > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-pagination .last.il-viewcontrol-mode > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-mode > .btn-ctrl:has(> .glyph.disabled),
+.il-viewcontrol-mode.il-viewcontrol-sortation > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-sortation .il-viewcontrol-mode.dropdown > .btn-default.btn:has(> .glyph.disabled),
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-mode.l-bar__element > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-mode.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-mode.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-mode.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-mode.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-mode.btn-group > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-mode.btn-group > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-mode.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-mode.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-mode.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-mode.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-mode.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-mode.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-mode.dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-mode.dropdown > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-mode.last > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-mode.last > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-mode > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-mode > .btn-link:has(> .glyph.disabled) {
   border: none;
   cursor: default;
   pointer-events: none;
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 
 .il-viewcontrol-sortation > .btn-default.btn,
@@ -11438,11 +12176,11 @@ div#agreement {
 
 .alert-success {
   color: #161616;
-  background-color: #ebf4e1;
-  border-color: #ebf4e1;
+  background-color: rgb(234.7, 243.9272727273, 225.4727272727);
+  border-color: rgb(234.7, 243.9272727273, 225.4727272727);
 }
 .alert-success hr {
-  border-top-color: #deedcf;
+  border-top-color: rgb(221.95, 236.9727272727, 206.9272727273);
 }
 .alert-success .alert-link {
   color: black;
@@ -11450,11 +12188,11 @@ div#agreement {
 
 .alert-info {
   color: #161616;
-  background-color: #deecf4;
-  border-color: #deecf4;
+  background-color: rgb(221.841875, 236.45, 243.638125);
+  border-color: rgb(221.841875, 236.45, 243.638125);
 }
 .alert-info hr {
-  border-top-color: #cbe2ed;
+  border-top-color: rgb(202.8496875, 225.825, 237.1303125);
 }
 .alert-info .alert-link {
   color: black;
@@ -11462,11 +12200,11 @@ div#agreement {
 
 .alert-warning {
   color: #161616;
-  background-color: #ffe5d1;
-  border-color: #ffe5d1;
+  background-color: rgb(255, 229.0435359116, 208.94);
+  border-color: rgb(255, 229.0435359116, 208.94);
 }
 .alert-warning hr {
-  border-top-color: #ffd7b7;
+  border-top-color: rgb(255, 214.6733701657, 183.44);
 }
 .alert-warning .alert-link {
   color: black;
@@ -11474,11 +12212,11 @@ div#agreement {
 
 .alert-danger {
   color: #161616;
-  background-color: #ffd7d7;
-  border-color: #ffd7d7;
+  background-color: rgb(255, 214.54, 214.54);
+  border-color: rgb(255, 214.54, 214.54);
 }
 .alert-danger hr {
-  border-top-color: #ffbdbd;
+  border-top-color: rgb(255, 189.04, 189.04);
 }
 .alert-danger .alert-link {
   color: black;
@@ -12218,7 +12956,7 @@ tbody.collapse.in {
   padding-left: 8px;
 }
 
-.btn-group > .btn-lg + .dropdown-toggle, .btn-group-lg.btn-group > .btn + .dropdown-toggle {
+.btn-group > .btn-lg + .dropdown-toggle, .btn-group.btn-group-lg > .btn + .dropdown-toggle {
   padding-right: 12px;
   padding-left: 12px;
 }
@@ -12509,7 +13247,7 @@ tbody.collapse.in {
   margin: 0;
   width: 12px;
   height: 12px;
-  background-color: #3a4c65;
+  background-color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
 }
 
 .carousel-caption {
@@ -12752,7 +13490,7 @@ div.ilBlogListItemTitle h3 {
 
 div.ilBlogListItemSubTitle {
   margin-top: 5px;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   font-size: 0.75rem;
   text-align: right;
 }
@@ -12785,7 +13523,7 @@ td.ilBlogSideBlockContent {
 
 td.ilBlogSideBlockCommand {
   font-size: 0.75rem;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   border-bottom: 1px solid #dddddd;
   padding: 1px 3px;
   background-color: #f9f9f9;
@@ -13005,14 +13743,14 @@ ul.il-book-obj-selection li {
   width: 100%;
 }
 
+.chatroom-centered-checkboxes label {
+  margin: 0 5px 0 0;
+}
 .chatroom-centered-checkboxes {
   display: flex;
   align-items: center;
   justify-content: space-between;
   margin-bottom: 5px;
-}
-.chatroom-centered-checkboxes label {
-  margin: 0 5px 0 0;
 }
 
 @media only screen and (max-width: 991px) {
@@ -13104,7 +13842,7 @@ td.chatroom {
   border-radius: 50%;
 }
 .ilChatroomUser .media-body h4, .ilChatroomUser .media-body p {
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   font-size: 0.75rem;
   padding: 5px 3px 0 3px;
   line-height: 1em;
@@ -13112,7 +13850,7 @@ td.chatroom {
 }
 .ilChatroomUser .media-body h4 {
   padding-top: 0;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -13139,7 +13877,7 @@ td.chatroom {
   margin-left: 100px;
 }
 .ilChatroomUser .media:hover {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 .ilChatroomUser .dropdown-menu > li > button.btn {
   padding-left: 10px;
@@ -13590,7 +14328,7 @@ div.ilForumQuoteHead {
 }
 
 div.ilFrmPostHeader span.small {
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
 }
 
 .ilFrmPostContentContainer {
@@ -13972,10 +14710,12 @@ div#right_bottom_area iframe {
 }
 #il-mcst-img-gallery .modal-content {
   min-height: 100%;
-  background-color: black;
 }
 #il-mcst-img-gallery .modal-content img {
   margin: 30px auto 0 auto;
+}
+#il-mcst-img-gallery .modal-content {
+  background-color: black;
 }
 #il-mcst-img-gallery .modal-title {
   color: white;
@@ -14078,7 +14818,7 @@ div#right_bottom_area iframe {
 .ilPollDescription {
   margin: 5px;
   font-size: 0.75rem;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
 }
 
 .ilPollQuestion {
@@ -14094,7 +14834,7 @@ div#right_bottom_area iframe {
   width: 97%;
   margin: 1.5%;
   font-size: 0.75rem;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
 }
 
 img.ilPollQuestionImage {
@@ -14161,12 +14901,12 @@ div.ilPrtfToc {
   margin-top: 40px;
 }
 
-body.ilPrtfPdfBody {
-  margin: 0;
-}
 body.ilPrtfPdfBody > div.ilInvisibleBorder {
   padding: 0;
   padding-left: 40px;
+}
+body.ilPrtfPdfBody {
+  margin: 0;
 }
 
 body.ilPrtfPdfBody h1.ilc_PrintPageTitle {
@@ -14325,15 +15065,15 @@ div.il-survey-question {
 }
 
 div.ilSurveyPageEditDropArea {
-  border-color: #88be51;
-  color: #88be51;
-  background-color: #aed389;
+  border-color: rgb(135.5, 189.8181818182, 81.1818181818);
+  color: rgb(135.5, 189.8181818182, 81.1818181818);
+  background-color: rgb(173.75, 210.6818181818, 136.8181818182);
 }
 
 div.ilSurveyPageEditDropAreaSelected {
-  border-color: #88be51;
-  color: #88be51;
-  background-color: #94c564;
+  border-color: rgb(135.5, 189.8181818182, 81.1818181818);
+  color: rgb(135.5, 189.8181818182, 81.1818181818);
+  background-color: rgb(148.25, 196.7727272727, 99.7272727273);
 }
 
 div.ilSurveyPageEditAreaDragging {
@@ -14941,7 +15681,7 @@ div.ilc_Page.readonly textarea[disabled] {
   border: 1px solid #dddddd;
 }
 .c-test__dropzone.c-test__dropzone--hover {
-  background: #e2e8ef;
+  background: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 .c-test__dropzone.c-test__dropzone--active {
   display: block;
@@ -14964,7 +15704,7 @@ div.ilc_Page.readonly textarea[disabled] {
 
 .c-test__term {
   border: 1px solid #dddddd;
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   margin: 5px 10px 5px 0;
   padding: 3px;
   cursor: move;
@@ -14996,7 +15736,7 @@ div.ilc_Page.readonly textarea[disabled] {
   cursor: default;
 }
 .c-test__longmenu__selectionlist li:hover {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 
 #tst_output {
@@ -15211,7 +15951,7 @@ li.ilWikiBlockItem {
   border: 0;
 }
 .il_VAccordionHead:hover, .il_HAccordionHead:hover {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 
 .il_VAccordionHead {
@@ -15234,7 +15974,7 @@ li.ilWikiBlockItem {
 
 .il_HAccordionHeadActive, .il_VAccordionHeadActive {
   background-image: url("../images/nav/tree_exp.svg");
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 
 .ilAccHideContent {
@@ -15283,7 +16023,7 @@ div.ilc_va_icont_VAccordICont {
   display: table;
 }
 #awareness-content .media:hover {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 #awareness-content .glyphicon {
   font-size: inherit;
@@ -15347,7 +16087,7 @@ div.ilc_va_icont_VAccordICont {
 }
 
 #awareness-content .media-body h4, #awareness-content .media-body p {
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   font-size: 0.75rem;
   padding: 5px 3px 0 3px;
   line-height: 1em;
@@ -15446,8 +16186,8 @@ div.ilc_va_icont_VAccordICont {
 }
 
 #awareness-content .ilHighlighted {
-  background-color: #e2e8ef;
-  color: #6f6f6f;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
+  color: rgb(111.25, 111.25, 111.25);
 }
 
 .ilAwrnBadgeHidden {
@@ -15565,13 +16305,13 @@ h3.ilBlockHeader {
 /* possibly deprecated */
 .il_BlockInfo {
   font-size: 0.75rem;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
 }
 
 /* new class */
 div.ilBlockInfo {
   font-size: 0.75rem;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   padding: 1px 3px;
   background-color: #f9f9f9;
   text-align: right;
@@ -15587,7 +16327,7 @@ div.ilBlockContent {
 }
 
 div.ilBlockPropertyCaption {
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
 }
 
 /* Services/Bookmarks */
@@ -15701,15 +16441,17 @@ table.calmini {
 table.calmini tr, table.calmini td, table.calmini th {
   border: none;
   padding: 5px 3px;
-  text-align: center;
-  vertical-align: middle;
-  color: #161616;
-  background-color: transparent;
 }
 @media only screen and (max-width: 991px) {
   table.calmini tr, table.calmini td, table.calmini th {
     padding: 5px 1px;
   }
+}
+table.calmini tr, table.calmini td, table.calmini th {
+  text-align: center;
+  vertical-align: middle;
+  color: #161616;
+  background-color: transparent;
 }
 table.calmini tr {
   background-color: white;
@@ -16146,7 +16888,7 @@ div.ilListItemSection {
 }
 
 div.ilContainerListItemOuterHighlight {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   zoom: 1;
 }
 
@@ -16398,8 +17140,8 @@ button.copg-add.dropdown-toggle.btn:hover .il-copg-add-text,
 }
 
 button.copg-add.dropdown-toggle.btn:hover {
-  background-color: #e2e8ef;
-  color: #6f6f6f;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
+  color: rgb(111.25, 111.25, 111.25);
 }
 
 [data-copg-ed-type=add-area] ul.dropdown-menu {
@@ -16407,14 +17149,14 @@ button.copg-add.dropdown-toggle.btn:hover {
 }
 
 button.copg-add:hover {
-  color: #88be51;
-  background-color: #f3f8ed;
+  color: rgb(135.5, 189.8181818182, 81.1818181818);
+  background-color: rgb(242.6, 248.2363636364, 236.9636363636);
 }
 
 div.il_droparea {
   padding: 1px 5px;
   border: 1px dashed #dddddd;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   text-align: center;
   font-size: 0.75rem;
   background-color: #fffed1;
@@ -16423,14 +17165,14 @@ div.il_droparea {
 }
 
 div.il_droparea:hover, div.ilCOPGDropActice, .il_droparea_valid_target {
-  border-color: #88be51;
-  color: #88be51;
-  background-color: #f3f8ed;
+  border-color: rgb(135.5, 189.8181818182, 81.1818181818);
+  color: rgb(135.5, 189.8181818182, 81.1818181818);
+  background-color: rgb(242.6, 248.2363636364, 236.9636363636);
 }
 
 div.ilCOPGNoPageContent {
   padding: 20px 5px;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
 }
 
 div.il_editarea_nojs {
@@ -16500,7 +17242,7 @@ div.il_editarea_disabled, div.copg-disabled-page {
 div.il_editarea_selected, div.copg-current-edit, #tinytarget_ifr {
   border-style: solid;
   border-width: 2px;
-  border-color: #bbda9b;
+  border-color: rgb(186.5, 217.6363636364, 155.3636363636);
 }
 
 div.il_editarea_selected:hover {
@@ -16583,7 +17325,7 @@ div.ilTinyMenuSection, .il-copg-button-group {
 div.ilTinyMenuSection p, .il-copg-button-group p {
   margin-bottom: 5px;
   padding: 2px 5px;
-  background-color: #efefef;
+  background-color: rgb(238.8, 238.8, 238.8);
 }
 
 div.ilTinyMenuSection button.btn {
@@ -16626,7 +17368,7 @@ div.il-copg-button-group-wide {
   margin: 0;
 }
 #iltinymenu .bd div .small {
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   font-style: italic;
 }
 #iltinymenu .btn-default .mce-ico {
@@ -16703,7 +17445,7 @@ a.ilc_page_toc_PageTOCLink {
 }
 
 a.ilc_page_toc_PageTOCLink:hover {
-  color: #3a4c65;
+  color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
 }
 
 a.ilc_page_toc_PageTOCLink:visited {
@@ -16811,11 +17553,11 @@ div.ilEditNew {
 }
 
 span.ilDiffDel {
-  background-color: #ff9c4f;
+  background-color: rgb(255, 155.817679558, 79);
 }
 
 span.ilDiffIns {
-  background-color: #bbda9b;
+  background-color: rgb(186.5, 217.6363636364, 155.3636363636);
 }
 
 a.nostyle:link, a.nostyle:visited {
@@ -16881,7 +17623,7 @@ a.nostyle:hover {
   text-align: center;
   display: table-cell;
   vertical-align: middle;
-  background-color: #3b5620;
+  background-color: rgb(59, 85.8181818182, 32.1818181818);
   color: white;
 }
 
@@ -16892,7 +17634,7 @@ a.nostyle:hover {
 }
 
 .ilCOPgEditStyleSelectionItem:hover {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 
 ul#ilAdvSelListTable_style_selection {
@@ -17117,7 +17859,7 @@ p#copg-auto-save {
 .copg-new-content-placeholder,
 .copg-content-placeholder-lso-curriculum {
   text-align: center;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   padding: 20px;
 }
 .copg-new-content-placeholder .icon,
@@ -17258,14 +18000,14 @@ select[size] {
   box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 5px #FFFFFF;
 }
 .form-control::-moz-placeholder {
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   opacity: 1;
 }
 .form-control:-ms-input-placeholder {
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
 }
 .form-control::-webkit-input-placeholder {
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
 }
 .form-control[required]::-moz-placeholder {
   color: #161616;
@@ -17482,16 +18224,6 @@ fieldset[disabled] .checkbox label {
 .form-horizontal {
   margin-bottom: 15px;
   background: white;
-  /*
-  // Reset spacing and right align labels, but scope to media queries so that
-  // labels on narrow viewports stack the same as a default form example.
-  @media (min-width: $screen-sm-min) {
-  	.control-label {
-  		text-align: right;
-  		margin-bottom: 0;
-  		padding-top: ($il-padding-base-vertical + 1); // Default padding plus a border
-  	}
-  } */
 }
 .form-horizontal .form-group {
   margin: 0px;
@@ -17544,6 +18276,18 @@ fieldset[disabled] .checkbox label {
 }
 .form-horizontal .control-label > .asterisk {
   padding-left: 3px;
+}
+.form-horizontal {
+  /*
+  // Reset spacing and right align labels, but scope to media queries so that
+  // labels on narrow viewports stack the same as a default form example.
+  @media (min-width: $screen-sm-min) {
+  	.control-label {
+  		text-align: right;
+  		margin-bottom: 0;
+  		padding-top: ($il-padding-base-vertical + 1); // Default padding plus a border
+  	}
+  } */
 }
 
 .ilFormHeader {
@@ -17735,7 +18479,7 @@ div[id$=color-picker-menu] {
   cursor: default;
 }
 .c-form__autocomplete li:hover {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 
 /* Services/Help */
@@ -17823,17 +18567,17 @@ a#ilHelpClose {
   }
 }
 
-.ilStartupSection {
-  padding-top: 20px;
-  width: fit-content;
-  margin-left: auto;
-  margin-right: auto;
-}
 .ilStartupSection .control-label {
   width: 33.33%;
 }
 .ilStartupSection .control-label + div {
   width: 66.67%;
+}
+.ilStartupSection {
+  padding-top: 20px;
+  width: fit-content;
+  margin-left: auto;
+  margin-right: auto;
 }
 @media only screen and (max-width: 991px) {
   .ilStartupSection {
@@ -17865,8 +18609,6 @@ ul.ilStartupSectionLoginLinks li {
 div.ilStartupSection form.form-horizontal {
   border: 1px solid #dddddd;
   border-radius: 3px;
-  text-align: left;
-  width: 40em;
 }
 div.ilStartupSection form.form-horizontal .ilFormHeader {
   padding: 9px 15px;
@@ -17874,6 +18616,10 @@ div.ilStartupSection form.form-horizontal .ilFormHeader {
 }
 div.ilStartupSection form.form-horizontal .form-group {
   margin: 9px 0;
+}
+div.ilStartupSection form.form-horizontal {
+  text-align: left;
+  width: 40em;
 }
 @media only screen and (max-width: 991px) {
   div.ilStartupSection form.form-horizontal {
@@ -18392,7 +19138,7 @@ span.ilNewsRssIcon {
 }
 span.ilNewsRssIcon:hover {
   text-decoration: none;
-  background-color: #823900;
+  background-color: rgb(130, 56.7403314917, 0);
 }
 
 /* timeline, see http://codepen.io/jasondavis/pen/fDGdK */
@@ -18799,10 +19545,10 @@ div.ilCreationFormSection .form-horizontal {
   background-color: white;
 }
 .table-striped > tbody > tr.ilObjListRow:hover > td {
-  background-color: #f3f5f8;
+  background-color: rgb(242.5571428571, 244.8785714286, 247.9428571429);
 }
 .table-striped > tbody > tr.ilObjListRow:hover:nth-child(2n+1) > td {
-  background-color: #f3f5f8;
+  background-color: rgb(242.5571428571, 244.8785714286, 247.9428571429);
 }
 
 [data-onscreenchat-inact-userid] {
@@ -18977,7 +19723,7 @@ div.ilCreationFormSection .form-horizontal {
 }
 #onscreenchat-container .chat-window-wrapper .chat li .chat-body p {
   margin: 0;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   font-size: 0.75rem;
 }
 #onscreenchat-container .chat-window-wrapper .panel {
@@ -19207,7 +19953,7 @@ div.ilSkill > h4 {
   margin: 10px 0;
   padding: 0;
   font-size: 0.875rem;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   float: left;
   clear: left;
 }
@@ -19307,7 +20053,7 @@ th.ilSkillEntryHead {
 }
 
 .ilSkillEvalItem.ilSkillEvalType3 {
-  border-color: #557b2e;
+  border-color: rgb(84.5, 122.9090909091, 46.0909090909);
 }
 
 .ilSkillEvalItem > .row > .ilSkillEvalType1 {
@@ -19319,7 +20065,7 @@ th.ilSkillEntryHead {
 }
 
 .ilSkillEvalItem > .row > .ilSkillEvalType3 {
-  color: #557b2e;
+  color: rgb(84.5, 122.9090909091, 46.0909090909);
 }
 
 .ilSkillFilter .ilToolbar select.form-control {
@@ -19698,7 +20444,7 @@ tr.tblheader {
 }
 
 .tblrowmarked {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   color: #161616;
   padding: 3px;
 }
@@ -19718,7 +20464,7 @@ tr.tblheader {
 }
 
 .tblrowmarkedtop {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   color: #161616;
   padding: 3px;
   vertical-align: top;
@@ -19776,19 +20522,19 @@ td > img[src$="icon_custom.svg"] {
   border-radius: 3px;
 }
 .ilTag .ilTagRelHigh {
-  background-color: #85d1da;
+  background-color: rgb(132.9, 209.3615384615, 218.1);
   color: #161616;
 }
 .ilTag .ilTagRelMiddle {
-  background-color: #95c5ca;
+  background-color: rgb(148.8, 196.7230769231, 202.2);
   color: #161616;
 }
 .ilTag .ilTagRelLow {
-  background-color: #a5b8ba;
+  background-color: rgb(164.7, 184.0846153846, 186.3);
   color: #161616;
 }
 .ilTag .ilTagRelVeryLow {
-  background-color: #b0b0b0;
+  background-color: rgb(175.5, 175.5, 175.5);
   color: #161616;
 }
 .ilTag.ilHighlighted, .ilTag.ilHighlighted:hover {
@@ -19796,7 +20542,7 @@ td > img[src$="icon_custom.svg"] {
   color: white;
 }
 .ilTag.ilHighlighted:hover, .ilTag.ilHighlighted:hover:hover {
-  background-color: #9c4400;
+  background-color: rgb(155.5, 67.8701657459, 0);
 }
 
 a.ilTag:hover, a.ilTag:active {
@@ -19973,11 +20719,11 @@ div.ilChecklist ul a:hover {
 }
 
 div.ilChecklist ul li a:hover {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 
 div.ilChecklist ul li p, div.ilChecklist ul li p:hover {
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   font-size: 0.625rem;
   text-decoration: none;
   padding: 0;
@@ -20053,14 +20799,14 @@ li.il_Explorer {
 }
 
 a.il_HighlightedNode, .ilHighlighted {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   padding: 0 5px;
 }
 
 li.ilExplSecHighlight {
   background-color: #f9f9f9 !important;
-  border-top: solid 2px #557196;
-  border-bottom: solid 2px #557196;
+  border-top: solid 2px rgb(85.2285714286, 113.2642857143, 150.2714285714);
+  border-bottom: solid 2px rgb(85.2285714286, 113.2642857143, 150.2714285714);
 }
 
 div.il_ExplorerItemDescription {
@@ -20260,7 +21006,7 @@ a.ilMediaLightboxClose:hover {
 .progress {
   height: 15px;
   min-width: 100px;
-  background-color: #b8b8b8;
+  background-color: rgb(184.25, 184.25, 184.25);
 }
 
 .progress-bar {
@@ -20559,7 +21305,7 @@ h3.ilProfileName {
 div.ilProfileSection {
   margin-top: 15px;
   font-size: 0.75rem;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
 }
 
 h3.ilProfileSectionHead {
@@ -20843,10 +21589,6 @@ div.ilFrame {
 }
 
 .il-multi-line-cap-2 {
-  /* edge, chrome, safari go here... */
-  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
-}
-.il-multi-line-cap-2 {
   position: relative;
   max-height: 3em;
   overflow: hidden;
@@ -20862,6 +21604,9 @@ div.ilFrame {
   height: 1.5em;
   background: linear-gradient(to right, rgba(255, 255, 255, 0), rgb(255, 255, 255) 80%);
 }
+.il-multi-line-cap-2 {
+  /* edge, chrome, safari go here... */
+}
 @supports (-webkit-line-clamp: 2) {
   .il-multi-line-cap-2 {
     overflow: hidden;
@@ -20873,6 +21618,9 @@ div.ilFrame {
   .il-multi-line-cap-2:after {
     display: none;
   }
+}
+.il-multi-line-cap-2 {
+  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
 }
 @supports (-moz-line-clamp: 2) {
   .il-multi-line-cap-2 {
@@ -20887,10 +21635,6 @@ div.ilFrame {
   }
 }
 
-.il-multi-line-cap-3 {
-  /* edge, chrome, safari go here... */
-  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
-}
 .il-multi-line-cap-3 {
   position: relative;
   max-height: 4.5em;
@@ -20907,6 +21651,9 @@ div.ilFrame {
   height: 1.5em;
   background: linear-gradient(to right, rgba(255, 255, 255, 0), rgb(255, 255, 255) 80%);
 }
+.il-multi-line-cap-3 {
+  /* edge, chrome, safari go here... */
+}
 @supports (-webkit-line-clamp: 2) {
   .il-multi-line-cap-3 {
     overflow: hidden;
@@ -20918,6 +21665,9 @@ div.ilFrame {
   .il-multi-line-cap-3:after {
     display: none;
   }
+}
+.il-multi-line-cap-3 {
+  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
 }
 @supports (-moz-line-clamp: 2) {
   .il-multi-line-cap-3 {
@@ -20932,10 +21682,6 @@ div.ilFrame {
   }
 }
 
-.il-multi-line-cap-5 {
-  /* edge, chrome, safari go here... */
-  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
-}
 .il-multi-line-cap-5 {
   position: relative;
   max-height: 7.5em;
@@ -20952,6 +21698,9 @@ div.ilFrame {
   height: 1.5em;
   background: linear-gradient(to right, rgba(255, 255, 255, 0), rgb(255, 255, 255) 80%);
 }
+.il-multi-line-cap-5 {
+  /* edge, chrome, safari go here... */
+}
 @supports (-webkit-line-clamp: 2) {
   .il-multi-line-cap-5 {
     overflow: hidden;
@@ -20963,6 +21712,9 @@ div.ilFrame {
   .il-multi-line-cap-5:after {
     display: none;
   }
+}
+.il-multi-line-cap-5 {
+  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
 }
 @supports (-moz-line-clamp: 2) {
   .il-multi-line-cap-5 {
@@ -20977,10 +21729,6 @@ div.ilFrame {
   }
 }
 
-.il-multi-line-cap-10 {
-  /* edge, chrome, safari go here... */
-  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
-}
 .il-multi-line-cap-10 {
   position: relative;
   max-height: 15em;
@@ -20997,6 +21745,9 @@ div.ilFrame {
   height: 1.5em;
   background: linear-gradient(to right, rgba(255, 255, 255, 0), rgb(255, 255, 255) 80%);
 }
+.il-multi-line-cap-10 {
+  /* edge, chrome, safari go here... */
+}
 @supports (-webkit-line-clamp: 2) {
   .il-multi-line-cap-10 {
     overflow: hidden;
@@ -21008,6 +21759,9 @@ div.ilFrame {
   .il-multi-line-cap-10:after {
     display: none;
   }
+}
+.il-multi-line-cap-10 {
+  /* may come with next firefox 68, https://caniuse.com/#search=clamp */
 }
 @supports (-moz-line-clamp: 2) {
   .il-multi-line-cap-10 {
@@ -21131,7 +21885,7 @@ div.Access {
 }
 
 .light {
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
 }
 
 /*# sourceMappingURL=delos.css.map */


### PR DESCRIPTION
Fix dropdown alignmen (and visibility problems) after change introduced in 27751. It better solves the original problem.

The solution for 27751 tried to fix the alignment of the dropdown at the top of the slate (the one used for example to select the style for a page), but affected other dropdowns in the slate.

The new solution points better at this dropdown to not affect the rest.