### PR TITLE
[Survey] fix: Delete option verification within routings

### DIFF
--- a/components/ILIAS/SurveyQuestionPool/Questions/class.SurveyMultipleChoiceQuestion.php
+++ b/components/ILIAS/SurveyQuestionPool/Questions/class.SurveyMultipleChoiceQuestion.php
@@ -459,10 +459,17 @@ class SurveyMultipleChoiceQuestion extends SurveyQuestion
         // #18136
         $category = $this->categories->getCategoryForScale((int) $value + 1);
 
+        $scale = "";
+        $title = "";
+        if ($category) {
+            $scale = $category->scale;
+            $title = $category->title;
+        }
+
         // #17895 - see getPreconditionOptions()
-        return $category->scale .
+        return $scale .
             " - " .
-            ((strlen($category->title ?? "")) ? $category->title : $this->lng->txt('other_answer'));
+            ((strlen($title)) ? $title : $this->lng->txt('other_answer'));
     }
 
     public function getCategories(): SurveyCategories


### PR DESCRIPTION
This PR fixes the issue reported in Mantis https://mantis.ilias.de/view.php?id=46998

It aligns the handling of Multiple Choice questions routing with the existing logic for Single Choice questions, preventing the survey from failing during processing.