### PR TITLE
News 47969: Sort Timeline Items Newest First

### DIFF
--- a/components/ILIAS/News/src/Data/NewsCollection.php
+++ b/components/ILIAS/News/src/Data/NewsCollection.php
@@ -442,7 +442,7 @@ class NewsCollection implements \Countable, \IteratorAggregate, \JsonSerializabl
 
         uasort(
             $ordered->news_items,
-            fn(NewsItem $a, NewsItem $b): int => $a->getCreationDate() <=> $b->getCreationDate()
+            fn(NewsItem $a, NewsItem $b): int => $b->getCreationDate() <=> $a->getCreationDate()
         );
 
         return $ordered;


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=47969

`NewsCollection` sorted news items by creation date ascending, so the timeline listed older entries first. Reversed the `uasort` comparator to order by newest creation date first.

/cc @thojou 