### PR TITLE
[Survey]: Correct mean calculation

### DIFF
--- a/components/ILIAS/SurveyQuestionPool/Questions/class.SurveyMatrixQuestionEvaluation.php
+++ b/components/ILIAS/SurveyQuestionPool/Questions/class.SurveyMatrixQuestionEvaluation.php
@@ -22,6 +22,23 @@
  */
 class SurveyMatrixQuestionEvaluation extends SurveyQuestionEvaluation
 {
+    protected function parseResults(
+        ilSurveyEvaluationResults $a_results,
+        array $a_answers,
+        SurveyCategories $a_categories = null
+    ): void {
+        parent::parseResults($a_results, $a_answers, $a_categories);
+
+        $total = $sum = 0;
+        foreach ($a_results->getAnswers() as $answer) {
+            $total++;
+            $sum += $answer->value;
+        }
+        if ($total > 0) {
+            $a_results->setMean($sum / $total);
+        }
+    }
+
     //
     // RESULTS
     //


### PR DESCRIPTION
This PR fixes an issue where the arithmetic mean was not calculated or displayed in the survey results view.

It addresses the following Mantis ticket:

[https://mantis.ilias.de/view.php?id=47919](https://mantis.ilias.de/view.php?id=47919)
