### PR TITLE
Fix 45780  Test start page for multiple attempts always shows full 'Limited Duration' instead of remaining time

### DIFF
--- a/components/ILIAS/Test/classes/class.ilObjTest.php
+++ b/components/ILIAS/Test/classes/class.ilObjTest.php
@@ -7683,6 +7683,26 @@ class ilObjTest extends ilObject
         }
     }
 
+	public function getRemainingProcessingTimeInSecondsForActiveId(int $active_id): int
+    {
+        if ($active_id < 1) {
+            return 0;
+        }
+
+        $processing_time = $this->getProcessingTimeInSeconds($active_id);
+
+        if ($processing_time <= 0) {
+            return 0;
+        }
+
+        $starting_time = $this->getStartingTimeOfUser($active_id);
+
+        return max(
+            0,
+            $starting_time + $processing_time - time()
+        );
+    }    
+	
     /**
      * @deprecated There is no reason for this to be interesting for other objects
      */

--- a/components/ILIAS/Test/src/Presentation/class.TestScreenGUI.php
+++ b/components/ILIAS/Test/src/Presentation/class.TestScreenGUI.php
@@ -175,10 +175,21 @@ class TestScreenGUI
         }
 
         if ($test_behaviour_settings->getProcessingTimeEnabled() && !$this->isUserOutOfProcessingTime()) {
-            $message_box_message_elements[] = sprintf(
-                $this->lng->txt('tst_time_limit_message'),
-                $test_behaviour_settings->getProcessingTimeAsMinutes()
-            );
+            $active_id = $this->test_session->getActiveId();
+        
+            if ($active_id > 0) {
+                $remaining_seconds = $this->object->getRemainingProcessingTimeInSecondsForActiveId($active_id);
+        
+                $message_box_message_elements[] = sprintf(
+                    $this->lng->txt('tst_time_limit_message'),
+                    (int) ceil($remaining_seconds / 60)
+                );
+            } else {
+                $message_box_message_elements[] = sprintf(
+                    $this->lng->txt('tst_time_limit_message'),
+                    $test_behaviour_settings->getProcessingTimeAsMinutes()
+                );
+            }
         }
 
         $nr_of_tries = $this->object->getNrOfTries();


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45780

This updates the remaining processing time shown on the test screen before resuming or starting a test attempt.
Instead of always displaying the configured processing time, the launcher now shows the remaining processing time based on the active test session.


Note: Verified on an unmodified ILIAS installation that the question page already displays "9 Minutes left" immediately after starting a 10-minute test. This is existing behavior and independent of this patch.