### PR TITLE
fix: preserve blocked status of course members in updateCourse SOAP call (0040575)

### DIFF
--- a/components/ILIAS/soap/classes/class.ilSoapCourseAdministration.php
+++ b/components/ILIAS/soap/classes/class.ilSoapCourseAdministration.php
@@ -364,8 +364,6 @@ class ilSoapCourseAdministration extends ilSoapAdministration
             return $this->raiseError('Check access failed. No permission to write course', 'Server');
         }
 
-        ilCourseParticipants::_deleteAllEntries($tmp_course->getId());
-
         ilCourseWaitingList::_deleteAll($tmp_course->getId());
 
 


### PR DESCRIPTION
Sister PR: https://github.com/ILIAS-eLearning/ILIAS/pull/11602