### PR TITLE
[Survey] fix: Access to appraisee ID

### DIFF
--- a/components/ILIAS/Survey/Evaluation/class.ilSurveyEvaluationGUI.php
+++ b/components/ILIAS/Survey/Evaluation/class.ilSurveyEvaluationGUI.php
@@ -288,7 +288,7 @@ class ilSurveyEvaluationGUI
     ): void {
         $finished_ids = null;
         if ($this->object->get360Mode()) {
-            $appr_id = $this->request->getAppraiseeId();
+            $appr_id = $this->getAppraiseeId();
             if (!$appr_id) {
                 $this->ctrl->redirect($this, $details ? "evaluationdetails" : "evaluation");
             }
@@ -1053,7 +1053,7 @@ class ilSurveyEvaluationGUI
 
         $finished_ids = null;
         if ($this->object->get360Mode()) {
-            $appr_id = $this->request->getAppraiseeId();
+            $appr_id = $this->getAppraiseeId();
             if (!$appr_id) {
                 $this->ctrl->redirect($this, "evaluationuser");
             }


### PR DESCRIPTION
This PR backports the fix for an issue affecting the export functionality in 360° Survey to ILIAS 11.

Thanks to the report in the following ticket, we were able to identify the root cause and implement a solution:

https://mantis.ilias.de/view.php?id=45957
