### PR TITLE
changed github handle for maintenance.md

### DIFF
--- a/docs/development/maintenance.md
+++ b/docs/development/maintenance.md
@@ -218,12 +218,12 @@ of ILIAS. The file contains the following fields:
 [//]: # (BEGIN BackgroundTasks)
 
 * **BackgroundTasks**
-    * Authority to Sign off on Conceptual Changes: [tjoussen](https://docu.ilias.de/go/usr/103745), [mjansen](https://docu.ilias.de/go/usr/8784)
-    * Authority to Sign off on Code Changes: [tjoussen](https://docu.ilias.de/go/usr/103745), [mjansen](https://docu.ilias.de/go/usr/8784)
+    * Authority to Sign off on Conceptual Changes: [thojou](https://docu.ilias.de/go/usr/103745), [mjansen](https://docu.ilias.de/go/usr/8784)
+    * Authority to Sign off on Code Changes: [thojou](https://docu.ilias.de/go/usr/103745), [mjansen](https://docu.ilias.de/go/usr/8784)
     * Authority to Curate Test Cases: MISSING
-    * Authority to (De-)Assign Authorities: [tjoussen (Databay AG)](https://docu.ilias.de/go/usr/103745)
-    * Assignee for Issues: [tjoussen](https://docu.ilias.de/go/usr/103745)
-    * Assignee for Security Reports: [tjoussen](https://docu.ilias.de/go/usr/103745)
+    * Authority to (De-)Assign Authorities: [thojou (Databay AG)](https://docu.ilias.de/go/usr/103745)
+    * Assignee for Issues: [thojou](https://docu.ilias.de/go/usr/103745)
+    * Assignee for Security Reports: [thojou](https://docu.ilias.de/go/usr/103745)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END BackgroundTasks)
@@ -285,11 +285,11 @@ of ILIAS. The file contains the following fields:
 
 * **Booking Pool**
     * Authority to Sign off on Conceptual Changes: [simon.lowe](https://docu.ilias.de/go/usr/79091), [oliver.samoila](https://docu.ilias.de/go/usr/26160)
-    * Authority to Sign off on Code Changes: [tjoussen](https://docu.ilias.de/go/usr/103745)
-    * Authority to Curate Test Cases: [simon.lowe](https://docu.ilias.de/go/usr/79091), [tjoussen](https://docu.ilias.de/go/usr/103745)
+    * Authority to Sign off on Code Changes: [thojou](https://docu.ilias.de/go/usr/103745)
+    * Authority to Curate Test Cases: [simon.lowe](https://docu.ilias.de/go/usr/79091), [thojou](https://docu.ilias.de/go/usr/103745)
     * Authority to (De-)Assign Authorities: [simon.lowe (Databay AG)](https://docu.ilias.de/go/usr/79091), [oliver.samoila (Databay AG)](https://docu.ilias.de/go/usr/26160)
-    * Assignee for Issues: [tjoussen](https://docu.ilias.de/go/usr/103745)
-    * Assignee for Security Reports: [tjoussen](https://docu.ilias.de/go/usr/103745)
+    * Assignee for Issues: [thojou](https://docu.ilias.de/go/usr/103745)
+    * Assignee for Security Reports: [thojou](https://docu.ilias.de/go/usr/103745)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END BookingPool)
@@ -556,7 +556,7 @@ of ILIAS. The file contains the following fields:
 
 * **ECS Interface**
     * Authority to Sign off on Conceptual Changes: [bogen](https://docu.ilias.de/go/usr/13815), [mglaubitz](https://docu.ilias.de/go/usr/28309)
-    * Authority to Sign off on Code Changes: [sdyhr](https://docu.ilias.de/go/usr/102107), [tjoussen](https://docu.ilias.de/go/usr/103745)
+    * Authority to Sign off on Code Changes: [sdyhr](https://docu.ilias.de/go/usr/102107), [thojou](https://docu.ilias.de/go/usr/103745)
     * Authority to Curate Test Cases: [jheim](https://docu.ilias.de/go/usr/40167), [SIG CampusConnect und ECS(A)](https://docu.ilias.de/go/grp/7893)
     * Authority to (De-)Assign Authorities: [bogen](https://docu.ilias.de/go/usr/13815), [mglaubitz](https://docu.ilias.de/go/usr/28309)
     * Assignee for Issues: [sdyhr](https://docu.ilias.de/go/usr/102107)
@@ -806,11 +806,11 @@ of ILIAS. The file contains the following fields:
 
 * **ItemGroup**
     * Authority to Sign off on Conceptual Changes: [oliver.samoila](https://docu.ilias.de/go/usr/26160)
-    * Authority to Sign off on Code Changes: [tjoussen](https://docu.ilias.de/go/usr/103745)
-    * Authority to Curate Test Cases: [oliver.samoila](https://docu.ilias.de/go/usr/26160), [tjoussen](https://docu.ilias.de/go/usr/103745)
+    * Authority to Sign off on Code Changes: [thojou](https://docu.ilias.de/go/usr/103745)
+    * Authority to Curate Test Cases: [oliver.samoila](https://docu.ilias.de/go/usr/26160), [thojou](https://docu.ilias.de/go/usr/103745)
     * Authority to (De-)Assign Authorities: [oliver.samoila (Databay AG)](https://docu.ilias.de/go/usr/26160)
-    * Assignee for Issues: [tjoussen](https://docu.ilias.de/go/usr/103745)
-    * Assignee for Security Reports: [tjoussen](https://docu.ilias.de/go/usr/103745)
+    * Assignee for Issues: [thojou](https://docu.ilias.de/go/usr/103745)
+    * Assignee for Security Reports: [thojou](https://docu.ilias.de/go/usr/103745)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END ItemGroup)
@@ -911,8 +911,8 @@ of ILIAS. The file contains the following fields:
 
 * **Like**
     * Authority to Sign off on Conceptual Changes: [oliver.samoila](https://docu.ilias.de/go/usr/26160)
-    * Authority to Sign off on Code Changes: [fhelfer](https://docu.ilias.de/go/usr/93367), [tjoussen](https://docu.ilias.de/go/usr/103745)
-    * Authority to Curate Test Cases: [fhelfer](https://docu.ilias.de/go/usr/93367), [tjoussen](https://docu.ilias.de/go/usr/103745), [oliver.samoila](https://docu.ilias.de/go/usr/26160)
+    * Authority to Sign off on Code Changes: [fhelfer](https://docu.ilias.de/go/usr/93367), [thojou](https://docu.ilias.de/go/usr/103745)
+    * Authority to Curate Test Cases: [fhelfer](https://docu.ilias.de/go/usr/93367), [thojou](https://docu.ilias.de/go/usr/103745), [oliver.samoila](https://docu.ilias.de/go/usr/26160)
     * Authority to (De-)Assign Authorities: [oliver.samoila (Databay AG)](https://docu.ilias.de/go/usr/26160)
     * Assignee for Issues: [fhelfer](https://docu.ilias.de/go/usr/93367)
     * Assignee for Security Reports: [fhelfer](https://docu.ilias.de/go/usr/93367)
@@ -937,9 +937,9 @@ of ILIAS. The file contains the following fields:
 
 * **Login, Auth & Registration**
     * Authority to Sign off on Conceptual Changes: [mjansen](https://docu.ilias.de/go/usr/8784)
-        , [tjoussen](https://docu.ilias.de/go/usr/103745)
+        , [thojou](https://docu.ilias.de/go/usr/103745)
     * Authority to Sign off on Code Changes: [mjansen](https://docu.ilias.de/go/usr/8784)
-        , [tjoussen](https://docu.ilias.de/go/usr/103745)
+        , [thojou](https://docu.ilias.de/go/usr/103745)
     * Authority to Curate Test Cases: [mjansen](https://docu.ilias.de/go/usr/8784)
     * Authority to (De-)Assign Authorities: [mjansen (Databay AG)](https://docu.ilias.de/go/usr/8784)
     * Assignee for Issues: [mjansen](https://docu.ilias.de/go/usr/8784)
@@ -1095,11 +1095,11 @@ of ILIAS. The file contains the following fields:
 
 * **News**
     * Authority to Sign off on Conceptual Changes: [oliver.samoila](https://docu.ilias.de/go/usr/26160)
-    * Authority to Sign off on Code Changes: [tjoussen](https://docu.ilias.de/go/usr/103745)
-    * Authority to Curate Test Cases: [tjoussen](https://docu.ilias.de/go/usr/103745), [oliver.samoila](https://docu.ilias.de/go/usr/26160)
+    * Authority to Sign off on Code Changes: [thojou](https://docu.ilias.de/go/usr/103745)
+    * Authority to Curate Test Cases: [thojou](https://docu.ilias.de/go/usr/103745), [oliver.samoila](https://docu.ilias.de/go/usr/26160)
     * Authority to (De-)Assign Authorities: [oliver.samoila (Databay AG)](https://docu.ilias.de/go/usr/26160)
-    * Assignee for Issues: [tjoussen](https://docu.ilias.de/go/usr/103745)
-    * Assignee for Security Reports: [tjoussen](https://docu.ilias.de/go/usr/103745)
+    * Assignee for Issues: [thojou](https://docu.ilias.de/go/usr/103745)
+    * Assignee for Security Reports: [thojou](https://docu.ilias.de/go/usr/103745)
     * Unit-specific Guidelines, Rules, and Regulations: [LINK MISSING]('')
 
 [//]: # (END News)
@@ -1479,7 +1479,7 @@ of ILIAS. The file contains the following fields:
 	* Authority to Sign off on Conceptual Changes: [dstrassner](https://docu.ilias.de/go/usr/48931)
     * Authority to Sign off on Code Changes: [skergomard](https://docu.ilias.de/go/usr/44474)
         , [dstrassner](https://docu.ilias.de/go/usr/48931)
-        , [tjoussen](https://docu.ilias.de/go/usr/103745)
+        , [thojou](https://docu.ilias.de/go/usr/103745)
     * Authority to Curate Test Cases: [dstrassner](https://docu.ilias.de/go/usr/48931)
     * Authority to (De-)Assign Authorities: [dstrassner](https://docu.ilias.de/go/usr/48931)
     * Assignee for Issues: [dstrassner](https://docu.ilias.de/go/usr/48931)


### PR DESCRIPTION
This changes the github handle of @thojou for the maintenance.md file to the actual github-account. This leads to the format [github-handle](url-to-docu-account). 
The github handle is used for correct identification on github, the other one is used to identify on docu.ilias.de 
This is probably not the end of the journey but at least this PR adds consistency for now.
