### PR TITLE
TestQuestionPool: Fix Question Type Key Mismatch

### DIFF
--- a/components/ILIAS/Test/classes/class.ilObjTest.php
+++ b/components/ILIAS/Test/classes/class.ilObjTest.php
@@ -2761,7 +2761,7 @@ class ilObjTest extends ilObject
 
         $query_result = $this->db->query("
 			SELECT		qpl_questions.*, qpl_questions.tstamp,
-						qpl_qst_type.type_tag, qpl_qst_type.plugin, qpl_qst_type.plugin_name,
+						qpl_qst_type.type_tag AS question_type, qpl_qst_type.plugin, qpl_qst_type.plugin_name,
 						object_data.title parent_title
 			FROM		qpl_questions, qpl_qst_type, object_data
 			WHERE $original_clause $available
@@ -2777,7 +2777,7 @@ class ilObjTest extends ilObject
                 $row = ilAssQuestionType::completeMissingPluginName($row);
 
                 if (!$row['plugin']) {
-                    $row[ 'ttype' ] = $this->lng->txt($row[ "type_tag" ]);
+                    $row[ 'ttype' ] = $this->lng->txt($row[ "question_type" ]);
 
                     $rows[] = $row;
                     continue;

--- a/components/ILIAS/Test/classes/class.ilTestRandomQuestionSetStagingPoolQuestionList.php
+++ b/components/ILIAS/Test/classes/class.ilTestRandomQuestionSetStagingPoolQuestionList.php
@@ -148,7 +148,7 @@ class ilTestRandomQuestionSetStagingPoolQuestionList implements Iterator
     {
         $query = "
 			SELECT		qpl_questions.question_id,
-						qpl_qst_type.type_tag,
+						qpl_qst_type.type_tag AS question_type,
 						qpl_qst_type.plugin,
 						qpl_qst_type.plugin_name
 

--- a/components/ILIAS/TestQuestionPool/classes/questions/class.ilAssQuestionType.php
+++ b/components/ILIAS/TestQuestionPool/classes/questions/class.ilAssQuestionType.php
@@ -104,9 +104,9 @@ class ilAssQuestionType
     public static function completeMissingPluginName(array $question_type_data): array
     {
         if ($question_type_data['plugin']
-            && $question_type_data['plugin_name'] !== null
-            && $question_type_data['plugin_name'] !== '') {
-            $question_type_data['plugin_name'] = $question_type_data['type_tag'];
+            && ($question_type_data['plugin_name'] === null
+                || $question_type_data['plugin_name'] === '')) {
+            $question_type_data['plugin_name'] = $question_type_data['question_type'];
         }
 
         return $question_type_data;

--- a/components/ILIAS/TestQuestionPool/classes/questions/class.ilAssQuestionTypeList.php
+++ b/components/ILIAS/TestQuestionPool/classes/questions/class.ilAssQuestionTypeList.php
@@ -50,14 +50,16 @@ class ilAssQuestionTypeList implements Iterator
 
     public function load(): void
     {
-        $res = $this->db->query("SELECT * FROM qpl_qst_type");
+        $res = $this->db->query(
+            'SELECT question_type_id, type_tag AS question_type, plugin, plugin_name FROM qpl_qst_type'
+        );
 
         while ($row = $this->db->fetchAssoc($res)) {
             $row = ilAssQuestionType::completeMissingPluginName($row);
 
             $qstType = new ilAssQuestionType();
             $qstType->setId($row['question_type_id']);
-            $qstType->setTag($row['type_tag']);
+            $qstType->setTag($row['question_type']);
             $qstType->setPlugin($row['plugin']);
             $qstType->setPluginName($row['plugin_name']);
             $this->types[] = $qstType;

--- a/components/ILIAS/TestQuestionPool/tests/ilAssQuestionListTest.php
+++ b/components/ILIAS/TestQuestionPool/tests/ilAssQuestionListTest.php
@@ -16,14 +16,16 @@
  *
  *********************************************************************/
 
+use ILIAS\Refinery\Encode\Group as EncodeGroup;
+use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Refinery\Transformation;
+
 /**
 * Unit tests
 *
 * @author Matheus Zych <mzych@databay.de>
 *
 * @ingroup components\ILIASTestQuestionPool
-*
-* This test was automatically generated.
 */
 class ilAssQuestionListTest extends assBaseTestCase
 {
@@ -38,15 +40,80 @@ class ilAssQuestionListTest extends assBaseTestCase
         $this->object = new ilAssQuestionList(
             $this->createMock(ilDBInterface::class),
             $this->createMock(ilLanguage::class),
-            $this->createMock(ILIAS\Refinery\Factory::class),
+            $this->createMock(Refinery::class),
             $this->createMock(ilComponentRepository::class),
             $this->createMock(ilComponentFactory::class),
-            $this->createMock(ILIAS\Notes\Service::class)
+            null
         );
     }
 
     public function testConstruct(): void
     {
         $this->assertInstanceOf(ilAssQuestionList::class, $this->object);
+    }
+
+    public function testLoadUsesQuestionTypeAliasAndWritesTranslatedLabel(): void
+    {
+        $db = $this->createMock(ilDBInterface::class);
+        $lng = $this->createMock(ilLanguage::class);
+        $refinery = $this->createMock(Refinery::class);
+        $component_repository = $this->createMock(ilComponentRepository::class);
+        $component_factory = $this->createMock(ilComponentFactory::class);
+
+        $encode_group = $this->createMock(EncodeGroup::class);
+        $transformation = $this->createMock(Transformation::class);
+        $transformation->method('transform')->willReturnArgument(0);
+        $encode_group->method('htmlSpecialCharsAsEntities')->willReturn($transformation);
+        $refinery->method('encode')->willReturn($encode_group);
+
+        $lng->method('txt')->with('assSingleChoice')->willReturn('Single Choice');
+
+        $statement = $this->createMock(ilDBStatement::class);
+        $captured_query = '';
+        $db->expects($this->once())
+            ->method('query')
+            ->willReturnCallback(static function (string $query) use (&$captured_query, $statement) {
+                $captured_query = $query;
+                return $statement;
+            });
+        $db->expects($this->exactly(2))
+            ->method('fetchAssoc')
+            ->with($statement)
+            ->willReturnOnConsecutiveCalls(
+                [
+                    'question_id' => 42,
+                    'obj_fi' => 7,
+                    'title' => 'Question title',
+                    'description' => 'Question description',
+                    'author' => 'Author',
+                    'lifecycle' => 'draft',
+                    'points' => 1.0,
+                    'complete' => 1,
+                    'tstamp' => 1,
+                    'created' => 1,
+                    'question_type' => 'assSingleChoice',
+                    'plugin' => false,
+                    'plugin_name' => null,
+                    'feedback' => 0,
+                ],
+                null
+            );
+
+        $list = new ilAssQuestionList(
+            $db,
+            $lng,
+            $refinery,
+            $component_repository,
+            $component_factory,
+            null
+        );
+        $list->setJoinObjectData(false);
+        $list->load();
+
+        $this->assertStringContainsString('qpl_qst_type.type_tag AS question_type', $captured_query);
+
+        $row = $list->getDataArrayForQuestionId(42);
+        $this->assertSame('Single Choice', $row['question_type']);
+        $this->assertArrayNotHasKey('type_tag', $row);
     }
 }

--- a/components/ILIAS/TestQuestionPool/tests/ilAssQuestionTypeTest.php
+++ b/components/ILIAS/TestQuestionPool/tests/ilAssQuestionTypeTest.php
@@ -22,8 +22,6 @@
 * @author Matheus Zych <mzych@databay.de>
 *
 * @ingroup components\ILIASTestQuestionPool
-*
-* This test was automatically generated.
 */
 class ilAssQuestionTypeTest extends assBaseTestCase
 {
@@ -41,5 +39,50 @@ class ilAssQuestionTypeTest extends assBaseTestCase
     public function testConstruct(): void
     {
         $this->assertInstanceOf(ilAssQuestionType::class, $this->object);
+    }
+
+    public function testCompleteMissingPluginNameFillsEmptyPluginNameFromQuestionType(): void
+    {
+        $result = ilAssQuestionType::completeMissingPluginName([
+            'plugin' => true,
+            'plugin_name' => '',
+            'question_type' => 'assExamplePluginQuestion',
+        ]);
+
+        $this->assertSame('assExamplePluginQuestion', $result['plugin_name']);
+    }
+
+    public function testCompleteMissingPluginNameFillsNullPluginNameFromQuestionType(): void
+    {
+        $result = ilAssQuestionType::completeMissingPluginName([
+            'plugin' => true,
+            'plugin_name' => null,
+            'question_type' => 'assExamplePluginQuestion',
+        ]);
+
+        $this->assertSame('assExamplePluginQuestion', $result['plugin_name']);
+    }
+
+    public function testCompleteMissingPluginNameKeepsExistingPluginName(): void
+    {
+        $result = ilAssQuestionType::completeMissingPluginName([
+            'plugin' => true,
+            'plugin_name' => 'ExampleQuestionPlugin',
+            'question_type' => 'assExamplePluginQuestion',
+        ]);
+
+        $this->assertSame('ExampleQuestionPlugin', $result['plugin_name']);
+    }
+
+    public function testCompleteMissingPluginNameDoesNotTouchNonPluginData(): void
+    {
+        $result = ilAssQuestionType::completeMissingPluginName([
+            'plugin' => false,
+            'plugin_name' => null,
+            'question_type' => 'assSingleChoice',
+        ]);
+
+        $this->assertNull($result['plugin_name']);
+        $this->assertSame('assSingleChoice', $result['question_type']);
     }
 }


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=48102

`ilAssQuestionList` exposes the DB column `type_tag` as `question_type`, but `completeMissingPluginName()` still read `type_tag` and inverted the plugin_name fallback condition. That caused `Undefined array key "type_tag"` when loading the question pool table. The shared key is now `question_type`, missing plugin names fall back correctly, and Test callers were aligned.

This change must be at least cherry-picked backwards into release_11. If release_10 need the same fix, has not been tested yet.

Kind Regards,
@thojou 