### PR TITLE
[Survey] Preselected language handling

### DIFF
--- a/components/ILIAS/Survey/classes/class.ilObjSurveyGUI.php
+++ b/components/ILIAS/Survey/classes/class.ilObjSurveyGUI.php
@@ -765,18 +765,22 @@ class ilObjSurveyGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
         $ctrl = $DIC->ctrl();
 
         $t_arr = explode("_", $a_target);
-        $ref_id = (int) $t_arr[0];
-        if ($a_access_code === "" && isset($t_arr[1])) {
-            $a_access_code = $t_arr[1];
-        }
-        // see ilObjSurveyAccess::_checkGoto()
-        if ($a_access_code !== '') {
-            $sess = $DIC->survey()->internal()->repo()
-                ->execution()->runSession();
+		$ref_id = (int) $t_arr[0];
+		if ($a_access_code === "" && isset($t_arr[1])) {
+		    $a_access_code = $t_arr[1];
+		}
+		$lang = $t_arr[2] ?? "";
+
+		// see ilObjSurveyAccess::_checkGoto()
+		if ($a_access_code !== '') {
+            $sess = $DIC->survey()->internal()->repo()->execution()->runSession();
             $sess->setCode(ilObject::_lookupObjId($ref_id), $a_access_code);
             $ctrl->setParameterByClass("ilObjSurveyGUI", "ref_id", $ref_id);
-            $ctrl->redirectByClass("ilObjSurveyGUI", "run");
-        }
+		if ($lang !== "") {
+		    $ctrl->setParameterByClass("ilObjSurveyGUI", "lang", $lang);
+		}
+		    $ctrl->redirectByClass("ilObjSurveyGUI", "run");
+		}
 
         // write permission -> info screen
         if ($ilAccess->checkAccess("write", "", $ref_id)) {

--- a/components/ILIAS/Survey/classes/class.ilObjSurveyGUI.php
+++ b/components/ILIAS/Survey/classes/class.ilObjSurveyGUI.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 use ILIAS\Survey\Participants;
 use ILIAS\Survey\InternalGUIService;
 use ILIAS\User\Profile\PublicProfileGUI;

--- a/components/ILIAS/Survey/classes/class.ilObjSurveyGUI.php
+++ b/components/ILIAS/Survey/classes/class.ilObjSurveyGUI.php
@@ -767,22 +767,22 @@ class ilObjSurveyGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
         $ctrl = $DIC->ctrl();
 
         $t_arr = explode("_", $a_target);
-		$ref_id = (int) $t_arr[0];
-		if ($a_access_code === "" && isset($t_arr[1])) {
-		    $a_access_code = $t_arr[1];
-		}
-		$lang = $t_arr[2] ?? "";
+        $ref_id = (int) $t_arr[0];
+        if ($a_access_code === "" && isset($t_arr[1])) {
+            $a_access_code = $t_arr[1];
+        }
+        $lang = $t_arr[2] ?? "";
 
-		// see ilObjSurveyAccess::_checkGoto()
-		if ($a_access_code !== '') {
+        // see ilObjSurveyAccess::_checkGoto()
+        if ($a_access_code !== '') {
             $sess = $DIC->survey()->internal()->repo()->execution()->runSession();
             $sess->setCode(ilObject::_lookupObjId($ref_id), $a_access_code);
             $ctrl->setParameterByClass("ilObjSurveyGUI", "ref_id", $ref_id);
-		if ($lang !== "") {
-		    $ctrl->setParameterByClass("ilObjSurveyGUI", "lang", $lang);
-		}
-		    $ctrl->redirectByClass("ilObjSurveyGUI", "run");
-		}
+            if ($lang !== "") {
+                $ctrl->setParameterByClass("ilObjSurveyGUI", "lang", $lang);
+            }
+            $ctrl->redirectByClass("ilObjSurveyGUI", "run");
+        }
 
         // write permission -> info screen
         if ($ilAccess->checkAccess("write", "", $ref_id)) {


### PR DESCRIPTION
This fix adjusts the handling of the language parameter to ensure that the preselected language in Survey is correctly applied and works as expected.

Related ticket: https://mantis.ilias.de/view.php?id=47279
