### PR TITLE
Test: Allow Pictures as Data in Feedback

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/feedback/class.ilAssQuestionFeedback.php
+++ b/components/ILIAS/TestQuestionPool/classes/feedback/class.ilAssQuestionFeedback.php
@@ -255,6 +255,10 @@ abstract class ilAssQuestionFeedback
                 $property->setUseRte(true);
                 $property->setRteTags(ilObjAdvancedEditing::_getUsedHTMLTags("assessment"));
                 $property->setRTESupport($this->questionOBJ->getId(), "qpl", "assessment");
+                $property->usePurifier(true);
+                $property->setPurifier(
+                    $this->questionOBJ->getHtmlQuestionContentPurifier()
+                );
             } else {
                 $property->setRteTags(ilAssSelfAssessmentQuestionFormatter::getSelfAssessmentTags());
                 $property->setUseTagsForRteOnly(false);


### PR DESCRIPTION
This might be a little bit risky as it does change how inputs are purified, but it would allow us to add pictures in feedback as `data-src`. I've no strict opinion if we should do this, but as I was already looking into it, when forming an opinion on

See: https://mantis.ilias.de/view.php?id=47955

I decided to create the PR.

Currently this would not be migrated to the new questions, but this might change if the Markdown editor would start supporting images in the data source.

Best,
@kergomard 