### PR TITLE
[Survey] fix: Questions parameters nullable

### DIFF
--- a/components/ILIAS/SurveyQuestionPool/Questions/class.SurveyMatrixQuestionEvaluation.php
+++ b/components/ILIAS/SurveyQuestionPool/Questions/class.SurveyMatrixQuestionEvaluation.php
@@ -25,7 +25,7 @@ class SurveyMatrixQuestionEvaluation extends SurveyQuestionEvaluation
     protected function parseResults(
         ilSurveyEvaluationResults $a_results,
         array $a_answers,
-        SurveyCategories $a_categories = null
+        ?SurveyCategories $a_categories = null
     ): void {
         parent::parseResults($a_results, $a_answers, $a_categories);
 


### PR DESCRIPTION
This PR cherry-picks the corresponding change for ILIAS 11 and updates the parameter type to explicitly accept `null`.
