### PR TITLE
ILIASObject: consistently use long description on object creation so that multilingualism does not get confused (48105)

### DIFF
--- a/components/ILIAS/ILIASObject/classes/class.ilObjectGUI.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObjectGUI.php
@@ -1059,7 +1059,7 @@ class ilObjectGUI implements ImplementsCreationCallback
         $new_obj->setType($this->requested_new_type);
         $new_obj->processAutoRating();
         $new_obj->setTitle($data['title_and_description']->getTitle());
-        $new_obj->setDescription($data['title_and_description']->getDescription());
+        $new_obj->setDescription($data['title_and_description']->getLongDescription());
         $new_obj->create();
 
         $new_obj->getObjectProperties()->storePropertyTitleAndDescription(


### PR DESCRIPTION
This PR fixes [48105](https://mantis.ilias.de/view.php?id=48105), where on creation of containers only the short description is written to `object_translation`. The entry in `object_translation` supersedes the long description persisted in `object_description`, so only the short description is shown everywhere.

The cause of this is that the initial translations of a container are set in `ilContainer::create`, from the description as it's currently set in the to-be-created object via `ilObject::getLongDescription`. The description set in the to-be-created object is however only the short version, see `ilObjectGUI::saveObject`.