### PR TITLE
[FIX] User: Preserve UDF references after integer-to-UUID field ID migration

### DIFF
--- a/components/ILIAS/User/ROADMAP.md
+++ b/components/ILIAS/User/ROADMAP.md
@@ -4,7 +4,17 @@ refactoring.
 - There are currently no new features on the roadmap.
 
 ## Short Term
-- There are no short-term plans
+
+### Remove Temporary UDF Field ID Mapping Table
+
+With ILIAS 11, custom user field identifiers were migrated from integer IDs
+to UUIDs. The temporary table `udf_field_id_map` stores the mapping from
+legacy integer IDs to the new UUIDs so plugins can update their own stored
+references after the update.
+
+Once plugins have had sufficient time to migrate (target: ILIAS 12), this
+table MUST be dropped via a database update step and this roadmap entry
+can be removed.
 
 ## Mid Term
 - Refactor User Actions

--- a/components/ILIAS/User/src/Setup/DBUpdateSteps11.php
+++ b/components/ILIAS/User/src/Setup/DBUpdateSteps11.php
@@ -155,6 +155,26 @@ class DBUpdateSteps11 implements \ilDatabaseUpdateSteps
             $this->db->manipulate('ALTER TABLE udf_definition ADD COLUMN field_id VARCHAR(64) NOT NULL FIRST');
             $this->db->modifyTableColumn('udf_clob', 'field_id', ['type' => 'text', 'length' => 64]);
             $this->db->modifyTableColumn('udf_text', 'field_id', ['type' => 'text', 'length' => 64]);
+
+            if (!$this->db->tableExists('udf_field_id_map')) {
+                $this->db->createTable(
+                    'udf_field_id_map',
+                    [
+                        'old_field_id' => [
+                            'type' => \ilDBConstants::T_INTEGER,
+                            'length' => 8,
+                            'notnull' => true
+                        ],
+                        'field_id' => [
+                            'type' => \ilDBConstants::T_TEXT,
+                            'length' => 64,
+                            'notnull' => true
+                        ]
+                    ]
+                );
+                $this->db->addPrimaryKey('udf_field_id_map', ['old_field_id']);
+            }
+
             $fields_query = $this->db->query('SELECT old_field_id FROM udf_definition');
             while (($row = $this->db->fetchObject($fields_query))) {
                 $uuid = $this->uuid_factory->uuid4AsString();
@@ -181,6 +201,25 @@ class DBUpdateSteps11 implements \ilDatabaseUpdateSteps
                 );
 
                 $this->migrateBadges("udf_{$row->old_field_id}", $uuid);
+
+                /*
+                 * Keep a temporary map from legacy integer field IDs to UUIDs
+                 * so plugins can migrate their own stored references. See
+                 * components/ILIAS/User/ROADMAP.md for planned removal.
+                 */
+                $this->db->insert(
+                    'udf_field_id_map',
+                    [
+                        'old_field_id' => [
+                            \ilDBConstants::T_INTEGER,
+                            (int) $row->old_field_id
+                        ],
+                        'field_id' => [
+                            \ilDBConstants::T_TEXT,
+                            $uuid
+                        ]
+                    ]
+                );
             }
             $this->db->dropTableColumn('udf_definition', 'old_field_id');
             $this->db->addPrimaryKey('udf_definition', ['field_id']);

--- a/components/ILIAS/User/src/Setup/DBUpdateSteps11.php
+++ b/components/ILIAS/User/src/Setup/DBUpdateSteps11.php
@@ -171,6 +171,9 @@ class DBUpdateSteps11 implements \ilDatabaseUpdateSteps
                     "UPDATE ldap_attribute_mapping SET keyword = 'udf_{$uuid}' WHERE keyword = 'udf_{$row->old_field_id}'"
                 );
                 $this->db->manipulate(
+                    "UPDATE auth_ext_attr_mapping SET attribute = 'udf_{$uuid}' WHERE attribute = 'udf_{$row->old_field_id}'"
+                );
+                $this->db->manipulate(
                     "UPDATE settings SET keyword = 'pmap_udf_{$uuid}' WHERE keyword = 'pmap_udf_{$row->old_field_id}'"
                 );
                 $this->db->manipulate(


### PR DESCRIPTION
This PR suggests preserving references to custom user fields (UDF) when ILIAS 11 migrates field IDs from integers to UUIDs for core SAML attribute mappings (see: https://mantis.ilias.de/view.php?id=48095).

Furthermore, in a separate/second commit, the PR suggests persisting a mapping in a new database table `udf_field_id_map` (`old_field_id` → UUID), so plugins can update their own stored references after the update.
The removal of this table is planned for ILIAS 12 and documented in the `User` ROADMAP. Of course, the additional database update step has to be implemented (and the ROADMAP item needs to be removed) when picking this change to `trunk`.