### PR TITLE
ItemGroup 48034: Fix Other Item Group Assignment Query

### DIFF
--- a/components/ILIAS/ItemGroup/classes/class.ilItemGroupItems.php
+++ b/components/ILIAS/ItemGroup/classes/class.ilItemGroupItems.php
@@ -249,7 +249,7 @@ class ilItemGroupItems
             'SELECT ref_id, title FROM item_group_item '
             . 'LEFT JOIN object_data ON item_group_item.item_group_id = object_data.obj_id '
             . 'LEFT JOIN object_reference ON object_data.obj_id = object_reference.obj_id '
-            . 'WHERE %s '
+            . 'WHERE item_ref_id = %s '
             . 'AND item_group_id != %s '
             . 'AND object_data.type = \'itgr\'',
             [ilDBConstants::T_INTEGER, ilDBConstants::T_INTEGER],


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=48034

The "Already assigned to another Item Group" column in the Assigned Materials table showed invalid values because `getItemGroupsAssociatedWithItem` used a malformed `WHERE` clause without the `item_ref_id` column. Fixed the query to filter by `item_ref_id` correctly.

/cc @thojou 