### PR TITLE
Compare PRIVACY.md for WorkspaceFolder

### DIFF
--- a/components/ILIAS/WorkspaceFolder/PRIVACY.md
+++ b/components/ILIAS/WorkspaceFolder/PRIVACY.md
@@ -1,46 +1,88 @@
-# Workspace Folder Privacy
+# WorkspaceFolder Privacy
 
-This documentation does not warrant completeness or correctness. Please report any
-missing or wrong information using the [ILIAS issue tracker](https://mantis.ilias.de)
-or contribute a fix via [Pull Request](../../../docs/development/contributing.md#pull-request-to-the-repositories).
-
-## Integrated Services
-
-The Workspace Folder component employs the following services, please consult the respective privacy documentation:
-
-- The **Object** service stores the account which created the object as its owner and creation and update timestamps for the object.
-- [AccessControl](../AccessControl/PRIVACY.md)
-- [PersonalWorkspace](../PersonalWorkspace/PRIVACY.md)
-- [Refinery](../Refinery/PRIVACY.md)
-- [Learning Object Metadata](../MetaData/Privacy.md)
-- [Background Tasks](../BackgroundTasks/PRIVACY.md)
-- The **Tree** service (via **PersonalWorkspace**) stores the structural position within the user's workspace in the `tree_workspace` table.
+> **Disclaimer: This documentation does not guarantee completeness or accuracy. Please report any missing or incorrect information by submitting a [Pull Request](docs/development/contributing.md#pull-request-to-the-repositories) or, if you prefer, via the [ILIAS bug tracker](https://mantis.ilias.de). When using the bug tracker, please select the corresponding component in the **Category** field.**
 
 ## General Information
 
-The Workspace Folder component is used to organize and structure personal and shared resources (files, blogs, links, and other folders) within the user's personal workspace. Personal data includes ownership information, structural tree position, and user-specific interface settings like sortation.
+The WorkspaceFolder component provides folders within the Personal Workspace of each user.
+Workspace folders allow users to organise files, blogs, and web links in a hierarchical structure
+within their own personal workspace area. Unlike repository folders, workspace folders are private
+to each user and exist outside the ILIAS repository. Workspace folders support sharing of contained
+objects (files and blogs) with other users and can be downloaded as ZIP archives via a background
+task.
 
-## Configuration
+Workspace objects do not have a trash: deletion within the workspace is always permanent and
+immediate.
 
-- **Sortation**: Users can configure the sortation of items within each workspace folder. This setting is stored per user and folder.
+## Integrated Components
+
+- The WorkspaceFolder component employs the following components, please consult the respective
+  PRIVACY.md files:
+    - [PersonalWorkspace](https://github.com/ILIAS-eLearning/ILIAS/blob/release_11/components/ILIAS/PersonalWorkspace/PRIVACY.md) – provides the workspace tree
+      structure, workspace access handler, sharing table, and explorer GUI that WorkspaceFolder
+      relies on.
+    - [AccessControl](https://github.com/ILIAS-eLearning/ILIAS/blob/release_11/components/ILIAS/AccessControl/PRIVACY.md) – manages workspace-level permissions
+      ("read", "write", "delete", "copy", "create") for workspace nodes.
+    - [BackgroundTasks](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/components/ILIAS/BackgroundTasks/PRIVACY.md) – the download feature uses the
+      BackgroundTasks service to collect, zip, and deliver workspace folder contents.
+    - [Notes](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/components/ILIAS/Notes/PRIVACY.md) – notes are enabled on items displayed within workspace
+      folders.
+    - [Tagging](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/components/ILIAS/Tagging/PRIVACY.md) – tagging is available on items displayed within
+      workspace folders via the common action dispatcher.
+    - ILIASObject – provides the base object lifecycle (creation, update, deletion) and object
+      ownership management.
+    - [Refinery](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/components/ILIAS/Refinery/PRIVACY.md) – `$DIC->refinery()` validates and casts request
+      parameters in `ilObjWorkspaceFolderGUI`.
 
 ## Data being stored
 
-The following personal or potentially personal data is persisted by the Workspace Folder component:
+- **User ID**: The **user ID** of the workspace folder owner is stored as part of the primary key
+  in the `wfld_user_setting` table to associate sortation preferences with a specific user.
+- **Sortation preference**: A per-folder **sortation value** (integer) is stored in the
+  `wfld_user_setting` table (columns: `user_id`, `wfld_id`, `sortation`). This records how the
+  user prefers items within each workspace folder to be sorted (e.g., alphabetically ascending,
+  by creation date). The purpose is to persist user-chosen display order across sessions.
 
-- **user ID**: Stored in `wfld_user_setting` to persist user-specific sortation settings.
-- **owner**: The user ID of the account that created the folder (handled by the **Object** service).
-- **timestamps**: Creation and update timestamps for the folder (handled by the **Object** service).
+The workspace folder object itself (title, description, creation date, owner) is managed by the
+ILIASObject base service and is not stored by this component directly.
 
 ## Data being presented
 
-- **Personal Resources**: The folder presents the resources owned by the user or shared with them that are located within the folder.
+- **Each user** can view the contents of their own workspace folders, including object titles,
+  descriptions, types, and shared status indicators.
+- **Each user** can choose a sortation order for any workspace folder they own. The selected
+  sortation is applied immediately and persisted.
+- **Each user** can view the "Shared Resources" tab, which shows workspace objects shared with
+  them or by them. The sharing table is provided by the PersonalWorkspace component.
+- **Each user** can access the "Ownership" tab to manage objects they own. This functionality
+  is provided by the ILIASObject component.
+- Persons who have been granted access to a shared workspace resource (via sharing link or
+  password) can view the shared item's title and contents through the "read" permission on the
+  shared node.
+
+No user names are displayed directly by the WorkspaceFolder component itself. User identity
+presentation (e.g., in shared resource listings) is handled by the PersonalWorkspace component.
 
 ## Data being deleted
 
-- **User Deletion**: When a user account is deleted, their personal workspace (including all folders and their settings in `wfld_user_setting`) is removed.
-- **Resource Deletion**: Deleting items within the workspace removes their respective entries in the tree and reference tables. Deleting a folder removes its associated settings.
+- **When a workspace folder is deleted** by its owner: the deletion is permanent and immediate
+  (the workspace has no trash). The workspace tree node, its reference, and all associated
+  workspace permissions are removed. All child objects (files, blogs, sub-folders) within the
+  folder are recursively deleted as well, including their data managed by the respective
+  components.
+- **When a workspace folder is moved (cut) to the repository**: the workspace tree node,
+  reference, and workspace permissions are removed. The object is then created in the repository
+  with new references and repository permissions.
+- **When a user account is deleted**: the user's entire workspace tree is removed by the
+  PersonalWorkspace component. However, **residual data** remains: the `wfld_user_setting` table
+  records for the deleted user are **not** explicitly cleaned up by any known deletion hook. The
+  sortation preferences (user ID and folder ID pairs) persist in the database as orphaned records.
 
 ## Data being exported
 
-- **Multi-download**: Users can download the contents of a workspace folder as a ZIP archive. The archive contains the files themselves, which may contain personal data depending on the file content.
+- The WorkspaceFolder component does not provide an export feature. Export is explicitly disabled
+  in the module configuration (`export="0"`).
+- A **download** feature exists that packages the contents of selected workspace folder items into
+  a ZIP archive via a background task. This download is initiated by the folder owner and includes
+  only files that the requesting user has "read" permission on. The ZIP file is offered as a
+  one-time download and does not persist as an export artefact.


### PR DESCRIPTION
Hi @alex40724,

I noticed the WorkspaceFolder privacy documentation merged here appears to be AI-generated. I've put together my own AI-assisted draft as well, which goes into a bit more detail and cross-references the relevant source code. Would you be open to comparing the two so we can reconcile them into one well-verified version?

Thanks, and best regards,
Elyesa