### PR TITLE
[FEATURE] ItemGroup 10: Display Other Item Group Assignments Per Material

### DIFF
--- a/components/ILIAS/ItemGroup/classes/class.ilItemGroupItems.php
+++ b/components/ILIAS/ItemGroup/classes/class.ilItemGroupItems.php
@@ -238,4 +238,27 @@ class ilItemGroupItems
         }
         return $items;
     }
+
+    public static function getItemGroupsAssociatedWithItem(int $ref_id, int $filter_item_group_id = 0): array
+    {
+        global $DIC;
+        $database = $DIC->database();
+
+        $item_groups = [];
+        $statement = $database->queryF(
+            'SELECT ref_id, title FROM item_group_item '
+            . 'LEFT JOIN object_data ON item_group_item.item_group_id = object_data.obj_id '
+            . 'LEFT JOIN object_reference ON object_data.obj_id = object_reference.obj_id '
+            . 'WHERE %s '
+            . 'AND item_group_id != %s '
+            . 'AND object_data.type = \'itgr\'',
+            [ilDBConstants::T_INTEGER, ilDBConstants::T_INTEGER],
+            [$ref_id, $filter_item_group_id]
+        );
+        while ($row = $database->fetchAssoc($statement)) {
+            $item_groups[$row['ref_id']] = $row['title'];
+        }
+
+        return $item_groups;
+    }
 }

--- a/components/ILIAS/ItemGroup/classes/class.ilItemGroupItemsTableGUI.php
+++ b/components/ILIAS/ItemGroup/classes/class.ilItemGroupItemsTableGUI.php
@@ -17,6 +17,9 @@
  *********************************************************************/
 
 use ILIAS\ItemGroup\InternalGUIService;
+use ILIAS\UI\Factory as UIFactory;
+use ILIAS\UI\Implementation\Component\Link\Standard;
+use ILIAS\UI\Renderer as UIRenderer;
 
 /**
  * Item group items table
@@ -25,95 +28,101 @@ use ILIAS\ItemGroup\InternalGUIService;
  */
 class ilItemGroupItemsTableGUI extends ilTable2GUI
 {
-    protected InternalGUIService $gui;
     protected array $items;
     protected ilItemGroupItems $item_group_items;
     protected ilTree $tree;
     protected ilObjectDefinition $obj_def;
+    private UIFactory $ui_factory;
+    private UIRenderer $ui_renderer;
 
     public function __construct(
-        InternalGUIService $gui,
+        protected readonly InternalGUIService $gui,
         ilObjItemGroupGUI $a_parent_obj,
         string $a_parent_cmd
     ) {
         global $DIC;
+        $this->lng = $DIC->language();
+        $this->ctrl = $DIC->ctrl();
+        $this->tree = $DIC->repositoryTree();
+        $this->obj_def = $DIC['objDefinition'];
+        $this->ui_factory = $this->gui->ui()->factory();
+        $this->ui_renderer = $this->gui->ui()->renderer();
 
-        $this->gui = $gui;
-        $lng = $DIC->language();
-        $ilCtrl = $DIC->ctrl();
-        $tree = $DIC->repositoryTree();
-        $objDefinition = $DIC["objDefinition"];
-
-        $this->lng = $lng;
-        $this->ctrl = $ilCtrl;
-        $this->tree = $tree;
-        $this->obj_def = $objDefinition;
-
-        $this->item_group_items = new ilItemGroupItems($a_parent_obj->getObject()->getRefId());
+        $this->item_group_items = new ilItemGroupItems($a_parent_obj->getObject()?->getRefId() ?? 0);
         $this->items = $this->item_group_items->getItems();
 
         parent::__construct($a_parent_obj, $a_parent_cmd);
         $this->setLimit(9999);
 
-        $this->getMaterials();
-        $this->setTitle($lng->txt("itgr_assigned_materials"));
+        $this->loadMaterials();
+        $this->setTitle($this->lng->txt('itgr_assigned_materials'));
 
-        $this->addColumn("", "", "1px", true);
-        $this->addColumn($this->lng->txt("itgr_item"));
-        $this->addColumn($this->lng->txt("itgr_assignment"));
-        $this->setSelectAllCheckbox("items[]");
+        $this->addColumn('', '', '1px', true);
+        $this->addColumn($this->lng->txt('itgr_item'));
+        $this->addColumn($this->lng->txt('itgr_assignment'));
+        $this->addColumn($this->lng->txt('itgr_assignment_to_other_itgr'));
+        $this->setSelectAllCheckbox('items[]');
 
         $this->setFormAction($this->ctrl->getFormAction($a_parent_obj));
-        $this->setRowTemplate("tpl.item_group_items_row.html", "components/ILIAS/ItemGroup");
+        $this->setRowTemplate('tpl.item_group_items_row.html', 'components/ILIAS/ItemGroup');
 
-        $this->addCommandButton("saveItemAssignment", $lng->txt("save"));
+        $this->addCommandButton('saveItemAssignment', $this->lng->txt('save'));
     }
 
-    public function getMaterials(): void
+    protected function loadMaterials(): void
     {
-        $materials = array();
-        $items = $this->item_group_items->getAssignableItems();
-
-        foreach ($items as $item) {
-            $item["sorthash"] = (int) (!in_array($item['ref_id'], $this->items)) . $item["title"];
+        $materials = [];
+        foreach ($this->item_group_items->getAssignableItems() as $item) {
+            $item['sorthash'] = (int) (!in_array($item['ref_id'], $this->items, true)) . $item['title'];
+            $item['assigned_items'] = ilItemGroupItems::getItemGroupsAssociatedWithItem(
+                $item['ref_id'],
+                $this->getParentObject()?->getObject()->getId() ?? 0
+            );
             $materials[] = $item;
         }
 
-        $materials = ilArrayUtil::sortArray($materials, "sorthash", "asc");
-        $this->setData($materials);
+        $this->setData(ilArrayUtil::sortArray($materials, 'sorthash', 'asc'));
     }
 
     protected function fillRow(array $a_set): void
     {
-        $lng = $this->lng;
-        $f = $this->gui->ui()->factory();
-        $r = $this->gui->ui()->renderer();
-
-        $this->tpl->setVariable("ITEM_REF_ID", $a_set["child"]);
-        $this->tpl->setVariable("TITLE", $a_set["title"]);
-        $this->tpl->setVariable("IMG", ilUtil::img(
-            ilObject::_getIcon((int) $a_set["obj_id"], "tiny"),
-            "",
-            "",
-            "",
-            "",
-            "",
-            "ilIcon"
+        $this->tpl->setVariable('ITEM_REF_ID', $a_set['child']);
+        $this->tpl->setVariable('TITLE', $a_set['title']);
+        $this->tpl->setVariable('IMG', ilUtil::img(
+            ilObject::_getIcon((int) $a_set['obj_id'], 'tiny'),
+            '',
+            '',
+            '',
+            '',
+            '',
+            'ilIcon'
         ));
 
-        if (in_array($a_set["child"], $this->items)) {
-            $i = $f->symbol()->icon()->custom(
-                ilUtil::getImagePath("standard/icon_ok.svg"),
-                $this->lng->txt("yes")
+        $assigned_items = array_map(
+            function (int $ref_id, string $assigned_item): Standard {
+                $this->ctrl->setParameter($this->getParentObject(), 'ref_id', $ref_id);
+                $link = $this->ui_factory->link()->standard($assigned_item, $this->ctrl->getLinkTarget($this->getParentObject(), 'listMaterials'));
+                $this->ctrl->setParameter($this->getParentObject(), 'ref_id', null);
+                return $link;
+            },
+            array_keys($a_set['assigned_items']),
+            $a_set['assigned_items']
+        );
+        $this->tpl->setVariable('ASSIGNED_LIST', $this->ui_renderer->render($this->ui_factory->listing()->unordered($assigned_items)));
+
+        if (in_array($a_set['child'], $this->items, true)) {
+            $i = $this->ui_factory->symbol()->icon()->custom(
+                ilUtil::getImagePath('standard/icon_ok.svg'),
+                $this->lng->txt('yes')
             );
-            $this->tpl->setVariable("IMG_ASSIGNED", $r->render($i));
-            $this->tpl->setVariable("CHECKED", "checked='checked'");
+            $this->tpl->setVariable('CHECKED', 'checked="checked"');
         } else {
-            $i = $f->symbol()->icon()->custom(
-                ilUtil::getImagePath("standard/icon_not_ok.svg"),
-                $this->lng->txt("no")
+            $i = $this->ui_factory->symbol()->icon()->custom(
+                ilUtil::getImagePath('standard/icon_not_ok.svg'),
+                $this->lng->txt('no')
             );
-            $this->tpl->setVariable("IMG_ASSIGNED", $r->render($i));
         }
+
+        $this->tpl->setVariable('IMG_ASSIGNED', $this->ui_renderer->render($i));
     }
 }

--- a/components/ILIAS/ItemGroup/templates/default/tpl.item_group_items_row.html
+++ b/components/ILIAS/ItemGroup/templates/default/tpl.item_group_items_row.html
@@ -8,4 +8,7 @@
 <td class="std">
 	{IMG_ASSIGNED}
 </td>
+<td class="std">
+	{ASSIGNED_LIST}
+</td>
 </tr>

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -10711,7 +10711,8 @@ irss#:#upload_modal_title#:#Dateien hinzufügen
 itgr#:#itgr_always_open#:#Immer offen
 itgr#:#itgr_assign_materials#:#Objekte auswählen
 itgr#:#itgr_assigned_materials#:#Objekte im Objekteblock
-itgr#:#itgr_assignment#:#Eingebunden
+itgr#:#itgr_assignment#:#Eingebunden in diesem Objekteblock
+itgr#:#itgr_assignment_to_other_itgr#:#Bereits einem anderen Objekteblock zugeordnet
 itgr#:#itgr_desc_info#:#Die Beschreibung wird bei der Anzeige des Objekteblocks nicht mit ausgegeben.
 itgr#:#itgr_display#:#Anzeige
 itgr#:#itgr_display_with_title#:#Mit Titel

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -10712,7 +10712,8 @@ irss#:#upload_modal_title#:#Add Files
 itgr#:#itgr_always_open#:#Always Open
 itgr#:#itgr_assign_materials#:#Assign Materials
 itgr#:#itgr_assigned_materials#:#Assigned Materials
-itgr#:#itgr_assignment#:#Assigned
+itgr#:#itgr_assignment#:#Assigned to this Item Group
+itgr#:#itgr_assignment_to_other_itgr#:#Already assigned to another Item Group
 itgr#:#itgr_desc_info#:#The description will not be a part of the item group's presentation in its container.
 itgr#:#itgr_display#:#Display
 itgr#:#itgr_display_with_title#:#With Title


### PR DESCRIPTION
See: https://docu.ilias.de/go/wiki/wpage_8623_1357

The materials assignment table did not indicate when repository objects were already assigned to another item group, which made cross-group usage opaque. Added `getItemGroupsAssociatedWithItem` to resolve other item groups per material, a new table column with UI listing links, and updated language strings for the assignment labels.