### PR TITLE
[FIX] #47986 UI: update `Text` and `Textarea` default value

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Text.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Text.php
@@ -67,6 +67,11 @@ class Text extends FormInput implements C\Input\Field\Text
         return $this->max_length;
     }
 
+    public function withValue($value): self
+    {
+        return parent::withValue($value ?? "");
+    }
+
     /**
      * @inheritdoc
      */

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Textarea.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Textarea.php
@@ -101,6 +101,11 @@ class Textarea extends FormInput implements C\Input\Field\Textarea, HasMustacheV
         return $this->min_limit;
     }
 
+    public function withValue($value): self
+    {
+        return parent::withValue($value ?? "");
+    }
+
     /**
      * @inheritdoc
      */


### PR DESCRIPTION
Hi all,

These `UI\Component\Input\Field` components cannot handle `null` as default value. Their constraint for requirement and default operations rely on working with a string. Hence the default value is changed to an empty string (`""`).

This fixes https://mantis.ilias.de/view.php?id=47986.

Kind regards,
@thibsy 