### PR TITLE
IRSS: Change il_resource_flavour.variant to length 638

### DIFF
--- a/components/ILIAS/ResourceStorage/classes/Setup/DB/UpdateStepsV12.php
+++ b/components/ILIAS/ResourceStorage/classes/Setup/DB/UpdateStepsV12.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\ResourceStorage\Setup\DB;
+
+class UpdateStepsV12 implements \ilDatabaseUpdateSteps
+{
+    private \ilDBInterface $db;
+
+    public function prepare(\ilDBInterface $db): void
+    {
+        $this->db = $db;
+    }
+
+    public function step_1(): void
+    {
+        $this->db->modifyTableColumn('il_resource_flavour', 'variant', [
+            'notnull' => false,
+            'length' => 638,
+            'type' => \ilDBConstants::T_TEXT,
+        ]);
+    }
+}

--- a/components/ILIAS/ResourceStorage/classes/Setup/class.ilResourceStorageSetupAgent.php
+++ b/components/ILIAS/ResourceStorage/classes/Setup/class.ilResourceStorageSetupAgent.php
@@ -25,6 +25,8 @@ use ILIAS\Setup\Agent;
 use ILIAS\Setup\Config;
 use ILIAS\Setup\Objective;
 use ILIAS\Setup\ObjectiveCollection;
+use ILIAS\ResourceStorage\Setup\DB\UpdateStepsV12;
+use ILIAS\Setup\Objective\ObjectiveWithPreconditions;
 
 /**
  * Class ilResourceStorageSetupAgent
@@ -65,9 +67,10 @@ class ilResourceStorageSetupAgent implements Agent
             new ilDatabaseUpdateStepsExecutedObjective(
                 new ilResourceStorageDB80()
             ),
-            new ilDatabaseUpdateStepsExecutedObjective(
-                new ilResourceStorageDB90()
-            )
+            new ObjectiveWithPreconditions(
+                new ilDatabaseUpdateStepsExecutedObjective(new UpdateStepsV12()),
+                new ilDatabaseUpdateStepsExecutedObjective(new ilResourceStorageDB90()),
+            ),
         );
     }
 

--- a/components/ILIAS/ResourceStorage/src/Flavour/Definition/FlavourDefinition.php
+++ b/components/ILIAS/ResourceStorage/src/Flavour/Definition/FlavourDefinition.php
@@ -51,7 +51,7 @@ interface FlavourDefinition
      * such variants must be distinguishable. For example, a variant name may contain "{height}x{width}"
      * if these are configurable values.
      *
-     * The Variant-Name MUST be less than 768 characters long!
+     * The Variant-Name MUST be less than 638 characters long!
      */
     public function getVariantName(): ?string;
 

--- a/components/ILIAS/ResourceStorage/src/Flavour/FlavourBuilder.php
+++ b/components/ILIAS/ResourceStorage/src/Flavour/FlavourBuilder.php
@@ -44,7 +44,7 @@ use ILIAS\ResourceStorage\Events\FlavourData;
  */
 class FlavourBuilder
 {
-    public const VARIANT_NAME_MAX_LENGTH = 768;
+    public const VARIANT_NAME_MAX_LENGTH = 638;
     private array $current_revision_cache = [];
     private array $resources_cache = [];
 

--- a/components/ILIAS/ResourceStorage/tests/Flavours/FlavourTest.php
+++ b/components/ILIAS/ResourceStorage/tests/Flavours/FlavourTest.php
@@ -85,7 +85,7 @@ class FlavourTest extends AbstractTestBase
         $flavour_definition = $this->createMock(FlavourDefinition::class);
         $flavour_definition->expects($this->exactly(2))
             ->method('getVariantName')
-            ->willReturn(str_repeat('a', 768));
+            ->willReturn(str_repeat('a', 638));
 
         $flavour_builder->has(
             new ResourceIdentification('1'),


### PR DESCRIPTION
This PR fixes an issue with the table `il_resource_flavour` when changing the database collation from utf8mb3 to utf8mb4.

Currently the table cannot be converted to utf8mb4 because the key for the table will be too long:
```
Error: query: Specified key was too long; max key length is 3072 bytes
```

This PR shortens the length of the `variant` field from 768 to 638, which is small enough.

I found one theoretically problematic place:

In `ILIAS\ResourceStorage\Flavour\Definition\CropToRectangle` 2 concatenated ints and 1 float are saved. Without the float the value has a max length of 40, which leaves 598 chars for the float. Theoretically this is not enough to store every float as a string but the previous value of 728 chars for the float wouldn't cover every float either. So I hope this is still acceptable.


For completeness here are all other (unproblematic) places with their max variant length, in case that I missed something:
- `ILIAS\ILIASObject\Properties\CoreProperties\TileImage\FlavourDefinition.php`: Constant 79 chars
- `FirstPageToTileImageFlavourDefinition`: Constant 79 chars
- `ilUserProfilePictureDefinition`: Constant 71 chars
- `ILIAS\ResourceStorage\Flavour\Definition\CropToSquare`: Max 39 chars
- `ILIAS\ResourceStorage\Flavour\Definition\FitToSquare`: Max 39 chars
- `ILIAS\ResourceStorage\Flavour\Definition\PagesToExtract`: Max 64 chars
- `ILIAS\ResourceStorage\Flavour\Definition\FlavourDefinition\ZipStructureDefinition`: Saves null
- `ILIAS\ResourceStorage\Flavour\Definition\ToGreyScale`: Saves null

This PR is in preparation for an upcoming PR to change the Database charset & collation from utf8mb3 to utf8mb4.