### PR TITLE
[FEATURE] UI: add `Column\Listing` component

### DIFF
--- a/components/ILIAS/Calendar/classes/ConsultationHours/BookingTableGUI.php
+++ b/components/ILIAS/Calendar/classes/ConsultationHours/BookingTableGUI.php
@@ -207,15 +207,15 @@ class BookingTableGUI implements DataRetrieval
             'booking_participant' => $this->ui_factory
                     ->table()
                     ->column()
-                    ->linkListing($this->lng->txt('cal_ch_booking_participants')),
+                    ->listing($this->lng->txt('cal_ch_booking_participants')),
             'booking_comment' => $this->ui_factory
                 ->table()
                 ->column()
-                ->linkListing($this->lng->txt('cal_ch_booking_col_comments')),
+                ->listing($this->lng->txt('cal_ch_booking_col_comments')),
             'booking_location' => $this->ui_factory
                 ->table()
                 ->column()
-                ->linkListing($this->lng->txt('cal_ch_target_object'))
+                ->listing($this->lng->txt('cal_ch_target_object'))
         ];
 
     }

--- a/components/ILIAS/Course/classes/Grouping/Table/GroupingHandler.php
+++ b/components/ILIAS/Course/classes/Grouping/Table/GroupingHandler.php
@@ -95,7 +95,7 @@ class GroupingHandler
             self::COL_DESCRIPTION => $f->text($this->lng->txt('description'))->withIsSortable(true),
             self::COL_SOURCE => $f->link($this->lng->txt('groupings_source'))->withIsSortable(true),
             self::COL_UNIQUE_FIELD => $f->text($this->lng->txt('unambiguousness'))->withIsSortable(true),
-            self::COL_ASSIGNED_OBJS => $f->linkListing($this->lng->txt('groupings_assigned_obj_' . $type))->withIsSortable(true)
+            self::COL_ASSIGNED_OBJS => $f->listing($this->lng->txt('groupings_assigned_obj_' . $type))->withIsSortable(true)
         ];
     }
 

--- a/components/ILIAS/Repository/Service/Table/TableAdapterGUI.php
+++ b/components/ILIAS/Repository/Service/Table/TableAdapterGUI.php
@@ -137,7 +137,7 @@ class TableAdapterGUI
         string $title,
         bool $sortable = false
     ): self {
-        $column = $this->ui->factory()->table()->column()->linkListing($title)->withIsSortable($sortable);
+        $column = $this->ui->factory()->table()->column()->listing($title)->withIsSortable($sortable);
         $this->addColumn($key, $column);
         return $this;
     }

--- a/components/ILIAS/Skill/Table/classes/class.AssignMaterialsTable.php
+++ b/components/ILIAS/Skill/Table/classes/class.AssignMaterialsTable.php
@@ -100,7 +100,7 @@ class AssignMaterialsTable
                                     ->withIsSortable(false),
             "description" => $this->ui_fac->table()->column()->text($this->lng->txt("description"))
                                           ->withIsSortable(false),
-            "resources" => $this->ui_fac->table()->column()->linkListing($this->lng->txt("skmg_materials"))
+            "resources" => $this->ui_fac->table()->column()->listing($this->lng->txt("skmg_materials"))
                                         ->withIsSortable(false)
         ];
 

--- a/components/ILIAS/UI/UI.php
+++ b/components/ILIAS/UI/UI.php
@@ -551,6 +551,16 @@ class UI implements Component\Component
                             $use[UI\HelpTextRetriever::class],
                             $internal[UI\Implementation\Component\Input\UploadLimitResolver::class],
                         ),
+                        new UI\Implementation\Component\Listing\ListingRendererFactory(
+                            $use[UI\Implementation\FactoryInternal::class],
+                            $internal[UI\Implementation\Render\TemplateFactory::class],
+                            $use[Language\Language::class],
+                            $internal[UI\Implementation\Render\JavaScriptBinding::class],
+                            $use[UI\Implementation\Render\ImagePathResolver::class],
+                            $pull[Data\Factory::class],
+                            $use[UI\HelpTextRetriever::class],
+                            $internal[UI\Implementation\Component\Input\UploadLimitResolver::class],
+                        ),
                     )
                 )
             );
@@ -593,6 +603,8 @@ class UI implements Component\Component
             new Component\Resource\ComponentJS($this, "js/Input/Field/input.js");
         $contribute[Component\Resource\PublicAsset::class] = fn() =>
             new Component\Resource\ComponentJS($this, "js/Item/dist/notification.js");
+        $contribute[Component\Resource\PublicAsset::class] = fn() =>
+            new Component\Resource\ComponentJS($this, "js/Listing/dist/listing.min.js");
         $contribute[Component\Resource\PublicAsset::class] = fn() =>
             new Component\Resource\ComponentJS($this, "js/MainControls/dist/mainbar.js");
         $contribute[Component\Resource\PublicAsset::class] = fn() =>

--- a/components/ILIAS/UI/resources/js/Listing/dist/listing.min.js
+++ b/components/ILIAS/UI/resources/js/Listing/dist/listing.min.js
@@ -1,0 +1,15 @@
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+!function(t,e){"use strict";t.UI=t.UI||{},t.UI.Listing={createExpandableList:i=>function(t,e){const i=e.parentElement.querySelector(`[aria-controls="${e.id}"]`);if(!i)throw new Error("Could not find button associated with list.");if(!e.hasAttribute("data-max-items"))throw new Error("Could not find max items attribute.");const a=parseInt(e.getAttribute("data-max-items"),10),n=e.querySelectorAll("li");i.addEventListener("click",()=>{!function(t,e,i,a){const n=e.hasAttribute("aria-expanded")&&"true"===e.getAttribute("aria-expanded");i.forEach((t,e)=>{e>a-1&&(n?t.classList.replace("visible","hidden"):t.classList.replace("hidden","visible"))}),n?(e.setAttribute("aria-expanded","false"),e.textContent=t.txt("show_more")):(e.setAttribute("aria-expanded","true"),e.textContent=t.txt("show_less"))}(t,i,n,a)})}({txt:e=>t.Language.txt(e)},e.getElementById(i))}}(il,document);

--- a/components/ILIAS/UI/resources/js/Listing/rollup.config.js
+++ b/components/ILIAS/UI/resources/js/Listing/rollup.config.js
@@ -1,0 +1,43 @@
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+import terser from '@rollup/plugin-terser';
+import copyright from '../../../../../../scripts/Copyright-Checker/copyright.js';
+import preserveCopyright from '../../../../../../scripts/Copyright-Checker/preserveCopyright.js';
+
+export default {
+  input: './src/listing.js',
+  external: [
+    'ilias',
+    'document',
+  ],
+  output: {
+    // file: '../../../../../../public/assets/js/listing.min.js',
+    file: './dist/listing.min.js',
+    format: 'iife',
+    banner: copyright,
+    globals: {
+      ilias: 'il',
+      document: 'document',
+    },
+    plugins: [
+      terser({
+        format: {
+          comments: preserveCopyright,
+        },
+      }),
+    ],
+  },
+};

--- a/components/ILIAS/UI/resources/js/Listing/src/createExpandableList.js
+++ b/components/ILIAS/UI/resources/js/Listing/src/createExpandableList.js
@@ -1,0 +1,74 @@
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+
+/**
+ * @param {{ txt: function(string): string }}
+ * @param {HTMLButtonElement} button
+ * @param {HTMLLIElement[]} listItems
+ * @param {number} maxItemCount
+ */
+function toggleListItems(
+  language,
+  button,
+  listItems,
+  maxItemCount,
+) {
+  const isExpanded = button.hasAttribute('aria-expanded')
+    && button.getAttribute('aria-expanded') === 'true';
+
+  listItems.forEach((item, index) => {
+    if (index > (maxItemCount - 1)) {
+      if (isExpanded) {
+        item.classList.replace('visible', 'hidden');
+      } else {
+        item.classList.replace('hidden', 'visible');
+      }
+    }
+  });
+  if (isExpanded) {
+    button.setAttribute('aria-expanded', 'false');
+    button.textContent = language.txt('show_more');
+  } else {
+    button.setAttribute('aria-expanded', 'true');
+    button.textContent = language.txt('show_less');
+  }
+}
+
+/**
+ * @param {{ txt: function(string): string }}
+ * @param {HTMLUListElement|HTMLOListElement} list
+ */
+export default function createExpandableList(language, list) {
+  const button = list.parentElement.querySelector(`[aria-controls="${list.id}"]`);
+  if (!button) {
+    throw new Error('Could not find button associated with list.');
+  }
+  if (!list.hasAttribute('data-max-items')) {
+    throw new Error('Could not find max items attribute.');
+  }
+  const maxItemCount = parseInt(list.getAttribute('data-max-items'), 10);
+  const listItems = list.querySelectorAll('li');
+
+  button.addEventListener('click', () => {
+    toggleListItems(
+      language,
+      button,
+      listItems,
+      maxItemCount,
+    );
+  });
+}

--- a/components/ILIAS/UI/resources/js/Listing/src/listing.js
+++ b/components/ILIAS/UI/resources/js/Listing/src/listing.js
@@ -1,5 +1,3 @@
-<?php
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -13,13 +11,17 @@
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- *
- *********************************************************************/
+ */
 
-declare(strict_types=1);
+import il from 'ilias';
+import document from 'document';
+import createExpandableList from './createExpandableList.js';
 
-namespace ILIAS\UI\Component\Table\Column;
+il.UI = il.UI || {};
 
-interface LinkListing extends Column
-{
-}
+il.UI.Listing = {
+  createExpandableList: (id) => createExpandableList(
+    { txt: (key) => il.Language.txt(key) },
+    document.getElementById(id),
+  ),
+};

--- a/components/ILIAS/UI/src/Component/Listing/Inline.php
+++ b/components/ILIAS/UI/src/Component/Listing/Inline.php
@@ -19,6 +19,8 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\Component\Listing;
 
-interface Inline extends Listing
+use ILIAS\UI\Component\JavaScriptBindable;
+
+interface Inline extends Listing, JavaScriptBindable
 {
 }

--- a/components/ILIAS/UI/src/Component/Listing/Unordered.php
+++ b/components/ILIAS/UI/src/Component/Listing/Unordered.php
@@ -20,10 +20,12 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\Component\Listing;
 
+use ILIAS\UI\Component\JavaScriptBindable;
+
 /**
  * Interface Unordered
  * @package ILIAS\UI\Component\Listing
  */
-interface Unordered extends Listing
+interface Unordered extends Listing, JavaScriptBindable
 {
 }

--- a/components/ILIAS/UI/src/Component/Table/Column/Factory.php
+++ b/components/ILIAS/UI/src/Component/Table/Column/Factory.php
@@ -136,12 +136,21 @@ interface Factory
      * ---
      * description:
      *   purpose: >
-     *      The LinkListing Column features an Ordered or Unordered Listing of Standard Links.
-     *
+     *     The Listing Column is used for representing lists inside a table. To
+     *     account for large lists, the Listing Column caps the amount of items
+     *     which are initially visible and provides a toggle to show/hide them.
+     *   composition: >
+     *     The Listing Column either consists of an Unordered or Ordered Listing.
+     *     If the Listing contains many items, some of them will be initially
+     *     hidden and a Shy Button appears below the Listing.
+     *   effect: >
+     *     Clicking the Shy Button will toggle the visibility of initially hidden
+     *     items of the Listing.
      * ---
-     * @return \ILIAS\UI\Component\Table\Column\LinkListing
+     * @param string $title
+     * @return \ILIAS\UI\Component\Table\Column\Listing
      */
-    public function linkListing(string $title): LinkListing;
+    public function listing(string $title): Listing;
 
     /**
      * ---

--- a/components/ILIAS/UI/src/Component/Table/Column/Listing.php
+++ b/components/ILIAS/UI/src/Component/Table/Column/Listing.php
@@ -18,14 +18,8 @@
 
 declare(strict_types=1);
 
-namespace ILIAS\UI\Component\Listing;
+namespace ILIAS\UI\Component\Table\Column;
 
-use ILIAS\UI\Component\JavaScriptBindable;
-
-/**
- * Interface Ordered
- * @package ILIAS\UI\Component\Listing
- */
-interface Ordered extends Listing, JavaScriptBindable
+interface Listing extends Column
 {
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Listing/Inline.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Listing/Inline.php
@@ -20,7 +20,9 @@ declare(strict_types=1);
 namespace ILIAS\UI\Implementation\Component\Listing;
 
 use ILIAS\UI\Component as C;
+use ILIAS\UI\Implementation\Component\JavaScriptBindable;
 
 class Inline extends Listing implements C\Listing\Inline
 {
+    use JavaScriptBindable;
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Listing/ListingRendererFactory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Listing/ListingRendererFactory.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\Implementation\Component\Listing;
+
+use ILIAS\UI\Implementation\Render\DefaultRendererFactory;
+use ILIAS\UI\Implementation\Render\ComponentRenderer;
+use ILIAS\UI\Component\Component;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+class ListingRendererFactory extends DefaultRendererFactory
+{
+    /** @var string[] cannonical names of table components */
+    protected const array TABLE_COLUMN_CONTEXTS = [
+        'OrderingRowTable',
+        'DataRowTable',
+    ];
+
+    public function getRendererInContext(Component $component, array $contexts): ComponentRenderer
+    {
+        if (!empty(array_intersect(self::TABLE_COLUMN_CONTEXTS, $contexts))) {
+            return new TableColumnContextRenderer(
+                $this->ui_factory,
+                $this->tpl_factory,
+                $this->lng,
+                $this->js_binding,
+                $this->image_path_resolver,
+                $this->data_factory,
+                $this->help_text_retriever,
+                $this->upload_limit_resolver,
+            );
+        }
+
+        return parent::getRendererInContext($component, $contexts);
+    }
+}

--- a/components/ILIAS/UI/src/Implementation/Component/Listing/Ordered.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Listing/Ordered.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace ILIAS\UI\Implementation\Component\Listing;
 
 use ILIAS\UI\Component as C;
+use ILIAS\UI\Implementation\Component\JavaScriptBindable;
 
 /**
  * Class Listing
@@ -28,4 +29,5 @@ use ILIAS\UI\Component as C;
  */
 class Ordered extends Listing implements C\Listing\Ordered
 {
+    use JavaScriptBindable;
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Listing/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Listing/Renderer.php
@@ -21,9 +21,9 @@ declare(strict_types=1);
 namespace ILIAS\UI\Implementation\Component\Listing;
 
 use ILIAS\UI\Implementation\Render\AbstractComponentRenderer;
-use ILIAS\UI\Implementation\Render\Template;
 use ILIAS\UI\Renderer as RendererInterface;
-use ILIAS\UI\Component\Component;
+use ILIAS\UI\Component;
+use ILIAS\UI\Implementation\Render\Template;
 
 /**
  * Class Renderer
@@ -37,28 +37,27 @@ class Renderer extends AbstractComponentRenderer
     /**
      * @inheritdocs
      */
-    public function render(Component $component, RendererInterface $default_renderer): string
+    public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
         if ($component instanceof Descriptive) {
-            return $this->renderDescriptive($component, $default_renderer);
+            return $this->renderDescriptiveList($component, $default_renderer);
         }
+
         if ($component instanceof Property) {
-            return $this->renderProperty($component, $default_renderer);
+            return $this->renderPropertyList($component, $default_renderer);
         }
-        if ($component instanceof Ordered) {
-            return $this->renderOrdered($component, $default_renderer);
-        }
-        if ($component instanceof Unordered) {
-            return $this->renderUnordered($component, $default_renderer);
-        }
-        if ($component instanceof Inline) {
-            return $this->renderInline($component, $default_renderer);
+
+        if ($component instanceof Unordered ||
+            $component instanceof Ordered ||
+            $component instanceof Inline
+        ) {
+            return $this->renderList($component, $default_renderer);
         }
 
         $this->cannotHandleComponent($component);
     }
 
-    protected function renderDescriptive(
+    protected function renderDescriptiveList(
         Descriptive $component,
         RendererInterface $default_renderer
     ): string {
@@ -81,51 +80,36 @@ class Renderer extends AbstractComponentRenderer
         return $tpl->get();
     }
 
-    protected function renderOrdered(Ordered $component, RendererInterface $default_renderer): string
+    protected function renderList(Unordered|Ordered|Inline $component, RendererInterface $default_renderer): string
     {
-        $tpl = $this->getTemplate("tpl.ordered.html", true, true);
+        if ($component instanceof Unordered) {
+            $tpl_name = "tpl.unordered.html";
+        } elseif ($component instanceof Ordered) {
+            $tpl_name = "tpl.ordered.html";
+        } elseif ($component instanceof Inline) {
+            $tpl_name = "tpl.inline.html";
+        } else {
+            $this->cannotHandleComponent($component);
+        }
 
-        $tpl = $this->fillItems($tpl, $component, $default_renderer);
+        $tpl = $this->getTemplate($tpl_name, true, true);
 
-        return $tpl->get();
-    }
-
-    protected function renderUnordered(Unordered $component, RendererInterface $default_renderer): string
-    {
-        $tpl = $this->getTemplate("tpl.unordered.html", true, true);
-
-        $tpl = $this->fillItems($tpl, $component, $default_renderer);
-
-        return $tpl->get();
-    }
-
-    protected function renderInline(Inline $component, RendererInterface $default_renderer): string
-    {
-        $tpl = $this->getTemplate("tpl.inline.html", true, true);
-
-        $tpl = $this->fillItems($tpl, $component, $default_renderer);
-
-        return $tpl->get();
-    }
-
-    protected function fillItems(Template $tpl, Listing $component, RendererInterface $default_renderer): Template
-    {
-        $items = $component->getItems();
-
-        foreach ($items as $item) {
+        foreach ($component->getItems() as $item) {
             $tpl->setCurrentBlock("item");
-            if ($item instanceof Component) {
-                $tpl->setVariable("ITEM", $default_renderer->render($item));
-            } else {
+            if (is_string($item)) {
                 $tpl->setVariable("ITEM", $item);
+            } else {
+                $tpl->setVariable("ITEM", $default_renderer->render($item));
             }
             $tpl->parseCurrentBlock();
         }
 
-        return $tpl;
+        $this->bindAndApplyJavaScript($component, $tpl);
+
+        return $tpl->get();
     }
 
-    protected function renderProperty(
+    protected function renderPropertyList(
         Property $component,
         RendererInterface $default_renderer
     ): string {
@@ -134,7 +118,7 @@ class Renderer extends AbstractComponentRenderer
         foreach ($component->getItems() as [$label, $value, $show_label]) {
             $tpl->setCurrentBlock("property");
             if ($show_label) {
-                if ($label instanceof Component) {
+                if ($label instanceof Component\Component) {
                     $tpl->setVariable('LABEL', $default_renderer->render($label));
                 } else {
                     $tpl->setVariable('LABEL', $this->convertSpecialCharacters($label));
@@ -148,11 +132,19 @@ class Renderer extends AbstractComponentRenderer
                 $tpl->parseCurrentBlock();
             } elseif (is_string($value)) {
                 $tpl->setVariable("SHORT_VALUE", $this->convertSpecialCharacters($value));
-            } elseif ($value instanceof Component) {
+            } elseif ($value instanceof Component\Component) {
                 $tpl->setVariable("SHORT_VALUE", $default_renderer->render($value));
             }
             $tpl->parseCurrentBlock();
         }
         return $tpl->get();
+    }
+
+    protected function bindAndApplyJavaScript(Component\JavaScriptBindable $component, Template $template): void
+    {
+        $id = $this->bindJavaScript($component);
+        if (null !== $id) {
+            $template->setVariable('ID', $id);
+        }
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Listing/TableColumnContextRenderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Listing/TableColumnContextRenderer.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\Implementation\Component\Listing;
+
+use ILIAS\UI\Renderer as RendererInterface;
+use ILIAS\UI\Implementation\Render\ResourceRegistry;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+class TableColumnContextRenderer extends Renderer
+{
+    protected const int LIST_DISPLAY_LIMIT = 3;
+
+    public function registerResources(ResourceRegistry $registry): void
+    {
+        $registry->register('assets/js/listing.min.js');
+    }
+
+    protected function renderList(Ordered|Unordered|Inline $component, RendererInterface $default_renderer): string
+    {
+        if ($component instanceof Inline || self::LIST_DISPLAY_LIMIT >= count($component->getItems())) {
+            return parent::renderList($component, $default_renderer);
+        }
+
+        $template = $this->getTemplate('tpl.table_column_context.html', true, true);
+        $template->setVariable('DISPLAY_LIMIT', self::LIST_DISPLAY_LIMIT);
+        $template->setVariable('SHOW_MORE_LABEL', $this->txt('show_more'));
+
+        if ($component instanceof Ordered) {
+            $template->setVariable('LIST_TYPE', 'ol');
+        } else {
+            $template->setVariable('LIST_TYPE', 'ul');
+        }
+
+        // array_values() ensures we can use $index for count
+        foreach (array_values($component->getItems()) as $index => $item) {
+            $template->setCurrentBlock("item");
+            if (is_string($item)) {
+                $template->setVariable("ITEM", $item);
+            } else {
+                $template->setVariable("ITEM", $default_renderer->render($item));
+            }
+            if (self::LIST_DISPLAY_LIMIT > $index) {
+                $template->setVariable('VISIBILITY', 'visible');
+            } else {
+                $template->setVariable('VISIBILITY', 'hidden');
+            }
+            $template->parseCurrentBlock();
+        }
+
+        $enriched_component = $component->withAdditionalOnLoadCode(
+            static fn($id) => "il.UI.Listing.createExpandableList('$id');",
+        );
+
+        $this->bindAndApplyJavaScript($enriched_component, $template);
+
+        $this->toJS('show_more');
+        $this->toJS('show_less');
+
+        return $template->get();
+    }
+}

--- a/components/ILIAS/UI/src/Implementation/Component/Listing/Unordered.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Listing/Unordered.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace ILIAS\UI\Implementation\Component\Listing;
 
 use ILIAS\UI\Component as C;
+use ILIAS\UI\Implementation\Component\JavaScriptBindable;
 
 /**
  * Class Listing
@@ -28,4 +29,5 @@ use ILIAS\UI\Component as C;
  */
 class Unordered extends Listing implements C\Listing\Unordered
 {
+    use JavaScriptBindable;
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Column/Factory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Column/Factory.php
@@ -81,9 +81,9 @@ class Factory implements I\Factory
         return new Link($this->lng, $title);
     }
 
-    public function linkListing(string $title): LinkListing
+    public function listing(string $title): Listing
     {
-        return new LinkListing($this->lng, $title);
+        return new Listing($this->lng, $title);
     }
 
     public function breadcrumb(string $title): I\Breadcrumb

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Column/Listing.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Column/Listing.php
@@ -21,19 +21,16 @@ declare(strict_types=1);
 namespace ILIAS\UI\Implementation\Component\Table\Column;
 
 use ILIAS\UI\Component\Table\Column as C;
-use ILIAS\UI\Component\Link\Standard;
 use ILIAS\UI\Component\Listing\Ordered;
 use ILIAS\UI\Component\Listing\Unordered;
 use ILIAS\UI\Component\Component;
 
-class LinkListing extends Column implements C\LinkListing
+class Listing extends Column implements C\Listing
 {
     public function format($value): string|Component
     {
         $listing = $this->toArray($value);
-        $this->checkArgListElements("value", $listing, [Ordered::class, Unordered::class]);
-        $listing_items = $value->getItems();
-        $this->checkArgListElements("list items", $listing_items, Standard::class);
+        $this->checkArgListElements('value', $listing, [Ordered::class, Unordered::class]);
         return $value;
     }
 

--- a/components/ILIAS/UI/src/Implementation/Render/FSLoader.php
+++ b/components/ILIAS/UI/src/Implementation/Render/FSLoader.php
@@ -28,6 +28,7 @@ use ILIAS\UI\Implementation\Component\Input\Field\FormInput;
 use ILIAS\UI\Implementation\Component\MessageBox\MessageBox;
 use ILIAS\UI\Implementation\Component\Input\Container\Form\Form;
 use ILIAS\UI\Implementation\Component\Menu\Menu;
+use ILIAS\UI\Implementation\Component\Listing\Listing;
 
 /**
  * Loads renderers for components from the file system.
@@ -51,6 +52,7 @@ class FSLoader implements Loader
         private RendererFactory $message_box_renderer_factory,
         private RendererFactory $form_renderer_factory,
         private RendererFactory $menu_renderer_factory,
+        private RendererFactory $listing_renderer_factory,
     ) {
     }
 
@@ -84,6 +86,10 @@ class FSLoader implements Loader
         if ($component instanceof Button) {
             return $this->button_renderer_factory;
         }
+        if ($component instanceof Listing) {
+            return $this->listing_renderer_factory;
+        }
+
         return $this->default_renderer_factory;
     }
 }

--- a/components/ILIAS/UI/src/examples/Table/Column/Listing/base.php
+++ b/components/ILIAS/UI/src/examples/Table/Column/Listing/base.php
@@ -18,7 +18,7 @@
 
 declare(strict_types=1);
 
-namespace ILIAS\UI\examples\Table\Column\LinkListing;
+namespace ILIAS\UI\examples\Table\Column\Listing;
 
 use ILIAS\UI\Component\Table as I;
 use ILIAS\Data\Range;
@@ -32,28 +32,39 @@ use ILIAS\Data\Order;
  */
 function base(): string
 {
+    /** @var \ILIAS\DI\Container $DIC */
     global $DIC;
     $f = $DIC->ui()->factory();
     $r = $DIC->ui()->renderer();
 
     $columns = [
-        'l1' => $f->table()->column()->linkListing("a link list column")
+        'l1' => $f->table()->column()->listing('A list column')
     ];
 
-    $some_link = $f->link()->standard('ILIAS Homepage', 'http://www.ilias.de');
-    $some_linklisting = $f->listing()->unordered([$some_link, $some_link, $some_link]);
-
-    $dummy_records = [
-        ['l1' => $some_linklisting],
-        ['l1' => $some_linklisting]
+    $records = [
+        [
+            'l1' => $f->listing()->unordered([
+                'Apples',
+                'Oranges',
+                'Bananas',
+                'Pears'
+            ])
+        ],
+        [
+            'l1' => $f->listing()->unordered([
+                'Bun',
+                'Croissant',
+                'Pumpernickel'
+            ])
+        ]
     ];
 
-    $data_retrieval = new class ($dummy_records) implements I\DataRetrieval {
+    $data_retrieval = new class ($records) implements I\DataRetrieval {
         protected array $records;
 
-        public function __construct(array $dummy_records)
+        public function __construct(array $records)
         {
-            $this->records = $dummy_records;
+            $this->records = $records;
         }
 
         public function getRows(
@@ -80,7 +91,7 @@ function base(): string
         }
     };
 
-    $table = $f->table()->data($data_retrieval, 'Link List Columns', $columns)
+    $table = $f->table()->data($data_retrieval, 'List Columns', $columns)
                ->withRequest($DIC->http()->request());
     return $r->render($table);
 }

--- a/components/ILIAS/UI/src/templates/default/Listing/tpl.ordered.html
+++ b/components/ILIAS/UI/src/templates/default/Listing/tpl.ordered.html
@@ -1,4 +1,4 @@
-<ol>
+<ol<!-- BEGIN with_id -->id="{ID}"<!-- END with_id -->>
 	<!-- BEGIN item -->
 	<li>{ITEM}</li>
 	<!-- END item -->

--- a/components/ILIAS/UI/src/templates/default/Listing/tpl.table_column_context.html
+++ b/components/ILIAS/UI/src/templates/default/Listing/tpl.table_column_context.html
@@ -1,0 +1,10 @@
+<div class="c-listing--table-column">
+  <{LIST_TYPE} id="{ID}" data-max-items="{DISPLAY_LIMIT}">
+    <!-- BEGIN item -->
+    <li class="{VISIBILITY}">{ITEM}</li>
+    <!-- END item -->
+  </{LIST_TYPE}>
+  <button type="button" class="btn btn-link" aria-expanded="false" aria-controls="{ID}">
+    {SHOW_MORE_LABEL}
+  </button>
+</div>

--- a/components/ILIAS/UI/src/templates/default/Listing/tpl.unordered.html
+++ b/components/ILIAS/UI/src/templates/default/Listing/tpl.unordered.html
@@ -1,4 +1,4 @@
-<ul>
+<ul<!-- BEGIN with_id -->id="{ID}"<!-- END with_id -->>
 	<!-- BEGIN item -->
 	<li>{ITEM}</li>
 	<!-- END item -->

--- a/components/ILIAS/UI/tests/Base.php
+++ b/components/ILIAS/UI/tests/Base.php
@@ -479,6 +479,16 @@ trait BaseUITestTrait
                         $data_factory,
                         $help_text_retriever,
                         $this->getUploadLimitResolver(),
+                    ),
+                    new I\Listing\ListingRendererFactory(
+                        $ui_factory,
+                        $tpl_factory,
+                        $lng,
+                        $js_binding,
+                        $image_path_resolver,
+                        $data_factory,
+                        $help_text_retriever,
+                        $this->getUploadLimitResolver(),
                     )
                 )
             )

--- a/components/ILIAS/UI/tests/Component/Table/Column/ColumnFactoryTest.php
+++ b/components/ILIAS/UI/tests/Component/Table/Column/ColumnFactoryTest.php
@@ -35,8 +35,8 @@ class ColumnFactoryTest extends AbstractFactoryTestCase
         "statusIcon" => ["context" => false, "rules" => false],
         "timeSpan" => ["context" => false, "rules" => false],
         "link" => ["context" => false, "rules" => false],
-        "linkListing" => ["context" => false, "rules" => false],
         "breadcrumb" => ["context" => false, "rules" => false],
+        "listing" => ["context" => false, "rules" => false]
     ];
 
     public static string $factory_title = 'ILIAS\\UI\\Component\\Table\\Column\\Factory';
@@ -66,7 +66,7 @@ class ColumnFactoryTest extends AbstractFactoryTestCase
             [static fn($f) => [Column\StatusIcon::class, $f->statusIcon("")]],
             [static fn($f) => [Column\Link::class, $f->link("")]],
             [static fn($f) => [Column\EMail::class, $f->eMail("")]],
-            [static fn($f) => [Column\LinkListing::class, $f->linkListing("")]]
+            [static fn($f) => [Column\Listing::class, $f->listing("")]]
         ];
     }
 

--- a/components/ILIAS/UI/tests/Component/Table/Column/ColumnTest.php
+++ b/components/ILIAS/UI/tests/Component/Table/Column/ColumnTest.php
@@ -143,26 +143,6 @@ class ColumnTest extends ILIAS_UI_TestBase
         };
         return [
             [
-                'column' => new Column\LinkListing($lng, ''),
-                'value' => new Listing\Unordered([(new Link\Standard('label', '#')),(new Link\Standard('label', '#'))]),
-                'ok' => true
-            ],
-            [
-                'column' => new Column\LinkListing($lng, ''),
-                'value' => new Listing\Unordered(['string', 'string']),
-                'ok' => false
-            ],
-            [
-                'column' => new Column\LinkListing($lng, ''),
-                'value' => new Listing\Ordered([(new Link\Standard('label', '#')),(new Link\Standard('label', '#'))]),
-                'ok' => true
-            ],
-            [
-                'column' => new Column\LinkListing($lng, ''),
-                'value' => 123,
-                'ok' => false
-            ],
-            [
                 'column' => new Column\Link($lng, ''),
                 'value' => new Link\Standard('label', '#'),
                 'ok' => true
@@ -182,6 +162,22 @@ class ColumnTest extends ILIAS_UI_TestBase
                 'value' => 'some string',
                 'ok' => false
             ],
+            [
+                'column' => new Column\Listing($lng, ''),
+                'value' => (new Listing\Ordered(['1', '2', '3'])),
+                'ok' => true
+            ],
+            [
+                'column' => new Column\Listing($lng, ''),
+                'value' => (new Listing\Unordered(['1', '2', '3'])),
+                'ok' => true
+            ],
+            [
+                'column' => new Column\Listing($lng, ''),
+                'value' => 123,
+                'ok' => false
+            ],
+
         ];
     }
 
@@ -191,42 +187,24 @@ class ColumnTest extends ILIAS_UI_TestBase
         mixed $value,
         bool $ok
     ): void {
-        if(! $ok) {
+        if (! $ok) {
             $this->expectException(\InvalidArgumentException::class);
         }
         $this->assertEquals($value, $column->format($value));
     }
 
 
-    public function testDataTableColumnLinkListingFormat(): void
+    public function testDataTableColumnListingFormat(): void
     {
-        $col = new Column\LinkListing($this->lng, 'col');
+        $col = new Column\Listing($this->lng, 'col');
         $link = new Link\Standard('label', '#');
-        $linklisting = new Listing\Unordered([$link, $link, $link]);
-        $this->assertEquals($linklisting, $col->format($linklisting));
-    }
-
-    public function testDataTableColumnLinkListingFormatAcceptsOnlyLinkListings(): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $col = new Column\LinkListing($this->lng, 'col');
-        $linklisting_invalid = new Link\Standard('label', '#');
-        $this->assertEquals($linklisting_invalid, $col->format($linklisting_invalid));
-    }
-
-    public function testDataTableColumnLinkListingItemsFormatAcceptsOnlyLinks(): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $col = new Column\LinkListing($this->lng, 'col');
-        $link = 'some string';
-        $linklisting_invalid = new Listing\Unordered([$link, $link, $link]);
-        $this->assertEquals($linklisting_invalid, $col->format($linklisting_invalid));
+        $listing = (new Listing\Unordered([$link, $link, $link]));
+        $this->assertEquals($listing, $col->format($listing));
     }
 
     public function testDataTableColumnCustomOrderingLabels(): void
     {
-        $col = (new Column\LinkListing($this->lng, 'col'))
-            ->withIsSortable(true)
+        $col = (new Column\Listing($this->lng, 'col'))
             ->withOrderingLabels(
                 'custom label ASC',
                 'custom label DESC',

--- a/components/ILIAS/UI/tests/InitUIFramework.php
+++ b/components/ILIAS/UI/tests/InitUIFramework.php
@@ -381,6 +381,16 @@ class InitUIFramework
                             $c["help.text_retriever"],
                             $c["ui.upload_limit_resolver"]
                         ),
+                        new ILIAS\UI\Implementation\Component\Listing\ListingRendererFactory(
+                            $c["ui.factory"],
+                            $c["ui.template_factory"],
+                            $c["lng"],
+                            $c["ui.javascript_binding"],
+                            $c["ui.pathresolver"],
+                            $c["ui.data_factory"],
+                            $c["help.text_retriever"],
+                            $c["ui.upload_limit_resolver"],
+                        ),
                     )
                 )
             );

--- a/components/ILIAS/UI/tests/Renderer/FSLoaderTest.php
+++ b/components/ILIAS/UI/tests/Renderer/FSLoaderTest.php
@@ -41,6 +41,7 @@ class FSLoaderTest extends TestCase
     protected RendererFactory & MockObject $message_box_renderer_factory;
     protected RendererFactory & MockObject $form_renderer_factory;
     protected RendererFactory & MockObject $menu_renderer_factory;
+    protected RendererFactory & MockObject $list_renderer_factory;
 
     protected FSLoader $fs_loader;
 
@@ -52,6 +53,7 @@ class FSLoaderTest extends TestCase
         $this->message_box_renderer_factory = $this->createMock(RendererFactory::class);
         $this->form_renderer_factory = $this->createMock(RendererFactory::class);
         $this->menu_renderer_factory = $this->createMock(RendererFactory::class);
+        $this->list_renderer_factory = $this->createMock(RendererFactory::class);
 
         $this->fs_loader = new FSLoader(
             $this->default_renderer_factory,
@@ -60,6 +62,7 @@ class FSLoaderTest extends TestCase
             $this->message_box_renderer_factory,
             $this->form_renderer_factory,
             $this->menu_renderer_factory,
+            $this->list_renderer_factory,
         );
 
         parent::setUp();

--- a/templates/default/070-components/UI-framework/Table/_ui-component_table.scss
+++ b/templates/default/070-components/UI-framework/Table/_ui-component_table.scss
@@ -308,7 +308,7 @@ th.c-table-data__cell:after {
 
 // Text
 .c-table-data__cell--link,
-.c-table-data__cell--linklisting,
+.c-table-data__cell--listing,
 .c-table-data__cell--text {
     .c-table-data__header__resize-wrapper {
         min-width: 140px;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -12623,7 +12623,7 @@ th.c-table-data__cell {
 }
 
 .c-table-data__cell--link .c-table-data__header__resize-wrapper,
-.c-table-data__cell--linklisting .c-table-data__header__resize-wrapper,
+.c-table-data__cell--listing .c-table-data__header__resize-wrapper,
 .c-table-data__cell--text .c-table-data__header__resize-wrapper {
   min-width: 140px;
   resize: horizontal;


### PR DESCRIPTION
Hi all, this

Introduces a new `UI\Component\Table\Column\Listing` component, which accepts an `UI\Component\Listing\Unordered` or `…\Ordered` component. To keep rows consistent a expand/collapse mechanism was put in place, truncating list items at some point if used inside a table column.

This makes the `UI\Component\Table\Column\LinkListing` component obsolete, which has been removed during this process. Usages in ILIAS were updated to use the new listing component instead.

This supersedes #9522 and takes over the work on behalf of @kergomard during his absence.

Kind regards,
@thibsy 