### PR TITLE
[Fix] Registration: Fix empty language preference after self-registra…

### DIFF
--- a/components/ILIAS/Registration/classes/class.ilAccountRegistrationGUI.php
+++ b/components/ILIAS/Registration/classes/class.ilAccountRegistrationGUI.php
@@ -500,8 +500,6 @@ class ilAccountRegistrationGUI
         $this->userObj->updateOwner();
 
         // setup user preferences
-        $this->userObj->setLanguage($this->form->getInput('usr_language'));
-
         global $DIC;
         $DIC['legalDocuments']->selfRegistration()->userCreation($this->userObj);
 


### PR DESCRIPTION
…tion

Remove obsolete setLanguage() call that read the legacy post variable 'usr_language'. The form field was migrated to 'language' via the User Settings API, so the old call overwrote the correctly chosen language with an empty string in usr_pref.

See: https://mantis.ilias.de/view.php?id=48055