### PR TITLE
[A11y] fix: Improve wiki title and language for further pdf print

### DIFF
--- a/components/ILIAS/UICore/classes/class.ilGlobalTemplate.php
+++ b/components/ILIAS/UICore/classes/class.ilGlobalTemplate.php
@@ -98,6 +98,7 @@ class ilGlobalTemplate implements ilGlobalTemplateInterface
     protected string $left_content = '';
     protected string $right_content = '';
     protected string $login_target_par = '';
+    protected ?string $content_language = null;
 
     /**
      * @throws ilTemplateException|ilSystemStyleException
@@ -854,10 +855,26 @@ class ilGlobalTemplate implements ilGlobalTemplateInterface
         global $DIC;
         $lng = $DIC->language();
 
+        if ($this->content_language !== null) {
+            $this->setVariable('META_CONTENT_LANGUAGE', $this->content_language);
+            $this->setVariable(
+                'LANGUAGE_DIRECTION',
+                in_array($this->content_language, ["ar", "fa", "ur", "he"], true)
+                    ? "rtl"
+                    : "ltr"
+            );
+            return;
+        }
+
         if (is_object($lng)) {
             $this->setVariable('META_CONTENT_LANGUAGE', $lng->getContentLanguage());
             $this->setVariable('LANGUAGE_DIRECTION', $lng->getTextDirection());
         }
+    }
+
+    public function setContentLanguage(string $content_language): void
+    {
+        $this->content_language = $content_language;
     }
 
     public function fillWindowTitle(): void

--- a/components/ILIAS/Wiki/PrintView/class.WikiPrintViewProviderGUI.php
+++ b/components/ILIAS/Wiki/PrintView/class.WikiPrintViewProviderGUI.php
@@ -61,12 +61,39 @@ class WikiPrintViewProviderGUI extends Export\AbstractPrintViewProvider
             $page
         );
         $resource_injector = new COPage\ResourcesInjector($resource_collector);
+        $document_title = $this->getDocumentTitle();
+        $document_language = $this->getDocumentLanguage();
 
         return [
-            function ($tpl) use ($resource_injector) {
+            function ($tpl) use ($resource_injector, $document_title, $document_language) {
+                $tpl->setHeaderPageTitle($document_title);
+                $tpl->setContentLanguage($document_language);
                 $resource_injector->inject($tpl);
             }
         ];
+    }
+
+    private function getDocumentTitle(): string
+    {
+        if (count($this->selected_pages) !== 1) {
+            return $this->wiki->getTitle();
+        }
+
+        $page_title = \ilWikiPage::lookupTitle($this->selected_pages[0]);
+        return $page_title === null
+            ? $this->wiki->getTitle()
+            : $this->wiki->getTitle() . " - " . $page_title;
+    }
+
+    private function getDocumentLanguage(): string
+    {
+        $language = $this->wiki->getObjectProperties()
+            ->getPropertyTranslations()
+            ->getBaseLanguage();
+
+        return $language !== ""
+            ? $language
+            : $this->lng->getContentLanguage();
     }
 
     public function getPages(): array


### PR DESCRIPTION
This PR addresses the accessibility issues reported in the following ticket:

[https://mantis.ilias.de/view.php?id=33543](https://mantis.ilias.de/view.php?id=33543)

The ticket describes several accessibility problems found in the generated results PDF.

After investigating the current implementation, my understanding is that ILIAS generates the HTML structure used for the print view, while the final PDF generation is handled by the browser. As a result, the output may vary depending on the browser, operating system, and PDF generation engine being used.

The changes proposed in this PR focus on stable document properties that ILIAS can control directly, particularly the document language and title. I have tested the resulting PDF with accessibility validation tools, and these changes reduce the number of reported issues.

@Annett7811, would it be possible for you to review these changes from an accessibility perspective?

@thibsy, I would also appreciate your feedback from the UI perspective, particularly regarding the fact that different browsers or operating systems may interpret and export the same HTML structure differently.

From my point of view, it may be reasonable to address this issue incrementally: first improving the general and consistently controllable aspects of the document, and then investigating more specific issues where the browser-dependent PDF generation allows us to do so.

Thanks,
Abraham
