### PR TITLE
Improvement/12/ci code rules superglobals

### DIFF
--- a/.github/workflows/code-rules.yml
+++ b/.github/workflows/code-rules.yml
@@ -1,0 +1,63 @@
+name: code-rules
+on: [pull_request, push]
+permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  code-rules:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: dom, curl, libxml, mbstring, zip, gd, json, readline, xsl, imagick
+          tools: composer:v2
+          coverage: none
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: vendor/composer/vendor
+          key: composer-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-
+
+      - name: Prepare Customizing directory
+        # The composer classmap includes ./public/Customizing/global/plugins; --no-scripts
+        # skips the pre-install-cmd that would create it, so create it here — otherwise
+        # autoload generation aborts ("Could not scan for classes inside ...").
+        run: mkdir -p public/Customizing/global/plugins
+
+      - name: Install Composer packages
+        # --no-scripts skips the post-autoload-dump build (cli/setup.php build), which
+        # copies front-end assets from node_modules. PHPStan only needs the autoloader
+        # and classmap (still generated), so neither the build nor Node.js is required.
+        run: composer install --no-interaction --no-progress --no-scripts
+
+      - name: Cache PHPStan result cache
+        uses: actions/cache@v4
+        with:
+          path: tmp/phpstan-code-rules
+          key: phpstan-code-rules-${{ github.run_id }}
+          restore-keys: phpstan-code-rules-
+
+      - name: ILIAS Code Rules
+        # Non-blocking for now: the gate reports violations (annotations + report) but
+        # does not fail the job while the existing findings are being fixed / exempted.
+        # Remove continue-on-error to make it a hard gate once the count reaches zero.
+        continue-on-error: true
+        run: scripts/PHPStan/run_code_rules.sh
+        env:
+          GHRUN: "yes"
+          ERROR_FORMAT: github
+
+      - name: Code Rules Summary
+        if: always()
+        run: ERROR_FORMAT=stepSummary scripts/PHPStan/run_code_rules.sh >> "$GITHUB_STEP_SUMMARY" || true
+        env:
+          GHRUN: "yes"

--- a/.github/workflows/code-rules.yml
+++ b/.github/workflows/code-rules.yml
@@ -42,15 +42,14 @@ jobs:
       - name: Cache PHPStan result cache
         uses: actions/cache@v4
         with:
-          path: tmp/phpstan-code-rules
+          path: scripts/PHPStan/.cache/code-rules
           key: phpstan-code-rules-${{ github.run_id }}
           restore-keys: phpstan-code-rules-
 
       - name: ILIAS Code Rules
-        # Non-blocking for now: the gate reports violations (annotations + report) but
-        # does not fail the job while the existing findings are being fixed / exempted.
-        # Remove continue-on-error to make it a hard gate once the count reaches zero.
-        continue-on-error: true
+        # Hard gate: the branch that introduced these rules also brought the count to
+        # zero, so any new violation has to be fixed or exempted in the pull request
+        # that adds it.
         run: scripts/PHPStan/run_code_rules.sh
         env:
           GHRUN: "yes"

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /.settings
 /errors
 /extern
+/tmp
 /components/ILIAS/PHPUnit/config/cfg.phpunit.php
 /nbproject
 /templates/default/delos.css.map

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 /.settings
 /errors
 /extern
-/tmp
+/scripts/PHPStan/.cache
 /components/ILIAS/PHPUnit/config/cfg.phpunit.php
 /nbproject
 /templates/default/delos.css.map

--- a/components/ILIAS/Calendar/classes/class.ilCalendarRemoteAccessHandler.php
+++ b/components/ILIAS/Calendar/classes/class.ilCalendarRemoteAccessHandler.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\HTTP\Services as HTTPServices;
+use ILIAS\Scripts\PHPStan\Attributes\AllowSuperglobalWrite;
 
 /**
  * @classDescription Handles requests from external calendar applications
@@ -49,6 +50,7 @@ class ilCalendarRemoteAccessHandler
     /**
      * Fetch client id, the chosen calendar...
      */
+    #[AllowSuperglobalWrite('resolves the client id for the remote calendar entry point before ilInitialisation runs, so no HTTP service exists yet.', 12)]
     public function parseRequest(): void
     {
         // before initialization: $_GET and $_COOKIE is required is unavoidable

--- a/components/ILIAS/CmiXapi/classes/XapiProxy/DataService.php
+++ b/components/ILIAS/CmiXapi/classes/XapiProxy/DataService.php
@@ -20,8 +20,11 @@ declare(strict_types=1);
 
 namespace XapiProxy;
 
+use ILIAS\Scripts\PHPStan\Attributes\AllowSuperglobalWrite;
+
 class DataService
 {
+    #[AllowSuperglobalWrite('the client id has to be visible to ilInitialisation, which runs before the HTTP service exists.', 12)]
     public static function initIlias(string $client_id): void
     {
         define("CLIENT_ID", $client_id);

--- a/components/ILIAS/CmiXapi/resources/xapitoken.php
+++ b/components/ILIAS/CmiXapi/resources/xapitoken.php
@@ -49,8 +49,10 @@ try {
         ilCmiXapiAuthToken::OPENSSL_IV
     ), true);
 
+    // @phpstan-ignore ilias.superglobalWrite.v12 (restores session and client id from the signed token before ilInitialisation runs, so no HTTP service exists yet)
     $_COOKIE[session_name()] = $param[session_name()];
 
+    // @phpstan-ignore ilias.superglobalWrite.v12 (restores session and client id from the signed token before ilInitialisation runs, so no HTTP service exists yet)
     $_COOKIE['ilClientId'] = $param['ilClientId'];
     $objId = $param['obj_id'];
     $refId = $param['ref_id'];

--- a/components/ILIAS/DataCollection/classes/Content/class.ilDclRecordEditGUI.php
+++ b/components/ILIAS/DataCollection/classes/Content/class.ilDclRecordEditGUI.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Scripts\PHPStan\Attributes\AllowSuperglobalWrite;
+
 class ilDclRecordEditGUI
 {
     /**
@@ -486,6 +488,10 @@ class ilDclRecordEditGUI
     /**
      * Save record
      */
+    #[AllowSuperglobalWrite(
+        'adds a $_FILES entry for every file input the form expects, because the legacy file inputs read their state from there. The placeholders come from the request, so the shape of the added entries is client-controlled; narrowing this to the field names the form knows is open work.',
+        12
+    )]
     public function save(): void
     {
         global $DIC;

--- a/components/ILIAS/DataCollection/classes/Helpers/class.ilDclPropertyFormGUI.php
+++ b/components/ILIAS/DataCollection/classes/Helpers/class.ilDclPropertyFormGUI.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Scripts\PHPStan\Attributes\AllowSuperglobalWrite;
+
 /**
  * Class ilDclPropertyFormGUI
  * @ilCtrl_Calls ilDclPropertyFormGUI: ilFormPropertyDispatchGUI
@@ -71,6 +73,7 @@ class ilDclPropertyFormGUI extends ilPropertyFormGUI
     /**
      * @throws ilDclException
      */
+    #[AllowSuperglobalWrite('re-injects files uploaded in an earlier step of the same form, because the file inputs read them from $_FILES.', 12)]
     public static function rebuildTempFileByHash(string $hash): void
     {
         $temp_path = ilFileUtils::getDataDir() . "/temp";

--- a/components/ILIAS/Form/classes/class.ilFileInputGUI.php
+++ b/components/ILIAS/Form/classes/class.ilFileInputGUI.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 use ILIAS\FileUpload\Exception\IllegalStateException;
 use ILIAS\FileUpload\FileUpload;
 use ILIAS\UI\Implementation\Component\Input\UploadLimitResolver;
+use ILIAS\Scripts\PHPStan\Attributes\AllowSuperglobalWrite;
 
 /**
  * This class represents a file property in a property form.
@@ -161,6 +162,7 @@ class ilFileInputGUI extends ilSubEnabledFormPropertyGUI implements ilToolbarIte
         return $this->allow_deletion;
     }
 
+    #[AllowSuperglobalWrite('sanitises the uploaded file name in place, because getInput() hands $_FILES[postVar] on to every caller.', 12)]
     public function checkInput(): bool
     {
         if (!$this->upload_service->hasBeenProcessed()) {

--- a/components/ILIAS/Form/classes/class.ilFileWizardInputGUI.php
+++ b/components/ILIAS/Form/classes/class.ilFileWizardInputGUI.php
@@ -19,6 +19,7 @@
 declare(strict_types=1);
 
 use ILIAS\Filesystem\Util;
+use ILIAS\Scripts\PHPStan\Attributes\AllowSuperglobalWrite;
 
 /**
  * This class represents a file wizard property in a property form.
@@ -79,6 +80,7 @@ class ilFileWizardInputGUI extends ilFileInputGUI
         return $this->allowMove;
     }
 
+    #[AllowSuperglobalWrite('sanitises the uploaded file names in place, because the inherited getInput() hands $_FILES[postVar] on to every caller.', 12)]
     public function checkInput(): bool
     {
         $lng = $this->lng;

--- a/components/ILIAS/Form/classes/class.ilPropertyFormGUI.php
+++ b/components/ILIAS/Form/classes/class.ilPropertyFormGUI.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 use ILIAS\HTTP;
 use ILIAS\Refinery;
+use ILIAS\Scripts\PHPStan\Attributes\AllowSuperglobalWrite;
 
 /**
  * This class represents a property form user interface
@@ -1012,6 +1013,7 @@ class ilPropertyFormGUI extends ilFormGUI
         return "";
     }
 
+    #[AllowSuperglobalWrite('re-injects files uploaded in an earlier step of the same form, because the file inputs read them from $_FILES.', 12)]
     protected function rebuildUploadedFiles(): void
     {
         $file_hash = (string) $this->getFileHash();

--- a/components/ILIAS/Init/classes/class.ilInitialisation.php
+++ b/components/ILIAS/Init/classes/class.ilInitialisation.php
@@ -37,6 +37,7 @@ use ILIAS\ILIASObject\Properties\AdditionalProperties\Icon\Factory as CustomIcon
 use ILIAS\User\PublicInterface as UserPublicInterface;
 use ILIAS\Mail\Service\MailService;
 use ILIAS\Init\AllModernComponents;
+use ILIAS\Scripts\PHPStan\Attributes\AllowSuperglobalWrite;
 
 // needed for slow queries, etc.
 if (!isset($GLOBALS['ilGlobalStartTime']) || !$GLOBALS['ilGlobalStartTime']) {
@@ -52,6 +53,7 @@ if (!isset($GLOBALS['ilGlobalStartTime']) || !$GLOBALS['ilGlobalStartTime']) {
  * @version $Id$
  * @ingroup ServicesInit
  */
+#[AllowSuperglobalWrite('Remove unsafe Characters, several other legacy mechanisms...')]
 class ilInitialisation
 {
     /**

--- a/components/ILIAS/Init/classes/class.ilInitialisation.php
+++ b/components/ILIAS/Init/classes/class.ilInitialisation.php
@@ -53,7 +53,7 @@ if (!isset($GLOBALS['ilGlobalStartTime']) || !$GLOBALS['ilGlobalStartTime']) {
  * @version $Id$
  * @ingroup ServicesInit
  */
-#[AllowSuperglobalWrite('Remove unsafe Characters, several other legacy mechanisms...')]
+#[AllowSuperglobalWrite('Remove unsafe Characters, several other legacy mechanisms...', 12)]
 class ilInitialisation
 {
     /**

--- a/components/ILIAS/Init/resources/sso/index.php
+++ b/components/ILIAS/Init/resources/sso/index.php
@@ -41,6 +41,7 @@ if (isset($_GET['client_id'])) {
     }
 
     setcookie('ilClientId', $_GET['client_id'], 0, $cookie_path, '');
+    // @phpstan-ignore ilias.superglobalWrite.v12 (the client id has to be visible to ilInitialisation, which runs before the HTTP service exists)
     $_COOKIE['ilClientId'] = $_GET['client_id'];
 }
 

--- a/components/ILIAS/Init/src/ErrorHandling/Infrastructure/Whoops/DelegatingHandler.php
+++ b/components/ILIAS/Init/src/ErrorHandling/Infrastructure/Whoops/DelegatingHandler.php
@@ -35,7 +35,7 @@ use ILIAS\Scripts\PHPStan\Attributes\AllowSuperglobalWrite;
  * This class is not ment to be extended, as the definition of error handlers should be handled in one place
  * in ilErrorHandling, so this class acts rather dump and asks ilErrorHandling for a handler.
  */
-#[AllowSuperglobalWrite('The error handler needs to write to SuperGlobals to remove secret data.')]
+#[AllowSuperglobalWrite('The error handler needs to write to SuperGlobals to remove secret data.', 12)]
 final class DelegatingHandler extends Handler
 {
     private ?HandlerInterface $current_handler = null;

--- a/components/ILIAS/Init/src/ErrorHandling/Infrastructure/Whoops/DelegatingHandler.php
+++ b/components/ILIAS/Init/src/ErrorHandling/Infrastructure/Whoops/DelegatingHandler.php
@@ -23,6 +23,7 @@ namespace ILIAS\Init\ErrorHandling\Infrastructure\Whoops;
 use ILIAS\Init\ErrorHandling\Application\ContextErrorHandlerProvider;
 use Whoops\Handler\Handler;
 use Whoops\Handler\HandlerInterface;
+use ILIAS\Scripts\PHPStan\Attributes\AllowSuperglobalWrite;
 
 /**
  * A Whoops error handler that delegates calls on it self to another handler that is created only in the
@@ -34,6 +35,7 @@ use Whoops\Handler\HandlerInterface;
  * This class is not ment to be extended, as the definition of error handlers should be handled in one place
  * in ilErrorHandling, so this class acts rather dump and asks ilErrorHandling for a handler.
  */
+#[AllowSuperglobalWrite('The error handler needs to write to SuperGlobals to remove secret data.')]
 final class DelegatingHandler extends Handler
 {
     private ?HandlerInterface $current_handler = null;

--- a/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilLTITool.php
+++ b/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilLTITool.php
@@ -23,6 +23,7 @@ use ceLTIc\LTI\ResourceLink;
 use ceLTIc\LTI\Tool;
 use ceLTIc\LTI\User;
 use ILIAS\HTTP\Wrapper\ArrayBasedRequestWrapper;
+use ILIAS\Scripts\PHPStan\Attributes\AllowSuperglobalWrite;
 
 /**
  * LTI provider for LTI launch
@@ -87,6 +88,7 @@ class ilLTITool extends Tool
         return $res;
     }
 
+    #[AllowSuperglobalWrite('the celtic/lti library reads the request from the superglobals, so the parsed PSR-7 request has to be written back into them.', 12)]
     public function handleRequest(?bool $strictMode = null, bool $disableCookieCheck = false, bool $generateWarnings = false): void
     {
         global $DIC;

--- a/components/ILIAS/LTIProvider/resources/lti.php
+++ b/components/ILIAS/LTIProvider/resources/lti.php
@@ -19,7 +19,9 @@
 declare(strict_types=1);
 
 
+// @phpstan-ignore ilias.superglobalWrite.v12 (pins the command for the LTI entry point before ilInitialisation runs, so no HTTP service exists yet)
 $_GET['cmd'] = 'post';
+// @phpstan-ignore ilias.superglobalWrite.v12 (pins the command for the LTI entry point before ilInitialisation runs, so no HTTP service exists yet)
 $_POST['cmd'] = 'doLTIAuthentication';
 
 require_once '../vendor/composer/vendor/autoload.php';

--- a/components/ILIAS/Test/classes/class.ilObjTestGUI.php
+++ b/components/ILIAS/Test/classes/class.ilObjTestGUI.php
@@ -2576,9 +2576,8 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
         }
 
         $question_pool = $this->createQuestionPool($title, $this->testrequest->raw('description'));
-        $_REQUEST['sel_qpl'] = $question_pool->getRefId();
 
-        $this->copyAndLinkQuestionsToPoolObject();
+        $this->copyAndLinkQuestionsToPoolObject($question_pool->getRefId());
     }
 
     /**

--- a/components/ILIAS/TestQuestionPool/classes/class.ilKprimChoiceWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilKprimChoiceWizardInputGUI.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+use ILIAS\Scripts\PHPStan\Attributes\AllowSuperglobalWrite;
+
 /**
  * @author		Björn Heyser <bheyser@databay.de>
  * @version		$Id$
@@ -307,6 +309,7 @@ class ilKprimChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
         $this->tpl->addJavascript('assets/js/ilAssKprimChoice.js');
     }
 
+    #[AllowSuperglobalWrite('flags a rejected image by writing a custom upload error into $_FILES, which the inherited getInput() then reports to the caller.', 12)]
     public function checkUploads($foundvalues): bool
     {
         if (is_array($_FILES) && count($_FILES) && $this->getSingleline()) {

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilIdentifiedMultiFilesJsPositionIndexRemover.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilIdentifiedMultiFilesJsPositionIndexRemover.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+use ILIAS\Scripts\PHPStan\Attributes\AllowSuperglobalWrite;
+
 /**
  * @author        Björn Heyser <bheyser@databay.de>
  */
@@ -65,6 +67,7 @@ class ilIdentifiedMultiFilesJsPositionIndexRemover extends ilIdentifiedMultiValu
         return true;
     }
 
+    #[AllowSuperglobalWrite('normalises the shape of $_FILES[postVar], because the inherited getInput() reads it back from there.', 12)]
     protected function prepareFileSubmit(): void
     {
         $_FILES[$this->getPostVar()] = $this->prepareMultiFilesSubmitValues(

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilImagemapFileInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilImagemapFileInputGUI.php
@@ -21,6 +21,7 @@ use ILIAS\TestQuestionPool\ilTestLegacyFormsHelper;
 use ILIAS\UI\Renderer;
 use ILIAS\UI\Component\Button\Factory as ButtonFactory;
 use ILIAS\UI\Component\Symbol\Glyph\Factory as GlyphFactory;
+use ILIAS\Scripts\PHPStan\Attributes\AllowSuperglobalWrite;
 
 /**
 * This class represents an image map file property in a property form.
@@ -177,6 +178,7 @@ class ilImagemapFileInputGUI extends ilImageFileInputGUI
     * Check input, strip slashes etc. set alert, if input is not ok.
     * @return	boolean		Input ok, true/false
     */
+    #[AllowSuperglobalWrite('sanitises the uploaded file name in place, because the inherited getInput() hands $_FILES[postVar] on to every caller.', 12)]
     public function checkInput(): bool
     {
         $lng = $this->lng;

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilMultiFilesSubmitRecursiveSlashesStripper.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilMultiFilesSubmitRecursiveSlashesStripper.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+use ILIAS\Scripts\PHPStan\Attributes\AllowSuperglobalWrite;
+
 /**
  * @author        Björn Heyser <bheyser@databay.de>
  */
@@ -64,6 +66,7 @@ class ilMultiFilesSubmitRecursiveSlashesStripper implements ilFormValuesManipula
     /**
      * perform the strip slashing on files submit
      */
+    #[AllowSuperglobalWrite('strips slashes in $_FILES[postVar], because the inherited getInput() reads it back from there.', 12)]
     protected function manipulateFileSubmitValues(): void
     {
         if ($_FILES) {

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilMultipleImagesAdditionalIndexLevelRemover.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilMultipleImagesAdditionalIndexLevelRemover.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+use ILIAS\Scripts\PHPStan\Attributes\AllowSuperglobalWrite;
+
 /**
  * @author        Björn Heyser <bheyser@databay.de>
  */
@@ -46,6 +48,7 @@ class ilMultipleImagesAdditionalIndexLevelRemover implements ilFormValuesManipul
         return $inputValues;
     }
 
+    #[AllowSuperglobalWrite('normalises the shape of $_FILES[postVar], because the inherited getInput() reads it back from there.', 12)]
     public function manipulateFormSubmitValues(array $submitValues): array
     {
         $submitValues = $this->removeAdditionalSubFieldsLevelFromSubmitValues($submitValues);

--- a/components/ILIAS/UI/tests/Examples/ExamplesTest.php
+++ b/components/ILIAS/UI/tests/Examples/ExamplesTest.php
@@ -48,7 +48,7 @@ class ExamplesTest extends ILIAS_UI_TestBase
     protected Container $dic;
     protected Crawler\ExamplesYamlParser $example_parser;
 
-    #[AllowSuperglobalWrite('Bypass Undefined index: ilfilehash for the moment. This is for examples only.')]
+    #[AllowSuperglobalWrite('Bypass Undefined index: ilfilehash for the moment. This is for examples only.', 12)]
     public function setUp(): void
     {
         //This avoids various index not set warnings, which are only relevant in test context.

--- a/components/ILIAS/UI/tests/Examples/ExamplesTest.php
+++ b/components/ILIAS/UI/tests/Examples/ExamplesTest.php
@@ -25,6 +25,7 @@ use ILIAS\UI\Implementation\Crawler as Crawler;
 use ILIAS\DI\Container;
 use ILIAS\UI\NotImplementedException;
 use ILIAS\FileUpload\FileUpload;
+use ILIAS\Scripts\PHPStan\Attributes\AllowSuperglobalWrite;
 
 /**
  * Class ExamplesTest Checks if all examples are implemented and properly returning strings
@@ -47,6 +48,7 @@ class ExamplesTest extends ILIAS_UI_TestBase
     protected Container $dic;
     protected Crawler\ExamplesYamlParser $example_parser;
 
+    #[AllowSuperglobalWrite('Bypass Undefined index: ilfilehash for the moment. This is for examples only.')]
     public function setUp(): void
     {
         //This avoids various index not set warnings, which are only relevant in test context.

--- a/components/ILIAS/WebDAV/src/Request/RequestTranslation.php
+++ b/components/ILIAS/WebDAV/src/Request/RequestTranslation.php
@@ -23,6 +23,7 @@ namespace ILIAS\WebDAV\Request;
 use Psr\Http\Message\ServerRequestInterface;
 use ILIAS\WebDAV\Config;
 use ILIAS\HTTP\Wrapper\SuperGlobalDropInReplacement;
+use ILIAS\Scripts\PHPStan\Attributes\AllowSuperglobalWrite;
 
 /**
  * @internal
@@ -92,6 +93,11 @@ class RequestTranslation
         return array_key_exists($this->config->getMountInstructionsQuery(), $this->request->getQueryParams());
     }
 
+    #[AllowSuperglobalWrite(
+        'as long as we use '
+        . \ILIAS\HTTP\Wrapper\SuperGlobalDropInReplacement::class
+        . ', we must cast back to array to make SabreDAV work.'
+    )]
     public function setup(): void
     {
         $this->post = $_POST;

--- a/components/ILIAS/WebDAV/src/Request/RequestTranslation.php
+++ b/components/ILIAS/WebDAV/src/Request/RequestTranslation.php
@@ -96,7 +96,8 @@ class RequestTranslation
     #[AllowSuperglobalWrite(
         'as long as we use '
         . \ILIAS\HTTP\Wrapper\SuperGlobalDropInReplacement::class
-        . ', we must cast back to array to make SabreDAV work.'
+        . ', we must cast back to array to make SabreDAV work.',
+        12
     )]
     public function setup(): void
     {
@@ -105,6 +106,7 @@ class RequestTranslation
         $HTTP_POST_VARS = $_POST;
     }
 
+    #[AllowSuperglobalWrite('restores what setup() replaced, so the superglobal is left as SabreDAV found it.', 12)]
     public function close(): void
     {
         $_POST = $this->post;

--- a/components/ILIAS/WebServices/Rest/server.php
+++ b/components/ILIAS/WebServices/Rest/server.php
@@ -20,7 +20,10 @@ chdir('../../..');
 
 ilContext::init(ilContext::CONTEXT_REST);
 
-$_COOKIE['client_id'] = $_GET['client_id'] = $_REQUEST['client_id'];
+// @phpstan-ignore ilias.superglobalWrite.v12 (the client id has to be visible to ilInitialisation, which runs before the HTTP service exists)
+$_GET['client_id'] = $_REQUEST['client_id'];
+// @phpstan-ignore ilias.superglobalWrite.v12 (the client id has to be visible to ilInitialisation, which runs before the HTTP service exists)
+$_COOKIE['client_id'] = $_GET['client_id'];
 
 ilInitialisation::initILIAS();
 

--- a/components/ILIAS/soap/classes/class.ilSoapUserAdministration.php
+++ b/components/ILIAS/soap/classes/class.ilSoapUserAdministration.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+use ILIAS\Scripts\PHPStan\Attributes\AllowSuperglobalWrite;
+
 /**
  * Soap user administration methods
  * @author  Stefan Meyer <meyer@leifos.com>
@@ -30,6 +32,7 @@ class ilSoapUserAdministration extends ilSoapAdministration
     /**
      * @return soap_fault|SoapFault|string|null
      */
+    #[AllowSuperglobalWrite('the SOAP entry point has no cookies of its own; the client id has to be visible to initIlias().', 12)]
     public function login(string $client, string $username, string $password)
     {
         unset($_COOKIE[session_name()]);

--- a/scripts/PHPStan/Attributes/AllowRuleViolation.php
+++ b/scripts/PHPStan/Attributes/AllowRuleViolation.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Scripts\PHPStan\Attributes;
+
+use Attribute;
+
+/**
+ * Marks a class, method or function that is deliberately allowed to violate one or
+ * more ILIAS custom code rules, exempting it from those rules.
+ *
+ * This is a zero-cost marker: it is never instantiated at runtime, only read via
+ * reflection by the rules ({@see RuleViolationAllowance}). Use it only for genuinely
+ * unavoidable cases and always give a reason.
+ *
+ * The rules are identified by their PHPStan error identifier (the value shown as
+ * `🪪 <identifier>` in the analysis output, e.g. `ilias.superglobalWrite`). Pass one
+ * or more; an allowance with no identifiers exempts nothing.
+ *
+ * PHP attributes can only sit on declarations, so this exempts the whole
+ * class/method/function. For a single free-standing statement (e.g. in a resource
+ * script without an enclosing function) use an inline
+ * `// @phpstan-ignore <identifier> (reason)` comment instead.
+ *
+ * For frequently exempted rules there are convenience subclasses that already carry
+ * the identifier, e.g. {@see AllowSuperglobalWrite}. The checker matches those via
+ * `ReflectionAttribute::IS_INSTANCEOF`, so subclasses work exactly like the base
+ * attribute.
+ *
+ * Example:
+ * ```php
+ * #[AllowRuleViolation('sanitizes $_GET before the HTTP service exists', 'ilias.superglobalWrite')]
+ * public static function recursivelyRemoveUnsafeCharacters(): void { ... }
+ * ```
+ */
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::TARGET_FUNCTION)]
+readonly class AllowRuleViolation
+{
+    /** @var list<string> */
+    public array $rules;
+
+    public function __construct(public string $reason, string ...$rules)
+    {
+        $this->rules = array_values($rules);
+    }
+}

--- a/scripts/PHPStan/Attributes/AllowRuleViolation.php
+++ b/scripts/PHPStan/Attributes/AllowRuleViolation.php
@@ -30,6 +30,12 @@ use Attribute;
  * reflection by the rules ({@see RuleViolationAllowance}). Use it only for genuinely
  * unavoidable cases and always give a reason.
  *
+ * An allowance is granted for one ILIAS major version and expires with the next one:
+ * `$ilias_version` names the major it was granted for, and the code position starts
+ * being reported again as soon as the analysis runs against a later major. Keeping an
+ * allowance means renewing it deliberately, so nothing is exempted forever by
+ * accident.
+ *
  * The rules are identified by their PHPStan error identifier (the value shown as
  * `🪪 <identifier>` in the analysis output, e.g. `ilias.superglobalWrite`). Pass one
  * or more; an allowance with no identifiers exempts nothing.
@@ -46,7 +52,7 @@ use Attribute;
  *
  * Example:
  * ```php
- * #[AllowRuleViolation('sanitizes $_GET before the HTTP service exists', 'ilias.superglobalWrite')]
+ * #[AllowRuleViolation('sanitizes $_GET before the HTTP service exists', 12, 'ilias.superglobalWrite')]
  * public static function recursivelyRemoveUnsafeCharacters(): void { ... }
  * ```
  */
@@ -56,8 +62,11 @@ readonly class AllowRuleViolation
     /** @var list<string> */
     public array $rules;
 
-    public function __construct(public string $reason, string ...$rules)
-    {
+    public function __construct(
+        public string $reason,
+        public int $ilias_version,
+        string ...$rules
+    ) {
         $this->rules = array_values($rules);
     }
 }

--- a/scripts/PHPStan/Attributes/AllowSuperglobalWrite.php
+++ b/scripts/PHPStan/Attributes/AllowSuperglobalWrite.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Scripts\PHPStan\Attributes;
+
+use Attribute;
+use ILIAS\Scripts\PHPStan\Rules\SuperGlobals\AbstractSuperglobalWriteRule;
+
+/**
+ * Convenience variant of {@see AllowRuleViolation} that already carries the
+ * "No Superglobal Write" rule identifier, so only a reason has to be given:
+ *
+ * ```php
+ * #[AllowSuperglobalWrite('sanitizes $_GET before the HTTP service exists')]
+ * public static function recursivelyRemoveUnsafeCharacters(): void { ... }
+ * ```
+ */
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::TARGET_FUNCTION)]
+final readonly class AllowSuperglobalWrite extends AllowRuleViolation
+{
+    public function __construct(string $reason)
+    {
+        parent::__construct($reason, AbstractSuperglobalWriteRule::IDENTIFIER);
+    }
+}

--- a/scripts/PHPStan/Attributes/AllowSuperglobalWrite.php
+++ b/scripts/PHPStan/Attributes/AllowSuperglobalWrite.php
@@ -28,15 +28,18 @@ use ILIAS\Scripts\PHPStan\Rules\SuperGlobals\AbstractSuperglobalWriteRule;
  * "No Superglobal Write" rule identifier, so only a reason has to be given:
  *
  * ```php
- * #[AllowSuperglobalWrite('sanitizes $_GET before the HTTP service exists')]
+ * #[AllowSuperglobalWrite('sanitizes $_GET before the HTTP service exists', 12)]
  * public static function recursivelyRemoveUnsafeCharacters(): void { ... }
  * ```
+ *
+ * The second argument is the ILIAS major the allowance is granted for; it expires
+ * with the next one. See {@see AllowRuleViolation}.
  */
 #[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::TARGET_FUNCTION)]
 final readonly class AllowSuperglobalWrite extends AllowRuleViolation
 {
-    public function __construct(string $reason)
+    public function __construct(string $reason, int $ilias_version)
     {
-        parent::__construct($reason, AbstractSuperglobalWriteRule::IDENTIFIER);
+        parent::__construct($reason, $ilias_version, AbstractSuperglobalWriteRule::IDENTIFIER);
     }
 }

--- a/scripts/PHPStan/Attributes/RuleViolationAllowance.php
+++ b/scripts/PHPStan/Attributes/RuleViolationAllowance.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace ILIAS\Scripts\PHPStan\Attributes;
 
+use ILIAS\Scripts\PHPStan\IliasVersion;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\Php\PhpFunctionReflection;
 
@@ -30,6 +31,10 @@ use PHPStan\Reflection\Php\PhpFunctionReflection;
  *
  * Rules call {@see self::isAllowedIn()} with their own error identifier before
  * emitting an error.
+ *
+ * An allowance only counts for the ILIAS major it was granted for. Once the analysis
+ * runs against a later major, the attribute is ignored and the position is reported
+ * again, so every exemption has to be renewed deliberately.
  */
 final class RuleViolationAllowance
 {
@@ -43,6 +48,10 @@ final class RuleViolationAllowance
                     \ReflectionAttribute::IS_INSTANCEOF
                 ) as $attribute) {
                     $allowance = $attribute->newInstance();
+                    if ($allowance->ilias_version < IliasVersion::major()) {
+                        // granted for an earlier release; it has expired.
+                        continue;
+                    }
                     if (in_array($rule_identifier, $allowance->rules, true)) {
                         return true;
                     }

--- a/scripts/PHPStan/Attributes/RuleViolationAllowance.php
+++ b/scripts/PHPStan/Attributes/RuleViolationAllowance.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Scripts\PHPStan\Attributes;
+
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\Php\PhpFunctionReflection;
+
+/**
+ * Shared helper for ILIAS custom PHPStan rules: decides whether the code position
+ * described by a {@see Scope} is exempt from a rule via an {@see AllowRuleViolation}
+ * attribute (or any subclass of it) on the enclosing class, method or function.
+ *
+ * Rules call {@see self::isAllowedIn()} with their own error identifier before
+ * emitting an error.
+ */
+final class RuleViolationAllowance
+{
+    public static function isAllowedIn(Scope $scope, string $rule_identifier): bool
+    {
+        try {
+            foreach (self::reflections($scope) as $reflection) {
+                // IS_INSTANCEOF so convenience subclasses (e.g. AllowSuperglobalWrite) match too.
+                foreach ($reflection->getAttributes(
+                    AllowRuleViolation::class,
+                    \ReflectionAttribute::IS_INSTANCEOF
+                ) as $attribute) {
+                    $allowance = $attribute->newInstance();
+                    if (in_array($rule_identifier, $allowance->rules, true)) {
+                        return true;
+                    }
+                }
+            }
+        } catch (\Throwable) {
+            // Reflection can fail for not-yet-loadable symbols; never break analysis over it.
+            return false;
+        }
+
+        return false;
+    }
+
+    /**
+     * @return iterable<\ReflectionClass<object>|\ReflectionMethod|\ReflectionFunction>
+     */
+    private static function reflections(Scope $scope): iterable
+    {
+        $class_reflection = $scope->getClassReflection();
+        if ($class_reflection !== null) {
+            $native_class = $class_reflection->getNativeReflection();
+            yield $native_class;
+
+            $function_name = $scope->getFunctionName();
+            if ($function_name !== null && $native_class->hasMethod($function_name)) {
+                yield $native_class->getMethod($function_name);
+            }
+
+            return;
+        }
+
+        $function = $scope->getFunction();
+        if ($function instanceof PhpFunctionReflection) {
+            yield $function->getNativeReflection();
+        }
+    }
+}

--- a/scripts/PHPStan/ErrorFormatter/StepSummaryFormatter.php
+++ b/scripts/PHPStan/ErrorFormatter/StepSummaryFormatter.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Scripts\PHPStan\ErrorFormatter;
+
+use PHPStan\Command\AnalysisResult;
+use PHPStan\Command\ErrorFormatter\ErrorFormatter;
+use PHPStan\Command\Output;
+
+/**
+ * Renders the code-rules result as a Markdown summary (violations per rule and per
+ * component) meant to be redirected into $GITHUB_STEP_SUMMARY.
+ *
+ * The human-readable rule name is taken from each error's `rule` metadata (which the
+ * rules set to their LABEL constant), so this formatter needs no knowledge of the
+ * individual rules — adding a rule requires no change here.
+ */
+final class StepSummaryFormatter implements ErrorFormatter
+{
+    private const COMPONENT_REGEX = '#/components/ILIAS/([^/]+)/#';
+    private const OTHER = 'other';
+    private const TOP_COMPONENTS = 10;
+
+    public function formatErrors(AnalysisResult $analysisResult, Output $output): int
+    {
+        $total = 0;
+        /** @var array<string, array{label: string, count: int}> $per_rule */
+        $per_rule = [];
+        /** @var array<string, int> $per_component */
+        $per_component = [];
+        /** @var array<string, array<string, array{label: string, count: int}>> $component_rules */
+        $component_rules = [];
+
+        foreach ($analysisResult->getFileSpecificErrors() as $error) {
+            $total++;
+
+            $identifier = $error->getIdentifier() ?? 'unknown';
+            $label = $error->getMetadata()['rule'] ?? $identifier;
+            $per_rule[$identifier] ??= ['label' => $label, 'count' => 0];
+            $per_rule[$identifier]['count']++;
+
+            $component = preg_match(self::COMPONENT_REGEX, $error->getFile(), $matches)
+                ? $matches[1]
+                : self::OTHER;
+            $per_component[$component] = ($per_component[$component] ?? 0) + 1;
+            $component_rules[$component][$identifier] ??= ['label' => $label, 'count' => 0];
+            $component_rules[$component][$identifier]['count']++;
+        }
+
+        uasort($per_rule, static fn(array $a, array $b): int => $b['count'] <=> $a['count']);
+        arsort($per_component);
+
+        $output->writeLineFormatted('## ILIAS Code Rules — ' . $total . ' violation' . ($total === 1 ? '' : 's'));
+        $output->writeLineFormatted('');
+
+        if ($total === 0) {
+            $output->writeLineFormatted('No violations. :white_check_mark:');
+            return 0;
+        }
+
+        $output->writeLineFormatted('| Rule | Violations |');
+        $output->writeLineFormatted('|---|--:|');
+        foreach ($per_rule as $identifier => $info) {
+            $output->writeLineFormatted('| ' . $info['label'] . ' (`' . $identifier . '`) | ' . $info['count'] . ' |');
+        }
+
+        $output->writeLineFormatted('');
+        $output->writeLineFormatted('**Top components**');
+        $output->writeLineFormatted('');
+        foreach (array_slice($per_component, 0, self::TOP_COMPONENTS, true) as $component => $count) {
+            $output->writeLineFormatted('- **' . $component . '** — ' . $count);
+
+            $rules = $component_rules[$component];
+            uasort($rules, static fn(array $a, array $b): int => $b['count'] <=> $a['count']);
+            foreach ($rules as $info) {
+                $output->writeLineFormatted('  - ' . $info['label'] . ': ' . $info['count']);
+            }
+        }
+
+        return 1;
+    }
+}

--- a/scripts/PHPStan/IliasVersion.php
+++ b/scripts/PHPStan/IliasVersion.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Scripts\PHPStan;
+
+/**
+ * The major version of the ILIAS installation the analysis runs against.
+ *
+ * Read straight from ilias_version.php, so the rules do not depend on a
+ * bootstrapped ILIAS. Rule-violation allowances are granted for one major
+ * version; see {@see Attributes\AllowRuleViolation}.
+ */
+final class IliasVersion
+{
+    private static ?int $major = null;
+
+    public static function major(): int
+    {
+        return self::$major ??= self::read();
+    }
+
+    private static function read(): int
+    {
+        $file = dirname(__DIR__, 2) . '/ilias_version.php';
+        if (!is_readable($file)) {
+            throw new \RuntimeException('Cannot read the ILIAS version from ' . $file . '.');
+        }
+
+        if (!preg_match('/ILIAS_VERSION_NUMERIC\s*=\s*[\'"](\d+)/', (string) file_get_contents($file), $match)) {
+            throw new \RuntimeException('Cannot find ILIAS_VERSION_NUMERIC in ' . $file . '.');
+        }
+
+        return (int) $match[1];
+    }
+}

--- a/scripts/PHPStan/README.md
+++ b/scripts/PHPStan/README.md
@@ -18,6 +18,7 @@ Rules/
   SuperGlobals/   ILIAS\Scripts\PHPStan\Rules\SuperGlobals   — no-superglobal-write rule
   LegacyUI/       ILIAS\Scripts\PHPStan\Rules\LegacyUI       — legacy UI component rules
 Attributes/       ILIAS\Scripts\PHPStan\Attributes           — the AllowRuleViolation exemption attribute + checker
+IliasVersion.php  ILIAS\Scripts\PHPStan\IliasVersion         — the ILIAS major the exemptions are checked against
 ```
 
 Add a new topic as a new subdirectory/namespace under `Rules/`.
@@ -77,30 +78,45 @@ appends to the GitHub step summary.
 ### Exempting a violation
 
 There is no blanket baseline. Genuinely unavoidable violations are exempted
-explicitly and locally, so every exception is visible and carries a reason:
+explicitly and locally, so every exception is visible and carries a reason.
+
+**Every exemption is granted for one ILIAS major version and expires with the next
+one.** An exemption written for ILIAS 12 stops being honoured as soon as the analysis
+runs against ILIAS 13, and the position is reported again. Keeping it means renewing
+it deliberately, which is the point: nothing gets exempted forever by accident. The
+current major is read from `ilias_version.php` (see
+`ILIAS\Scripts\PHPStan\IliasVersion`).
 
 - **On a class, method or function** — annotate it with the
-  `ILIAS\Scripts\PHPStan\Attributes\AllowRuleViolation` attribute, passing a reason
-  and one or more rule identifiers:
+  `ILIAS\Scripts\PHPStan\Attributes\AllowRuleViolation` attribute, passing a reason,
+  the ILIAS major it is granted for, and one or more rule identifiers:
 
   ```php
   use ILIAS\Scripts\PHPStan\Attributes\AllowRuleViolation;
 
-  #[AllowRuleViolation('populates $_GET before the HTTP service exists', 'ilias.superglobalWrite')]
+  #[AllowRuleViolation('populates $_GET before the HTTP service exists', 12, 'ilias.superglobalWrite')]
   public static function sanitizeRequest(): void { /* … */ }
   ```
 
   Some rule sets additionally ship a convenience subclass of `AllowRuleViolation`
-  that already carries the identifier, so only the reason is needed. The checker
-  matches those via `ReflectionAttribute::IS_INSTANCEOF`.
+  that already carries the identifier, so only the reason and the version are needed.
+  The checker matches those via `ReflectionAttribute::IS_INSTANCEOF`.
 
 - **On a single free-standing statement** (e.g. in a resource script without an
   enclosing function, where an attribute cannot be placed) — use an inline comment
-  with the identifier and a reason:
+  with the identifier and a reason. The identifier carries the major, because that is
+  what makes the ignore expire:
 
   ```php
-  $_COOKIE['ilClientId'] = $client_id; // @phpstan-ignore ilias.superglobalWrite (bootstrap before request wrapper)
+  // @phpstan-ignore ilias.superglobalWrite.v12 (bootstrap before request wrapper)
+  $_COOKIE['ilClientId'] = $client_id;
   ```
+
+  Under ILIAS 13 the rule reports `ilias.superglobalWrite.v13`, so the ignore above no
+  longer matches and PHPStan reports both the violation and the stale ignore.
+
+Renewing an exemption is a one-character edit (`12` → `13`), but it is an edit
+somebody has to make and a reviewer gets to see.
 
 There is no baseline file: the gate must stay green through in-code exemptions, not
 by grandfathering. (If a mass migration ever needs one, `--generate-baseline` can

--- a/scripts/PHPStan/README.md
+++ b/scripts/PHPStan/README.md
@@ -15,6 +15,7 @@ matching namespace) per topic, and are autoloaded via composer PSR-4
 
 ```
 Rules/
+  SuperGlobals/   ILIAS\Scripts\PHPStan\Rules\SuperGlobals   — no-superglobal-write rule
   LegacyUI/       ILIAS\Scripts\PHPStan\Rules\LegacyUI       — legacy UI component rules
 Attributes/       ILIAS\Scripts\PHPStan\Attributes           — the AllowRuleViolation exemption attribute + checker
 ```
@@ -51,6 +52,7 @@ appends to the GitHub step summary.
 
 | Rule classes | Identifier | Policy |
 |---|---|---|
+| `SuperglobalAssignRule`, `SuperglobalAssignOpRule`, `SuperglobalAssignRefRule` | `ilias.superglobalWrite` | No writing to request-input superglobals (`$_GET`, `$_POST`, `$_REQUEST`, `$_COOKIE`, `$_FILES`). The request is immutable — use the HTTP service / request wrapper instead. |
 
 ### Adding a policy rule
 

--- a/scripts/PHPStan/README.md
+++ b/scripts/PHPStan/README.md
@@ -1,6 +1,112 @@
 PHPStan Custom Rules
 ====================
 
+This directory holds ILIAS' custom PHPStan rules. They come in two independent
+rulesets with different purposes and lifecycles:
+
+| Ruleset | Config | Purpose | CI |
+|---|---|---|---|
+| Legacy-UI report | `legacy_ui.neon` | Track migration of legacy UI components | `legacy-ui.yml` — nightly, non-gating, uploads a CSV report |
+| Code rules | `code_rules.neon` | Enforce code policies | `code-rules.yml` — per pull request, **hard gate** |
+
+The rule classes for both live under `Rules/`, grouped into one subdirectory (and
+matching namespace) per topic, and are autoloaded via composer PSR-4
+(`ILIAS\Scripts` → `./scripts`):
+
+```
+Rules/
+  LegacyUI/       ILIAS\Scripts\PHPStan\Rules\LegacyUI       — legacy UI component rules
+Attributes/       ILIAS\Scripts\PHPStan\Attributes           — the AllowRuleViolation exemption attribute + checker
+```
+
+Add a new topic as a new subdirectory/namespace under `Rules/`.
+
+Code Rules (policy gate)
+------------------------
+
+The code-rules ruleset enforces mandatory coding policies. It is a hard gate: the
+CI job `code-rules.yml` fails a pull request on any violation. The policies are
+enforced everywhere; genuinely unavoidable cases are exempted explicitly in the code
+(see [Exempting a violation](#exempting-a-violation) below), not silently
+grandfathered.
+
+Run the full gate locally:
+
+```bash
+./scripts/PHPStan/run_code_rules.sh
+```
+
+Run it for a single directory (e.g. `components/ILIAS/File`):
+
+```bash
+./scripts/PHPStan/run_code_rules.sh components/ILIAS/File
+```
+
+CI runs the same script with `ERROR_FORMAT=github` so violations show up as inline
+annotations on the pull request; any PHPStan `--error-format` can be set via that
+environment variable. `ERROR_FORMAT=stepSummary` renders the Markdown summary that CI
+appends to the GitHub step summary.
+
+### Active policies
+
+| Rule classes | Identifier | Policy |
+|---|---|---|
+
+### Adding a policy rule
+
+1. Create a subdirectory under `Rules/` for the topic (namespace
+   `ILIAS\Scripts\PHPStan\Rules\<Topic>`) and add a rule class implementing
+   `PHPStan\Rules\Rule` (or extending a shared base). Expose two constants on it:
+   - `public const IDENTIFIER = 'ilias.<policy>';` — the stable error identifier,
+     passed to `->identifier(self::IDENTIFIER)` and referenced by exemptions.
+   - `public const LABEL = '<human name>';` — the human-readable name. Pass it into
+     the error metadata (`->metadata(['rule' => self::LABEL, ...])`); the step-summary
+     error formatter reads the label from there, so the name has a single source.
+
+   For a rule family that shares one identifier across several node-type subclasses
+   (e.g. the superglobal / `$GLOBALS` rules), put both constants on the abstract base.
+2. Register the class under `rules:` in `code_rules.neon`. There is nothing else to
+   wire up: the gate runs it from that list, and the step-summary formatter
+   (`ErrorFormatter/StepSummaryFormatter`, registered as the `stepSummary` error
+   format) picks up its label straight from the error metadata.
+3. Run the gate and either fix the code it flags or exempt the unavoidable cases
+   (next section). The gate must be green before the rule is merged.
+
+### Exempting a violation
+
+There is no blanket baseline. Genuinely unavoidable violations are exempted
+explicitly and locally, so every exception is visible and carries a reason:
+
+- **On a class, method or function** — annotate it with the
+  `ILIAS\Scripts\PHPStan\Attributes\AllowRuleViolation` attribute, passing a reason
+  and one or more rule identifiers:
+
+  ```php
+  use ILIAS\Scripts\PHPStan\Attributes\AllowRuleViolation;
+
+  #[AllowRuleViolation('populates $_GET before the HTTP service exists', 'ilias.superglobalWrite')]
+  public static function sanitizeRequest(): void { /* … */ }
+  ```
+
+  Some rule sets additionally ship a convenience subclass of `AllowRuleViolation`
+  that already carries the identifier, so only the reason is needed. The checker
+  matches those via `ReflectionAttribute::IS_INSTANCEOF`.
+
+- **On a single free-standing statement** (e.g. in a resource script without an
+  enclosing function, where an attribute cannot be placed) — use an inline comment
+  with the identifier and a reason:
+
+  ```php
+  $_COOKIE['ilClientId'] = $client_id; // @phpstan-ignore ilias.superglobalWrite (bootstrap before request wrapper)
+  ```
+
+There is no baseline file: the gate must stay green through in-code exemptions, not
+by grandfathering. (If a mass migration ever needs one, `--generate-baseline` can
+create it and add its `includes:` entry back to `code_rules.neon`.)
+
+Legacy-UI report
+----------------
+
 With the ["Removing of Legacy-UIComponents-Service and Table" project](https://docu.ilias.de/goto_docu_grp_12110.html), a large number of UI elements that are not available in the UI service will be replaced by ILIAS 10. With the rules collected here, violations of the deprecations are found and collected in reports.
 
 The entire report comprises a CSV file for each component and a summarised file for the entire code base, this form of the report can be generated as follows:

--- a/scripts/PHPStan/README.md
+++ b/scripts/PHPStan/README.md
@@ -118,6 +118,19 @@ current major is read from `ilias_version.php` (see
 Renewing an exemption is a one-character edit (`12` → `13`), but it is an edit
 somebody has to make and a reviewer gets to see.
 
+### Listing the exemptions
+
+```bash
+scripts/PHPStan/list_exemptions.sh                       # everything, with reasons
+scripts/PHPStan/list_exemptions.sh components/ILIAS/Form # one component
+scripts/PHPStan/list_exemptions.sh --version=13          # what expires in ILIAS 13
+```
+
+Prints every exemption with its rule, the version it was granted for, the
+declaration it sits on and the reason, grouped by component. It exits non-zero when
+an exemption has expired or carries no version at all, so it can be used as a check
+of its own after a version bump.
+
 There is no baseline file: the gate must stay green through in-code exemptions, not
 by grandfathering. (If a mass migration ever needs one, `--generate-baseline` can
 create it and add its `includes:` entry back to `code_rules.neon`.)

--- a/scripts/PHPStan/Rules/LegacyUI/LegacyClassUsageRule.php
+++ b/scripts/PHPStan/Rules/LegacyUI/LegacyClassUsageRule.php
@@ -16,7 +16,7 @@
  *
  *********************************************************************/
 
-namespace ILIAS\Scripts\PHPStan\Rules;
+namespace ILIAS\Scripts\PHPStan\Rules\LegacyUI;
 
 use PhpParser\Node\Expr\CallLike;
 use PHPStan\Reflection\ReflectionProvider;

--- a/scripts/PHPStan/Rules/LegacyUI/NoLegacyButtonUsagesRule.php
+++ b/scripts/PHPStan/Rules/LegacyUI/NoLegacyButtonUsagesRule.php
@@ -16,7 +16,7 @@
  *
  *********************************************************************/
 
-namespace ILIAS\Scripts\PHPStan\Rules;
+namespace ILIAS\Scripts\PHPStan\Rules\LegacyUI;
 
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
@@ -24,21 +24,20 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\RuleErrorBuilder;
 
-class NoLegacyModalUsagesRule extends LegacyClassUsageRule implements Rule
+class NoLegacyButtonUsagesRule extends LegacyClassUsageRule implements Rule
 {
     protected function getHumanReadableRuleName(): string
     {
-        return 'Legacy Modal Usages';
+        return 'Legacy Button Usages';
     }
 
     protected function getRelevantILIASVersion(): int
     {
-        return 10;
+        return 9;
     }
-
 
     protected function getForbiddenClasses(): array
     {
-        return ['ilModalGUI'];
+        return ['ilLinkButton'];
     }
 }

--- a/scripts/PHPStan/Rules/LegacyUI/NoLegacyCheckboxListUsagesRule.php
+++ b/scripts/PHPStan/Rules/LegacyUI/NoLegacyCheckboxListUsagesRule.php
@@ -16,7 +16,7 @@
  *
  *********************************************************************/
 
-namespace ILIAS\Scripts\PHPStan\Rules;
+namespace ILIAS\Scripts\PHPStan\Rules\LegacyUI;
 
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
@@ -24,21 +24,21 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\RuleErrorBuilder;
 
-class NoLegacyTableUsagesRule extends LegacyClassUsageRule implements Rule
+class NoLegacyCheckboxListUsagesRule extends LegacyClassUsageRule implements Rule
 {
     protected function getHumanReadableRuleName(): string
     {
-        return 'Legacy Table Usages';
+        return 'Legacy Checkbox List Usages';
     }
 
     protected function getRelevantILIASVersion(): int
     {
-        return 10;
+        return 9;
     }
 
 
     protected function getForbiddenClasses(): array
     {
-        return ['ilTable2GUI', 'ilTableGUI'];
+        return ['ilCheckboxListOverlayGUI'];
     }
 }

--- a/scripts/PHPStan/Rules/LegacyUI/NoLegacyConfirmationUsagesRule.php
+++ b/scripts/PHPStan/Rules/LegacyUI/NoLegacyConfirmationUsagesRule.php
@@ -16,7 +16,7 @@
  *
  *********************************************************************/
 
-namespace ILIAS\Scripts\PHPStan\Rules;
+namespace ILIAS\Scripts\PHPStan\Rules\LegacyUI;
 
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
@@ -24,11 +24,11 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\RuleErrorBuilder;
 
-class NoLegacyProgressBarUsagesRule extends LegacyClassUsageRule implements Rule
+class NoLegacyConfirmationUsagesRule extends LegacyClassUsageRule implements Rule
 {
     protected function getHumanReadableRuleName(): string
     {
-        return 'Legacy Progress Bar Usages';
+        return 'Legacy Confirmation Screen Usages';
     }
 
     protected function getRelevantILIASVersion(): int
@@ -39,6 +39,6 @@ class NoLegacyProgressBarUsagesRule extends LegacyClassUsageRule implements Rule
 
     protected function getForbiddenClasses(): array
     {
-        return ['ilProgressBar'];
+        return ['ilConfirmationGUI'];
     }
 }

--- a/scripts/PHPStan/Rules/LegacyUI/NoLegacyExplorerUsagesRule.php
+++ b/scripts/PHPStan/Rules/LegacyUI/NoLegacyExplorerUsagesRule.php
@@ -16,7 +16,7 @@
  *
  *********************************************************************/
 
-namespace ILIAS\Scripts\PHPStan\Rules;
+namespace ILIAS\Scripts\PHPStan\Rules\LegacyUI;
 
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
@@ -24,11 +24,11 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\RuleErrorBuilder;
 
-class NoLegacyToolbarUsagesRule extends LegacyClassUsageRule implements Rule
+class NoLegacyExplorerUsagesRule extends LegacyClassUsageRule implements Rule
 {
     protected function getHumanReadableRuleName(): string
     {
-        return 'Legacy Toolbar Usages';
+        return 'Legacy Explorer Usages';
     }
 
     protected function getRelevantILIASVersion(): int
@@ -36,13 +36,9 @@ class NoLegacyToolbarUsagesRule extends LegacyClassUsageRule implements Rule
         return 10;
     }
 
+
     protected function getForbiddenClasses(): array
     {
-        return ['ilToolbarGUI'];
-    }
-
-    protected function findMethodUsages(): bool
-    {
-        return true;
+        return ['ilExplorer', 'ilExplorerBaseGUI', 'ilTreeExplorerGUI'];
     }
 }

--- a/scripts/PHPStan/Rules/LegacyUI/NoLegacyLightboxUsagesRule.php
+++ b/scripts/PHPStan/Rules/LegacyUI/NoLegacyLightboxUsagesRule.php
@@ -16,7 +16,7 @@
  *
  *********************************************************************/
 
-namespace ILIAS\Scripts\PHPStan\Rules;
+namespace ILIAS\Scripts\PHPStan\Rules\LegacyUI;
 
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
@@ -24,20 +24,21 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\RuleErrorBuilder;
 
-class NoLegacyButtonUsagesRule extends LegacyClassUsageRule implements Rule
+class NoLegacyLightboxUsagesRule extends LegacyClassUsageRule implements Rule
 {
     protected function getHumanReadableRuleName(): string
     {
-        return 'Legacy Button Usages';
+        return 'Legacy Lightbox Usages';
     }
 
     protected function getRelevantILIASVersion(): int
     {
-        return 9;
+        return 10;
     }
+
 
     protected function getForbiddenClasses(): array
     {
-        return ['ilLinkButton'];
+        return ['ilLightboxGUI'];
     }
 }

--- a/scripts/PHPStan/Rules/LegacyUI/NoLegacyModalUsagesRule.php
+++ b/scripts/PHPStan/Rules/LegacyUI/NoLegacyModalUsagesRule.php
@@ -16,7 +16,7 @@
  *
  *********************************************************************/
 
-namespace ILIAS\Scripts\PHPStan\Rules;
+namespace ILIAS\Scripts\PHPStan\Rules\LegacyUI;
 
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
@@ -24,11 +24,11 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\RuleErrorBuilder;
 
-class NoLegacyTextHighlighterUsagesRule extends LegacyClassUsageRule implements Rule
+class NoLegacyModalUsagesRule extends LegacyClassUsageRule implements Rule
 {
     protected function getHumanReadableRuleName(): string
     {
-        return 'Legacy Text Highlighter Usages';
+        return 'Legacy Modal Usages';
     }
 
     protected function getRelevantILIASVersion(): int
@@ -39,6 +39,6 @@ class NoLegacyTextHighlighterUsagesRule extends LegacyClassUsageRule implements 
 
     protected function getForbiddenClasses(): array
     {
-        return ['ilTextHighlighterGUI'];
+        return ['ilModalGUI'];
     }
 }

--- a/scripts/PHPStan/Rules/LegacyUI/NoLegacyNestedListUsagesRule.php
+++ b/scripts/PHPStan/Rules/LegacyUI/NoLegacyNestedListUsagesRule.php
@@ -16,7 +16,7 @@
  *
  *********************************************************************/
 
-namespace ILIAS\Scripts\PHPStan\Rules;
+namespace ILIAS\Scripts\PHPStan\Rules\LegacyUI;
 
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;

--- a/scripts/PHPStan/Rules/LegacyUI/NoLegacyPanelUsagesRule.php
+++ b/scripts/PHPStan/Rules/LegacyUI/NoLegacyPanelUsagesRule.php
@@ -16,7 +16,7 @@
  *
  *********************************************************************/
 
-namespace ILIAS\Scripts\PHPStan\Rules;
+namespace ILIAS\Scripts\PHPStan\Rules\LegacyUI;
 
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
@@ -24,11 +24,11 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\RuleErrorBuilder;
 
-class NoLegacyConfirmationUsagesRule extends LegacyClassUsageRule implements Rule
+class NoLegacyPanelUsagesRule extends LegacyClassUsageRule implements Rule
 {
     protected function getHumanReadableRuleName(): string
     {
-        return 'Legacy Confirmation Screen Usages';
+        return 'Legacy Panel Usages';
     }
 
     protected function getRelevantILIASVersion(): int
@@ -39,6 +39,6 @@ class NoLegacyConfirmationUsagesRule extends LegacyClassUsageRule implements Rul
 
     protected function getForbiddenClasses(): array
     {
-        return ['ilConfirmationGUI'];
+        return ['ilPanelGUI'];
     }
 }

--- a/scripts/PHPStan/Rules/LegacyUI/NoLegacyProgressBarUsagesRule.php
+++ b/scripts/PHPStan/Rules/LegacyUI/NoLegacyProgressBarUsagesRule.php
@@ -16,7 +16,7 @@
  *
  *********************************************************************/
 
-namespace ILIAS\Scripts\PHPStan\Rules;
+namespace ILIAS\Scripts\PHPStan\Rules\LegacyUI;
 
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
@@ -24,11 +24,11 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\RuleErrorBuilder;
 
-class NoLegacyExplorerUsagesRule extends LegacyClassUsageRule implements Rule
+class NoLegacyProgressBarUsagesRule extends LegacyClassUsageRule implements Rule
 {
     protected function getHumanReadableRuleName(): string
     {
-        return 'Legacy Explorer Usages';
+        return 'Legacy Progress Bar Usages';
     }
 
     protected function getRelevantILIASVersion(): int
@@ -39,6 +39,6 @@ class NoLegacyExplorerUsagesRule extends LegacyClassUsageRule implements Rule
 
     protected function getForbiddenClasses(): array
     {
-        return ['ilExplorer', 'ilExplorerBaseGUI', 'ilTreeExplorerGUI'];
+        return ['ilProgressBar'];
     }
 }

--- a/scripts/PHPStan/Rules/LegacyUI/NoLegacySyntaxHighlighterUsagesRule.php
+++ b/scripts/PHPStan/Rules/LegacyUI/NoLegacySyntaxHighlighterUsagesRule.php
@@ -16,7 +16,7 @@
  *
  *********************************************************************/
 
-namespace ILIAS\Scripts\PHPStan\Rules;
+namespace ILIAS\Scripts\PHPStan\Rules\LegacyUI;
 
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
@@ -24,11 +24,11 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\RuleErrorBuilder;
 
-class NoLegacyPanelUsagesRule extends LegacyClassUsageRule implements Rule
+class NoLegacySyntaxHighlighterUsagesRule extends LegacyClassUsageRule implements Rule
 {
     protected function getHumanReadableRuleName(): string
     {
-        return 'Legacy Panel Usages';
+        return 'Legacy Syntax Highlighter Usages';
     }
 
     protected function getRelevantILIASVersion(): int
@@ -39,6 +39,6 @@ class NoLegacyPanelUsagesRule extends LegacyClassUsageRule implements Rule
 
     protected function getForbiddenClasses(): array
     {
-        return ['ilPanelGUI'];
+        return ['ilSyntaxHighlighter'];
     }
 }

--- a/scripts/PHPStan/Rules/LegacyUI/NoLegacyTableUsagesRule.php
+++ b/scripts/PHPStan/Rules/LegacyUI/NoLegacyTableUsagesRule.php
@@ -16,7 +16,7 @@
  *
  *********************************************************************/
 
-namespace ILIAS\Scripts\PHPStan\Rules;
+namespace ILIAS\Scripts\PHPStan\Rules\LegacyUI;
 
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
@@ -24,21 +24,21 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\RuleErrorBuilder;
 
-class NoLegacyCheckboxListUsagesRule extends LegacyClassUsageRule implements Rule
+class NoLegacyTableUsagesRule extends LegacyClassUsageRule implements Rule
 {
     protected function getHumanReadableRuleName(): string
     {
-        return 'Legacy Checkbox List Usages';
+        return 'Legacy Table Usages';
     }
 
     protected function getRelevantILIASVersion(): int
     {
-        return 9;
+        return 10;
     }
 
 
     protected function getForbiddenClasses(): array
     {
-        return ['ilCheckboxListOverlayGUI'];
+        return ['ilTable2GUI', 'ilTableGUI'];
     }
 }

--- a/scripts/PHPStan/Rules/LegacyUI/NoLegacyTabsUsagesRule.php
+++ b/scripts/PHPStan/Rules/LegacyUI/NoLegacyTabsUsagesRule.php
@@ -16,19 +16,15 @@
  *
  *********************************************************************/
 
-namespace ILIAS\Scripts\PHPStan\Rules;
+namespace ILIAS\Scripts\PHPStan\Rules\LegacyUI;
 
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
-use PhpParser\Node;
-use PHPStan\Analyser\Scope;
-use PHPStan\Rules\RuleErrorBuilder;
 
-class NoLegacyLightboxUsagesRule extends LegacyClassUsageRule implements Rule
+class NoLegacyTabsUsagesRule extends LegacyClassUsageRule implements Rule
 {
     protected function getHumanReadableRuleName(): string
     {
-        return 'Legacy Lightbox Usages';
+        return 'Legacy Tabs Usages';
     }
 
     protected function getRelevantILIASVersion(): int
@@ -36,9 +32,13 @@ class NoLegacyLightboxUsagesRule extends LegacyClassUsageRule implements Rule
         return 10;
     }
 
-
     protected function getForbiddenClasses(): array
     {
-        return ['ilLightboxGUI'];
+        return ['ilTabsGUI'];
+    }
+
+    protected function findMethodUsages(): bool
+    {
+        return true;
     }
 }

--- a/scripts/PHPStan/Rules/LegacyUI/NoLegacyTextHighlighterUsagesRule.php
+++ b/scripts/PHPStan/Rules/LegacyUI/NoLegacyTextHighlighterUsagesRule.php
@@ -16,7 +16,7 @@
  *
  *********************************************************************/
 
-namespace ILIAS\Scripts\PHPStan\Rules;
+namespace ILIAS\Scripts\PHPStan\Rules\LegacyUI;
 
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
@@ -24,11 +24,11 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\RuleErrorBuilder;
 
-class NoLegacySyntaxHighlighterUsagesRule extends LegacyClassUsageRule implements Rule
+class NoLegacyTextHighlighterUsagesRule extends LegacyClassUsageRule implements Rule
 {
     protected function getHumanReadableRuleName(): string
     {
-        return 'Legacy Syntax Highlighter Usages';
+        return 'Legacy Text Highlighter Usages';
     }
 
     protected function getRelevantILIASVersion(): int
@@ -39,6 +39,6 @@ class NoLegacySyntaxHighlighterUsagesRule extends LegacyClassUsageRule implement
 
     protected function getForbiddenClasses(): array
     {
-        return ['ilSyntaxHighlighter'];
+        return ['ilTextHighlighterGUI'];
     }
 }

--- a/scripts/PHPStan/Rules/LegacyUI/NoLegacyToolbarUsagesRule.php
+++ b/scripts/PHPStan/Rules/LegacyUI/NoLegacyToolbarUsagesRule.php
@@ -16,15 +16,19 @@
  *
  *********************************************************************/
 
-namespace ILIAS\Scripts\PHPStan\Rules;
+namespace ILIAS\Scripts\PHPStan\Rules\LegacyUI;
 
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\RuleErrorBuilder;
 
-class NoLegacyTabsUsagesRule extends LegacyClassUsageRule implements Rule
+class NoLegacyToolbarUsagesRule extends LegacyClassUsageRule implements Rule
 {
     protected function getHumanReadableRuleName(): string
     {
-        return 'Legacy Tabs Usages';
+        return 'Legacy Toolbar Usages';
     }
 
     protected function getRelevantILIASVersion(): int
@@ -34,7 +38,7 @@ class NoLegacyTabsUsagesRule extends LegacyClassUsageRule implements Rule
 
     protected function getForbiddenClasses(): array
     {
-        return ['ilTabsGUI'];
+        return ['ilToolbarGUI'];
     }
 
     protected function findMethodUsages(): bool

--- a/scripts/PHPStan/Rules/SuperGlobals/AbstractSuperglobalWriteRule.php
+++ b/scripts/PHPStan/Rules/SuperGlobals/AbstractSuperglobalWriteRule.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace ILIAS\Scripts\PHPStan\Rules\SuperGlobals;
 
 use ILIAS\Scripts\PHPStan\Attributes\RuleViolationAllowance;
+use ILIAS\Scripts\PHPStan\IliasVersion;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrayDimFetch;
@@ -46,6 +47,13 @@ use PHPStan\Rules\RuleErrorBuilder;
  * {@see \ILIAS\Scripts\PHPStan\Attributes\AllowRuleViolation} attribute (or its
  * convenience subclass {@see \ILIAS\Scripts\PHPStan\Attributes\AllowSuperglobalWrite}).
  *
+ * Exemptions are granted for one ILIAS major version. The attribute names the major it
+ * was granted for, and the reported error identifier carries the major the analysis
+ * runs against ({@see self::identifier()}), so an inline
+ * `// @phpstan-ignore ilias.superglobalWrite.v12 (reason)` stops matching in ILIAS 13
+ * and PHPStan reports both the violation and the stale ignore. Renewing an exemption
+ * is therefore always a deliberate edit.
+ *
  * Known, deliberately uncovered write vectors (documented gaps, out of scope):
  * extract(), variable-variables ($$name), by-reference function parameters and
  * list()/array-destructuring targets.
@@ -64,6 +72,17 @@ abstract class AbstractSuperglobalWriteRule implements Rule
     protected function getForbiddenSuperglobals(): array
     {
         return ['_GET', '_POST', '_REQUEST', '_COOKIE', '_FILES'];
+    }
+
+    /**
+     * The reported identifier, carrying the ILIAS major the analysis runs against.
+     *
+     * Inline ignores name this identifier and therefore expire with the release they
+     * were written for, exactly like the attribute-based allowances.
+     */
+    final public static function identifier(): string
+    {
+        return self::IDENTIFIER . '.v' . IliasVersion::major();
     }
 
     final public function processNode(Node $node, Scope $scope): array
@@ -87,7 +106,7 @@ abstract class AbstractSuperglobalWriteRule implements Rule
                 "Writing to the superglobal \$$superglobal is forbidden. "
                 . 'The request is immutable; use the HTTP service / request wrapper instead.'
             )
-                ->identifier(self::IDENTIFIER)
+                ->identifier(self::identifier())
                 ->metadata([
                     'rule' => self::LABEL,
                     'version' => 12,

--- a/scripts/PHPStan/Rules/SuperGlobals/AbstractSuperglobalWriteRule.php
+++ b/scripts/PHPStan/Rules/SuperGlobals/AbstractSuperglobalWriteRule.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Scripts\PHPStan\Rules\SuperGlobals;
+
+use ILIAS\Scripts\PHPStan\Attributes\RuleViolationAllowance;
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrayDimFetch;
+use PhpParser\Node\Expr\Variable;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Forbids writing to request-input superglobals.
+ *
+ * The request is immutable: values read from PHP's request-input superglobals
+ * ($_GET, $_POST, $_REQUEST, $_COOKIE, $_FILES) must never be mutated. Code that
+ * needs to pass values around has to use the HTTP service / request wrapper, not
+ * write back into the superglobal.
+ *
+ * Concrete subclasses only pick the assignment node type they analyse; the actual
+ * detection logic lives here. All handled node types ({@see Expr\Assign},
+ * {@see Expr\AssignOp}, {@see Expr\AssignRef}) expose the assignment target as
+ * their public `$var` property, which is what {@see self::processNode()} inspects.
+ *
+ * A class, method or function may be exempted from this rule with the
+ * {@see \ILIAS\Scripts\PHPStan\Attributes\AllowRuleViolation} attribute (or its
+ * convenience subclass {@see \ILIAS\Scripts\PHPStan\Attributes\AllowSuperglobalWrite}).
+ *
+ * Known, deliberately uncovered write vectors (documented gaps, out of scope):
+ * extract(), variable-variables ($$name), by-reference function parameters and
+ * list()/array-destructuring targets.
+ */
+abstract class AbstractSuperglobalWriteRule implements Rule
+{
+    public const IDENTIFIER = 'ilias.superglobalWrite';
+
+    public const LABEL = 'Superglobal write';
+
+    /**
+     * Variable names (without leading `$`) that must not be written to.
+     *
+     * @return list<string>
+     */
+    protected function getForbiddenSuperglobals(): array
+    {
+        return ['_GET', '_POST', '_REQUEST', '_COOKIE', '_FILES'];
+    }
+
+    final public function processNode(Node $node, Scope $scope): array
+    {
+        // All handled assignment nodes expose the write target as `$var`.
+        if (!isset($node->var) || !$node->var instanceof Expr) {
+            return [];
+        }
+
+        $superglobal = $this->findWrittenSuperglobal($node->var);
+        if ($superglobal === null) {
+            return [];
+        }
+
+        if (RuleViolationAllowance::isAllowedIn($scope, self::IDENTIFIER)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                "Writing to the superglobal \$$superglobal is forbidden. "
+                . 'The request is immutable; use the HTTP service / request wrapper instead.'
+            )
+                ->identifier(self::IDENTIFIER)
+                ->metadata([
+                    'rule' => self::LABEL,
+                    'version' => 12,
+                ])
+                ->build()
+        ];
+    }
+
+    /**
+     * Walks an assignment target down to its root variable and returns the
+     * superglobal name (without `$`) if that root is a forbidden superglobal.
+     *
+     * Covers `$_GET['x'] = …`, nested dimensions `$_GET['a']['b'] = …`,
+     * appends `$_GET[] = …` and whole-array overwrites `$_GET = …`.
+     */
+    private function findWrittenSuperglobal(Expr $target): ?string
+    {
+        while ($target instanceof ArrayDimFetch) {
+            $target = $target->var;
+        }
+
+        if (!$target instanceof Variable || !is_string($target->name)) {
+            return null;
+        }
+
+        return in_array($target->name, $this->getForbiddenSuperglobals(), true)
+            ? $target->name
+            : null;
+    }
+}

--- a/scripts/PHPStan/Rules/SuperGlobals/SuperglobalAssignOpRule.php
+++ b/scripts/PHPStan/Rules/SuperGlobals/SuperglobalAssignOpRule.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Scripts\PHPStan\Rules\SuperGlobals;
+
+use PhpParser\Node\Expr\AssignOp;
+
+/**
+ * Catches compound-assignment writes to a superglobal, e.g. `$_GET['x'] .= …`
+ * or `$_POST['n'] += …`.
+ *
+ * AssignOp is the abstract base of all compound-assignment nodes (Concat, Plus, …);
+ * registering for it matches every operator variant.
+ *
+ * @implements \PHPStan\Rules\Rule<AssignOp>
+ */
+final class SuperglobalAssignOpRule extends AbstractSuperglobalWriteRule
+{
+    public function getNodeType(): string
+    {
+        return AssignOp::class;
+    }
+}

--- a/scripts/PHPStan/Rules/SuperGlobals/SuperglobalAssignRefRule.php
+++ b/scripts/PHPStan/Rules/SuperGlobals/SuperglobalAssignRefRule.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Scripts\PHPStan\Rules\SuperGlobals;
+
+use PhpParser\Node\Expr\AssignRef;
+
+/**
+ * Catches by-reference assignment to a superglobal, e.g. `$_GET =& $x`.
+ *
+ * @implements \PHPStan\Rules\Rule<AssignRef>
+ */
+final class SuperglobalAssignRefRule extends AbstractSuperglobalWriteRule
+{
+    public function getNodeType(): string
+    {
+        return AssignRef::class;
+    }
+}

--- a/scripts/PHPStan/Rules/SuperGlobals/SuperglobalAssignRule.php
+++ b/scripts/PHPStan/Rules/SuperGlobals/SuperglobalAssignRule.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Scripts\PHPStan\Rules\SuperGlobals;
+
+use PhpParser\Node\Expr\Assign;
+
+/**
+ * Catches plain assignments to a superglobal, e.g. `$_GET['x'] = …`, `$_GET = […]`
+ * or chained `$_COOKIE[…] = $_GET[…] = …`.
+ *
+ * @implements \PHPStan\Rules\Rule<Assign>
+ */
+final class SuperglobalAssignRule extends AbstractSuperglobalWriteRule
+{
+    public function getNodeType(): string
+    {
+        return Assign::class;
+    }
+}

--- a/scripts/PHPStan/code_rules.neon
+++ b/scripts/PHPStan/code_rules.neon
@@ -6,7 +6,7 @@ services:
     errorFormatter.stepSummary:
         class: ILIAS\Scripts\PHPStan\ErrorFormatter\StepSummaryFormatter
 parameters:
-    tmpDir: %currentWorkingDirectory%/tmp/phpstan-code-rules
+    tmpDir: %currentWorkingDirectory%/scripts/PHPStan/.cache/code-rules
     parallel:
         maximumNumberOfProcesses: 10
     customRulesetUsed: true

--- a/scripts/PHPStan/code_rules.neon
+++ b/scripts/PHPStan/code_rules.neon
@@ -1,4 +1,7 @@
-rules: []
+rules:
+    - ILIAS\Scripts\PHPStan\Rules\SuperGlobals\SuperglobalAssignRule
+    - ILIAS\Scripts\PHPStan\Rules\SuperGlobals\SuperglobalAssignOpRule
+    - ILIAS\Scripts\PHPStan\Rules\SuperGlobals\SuperglobalAssignRefRule
 services:
     errorFormatter.stepSummary:
         class: ILIAS\Scripts\PHPStan\ErrorFormatter\StepSummaryFormatter

--- a/scripts/PHPStan/code_rules.neon
+++ b/scripts/PHPStan/code_rules.neon
@@ -1,0 +1,27 @@
+rules: []
+services:
+    errorFormatter.stepSummary:
+        class: ILIAS\Scripts\PHPStan\ErrorFormatter\StepSummaryFormatter
+parameters:
+    tmpDir: %currentWorkingDirectory%/tmp/phpstan-code-rules
+    parallel:
+        maximumNumberOfProcesses: 10
+    customRulesetUsed: true
+    bootstrapFiles:
+        - constants.php
+    excludePaths:
+        - '%currentWorkingDirectory%/vendor/*'
+        - '%currentWorkingDirectory%/Customizing/*'
+        - '%currentWorkingDirectory%/scripts/*'
+        - '%currentWorkingDirectory%/data/*'
+        - '%currentWorkingDirectory%/dicto/*'
+        - '%currentWorkingDirectory%/public/*'
+        - '%currentWorkingDirectory%/docs/*'
+        - '%currentWorkingDirectory%/lang/*'
+        - '%currentWorkingDirectory%/soap/lib/*'
+        - '%currentWorkingDirectory%/node_modules/*'
+        - '%currentWorkingDirectory%/templates/*'
+        - '%currentWorkingDirectory%/xml/*'
+        - '%currentWorkingDirectory%/.github/*'
+        - '%currentWorkingDirectory%/**/mediawiki/*'
+        - '%currentWorkingDirectory%/**/Wiki/libs/*'

--- a/scripts/PHPStan/legacy_ui.neon
+++ b/scripts/PHPStan/legacy_ui.neon
@@ -2,20 +2,20 @@ services:
 	errorFormatter.csv:
 		class: \ILIAS\Scripts\PHPStan\ErrorFormatter\CSVFormatter
 rules:
-    - ILIAS\Scripts\PHPStan\Rules\NoLegacyButtonUsagesRule # ILIAS 9
-    - ILIAS\Scripts\PHPStan\Rules\NoLegacyCheckboxListUsagesRule # ILIAS 9
-    - ILIAS\Scripts\PHPStan\Rules\NoLegacyConfirmationUsagesRule # ILIAS 9
-    - ILIAS\Scripts\PHPStan\Rules\NoLegacyExplorerUsagesRule # ILIAS 10git
-    - ILIAS\Scripts\PHPStan\Rules\NoLegacyLightboxUsagesRule # ILIAS 10
-    - ILIAS\Scripts\PHPStan\Rules\NoLegacyModalUsagesRule # ILIAS 10
-    - ILIAS\Scripts\PHPStan\Rules\NoLegacyNestedListUsagesRule # ILIAS 10
-    - ILIAS\Scripts\PHPStan\Rules\NoLegacyPanelUsagesRule # ILIAS 10
-    - ILIAS\Scripts\PHPStan\Rules\NoLegacyProgressBarUsagesRule # ILIAS 10
-    - ILIAS\Scripts\PHPStan\Rules\NoLegacySyntaxHighlighterUsagesRule # ILIAS 10
-    - ILIAS\Scripts\PHPStan\Rules\NoLegacyTableUsagesRule # ILIAS 10
-    - ILIAS\Scripts\PHPStan\Rules\NoLegacyTextHighlighterUsagesRule # ILIAS 10
-    - ILIAS\Scripts\PHPStan\Rules\NoLegacyToolbarUsagesRule # ILIAS 10
-    - ILIAS\Scripts\PHPStan\Rules\NoLegacyTabsUsagesRule # ILIAS 10
+    - ILIAS\Scripts\PHPStan\Rules\LegacyUI\NoLegacyButtonUsagesRule # ILIAS 9
+    - ILIAS\Scripts\PHPStan\Rules\LegacyUI\NoLegacyCheckboxListUsagesRule # ILIAS 9
+    - ILIAS\Scripts\PHPStan\Rules\LegacyUI\NoLegacyConfirmationUsagesRule # ILIAS 9
+    - ILIAS\Scripts\PHPStan\Rules\LegacyUI\NoLegacyExplorerUsagesRule # ILIAS 10git
+    - ILIAS\Scripts\PHPStan\Rules\LegacyUI\NoLegacyLightboxUsagesRule # ILIAS 10
+    - ILIAS\Scripts\PHPStan\Rules\LegacyUI\NoLegacyModalUsagesRule # ILIAS 10
+    - ILIAS\Scripts\PHPStan\Rules\LegacyUI\NoLegacyNestedListUsagesRule # ILIAS 10
+    - ILIAS\Scripts\PHPStan\Rules\LegacyUI\NoLegacyPanelUsagesRule # ILIAS 10
+    - ILIAS\Scripts\PHPStan\Rules\LegacyUI\NoLegacyProgressBarUsagesRule # ILIAS 10
+    - ILIAS\Scripts\PHPStan\Rules\LegacyUI\NoLegacySyntaxHighlighterUsagesRule # ILIAS 10
+    - ILIAS\Scripts\PHPStan\Rules\LegacyUI\NoLegacyTableUsagesRule # ILIAS 10
+    - ILIAS\Scripts\PHPStan\Rules\LegacyUI\NoLegacyTextHighlighterUsagesRule # ILIAS 10
+    - ILIAS\Scripts\PHPStan\Rules\LegacyUI\NoLegacyToolbarUsagesRule # ILIAS 10
+    - ILIAS\Scripts\PHPStan\Rules\LegacyUI\NoLegacyTabsUsagesRule # ILIAS 10
 parameters:
     tmpDir: %currentWorkingDirectory%/tmp/phpstan
     parallel:

--- a/scripts/PHPStan/list_exemptions.php
+++ b/scripts/PHPStan/list_exemptions.php
@@ -1,0 +1,285 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+/**
+ * Lists every rule-violation exemption granted in the code base.
+ *
+ * Exemptions are granted per ILIAS major version and expire with the next one, so
+ * this is the list somebody has to walk through when the version is bumped. Run it
+ * through scripts/PHPStan/list_exemptions.sh.
+ */
+
+namespace ILIAS\Scripts\PHPStan;
+
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+use PhpParser\ParserFactory;
+use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
+
+require_once __DIR__ . '/../../vendor/composer/vendor/autoload.php';
+require_once __DIR__ . '/IliasVersion.php';
+
+/** Attribute short names that grant an exemption. */
+const EXEMPTION_ATTRIBUTES = ['AllowRuleViolation', 'AllowSuperglobalWrite'];
+
+$target = 'components/ILIAS';
+$against = IliasVersion::major();
+foreach (array_slice($argv, 1) as $argument) {
+    if (str_starts_with($argument, '--version=')) {
+        $against = (int) substr($argument, strlen('--version='));
+        continue;
+    }
+    $target = rtrim($argument, '/');
+}
+
+if (!is_dir($target)) {
+    fwrite(STDERR, "Not a directory: {$target}\n");
+    exit(2);
+}
+
+$parser = (new ParserFactory())->createForNewestSupportedVersion();
+$printer = new PrettyPrinter();
+
+/**
+ * Collects the exemption attributes of one file together with the declaration they
+ * sit on.
+ */
+final class ExemptionVisitor extends NodeVisitorAbstract
+{
+    /** @var list<array{line:int, on:string, rules:string, version:?int, reason:string}> */
+    public array $found = [];
+
+    /** @var list<string> */
+    private array $scope = [];
+
+    public function __construct(private readonly PrettyPrinter $printer)
+    {
+    }
+
+    public function enterNode(Node $node): null
+    {
+        if ($node instanceof Node\Stmt\ClassLike && $node->name !== null) {
+            $this->scope[] = $node->name->toString();
+        }
+        if ($node instanceof Node\Stmt\ClassMethod || $node instanceof Node\Stmt\Function_) {
+            $this->scope[] = $node->name->toString() . '()';
+        }
+
+        if ($node instanceof Node\Stmt\ClassLike
+            || $node instanceof Node\Stmt\ClassMethod
+            || $node instanceof Node\Stmt\Function_) {
+            $this->collect($node);
+        }
+
+        return null;
+    }
+
+    public function leaveNode(Node $node): null
+    {
+        if ($node instanceof Node\Stmt\ClassLike && $node->name !== null) {
+            array_pop($this->scope);
+        }
+        if ($node instanceof Node\Stmt\ClassMethod || $node instanceof Node\Stmt\Function_) {
+            array_pop($this->scope);
+        }
+
+        return null;
+    }
+
+    private function collect(Node\Stmt\ClassLike|Node\Stmt\ClassMethod|Node\Stmt\Function_ $node): void
+    {
+        foreach ($node->attrGroups as $group) {
+            foreach ($group->attrs as $attribute) {
+                $short = $attribute->name->getLast();
+                if (!in_array($short, EXEMPTION_ATTRIBUTES, true)) {
+                    continue;
+                }
+
+                $reason = null;
+                $version = null;
+                $rules = [];
+                foreach ($attribute->args as $argument) {
+                    $value = $argument->value;
+                    if ($value instanceof Node\Scalar\Int_) {
+                        $version ??= $value->value;
+                        continue;
+                    }
+                    if ($value instanceof Node\Scalar\String_) {
+                        if ($reason === null) {
+                            $reason = $value->value;
+                        } else {
+                            $rules[] = $value->value;
+                        }
+                        continue;
+                    }
+                    // concatenations of strings and ::class constants
+                    $reason ??= $this->text($value);
+                }
+
+                if ($rules === []) {
+                    $rules = [$short === 'AllowSuperglobalWrite' ? 'ilias.superglobalWrite' : '(unspecified)'];
+                }
+
+                $this->found[] = [
+                    'line' => $attribute->getStartLine(),
+                    'on' => implode('::', $this->scope),
+                    'rules' => implode(', ', $rules),
+                    'version' => $version,
+                    'reason' => self::flatten($reason ?? ''),
+                ];
+            }
+        }
+    }
+
+    /**
+     * Best-effort rendering of an argument that is not a plain string literal,
+     * so a reason built by concatenation still reads like a sentence.
+     */
+    private function text(Node\Expr $expr): string
+    {
+        if ($expr instanceof Node\Scalar\String_) {
+            return $expr->value;
+        }
+        if ($expr instanceof Node\Expr\BinaryOp\Concat) {
+            return $this->text($expr->left) . $this->text($expr->right);
+        }
+        if ($expr instanceof Node\Expr\ClassConstFetch
+            && $expr->name instanceof Node\Identifier
+            && $expr->name->toString() === 'class'
+            && $expr->class instanceof Node\Name) {
+            return $expr->class->getLast();
+        }
+
+        return $this->printer->prettyPrintExpr($expr);
+    }
+
+    private static function flatten(string $text): string
+    {
+        return trim((string) preg_replace('/\s+/', ' ', $text));
+    }
+}
+
+$rows = [];
+
+$iterator = new \RecursiveIteratorIterator(
+    new \RecursiveCallbackFilterIterator(
+        new \RecursiveDirectoryIterator($target, \FilesystemIterator::SKIP_DOTS),
+        static fn(\SplFileInfo $file): bool =>
+            !in_array($file->getFilename(), ['node_modules', 'vendor', 'libs', 'lib'], true)
+    )
+);
+
+foreach ($iterator as $file) {
+    if (!$file->isFile() || $file->getExtension() !== 'php') {
+        continue;
+    }
+
+    $path = $file->getPathname();
+    $code = (string) file_get_contents($path);
+
+    // attribute-based exemptions
+    if (str_contains($code, 'AllowRuleViolation') || str_contains($code, 'AllowSuperglobalWrite')) {
+        try {
+            $ast = $parser->parse($code);
+        } catch (\Throwable $e) {
+            fwrite(STDERR, "Could not parse {$path}: {$e->getMessage()}\n");
+            $ast = null;
+        }
+        if ($ast !== null) {
+            $visitor = new ExemptionVisitor($printer);
+            $traverser = new NodeTraverser();
+            $traverser->addVisitor($visitor);
+            $traverser->traverse($ast);
+            foreach ($visitor->found as $entry) {
+                $rows[] = $entry + ['file' => $path, 'kind' => 'attribute'];
+            }
+        }
+    }
+
+    // inline ignores
+    if (str_contains($code, '@phpstan-ignore')) {
+        foreach (explode("\n", $code) as $index => $line) {
+            if (!preg_match('/@phpstan-ignore\s+(ilias\.[A-Za-z0-9_.]+)\s*(?:\((.*)\))?/', $line, $match)) {
+                continue;
+            }
+            $rule = $match[1];
+            $version = null;
+            if (preg_match('/^(.*)\.v(\d+)$/', $rule, $version_match)) {
+                $rule = $version_match[1];
+                $version = (int) $version_match[2];
+            }
+            $rows[] = [
+                'file' => $path,
+                'line' => $index + 1,
+                'on' => '(statement)',
+                'rules' => $rule,
+                'version' => $version,
+                'reason' => trim($match[2] ?? ''),
+                'kind' => 'inline',
+            ];
+        }
+    }
+}
+
+usort($rows, static fn(array $a, array $b): int => [$a['file'], $a['line']] <=> [$b['file'], $b['line']]);
+
+$expired = 0;
+$unversioned = 0;
+$grouped = [];
+foreach ($rows as $row) {
+    $parts = explode('/', $row['file']);
+    $component = ($parts[0] === 'components' && isset($parts[2])) ? $parts[2] : $parts[0];
+    $grouped[$component][] = $row;
+}
+
+echo "Rule-violation exemptions, checked against ILIAS {$against}\n";
+echo str_repeat('=', 72), "\n";
+
+foreach ($grouped as $component => $entries) {
+    echo "\n", $component, "\n";
+    foreach ($entries as $row) {
+        if ($row['version'] === null) {
+            $status = 'NO VERSION';
+            $unversioned++;
+        } elseif ($row['version'] < $against) {
+            $status = 'EXPIRED';
+            $expired++;
+        } else {
+            $status = 'valid for ' . $row['version'];
+        }
+
+        printf(
+            "  [%-12s] %s:%d\n      %s  on %s\n      %s\n",
+            $status,
+            $row['file'],
+            $row['line'],
+            $row['rules'],
+            $row['on'],
+            $row['reason'] === '' ? '(no reason given)' : $row['reason']
+        );
+    }
+}
+
+$total = count($rows);
+echo "\n", str_repeat('-', 72), "\n";
+printf("%d exemption(s); %d expired, %d without a version\n", $total, $expired, $unversioned);
+
+exit(($expired + $unversioned) > 0 ? 1 : 0);

--- a/scripts/PHPStan/list_exemptions.sh
+++ b/scripts/PHPStan/list_exemptions.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Lists every rule-violation exemption granted in the code base, with the reason,
+# the ILIAS major it was granted for, and whether it still counts.
+#
+# Exemptions expire with the next major (see scripts/PHPStan/README.md), so this is
+# the list to walk through when the version is bumped.
+#
+# Usage:
+#   scripts/PHPStan/list_exemptions.sh                      # all components
+#   scripts/PHPStan/list_exemptions.sh components/ILIAS/Form
+#   scripts/PHPStan/list_exemptions.sh --version=13         # what expires in ILIAS 13
+#
+# Exits non-zero when an exemption has expired or carries no version.
+
+php -dxdebug.mode=off scripts/PHPStan/list_exemptions.php "$@"

--- a/scripts/PHPStan/run_code_rules.sh
+++ b/scripts/PHPStan/run_code_rules.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Runs the ILIAS custom code rules (policy gate) via PHPStan.
+#
+# Hard gate: exits non-zero on any violation, so CI fails the pull request.
+# Genuinely unavoidable cases are exempted in the code (AllowRuleViolation
+# attribute / inline @phpstan-ignore), not via a baseline.
+#
+# Environment variables:
+#   ERROR_FORMAT   PHPStan --error-format to use. Default: "table" (human
+#                  readable). CI sets "github" so violations show up as inline
+#                  annotations on the pull request. Any PHPStan format works
+#                  (table, github, json, checkstyle, ...).
+
+# Never truncate the table output — with a large number of findings the table
+# formatter otherwise collapses the list ("... and N more errors").
+export PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS=1
+
+CONFIG=scripts/PHPStan/code_rules.neon
+MEMORY_LIMIT=4G
+ERROR_FORMAT="${ERROR_FORMAT:-table}"
+
+# Target directory: explicit script parameter, or all ILIAS components at once.
+if [ -d "$1" ]; then
+    TARGET="$1"
+else
+    TARGET="components/ILIAS"
+fi
+
+# Informational line goes to stderr so `ERROR_FORMAT=json ... > out.json` stays pure JSON.
+echo "Running ILIAS code rules on ${TARGET} (error-format: ${ERROR_FORMAT})" >&2
+php -dxdebug.mode=off vendor/composer/vendor/bin/phpstan analyse \
+    -c "${CONFIG}" \
+    -a vendor/composer/vendor/autoload.php \
+    --no-progress \
+    --no-interaction \
+    --memory-limit=${MEMORY_LIMIT} \
+    --error-format="${ERROR_FORMAT}" \
+    "${TARGET}"

--- a/scripts/PHPStan/run_code_rules.sh
+++ b/scripts/PHPStan/run_code_rules.sh
@@ -17,7 +17,7 @@
 export PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS=1
 
 CONFIG=scripts/PHPStan/code_rules.neon
-TMP_DIR=tmp/phpstan-code-rules
+TMP_DIR=scripts/PHPStan/.cache/code-rules
 MEMORY_LIMIT=4G
 ERROR_FORMAT="${ERROR_FORMAT:-table}"
 

--- a/scripts/PHPStan/run_code_rules.sh
+++ b/scripts/PHPStan/run_code_rules.sh
@@ -17,8 +17,21 @@
 export PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS=1
 
 CONFIG=scripts/PHPStan/code_rules.neon
+TMP_DIR=tmp/phpstan-code-rules
 MEMORY_LIMIT=4G
 ERROR_FORMAT="${ERROR_FORMAT:-table}"
+
+# Rule-violation allowances are granted per ILIAS major version, and the reported
+# error identifiers carry that major. The result cache is keyed by file contents
+# only, so a version bump would otherwise serve stale findings from the previous
+# release. Drop the cache whenever the major changes.
+ILIAS_MAJOR="$(sed -n 's/.*ILIAS_VERSION_NUMERIC[^0-9]*\([0-9]\{1,\}\).*/\1/p' ilias_version.php | head -1)"
+STAMP="${TMP_DIR}/.ilias-major"
+if [ ! -f "${STAMP}" ] || [ "$(cat "${STAMP}")" != "${ILIAS_MAJOR}" ]; then
+    rm -rf "${TMP_DIR}"
+    mkdir -p "${TMP_DIR}"
+    printf '%s' "${ILIAS_MAJOR}" > "${STAMP}"
+fi
 
 # Target directory: explicit script parameter, or all ILIAS components at once.
 if [ -d "$1" ]; then


### PR DESCRIPTION
as mentioned in #11471 I here'd like to introduce the basic infrastructure for ILIAS PHStan-Rules and it's first usage to prevent more SuperGlobal changes.

I must mark this as WIP for the moment since we still have 66 violations. as you can see, there is a possibility to exclude a class/method from a violation-report as I implemented in ilInitialisation: https://github.com/ILIAS-eLearning/ILIAS/commit/1b7048d0ddd6f4fba276d5810a725286643358e0#diff-1a374c973bc1ede22ce53539af43a3911c28bb6dcefb858ac77d2fc3000a8344R55

but there are several other location where the authorities must have a look first