### PR TITLE
[IMPROVEMENT] Cron: Remove `client_id` argument from CLI command

### DIFF
--- a/components/ILIAS/Cron/src/CLI/Commands/RunActiveJobsCommand.php
+++ b/components/ILIAS/Cron/src/CLI/Commands/RunActiveJobsCommand.php
@@ -40,7 +40,6 @@ class RunActiveJobsCommand extends Command
         $this->setDescription('Runs cron jobs depending on the respective schedule');
 
         $this->addArgument('user', InputArgument::REQUIRED, 'The ILIAS user the script is executed with');
-        $this->addArgument('client_id', InputArgument::REQUIRED, 'The ILIAS client_id');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -48,7 +47,6 @@ class RunActiveJobsCommand extends Command
         $this->style = new SymfonyStyle($input, $output);
 
         $cron = new \ILIAS\Cron\CLI\StartUp(
-            $input->getArgument('client_id'),
             $input->getArgument('user')
         );
 

--- a/components/ILIAS/Cron/src/CLI/StartUp.php
+++ b/components/ILIAS/Cron/src/CLI/StartUp.php
@@ -28,15 +28,11 @@ class StartUp
     private bool $is_authenticated = false;
 
     public function __construct(
-        private readonly string $client,
         private readonly string $username,
         ?\ilAuthSession $authSession = null
     ) {
         /** @noRector */
         \ilContext::init(\ilContext::CONTEXT_CRON);
-
-        // TODO @see mantis 20371: To get rid of this, the authentication service has to provide a mechanism to pass the client_id
-        $_GET['client_id'] = $this->client;
 
         require_once __DIR__ . '/../../../../../artifacts/bootstrap_default.php';
         entry_point('ILIAS Legacy Initialisation Adapter');


### PR DESCRIPTION
This commit suggests removing the `client_id` argument and the mutation of the super global `$_GET` variable.