### PR TITLE
BookingPool 48018: Redirect to Post-Booking Information

### DIFF
--- a/components/ILIAS/BookingManager/BookingProcess/class.ProcessUtilGUI.php
+++ b/components/ILIAS/BookingManager/BookingProcess/class.ProcessUtilGUI.php
@@ -76,6 +76,11 @@ class ProcessUtilGUI
             return;
         }
 
+        if ($retCmd === 'render') {
+            $this->redirectToRender();
+            return;
+        }
+
         if ($retCmd !== "") {
             $this->ctrl->redirectByClass(get_class($this->parent_gui), $retCmd);
         } else {
@@ -184,107 +189,205 @@ class ProcessUtilGUI
         int $user_id,
         string $file_deliver_cmd
     ): void {
-        $this->log->debug("displayPostInfo");
-        $main_tpl = $this->gui->mainTemplate();
-        $ctrl = $this->gui->ctrl();
-        $lng = $this->domain->lng();
-        $id = $book_obj_id;
-        $request = $this->gui->standardRequest();
+        $this->log->debug('displayPostInfo');
+        $booking_ids = $this->request->getReservationIdsFromString();
 
-        if (!$id) {
+        $objects_with_periods = $this->resolveObjectsWithPeriodsForPostInfo(
+            $book_obj_id,
+            $user_id,
+            $booking_ids
+        );
+
+        if ($objects_with_periods === []) {
+            $this->ctrl->redirect($this->parent_gui, 'back');
             return;
         }
 
-        $rsv_ids = $request->getReservationIdsFromString();
+        $booking_objects = [];
+        $booking_info_filenames = [];
 
-        $tmp = [];
-        if ($rsv_ids === [] && $request->getReservationId() !== '') {
-            $reservationIdParts = explode('_', $request->getReservationId());
+        $objects_with_info = [];
+        foreach ($objects_with_periods as $object_id => $periods) {
+            $booking_objects[$object_id] = new \ilBookingObject($object_id);
+            $booking_info_filenames[$object_id] = trim($this->objects_manager->getBookingInfoFilename($object_id));
 
-            $user_id = (int) ($reservationIdParts[1] ?? 0);
-            $from = (int) ($reservationIdParts[2] ?? 0);
+            if (
+                trim($booking_objects[$object_id]->getPostText()) === ''
+                && $booking_info_filenames[$object_id] === ''
+            ) {
+                continue;
+            }
+
+            $objects_with_info[$object_id] = $periods;
+        }
+
+        if ($objects_with_info === []) {
+            $this->ctrl->redirect($this->parent_gui, 'back');
+            return;
+        }
+
+        $template = new \ilTemplate(
+            'tpl.booking_reservation_post.html',
+            true,
+            true,
+            'components/ILIAS/BookingManager/BookingProcess'
+        );
+        $multiple_objects = count($objects_with_info) > 1;
+        $submit_url = $this->ctrl->getLinkTarget($this->parent_gui, 'back');
+
+        foreach ($objects_with_info as $object_id => $periods) {
+            $booking_object = $booking_objects[$object_id];
+            $post_text = trim($booking_object->getPostText());
+
+            $template->setCurrentBlock('info_block');
+            $title = $multiple_objects
+                ? sprintf($this->lng->txt('book_post_booking_information_for'), $booking_object->getTitle())
+                : $this->lng->txt('book_post_booking_information');
+            $template->setVariable('TITLE', $title);
+
+            if ($post_text !== '') {
+                $post_text = str_replace(
+                    ['[OBJECT]', '[PERIOD]'],
+                    [$booking_object->getTitle(), implode('<br />', $periods)],
+                    $post_text
+                );
+                $template->setVariable('POST_TEXT', nl2br($post_text));
+            }
+
+            if ($booking_info_filenames[$object_id] === '') {
+                $template->parseCurrentBlock();
+                continue;
+            }
+
+            $this->ctrl->setParameter($this->parent_gui, 'object_id', $object_id);
+            $url = $this->ctrl->getLinkTarget($this->parent_gui, $file_deliver_cmd);
+            $this->ctrl->clearParameterByClass($this->parent_gui::class, 'object_id');
+
+            $template->setCurrentBlock('download');
+            $template->setVariable('DOWNLOAD', $this->lng->txt('download'));
+            $template->setVariable('URL_FILE', $url);
+            $template->setVariable('TXT_FILE', $booking_info_filenames[$object_id]);
+            $template->parseCurrentBlock();
+            $template->setCurrentBlock('info_block');
+
+            $template->parseCurrentBlock();
+        }
+
+        $template->setCurrentBlock('submit');
+        $template->setVariable('TXT_SUBMIT', $this->lng->txt('ok'));
+        $template->setVariable('URL_SUBMIT', $submit_url);
+        $template->parseCurrentBlock();
+
+        $this->tpl->setContent($template->get());
+    }
+
+    /**
+     * @return array<int, string[]>
+     */
+    protected function resolveObjectsWithPeriodsForPostInfo(
+        int $book_obj_id,
+        int $user_id,
+        array $booking_ids
+    ): array {
+        if ($booking_ids !== []) {
+            return $this->resolvePeriodsFromReservationIds($booking_ids);
+        }
+
+        if ($book_obj_id <= 0) {
+            return [];
+        }
+
+        $period_slots = [];
+        if ($this->request->getReservationId() !== '') {
+            $reservation_id_parts = explode('_', $this->request->getReservationId());
+            $user_id = (int) ($reservation_id_parts[1] ?? 0);
+            $from = (int) ($reservation_id_parts[2] ?? 0);
 
             if ($from > time()) {
-                $to = (int) ($reservationIdParts[3] ?? 0);
-                $tmp["$from-" . ($to + 1)] = 1;
+                $to = (int) ($reservation_id_parts[3] ?? 0);
+                $period_slots["$from-$to"] = 1;
             }
-            $rsv_ids = [0];
+            $booking_ids = [0];
         }
 
-        // placeholder
-
-        $book_ids = \ilBookingReservation::getObjectReservationForUser($id, $user_id);
+        $book_ids = \ilBookingReservation::getObjectReservationForUser($book_obj_id, $user_id);
         foreach ($book_ids as $book_id) {
-            if (in_array($book_id, $rsv_ids) || count($rsv_ids) === 0) {
-                $obj = new \ilBookingReservation($book_id);
-                $from = $obj->getFrom();
-                $to = $obj->getTo();
-                if ($from > time()) {
-                    $tmp[$from . "-" . $to + 1] = $tmp[$from . "-" . $to + 1] ?? 0;
-                    $tmp[$from . "-" . $to + 1]++;
-                }
+            if (!in_array($book_id, $booking_ids, true) && $booking_ids !== []) {
+                continue;
+            }
+
+            $reservation = new \ilBookingReservation($book_id);
+            $from = $reservation->getFrom();
+            $to = $reservation->getTo();
+            if ($from > time()) {
+                $key = "$from-$to";
+                $period_slots[$key] = ($period_slots[$key] ?? 0) + 1;
             }
         }
 
+        return $period_slots === []
+            ? []
+            : [$book_obj_id => $this->formatPeriodSlots($period_slots)];
+    }
+
+    /**
+     * @param string[] $booking_ids
+     * @return array<int, string[]>
+     */
+    protected function resolvePeriodsFromReservationIds(array $booking_ids): array
+    {
+        $period_slots_by_object = [];
+
+        foreach ($booking_ids as $booking_id) {
+            $booking_id = (int) $booking_id;
+            if ($booking_id <= 0) {
+                continue;
+            }
+
+            $reservation = new \ilBookingReservation($booking_id);
+            $object_id = $reservation->getObjectId();
+            $key = "{$reservation->getFrom()}-{$reservation->getTo()}";
+            $period_slots_by_object[$object_id][$key] = ($period_slots_by_object[$object_id][$key] ?? 0) + 1;
+        }
+
+        $objects_with_periods = [];
+        foreach ($period_slots_by_object as $object_id => $period_slots) {
+            $objects_with_periods[$object_id] = $this->formatPeriodSlots($period_slots);
+        }
+
+        ksort($objects_with_periods);
+
+        return $objects_with_periods;
+    }
+
+    /**
+     * @param array<string, int> $period_slots
+     * @return string[]
+     */
+    protected function formatPeriodSlots(array $period_slots): array
+    {
         $olddt = \ilDatePresentation::useRelativeDates();
         \ilDatePresentation::setUseRelativeDates(false);
 
-        $period = array();
-        ksort($tmp);
-        foreach ($tmp as $time => $counter) {
-            $time = explode("-", $time);
-            $time = \ilDatePresentation::formatPeriod(
-                new \ilDateTime($time[0], IL_CAL_UNIX),
-                new \ilDateTime($time[1], IL_CAL_UNIX)
+        $period = [];
+        ksort($period_slots);
+        foreach ($period_slots as $time => $counter) {
+            $time_parts = explode('-', $time);
+            $formatted = \ilDatePresentation::formatPeriod(
+                new \ilDateTime((int) $time_parts[0], IL_CAL_UNIX),
+                new \ilDateTime((int) $time_parts[1], IL_CAL_UNIX)
             );
+
             if ($counter > 1) {
-                $time .= " (" . $counter . ")";
+                $formatted .= " ($counter)";
             }
-            $period[] = $time;
+
+            $period[] = $formatted;
         }
-        $book_id = array_shift($book_ids);
 
         \ilDatePresentation::setUseRelativeDates($olddt);
 
-        /*
-        #23578 since Booking pool participants.
-        $obj = new ilBookingReservation($book_id);
-        if ($obj->getUserId() != $ilUser->getId())
-        {
-            return;
-        }
-        */
-
-        $obj = new \ilBookingObject($id);
-        $pfile = $this->objects_manager->getBookingInfoFilename($id);
-        $ptext = $obj->getPostText();
-
-        $mytpl = new \ilTemplate('tpl.booking_reservation_post.html', true, true, 'components/ILIAS/BookingManager/BookingProcess');
-        $mytpl->setVariable("TITLE", $lng->txt('book_post_booking_information'));
-
-        if ($ptext) {
-            // placeholder
-            $ptext = str_replace(
-                ["[OBJECT]", "[PERIOD]"],
-                [$obj->getTitle(), implode("<br />", $period)],
-                $ptext
-            );
-
-            $mytpl->setVariable("POST_TEXT", nl2br($ptext));
-        }
-
-        if ($pfile) {
-            $url = $ctrl->getLinkTarget($this->parent_gui, $file_deliver_cmd);
-
-            $mytpl->setVariable("DOWNLOAD", $lng->txt('download'));
-            $mytpl->setVariable("URL_FILE", $url);
-            $mytpl->setVariable("TXT_FILE", $pfile);
-        }
-
-        $mytpl->setVariable("TXT_SUBMIT", $lng->txt('ok'));
-        $mytpl->setVariable("URL_SUBMIT", $ctrl->getLinkTarget($this->parent_gui, "back"));
-
-        $main_tpl->setContent($mytpl->get());
+        return $period;
     }
 
     /**

--- a/components/ILIAS/BookingManager/BookingProcess/templates/default/tpl.booking_reservation_post.html
+++ b/components/ILIAS/BookingManager/BookingProcess/templates/default/tpl.booking_reservation_post.html
@@ -1,3 +1,4 @@
+<!-- BEGIN info_block -->
 <div class="panel panel-primary">
 	<div class="panel-heading ilHeader">
 		<h3>{TITLE}</h3>
@@ -13,9 +14,10 @@
 		</div>
 		<!-- END download -->
 	</div>
-	<div class="panel-footer ilBlockInfo">
-		<form action="{URL_SUBMIT}" method="POST">
-		<input type="submit" class="btn btn-default" value="{TXT_SUBMIT}" />
-		</form>
-	</div>
 </div>
+<!-- END info_block -->
+<!-- BEGIN submit -->
+<div class="ilRight">
+	<a href="{URL_SUBMIT}" class="btn btn-default">{TXT_SUBMIT}</a>
+</div>
+<!-- END submit -->

--- a/components/ILIAS/BookingManager/src/BookableItem/Table/Action/BookableItemTableBookAction.php
+++ b/components/ILIAS/BookingManager/src/BookableItem/Table/Action/BookableItemTableBookAction.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 namespace ILIAS\BookingManager\BookableItem\Table\Action;
 
 use ilBookingObjectGUI;
+use ilBookingProcessWithScheduleGUI;
+use ilBookingProcessWithoutScheduleGUI;
 use ilBookingReservation;
 use ilCtrlInterface;
 use ilDatePresentation;
@@ -43,8 +45,6 @@ use ILIAS\UI\Component\Modal\RoundTrip;
 use ilBookingObject;
 use ILIAS\BookingManager\BookingProcess\BookingProcessManager;
 use ilObjUser;
-use DateTimeZone;
-use DateTime;
 
 class BookableItemTableBookAction implements TableAction
 {
@@ -290,6 +290,7 @@ class BookableItemTableBookAction implements TableAction
 
         $booked_total = 0;
         $unavailable = [];
+        $booking_ids = [];
 
         foreach ($data as $object_id => $section) {
             $message = $section['message'] ?? '';
@@ -318,6 +319,9 @@ class BookableItemTableBookAction implements TableAction
 
                 if ($booked !== []) {
                     $booked_total += count($booked);
+                    foreach ($booked as $booking_id) {
+                        $booking_ids[] = $booking_id;
+                    }
                     continue;
                 }
 
@@ -347,6 +351,15 @@ class BookableItemTableBookAction implements TableAction
                 $this->lng->txt('book_reservation_confirmed'),
                 true
             );
+
+            $booking_process_gui_class = $this->pool->getScheduleType() === ilObjBookingPool::TYPE_FIX_SCHEDULE
+                ? ilBookingProcessWithScheduleGUI::class
+                : ilBookingProcessWithoutScheduleGUI::class;
+
+            $this->ctrl->setParameterByClass($booking_process_gui_class, 'rsv_ids', implode(';', array_unique($booking_ids)));
+            $this->ctrl->setParameterByClass($booking_process_gui_class, 'returnCmd', 'render');
+            $this->ctrl->redirectByClass($booking_process_gui_class, 'displayPostInfo');
+            return null;
         }
 
         $this->ctrl->redirectByClass(ilBookingObjectGUI::class, 'render');

--- a/components/ILIAS/BookingManager/src/Booking/Table/Action/BookingTableActionsFactory.php
+++ b/components/ILIAS/BookingManager/src/Booking/Table/Action/BookingTableActionsFactory.php
@@ -23,6 +23,7 @@ namespace ILIAS\BookingManager\Booking;
 use ilCtrlInterface;
 use ilGlobalTemplateInterface;
 use ILIAS\BookingManager\Access\AccessManager;
+use ILIAS\BookingManager\Bookings\Table\Action\BookingsTableBookingInformationAction;
 use ILIAS\BookingManager\Bookings\Table\Action\BookingsTableCancelAction;
 use ILIAS\BookingManager\Bookings\Table\Action\BookingsTableDeleteAction;
 use ILIAS\BookingManager\Bookings\Table\Action\BookingsTableMailAction;
@@ -43,6 +44,8 @@ class BookingTableActionsFactory implements TableActionsFactory
     public const string ACTION_DELETE = 'delete';
 
     public const string ACTION_MAIL = 'mail';
+
+    public const string ACTION_BOOKING_INFORMATION = 'booking_information';
 
     public function __construct(
         protected readonly ilCtrlInterface $ctrl,
@@ -73,6 +76,7 @@ class BookingTableActionsFactory implements TableActionsFactory
                 self::ACTION_CANCEL => $this->getCancelAction(),
                 self::ACTION_DELETE => $this->getDeleteAction(),
                 self::ACTION_MAIL => $this->getMailAction(),
+                self::ACTION_BOOKING_INFORMATION => $this->getBookingInformationAction(),
             ]
         );
     }
@@ -121,6 +125,18 @@ class BookingTableActionsFactory implements TableActionsFactory
             $this->tpl,
             $this->ctrl,
             $this->booking_pool,
+            $this->bookings
+        );
+    }
+
+    protected function getBookingInformationAction(): BookingsTableBookingInformationAction
+    {
+        return new BookingsTableBookingInformationAction(
+            $this->ui_factory,
+            $this->lng,
+            $this->http,
+            $this->tpl,
+            $this->ctrl,
             $this->bookings
         );
     }

--- a/components/ILIAS/BookingManager/src/Booking/Table/Action/BookingsTableBookingInformationAction.php
+++ b/components/ILIAS/BookingManager/src/Booking/Table/Action/BookingsTableBookingInformationAction.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\BookingManager\Bookings\Table\Action;
+
+use ilBookingReservationsGUI;
+use ilCtrlInterface;
+use ilGlobalTemplateInterface;
+use ILIAS\BookingManager\Common\HttpService;
+use ILIAS\BookingManager\Common\Table\TableAction;
+use ILIAS\Language\Language;
+use ILIAS\UI\Component\Table\Action\Action;
+use ILIAS\UI\Factory as UIFactory;
+use ILIAS\UI\URLBuilder;
+use ILIAS\UI\URLBuilderToken;
+
+class BookingsTableBookingInformationAction implements TableAction
+{
+    public const string ACTION_ID = 'booking_information';
+
+    public const string ACTION_LABEL = 'book_post_booking_information';
+
+    public function __construct(
+        private readonly UIFactory $ui_factory,
+        private readonly Language $lng,
+        private readonly HttpService $http,
+        private readonly ilGlobalTemplateInterface $tpl,
+        private readonly ilCtrlInterface $ctrl,
+        private readonly array $bookings
+    ) {
+    }
+
+    public function getActionId(): string
+    {
+        return self::ACTION_ID;
+    }
+
+    public function getActionLabel(): string
+    {
+        return self::ACTION_LABEL;
+    }
+
+    public function isAvailable(): bool
+    {
+        return true;
+    }
+
+    public function allowActionForRecord(mixed $record): bool
+    {
+        return true;
+    }
+
+    public function getTableAction(
+        URLBuilder $url_builder,
+        URLBuilderToken $row_id_token,
+        URLBuilderToken $action_token,
+        URLBuilderToken $action_type_token
+    ): Action {
+        return $this->ui_factory->table()->action()->standard(
+            $this->lng->txt($this->getActionLabel()),
+            $url_builder
+                ->withParameter($action_token, $this->getActionId())
+                ->withParameter($action_type_token, 'booking_information'),
+            $row_id_token
+        );
+    }
+
+    public function onExecute(
+        URLBuilder $url_builder,
+        URLBuilderToken $row_id_token,
+        URLBuilderToken $action_token,
+        URLBuilderToken $action_type_token
+    ): mixed {
+        $row_parameters = $this->http->resolveRowParameters($row_id_token->getName());
+        if ($row_parameters === HttpService::ALL_OBJECTS) {
+            $selected_ids = null;
+        } elseif (is_string($row_parameters)) {
+            $selected_ids = [$row_parameters];
+        } else {
+            $selected_ids = $row_parameters;
+        }
+
+        $reservation_ids = $this->resolveRecords($selected_ids);
+
+        if ($reservation_ids === []) {
+            $this->tpl->setOnScreenMessage(
+                ilGlobalTemplateInterface::MESSAGE_TYPE_FAILURE,
+                $this->lng->txt('no_valid_selection'),
+                true
+            );
+            return null;
+        }
+
+        $this->ctrl->setParameterByClass(
+            ilBookingReservationsGUI::class,
+            'rsv_ids',
+            implode(';', $reservation_ids)
+        );
+        $this->ctrl->redirectByClass(ilBookingReservationsGUI::class, 'displayPostInfo');
+        return null;
+    }
+
+    /**
+     * @return int[]
+     */
+    protected function resolveRecords(?array $selected_ids = null): array
+    {
+        return array_map(
+            'intval',
+            $selected_ids ?? array_keys($this->bookings)
+        );
+    }
+}

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -2656,6 +2656,7 @@ book#:#book_pool_added#:#Ein Buchungspool wurde angelegt.
 book#:#book_pool_selection#:#Auswahl Buchungspool
 book#:#book_post_booking_file#:#Datei
 book#:#book_post_booking_information#:#Informationen zur Buchung
+book#:#book_post_booking_information_for#:#Informationen zur Buchung von "%s"
 book#:#book_post_booking_text#:#Text
 book#:#book_post_booking_text_info#:#Die Platzhalter können genutzt werden, um Buchungsdetails zum Infotext hinzuzufügen.<br />Der Platzhalter [OBJECT] wird durch das jeweilige Angebot ersetzt.<br />Der Platzhalter [PERIOD] wird durch den gewählten Buchungszeitraum ersetzt.
 book#:#book_pref_book_cron#:#Buchung mit Präferenzen

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -2657,6 +2657,7 @@ book#:#book_pool_added#:#Booking pool successfully created.
 book#:#book_pool_selection#:#Booking Pool Selection
 book#:#book_post_booking_file#:#File
 book#:#book_post_booking_information#:#Booking Information
+book#:#book_post_booking_information_for#:#Booking Information for "%s"
 book#:#book_post_booking_text#:#Text
 book#:#book_post_booking_text_info#:#Use placeholders to include booking-specific information. <br />[OBJECT] will be replaced by the respective Bookable Item. <br />[PERIOD] will be replaced by the respective schedule.
 book#:#book_pref_book_cron#:#Booking with Preferences


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=48018

After booking from the bookable items table, users were not sent to post-booking information when an item had post text or a file attached. `BookableItemTableBookAction` now collects reservation ids and redirects to `displayPostInfo` when bookings succeed. `ProcessUtilGUI::displayPostInfo()` was refactored to resolve periods per object, render one info block per bookable item with booking information, and support multiple objects via `book_post_booking_information_for`. Added `BookingsTableBookingInformationAction` for the bookings table and handled `returnCmd` `render` in `back()`.

/cc @thojou 