### PR TITLE
[Survey] fix: Get maximum directly

### DIFF
--- a/components/ILIAS/SurveyQuestionPool/Questions/class.SurveyMetricQuestion.php
+++ b/components/ILIAS/SurveyQuestionPool/Questions/class.SurveyMetricQuestion.php
@@ -176,11 +176,7 @@ class SurveyMetricQuestion extends SurveyQuestion
                 array($this->getId())
             );
 
-            if (preg_match("/[\D]/", $this->maximum) or (strcmp($this->maximum, "&infin;") == 0)) {
-                $max = -1;
-            } else {
-                $max = $this->getMaximum();
-            }
+            $max = $this->getMaximum();
             $next_id = $ilDB->nextId('svy_variable');
             $ilDB->manipulateF(
                 "INSERT INTO svy_variable (variable_id, category_fi, question_fi, value1, value2, sequence, tstamp) VALUES (%s, %s, %s, %s, %s, %s, %s)",


### PR DESCRIPTION
This change cherry-picks a commit that fixes an issue where the question's maximum value was not correctly restored.

The previous implementation replaced the imported maximum value with -1 when it contained a non-numeric value or represented infinity. By directly using getMaximum(), the imported question now preserves the correct maximum value.