### PR TITLE
[Survey] fix: Questions parameters nullable

### DIFF
--- a/components/ILIAS/SurveyQuestionPool/Questions/class.SurveyMatrixQuestionEvaluation.php
+++ b/components/ILIAS/SurveyQuestionPool/Questions/class.SurveyMatrixQuestionEvaluation.php
@@ -25,7 +25,7 @@ class SurveyMatrixQuestionEvaluation extends SurveyQuestionEvaluation
     protected function parseResults(
         ilSurveyEvaluationResults $a_results,
         array $a_answers,
-        SurveyCategories $a_categories = null
+        ?SurveyCategories $a_categories = null
     ): void {
         parent::parseResults($a_results, $a_answers, $a_categories);
 

--- a/components/ILIAS/SurveyQuestionPool/Questions/class.SurveyQuestionGUI.php
+++ b/components/ILIAS/SurveyQuestionPool/Questions/class.SurveyQuestionGUI.php
@@ -304,7 +304,7 @@ abstract class SurveyQuestionGUI
         }
     }
 
-    protected function editQuestion(ilPropertyFormGUI $a_form = null): void
+    protected function editQuestion(?ilPropertyFormGUI $a_form = null): void
     {
         $ilTabs = $this->tabs;
 
@@ -642,11 +642,11 @@ abstract class SurveyQuestionGUI
     //
 
     abstract public function getWorkingForm(
-        array $working_data = null,
+        ?array $working_data = null,
         int $question_title = 1,
         bool $show_questiontext = true,
         string $error_message = "",
-        int $survey_id = null,
+        ?int $survey_id = null,
         bool $compress_view = false
     ): string;
 
@@ -654,7 +654,7 @@ abstract class SurveyQuestionGUI
     protected function renderStatisticsDetailsTable(
         array $a_head,
         array $a_rows,
-        array $a_foot = null
+        ?array $a_foot = null
     ): string {
         $html = array();
         $html[] = '<div class="ilTableOuter table-responsive">';


### PR DESCRIPTION
This PR ensures compatibility with PHP 8.4 by explicitly declaring nullable parameters that use `null` as their default value.

The affected parameter types have been updated from `Type $parameter = null` to `?Type $parameter = null`, avoiding PHP 8.4 deprecation warnings related to implicitly nullable parameters.

The changes affect the Survey Matrix evaluation and Survey Question GUI classes.
