### PR TITLE
[Improvement] UI: Input ViewControls dont display selected value

### DIFF
--- a/components/ILIAS/UI/src/Component/Input/ViewControl/Sortation.php
+++ b/components/ILIAS/UI/src/Component/Input/ViewControl/Sortation.php
@@ -27,4 +27,8 @@ use ILIAS\UI\Component\Input\Container\ViewControl\ViewControlInput;
  */
 interface Sortation extends ViewControlInput
 {
+    /**
+     * Set the prefix of the label
+     */
+    public function withLabelPrefix(string $label_prefix): self;
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/Renderer.php
@@ -126,6 +126,8 @@ class Renderer extends AbstractComponentRenderer
     {
         $tpl = $this->getTemplate("tpl.viewcontrol_sortation.html", true, true);
         $ui_factory = $this->getUIFactory();
+        $label_prefix = $component->getLabelPrefix() ?? $this->txt('vc_sort');
+        $selected_label = $this->getSelectedSortationLabel($component);
 
         foreach ($component->getOptions() as $opt_label => $order) {
             $opt_value = $order->join(':', fn($ret, $key, $value) => [$key, $value]);
@@ -141,7 +143,7 @@ class Renderer extends AbstractComponentRenderer
                 $this->isDropdownOptionSelected(
                     $opt_value,
                     $component->getValue(),
-                    $opt_label === array_key_first($component->getOptions())
+                    $opt_label === $selected_label
                 )
             );
         }
@@ -165,6 +167,7 @@ class Renderer extends AbstractComponentRenderer
         $tpl->setVariable('ID', $id);
         $tpl->setVariable("ID_MENU", $id . '_ctrl');
         $tpl->setVariable("ARIA_LABEL", $this->txt(self::DEFAULT_SORTATION_DROPDOWN_LABEL));
+        $tpl->setVariable("LABEL", $label_prefix . ' ' . $selected_label . ' ');
 
         $tpl->setVariable(
             "VALUES",
@@ -402,6 +405,26 @@ class Renderer extends AbstractComponentRenderer
             $tpl->setCurrentBlock($block);
         }
         $tpl->parseCurrentBlock();
+    }
+
+    protected function getSelectedSortationLabel(Sortation $component): string
+    {
+        $options = $component->getOptions();
+        if ($options === []) {
+            return '';
+        }
+
+        $current_value = $component->getValue();
+        if (!$this->isUnsetViewControlValue($current_value)) {
+            foreach ($options as $opt_label => $order) {
+                $opt_value = $order->join(':', fn($ret, $key, $value) => [$key, $value]);
+                if ($opt_value === $current_value) {
+                    return (string) $opt_label;
+                }
+            }
+        }
+
+        return (string) array_key_first($options);
     }
 
     /**

--- a/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/Renderer.php
@@ -22,6 +22,7 @@ namespace ILIAS\UI\Implementation\Component\Input\ViewControl;
 
 use ILIAS\UI\Implementation\Render\AbstractComponentRenderer;
 use ILIAS\UI\Implementation\Render\ResourceRegistry;
+use ILIAS\UI\Implementation\Render\Template;
 use ILIAS\UI\Renderer as RendererInterface;
 use ILIAS\UI\Component;
 use LogicException;
@@ -132,14 +133,17 @@ class Renderer extends AbstractComponentRenderer
             $internal_signal->addOption('value', $opt_value);
             $item = $ui_factory->button()->shy((string) $opt_label, '#')
                 ->withOnClick($internal_signal);
-            $tpl->setCurrentBlock("option");
-            $tpl->setVariable("OPTION", $default_renderer->render($item));
-
-            if ($opt_value === $component->getValue()) {
-                $tpl->touchBlock("selected");
-                $tpl->setCurrentBlock("option");
-            }
-            $tpl->parseCurrentBlock();
+            $this->appendDropdownMenuItem(
+                $tpl,
+                'option',
+                'OPTION',
+                $default_renderer->render($item),
+                $this->isDropdownOptionSelected(
+                    $opt_value,
+                    $component->getValue(),
+                    $opt_label === array_key_first($component->getOptions())
+                )
+            );
         }
 
         if ($container_submit_signal = $component->getOnChangeSignal()) {
@@ -306,13 +310,13 @@ class Renderer extends AbstractComponentRenderer
 
             $item = $ui_factory->button()->shy($option_label, '#')
                 ->withOnClick($signal);
-            $tpl->setCurrentBlock("option_limit");
-            $tpl->setVariable("OPTION_LIMIT", $default_renderer->render($item));
-            if ($option === $limit) {
-                $tpl->touchBlock("selected");
-                $tpl->setCurrentBlock("option_limit");
-            }
-            $tpl->parseCurrentBlock();
+            $this->appendDropdownMenuItem(
+                $tpl,
+                'option_limit',
+                'OPTION_LIMIT',
+                $default_renderer->render($item),
+                $option === $limit
+            );
         }
 
         if ($container_submit_signal = $component->getOnChangeSignal()) {
@@ -382,6 +386,51 @@ class Renderer extends AbstractComponentRenderer
 
         $id = $this->bindJavaScript($component);
         return $tpl->get();
+    }
+
+    protected function appendDropdownMenuItem(
+        Template $tpl,
+        string $block,
+        string $content_variable,
+        string $content,
+        bool $is_selected
+    ): void {
+        $tpl->setCurrentBlock($block);
+        $tpl->setVariable($content_variable, $content);
+        if ($is_selected) {
+            $tpl->touchBlock('selected');
+            $tpl->setCurrentBlock($block);
+        }
+        $tpl->parseCurrentBlock();
+    }
+
+    /**
+     * @param array<int|string, mixed>|null $current_value
+     */
+    protected function isDropdownOptionSelected(
+        mixed $option_value,
+        ?array $current_value,
+        bool $is_sortation_default_option
+    ): bool {
+        if ($this->isUnsetViewControlValue($current_value)) {
+            return $is_sortation_default_option;
+        }
+
+        return $option_value === $current_value;
+    }
+
+    /**
+     * @param array<int|string, mixed>|null $value
+     */
+    protected function isUnsetViewControlValue(?array $value): bool
+    {
+        if ($value === null) {
+            return true;
+        }
+
+        $first = $value[0] ?? null;
+
+        return $first === null || $first === '';
     }
 
     /**

--- a/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/Sortation.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/Sortation.php
@@ -37,6 +37,7 @@ class Sortation extends ViewControlInput implements VCInterface\Sortation, HasIn
     protected Signal $internal_selection_signal;
     protected string $aspect;
     protected string $direction;
+    protected ?string $label_prefix = null;
 
     /**
      * @var array<string, Order>
@@ -99,5 +100,17 @@ class Sortation extends ViewControlInput implements VCInterface\Sortation, HasIn
         $clone = clone $this;
         $clone->label = $label;
         return $clone;
+    }
+
+    public function withLabelPrefix(string $label_prefix): self
+    {
+        $clone = clone $this;
+        $clone->label_prefix = $label_prefix;
+        return $clone;
+    }
+
+    public function getLabelPrefix(): ?string
+    {
+        return $this->label_prefix;
     }
 }

--- a/components/ILIAS/UI/src/templates/default/Input/tpl.viewcontrol_sortation.html
+++ b/components/ILIAS/UI/src/templates/default/Input/tpl.viewcontrol_sortation.html
@@ -1,5 +1,5 @@
 <div class="dropdown il-viewcontrol il-viewcontrol-sortation l-bar__element<!-- BEGIN disabled --> disabled<!-- END disabled -->"<!-- BEGIN id --> id="{ID}" <!-- END id -->>
-    <button class="btn btn-ctrl dropdown-toggle" type="button" data-toggle="dropdown"<!-- BEGIN aria_label --> aria-label="{ARIA_LABEL}"<!-- END aria_label -->  aria-expanded="false" aria-controls="{ID_MENU}"><span class="glyphicon-sort"></span></button>
+    <button class="btn btn-ctrl dropdown-toggle" type="button" data-toggle="dropdown"<!-- BEGIN aria_label --> aria-label="{ARIA_LABEL}"<!-- END aria_label -->  aria-expanded="false" aria-controls="{ID_MENU}"><span class="label">{LABEL}</span><span class="glyphicon-sort"></span></button>
     
     <ul id="{ID_MENU}" class="dropdown-menu">
         <!-- BEGIN option -->

--- a/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlSortationTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlSortationTest.php
@@ -93,7 +93,7 @@ class ViewControlSortationTest extends ViewControlTestBase
 <div class="dropdown il-viewcontrol il-viewcontrol-sortation l-bar__element" id="id_3">
     <button class="btn btn-ctrl dropdown-toggle" type="button" data-toggle="dropdown" aria-label="label_sortation" aria-expanded="false" aria-controls="id_3_ctrl"><span class="glyphicon-sort"></span></button>
     <ul id="id_3_ctrl" class="dropdown-menu">
-        <li><button class="btn btn-link" id="id_1">A</button></li>
+        <li class="selected"><button class="btn btn-link" id="id_1">A</button></li>
         <li><button class="btn btn-link" id="id_2">B</button></li>
     </ul>
     <div class="il-viewcontrol-value" role="none">
@@ -128,7 +128,7 @@ class ViewControlSortationTest extends ViewControlTestBase
 <div class="dropdown il-viewcontrol il-viewcontrol-sortation l-bar__element" id="id_3">
     <button class="btn btn-ctrl dropdown-toggle" type="button" data-toggle="dropdown" aria-label="label_sortation" aria-expanded="false" aria-controls="id_3_ctrl"><span class="glyphicon-sort"></span></button>
     <ul id="id_3_ctrl" class="dropdown-menu">
-        <li><button class="btn btn-link" id="id_1">A</button></li>
+        <li class="selected"><button class="btn btn-link" id="id_1">A</button></li>
         <li><button class="btn btn-link" id="id_2">B</button></li>
     </ul>
     <div class="il-viewcontrol-value" role="none">

--- a/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlSortationTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlSortationTest.php
@@ -91,7 +91,7 @@ class ViewControlSortationTest extends ViewControlTestBase
 
         $expected = $this->brutallyTrimHTML('
 <div class="dropdown il-viewcontrol il-viewcontrol-sortation l-bar__element" id="id_3">
-    <button class="btn btn-ctrl dropdown-toggle" type="button" data-toggle="dropdown" aria-label="label_sortation" aria-expanded="false" aria-controls="id_3_ctrl"><span class="glyphicon-sort"></span></button>
+    <button class="btn btn-ctrl dropdown-toggle" type="button" data-toggle="dropdown" aria-label="label_sortation" aria-expanded="false" aria-controls="id_3_ctrl"><span class="label">vc_sort A </span><span class="glyphicon-sort"></span></button>
     <ul id="id_3_ctrl" class="dropdown-menu">
         <li class="selected"><button class="btn btn-link" id="id_1">A</button></li>
         <li><button class="btn btn-link" id="id_2">B</button></li>
@@ -99,6 +99,35 @@ class ViewControlSortationTest extends ViewControlTestBase
     <div class="il-viewcontrol-value" role="none">
         <input id="id_4" type="hidden" value="" />
         <input id="id_5" type="hidden" value="" />
+    </div>
+</div>
+');
+        $html = $this->brutallyTrimHTML($r->render($vc));
+        $this->assertEquals($expected, $html);
+    }
+
+    public function testViewControlSortationRenderingWithValueAndLabelPrefix(): void
+    {
+        $r = $this->getDefaultRenderer();
+        $options = [
+            'A' => new Order('opt', 'ASC'),
+            'B' => new Order('opt', 'DESC')
+        ];
+        $vc = $this->buildVCFactory()->sortation($options)
+            ->withValue(['opt', 'DESC'])
+            ->withLabelPrefix('Order by:')
+            ->withOnChange((new SignalGenerator())->create());
+
+        $expected = $this->brutallyTrimHTML('
+<div class="dropdown il-viewcontrol il-viewcontrol-sortation l-bar__element" id="id_3">
+    <button class="btn btn-ctrl dropdown-toggle" type="button" data-toggle="dropdown" aria-label="label_sortation" aria-expanded="false" aria-controls="id_3_ctrl"><span class="label">Order by: B </span><span class="glyphicon-sort"></span></button>
+    <ul id="id_3_ctrl" class="dropdown-menu">
+        <li><button class="btn btn-link" id="id_1">A</button></li>
+        <li class="selected"><button class="btn btn-link" id="id_2">B</button></li>
+    </ul>
+    <div class="il-viewcontrol-value" role="none">
+        <input id="id_4" type="hidden" value="opt" />
+        <input id="id_5" type="hidden" value="DESC" />
     </div>
 </div>
 ');
@@ -126,7 +155,7 @@ class ViewControlSortationTest extends ViewControlTestBase
 
         $expected = $this->brutallyTrimHTML('
 <div class="dropdown il-viewcontrol il-viewcontrol-sortation l-bar__element" id="id_3">
-    <button class="btn btn-ctrl dropdown-toggle" type="button" data-toggle="dropdown" aria-label="label_sortation" aria-expanded="false" aria-controls="id_3_ctrl"><span class="glyphicon-sort"></span></button>
+    <button class="btn btn-ctrl dropdown-toggle" type="button" data-toggle="dropdown" aria-label="label_sortation" aria-expanded="false" aria-controls="id_3_ctrl"><span class="label">vc_sort A </span><span class="glyphicon-sort"></span></button>
     <ul id="id_3_ctrl" class="dropdown-menu">
         <li class="selected"><button class="btn btn-link" id="id_1">A</button></li>
         <li><button class="btn btn-link" id="id_2">B</button></li>

--- a/templates/default/070-components/UI-framework/ViewControl/_ui-component_viewcontrol.scss
+++ b/templates/default/070-components/UI-framework/ViewControl/_ui-component_viewcontrol.scss
@@ -67,13 +67,7 @@ $il-vc-pagination-btn-active-bg: $il-main-bg;
 
 // viewcontrols as single buttons
 // should in the future be done by using btn-ctrl class on these buttons
-.il-viewcontrol-sortation,
-.il-viewcontrol-sortation .dropdown,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element {
-	> .btn-default.btn {
-		@extend .btn-ctrl;
-		border-radius: $il-border-radius-secondary-large;
-	}
+@mixin il-viewcontrol-dropdown-selected-item {
 	li .btn.btn-link {
 		padding-left: $il-padding-large-horizontal * 3;
 	}
@@ -85,6 +79,20 @@ $il-vc-pagination-btn-active-bg: $il-main-bg;
 		color: $il-btn-ctrl-color;
 		content: "\e013";
 	}
+}
+
+.il-viewcontrol-sortation,
+.il-viewcontrol-sortation .dropdown,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element {
+	> .btn-default.btn {
+		@extend .btn-ctrl;
+		border-radius: $il-border-radius-secondary-large;
+	}
+	@include il-viewcontrol-dropdown-selected-item;
+}
+
+.il-viewcontrol-pagination__num-of-items {
+	@include il-viewcontrol-dropdown-selected-item;
 }
 
 .il-viewcontrol-fieldselection .dropdown-menu {

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -13386,6 +13386,17 @@ tr.c-table-data__row.c-table-data__row--drag-settle {
   content: "\e013";
 }
 
+.il-viewcontrol-pagination__num-of-items li .btn.btn-link {
+  padding-left: 36px;
+}
+.il-viewcontrol-pagination__num-of-items li.selected .btn::before {
+  position: absolute;
+  left: 12px;
+  font-family: "Glyphicons Halflings";
+  color: #4c6586;
+  content: "\e013";
+}
+
 .il-viewcontrol-fieldselection .dropdown-menu {
   padding: 15px 9px;
 }


### PR DESCRIPTION
Problem: In Input ViewControls (Pagination limit dropdown, Sortation), the active option was not shown with a checkmark. Sortation also did not mark the default option when no value was set.

Fix: Added missing CSS for the pagination limit dropdown. In the renderer, shared logic marks the selected \<li>; for pagination