### PR TITLE
Update class.ilCSVWriter.php

### DIFF
--- a/components/ILIAS/CSV/classes/class.ilCSVWriter.php
+++ b/components/ILIAS/CSV/classes/class.ilCSVWriter.php
@@ -34,6 +34,29 @@ class ilCSVWriter
         $this->delimiter = $a_del;
     }
 
+    public function setNewline(string $a_new): void
+    {
+        $this->new_line = $a_new;
+    }
+
+    public function withSeparator(string $a_sep): ilCSVWriter
+    {
+        $this->setSeparator($a_sep);
+        return $this;
+    }
+
+    public function withDelimiter(string $a_del): ilCSVWriter
+    {
+        $this->setDelimiter($a_del);
+        return $this;
+    }
+
+    public function withNewline(string $a_new): ilCSVWriter
+    {
+        $this->setNewline($a_new);
+        return $this;
+    }
+
     public function addRow(): void
     {
         $this->csv .= $this->new_line;


### PR DESCRIPTION
This PR adds a couple of functions to `class.ilCSVWriter.php`:

- `setNewline(string $a_new)` allows extending classes to modify the newline character(s) to use, which can prove helpful in some scenarios (e.g. if you require a carriage return (`\r`) and newline symbol (`\n`) at the end of a line).
- `withXYZ(...)` functions allow for one-lined instantation of `ilCSVWriter`, see the following example.

```php
// before
$writer = new ilCSVWriter();
$writer->setSeparator("a");
$writer->setDelimiter("b");

// after
$writer = new ilCSVWriter()->withSeparator("a")->withDelimiter("b");
``` 