### PR TITLE
[Survey] fix: Handle non auth access to Survey

### DIFF
--- a/components/ILIAS/Survey/classes/class.ilObjSurveyGUI.php
+++ b/components/ILIAS/Survey/classes/class.ilObjSurveyGUI.php
@@ -305,7 +305,7 @@ class ilObjSurveyGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
 
     protected function noPermission(): void
     {
-        throw new ilObjectException($this->lng->txt("permission_denied"));
+        $this->checkPermission("read");
     }
 
     protected function addToNavigationHistory(): void


### PR DESCRIPTION
This PR fixes an issue that occurred when a non auth user accessed certain Survey-related URLs directly.

These requests are now handled through the standard Survey workflow, preventing the user from encountering an error.

The fix will also be cherry-picked to ILIAS 11 and trunk.

https://mantis.ilias.de/view.php?id=47134