### PR TITLE
Fix export of files as part of a container object.

### DIFF
--- a/components/ILIAS/Export/classes/ExportHandler/Manager/Handler.php
+++ b/components/ILIAS/Export/classes/ExportHandler/Manager/Handler.php
@@ -193,9 +193,10 @@ class Handler implements ilExportHandlerManagerInterface
         # write files from legacy export run dir to irss
         # tmp solution, remove later if no longer needed
         $writer = $this->export_handler->consumer()->handler()->exportWriter($element);
+        $is_container_export = $element->getIRSS()->isContainerExport();
         $writer->writeDirectoryRecursive(
             $export_info->getLegacyExportRunDir(),
-            $export_info->getExportFolderName()
+            ($is_container_export) ? '' : $export_info->getExportFolderName()
         );
 
         # delete legacy export run dir

--- a/components/ILIAS/File/classes/class.ilFileExporter.php
+++ b/components/ILIAS/File/classes/class.ilFileExporter.php
@@ -88,11 +88,15 @@ class ilFileExporter extends ilXmlExporter
     protected function prepareExportDirectories(
         ilFileXMLWriter $writer
     ): void {
-        $path = str_replace('\\', '/', $this->exp->getExportDirInContainer());
+        $path = str_replace('\\', '/', $this->exp->getPathToComponentExpDirInContainer());
         $segments = explode('/', $path);
         array_shift($segments);
-        $target_dir_relative = implode('/', $segments) . '/expDir_1';
-        $target_dir_absolute = rtrim($this->getAbsoluteExportDirectory(), '/') . '/' . $target_dir_relative;
+        $target_dir_relative = implode('/', $segments);
+        if ($this->exp->isContainerExport()) {
+            $target_dir_absolute = rtrim($this->getAbsoluteExportDirectory(), '/') . '/' . $this->exp->getPathToComponentExpDirInContainerWithLeadingSetNumber();
+        } else {
+            $target_dir_absolute = rtrim($this->getAbsoluteExportDirectory(), '/') . '/' . $target_dir_relative;
+        }
         ilFileUtils::makeDirParents($target_dir_absolute);
         $writer->setFileTargetDirectories(
             $target_dir_relative,


### PR DESCRIPTION
Currently files that are part of a container object are placed at the wrong location in the export zip file. This is for example the case if the ilPCFileList element is used in the page editor.

This PR adjust export paths to support files as part of the container object export. 

@chfsx, I adjusted the export file paths in [class.ilFileExporter.php](https://github.com/ILIAS-eLearning/ILIAS/compare/release_10...leifos-gmbh:ILIAS:10_bugfix_filelist_export?expand=1#diff-3763bf21708533bee33cfb8283686cd8e3dca65ff76719825a4d1d3fe2f26aec), please take a look at the changes.

@smeyer-ilias, I also adjusted paths in [ExportHandler/Manager/Handler.php](https://github.com/ILIAS-eLearning/ILIAS/compare/release_10...leifos-gmbh:ILIAS:10_bugfix_filelist_export?expand=1#diff-f19df85fff1ad42cdef06a8ff177dbaa5029c1c75e36e1f309d3babc27182ad2).