### PR TITLE
[FEATURE] User Content Isolation

### DIFF
--- a/components/ILIAS/FileDelivery/README.md
+++ b/components/ILIAS/FileDelivery/README.md
@@ -233,3 +233,115 @@ http://trunk.ilias.localhost/src/FileDelivery/deliver.php/LY3NasMwEITy[...]RFiKc
 
 > Important: Do not combine the Singed Delivery with other mechanisms such 
 > as the [WebAcceessChecker](../WebAccessChecker/README.md) 
+
+# IRSS User Content Isolation
+
+User-uploaded content (and derived files such as previews) can contain active
+markup (SVG, HTML, …). Serving it from the same origin as the application allows
+attacks such as stored XSS, content sniffing or canvas exfiltration against the
+logged-in session. *User Content Isolation* serves all IRSS assets from a
+dedicated, cookie-less **content domain** while the application keeps running on
+the ILIAS domain (OWASP: *"use an isolated server with a different domain to
+serve uploaded files"*).
+
+This is **proxy mode**: the content domain is an additional vhost pointing at the
+*same* ILIAS installation. Signed token delivery (`deliver.php`) is unchanged;
+only the host that the embed URLs point to differs.
+
+## What ILIAS enforces when the feature is active
+
+* `Services::getBaseURI()` generates all IRSS embed URLs against the content
+  domain instead of the request host — consumers need no changes.
+* `deliver.php` (`StreamDelivery::deliverFromToken()`) serves assets **only** when
+  reached via the content host; a request on the ILIAS host returns `404`.
+* `LegacyDelivery` refuses to serve on the content host (`404`) — the content
+  domain is reserved for signed token delivery.
+* `HttpPathBuilder` rejects any attempt to load the regular ILIAS application via
+  the content domain.
+* Delivery responses are hardened with `X-Content-Type-Options: nosniff`,
+  `Cross-Origin-Resource-Policy: cross-origin`, `Referrer-Policy: no-referrer`
+  and a CORS `Access-Control-Allow-Origin` restricted to the ILIAS domain (with
+  `Vary: Origin`). No credentials are allowed, so session cookies are never used
+  for asset requests.
+
+## Configuration (Setup only — no GUI)
+
+Per JourFixe decision the feature is configured exclusively through the Setup so
+that installations can be made secure-by-default via CLI. The settings are
+written to a static PHP artefact (`public/data/isolation.php`) and read at
+runtime without any DB access.
+
+Add the following block to your setup `config.json`. The top-level key is
+`content_isolation`:
+
+```json
+{
+    "content_isolation": {
+        "activated": true,
+        "content_domain": "content.example.org"
+    }
+}
+```
+
+* `content_domain` is the dedicated origin user content is served from. Either a
+  bare host (`content.example.org`, normalised to `https://`) or a full `http(s)`
+  origin (`scheme://host[:port]`, no userinfo/path/query) is accepted. It is
+  **required** and must differ from the ILIAS origin when `activated` is `true`,
+  otherwise the Setup aborts with a clear error.
+* The **ILIAS domain** (used as the CORS `Access-Control-Allow-Origin` for asset
+  requests) is **not** configured here. It is derived from the installed
+  `http.path` at setup time and baked into the artefact, so it never has to be
+  repeated in this block and the runtime never reads `ilias.ini.php` to obtain it.
+  Reconfiguring `http.path` and re-running the Setup updates it automatically.
+* `activated: false` (the default) keeps the previous behaviour: assets are
+  served from the ILIAS domain via the regular signed delivery.
+
+Run `setup install`/`setup update` to write the artefact. Because the ILIAS domain
+is taken from `http.path`, run the FileDelivery setup *after* `http.path` is
+configured (the Setup enforces this ordering via objective preconditions).
+
+> **`http.allowed_hosts` is not involved.** The content domain does **not** need to
+> be added to `http.allowed_hosts`. Asset delivery runs through `deliver.php`, which
+> boots via the FileDelivery component entry point and never reaches the
+> `allowed_hosts` check in `HttpPathBuilder`. Keeping the content host out of
+> `allowed_hosts` is in fact intended: the regular application must not be reachable
+> under the content domain.
+
+## Operational requirements
+
+* **DNS/TLS/vhost**: the content domain needs its own DNS record and TLS
+  certificate and must be served by a vhost pointing at the *same* ILIAS
+  installation. Use a domain clearly different from the ILIAS domain
+  (e.g. `iliascontent.de` vs `ilias.de`).
+* **Session cookie must stay host-only**: ILIAS sets the session cookie without a
+  `Domain` attribute (`IL_COOKIE_DOMAIN = ''`), so it is never sent to the
+  content host. Do **not** configure a shared parent cookie domain — that would
+  leak the session to the content domain and defeat the isolation.
+* **Extra headers**: ILIAS already emits the headers needed for image/asset
+  embedding. For cross-origin embedding of `.css`/`.js`/`.html` you may still
+  need to set the corresponding headers on your web server / the content vhost.
+
+## Example web server setup (one possible approach)
+
+The content domain is not a second installation: it points at the **same**
+document root and the same PHP as the ILIAS domain, and the isolation is enforced
+in PHP by host name. So in the simplest case you just let your existing ILIAS
+vhost answer both host names — no second vhost, no extra rules. Point the content
+domain at the same server via DNS and use a certificate covering both names.
+
+Apache — add one line to the existing vhost:
+
+```apache
+ServerName   ilias.example.org
+ServerAlias  content.example.org
+```
+
+nginx — add the host to the existing `server_name`:
+
+```nginx
+server_name ilias.example.org content.example.org;
+```
+
+Everything else stays as it is. Depending on your setup (reverse proxy,
+container, where TLS is terminated) the details will differ — the only
+requirement is that the content domain reaches the same ILIAS installation.

--- a/components/ILIAS/FileDelivery/src/Delivery/BaseDelivery.php
+++ b/components/ILIAS/FileDelivery/src/Delivery/BaseDelivery.php
@@ -22,6 +22,7 @@ namespace ILIAS\FileDelivery\Delivery;
 
 use ILIAS\HTTP\Services;
 use ILIAS\FileDelivery\Delivery\ResponseBuilder\ResponseBuilder;
+use ILIAS\FileDelivery\Isolation\IsolationConfig;
 use ILIAS\HTTP\Response\ResponseHeader;
 use Psr\Http\Message\ResponseInterface;
 
@@ -38,11 +39,63 @@ abstract class BaseDelivery
         protected Services $http,
         protected ResponseBuilder $response_builder,
         protected ResponseBuilder $fallback_response_builder,
+        protected IsolationConfig $isolation = new IsolationConfig(false, null, null),
     ) {
         if (is_readable(self::MIME_TYPE_MAP)) {
             $map = include self::MIME_TYPE_MAP;
         }
         $this->mime_type_map = $map ?? [];
+    }
+
+    /**
+     * When user content isolation is active, only requests targeting the
+     * configured content domain may be served. Requests reaching the
+     * delivery endpoint via the main ILIAS domain are rejected.
+     */
+    protected function isRequestHostAllowed(): bool
+    {
+        if (!$this->isolation->isActivated()) {
+            return true;
+        }
+
+        $expected = $this->isolation->getContentHost();
+        if ($expected === null) {
+            return true;
+        }
+
+        return strcasecmp($this->http->request()->getUri()->getHost(), $expected) === 0;
+    }
+
+    /**
+     * Inverse of {@see self::isRequestHostAllowed()} for the legacy/internal
+     * delivery path: the content domain is reserved for signed token delivery
+     * via deliver.php. Legacy or app-context delivery must never happen on the
+     * content host, so callers reject such requests.
+     */
+    protected function isRequestOnContentHost(): bool
+    {
+        if (!$this->isolation->isActivated()) {
+            return false;
+        }
+
+        $content_host = $this->isolation->getContentHost();
+        if ($content_host === null) {
+            return false;
+        }
+
+        return strcasecmp($this->http->request()->getUri()->getHost(), $content_host) === 0;
+    }
+
+    /**
+     * Send an empty 404 response and terminate. Declared `never` so the type
+     * system guarantees callers cannot fall through to actually serving a file
+     * after a rejected request.
+     */
+    protected function notFound(ResponseInterface $r): never
+    {
+        $this->http->saveResponse($r->withStatus(404));
+        $this->http->sendResponse();
+        $this->http->close();
     }
 
     protected function saveAndClose(
@@ -86,10 +139,36 @@ abstract class BaseDelivery
             $disposition->value . '; filename="' . $file_name . '"'
         );
         $r = $r->withHeader(ResponseHeader::CACHE_CONTROL, 'max-age=31536000, immutable, private');
-
-        return $r->withHeader(
+        $r = $r->withHeader(
             ResponseHeader::EXPIRES,
             date("D, j M Y H:i:s", strtotime('+5 days')) . " GMT"
         );
+
+        return $this->applyIsolationHeaders($r);
+    }
+
+    /**
+     * When isolation is active, harden delivery responses:
+     *  - prevent MIME sniffing
+     *  - mark as cross-origin so the main app may embed assets via <img>, <iframe>, …
+     *  - allow CORS access only from the configured ILIAS domain
+     *  - strip referrer to avoid leaking the content domain back to the app
+     */
+    protected function applyIsolationHeaders(ResponseInterface $r): ResponseInterface
+    {
+        if (!$this->isolation->isActivated()) {
+            return $r;
+        }
+
+        $r = $r->withHeader(ResponseHeader::X_CONTENT_TYPE_OPTIONS, 'nosniff');
+        $r = $r->withHeader('Cross-Origin-Resource-Policy', 'cross-origin');
+        $r = $r->withHeader('Referrer-Policy', 'no-referrer');
+
+        if (($ilias_domain = $this->isolation->getIliasDomain()) !== null) {
+            $r = $r->withHeader(ResponseHeader::ACCESS_CONTROL_ALLOW_ORIGIN, $ilias_domain);
+            $r = $r->withAddedHeader('Vary', 'Origin');
+        }
+
+        return $r;
     }
 }

--- a/components/ILIAS/FileDelivery/src/Delivery/LegacyDelivery.php
+++ b/components/ILIAS/FileDelivery/src/Delivery/LegacyDelivery.php
@@ -64,6 +64,12 @@ final class LegacyDelivery extends BaseDelivery
         ?string $mime_type = null,
         ?bool $delete_file = false
     ): never {
+        // The content domain is reserved for signed token delivery via deliver.php.
+        // Legacy delivery must never serve files on the content host.
+        if ($this->isRequestOnContentHost()) {
+            $this->notFound($this->http->response());
+        }
+
         $r = $this->setGeneralHeaders(
             $this->http->response(),
             $path_to_file,

--- a/components/ILIAS/FileDelivery/src/Delivery/StreamDelivery.php
+++ b/components/ILIAS/FileDelivery/src/Delivery/StreamDelivery.php
@@ -21,7 +21,6 @@ declare(strict_types=1);
 namespace ILIAS\FileDelivery\Delivery;
 
 use ILIAS\HTTP\Services;
-use Psr\Http\Message\ResponseInterface;
 use ILIAS\FileDelivery\Token\DataSigner;
 use ILIAS\FileDelivery\Delivery\ResponseBuilder\ResponseBuilder;
 use ILIAS\Filesystem\Stream\FileStream;
@@ -29,6 +28,7 @@ use ILIAS\FileDelivery\Token\Signer\Payload\FilePayload;
 use ILIAS\Filesystem\Stream\Streams;
 use ILIAS\FileDelivery\Token\Signer\Payload\ShortFilePayload;
 use ILIAS\Filesystem\Stream\ZIPStream;
+use ILIAS\FileDelivery\Isolation\IsolationConfig;
 
 /**
  * @author Fabian Schmid <fabian@sr.solutions>
@@ -45,18 +45,9 @@ final class StreamDelivery extends BaseDelivery
         Services $http,
         ResponseBuilder $response_builder,
         ResponseBuilder $fallback_response_builder,
+        IsolationConfig $isolation = new IsolationConfig(false, null, null),
     ) {
-        parent::__construct($http, $response_builder, $fallback_response_builder);
-    }
-
-    /**
-     * @throws \ILIAS\HTTP\Response\Sender\ResponseSendingException
-     */
-    private function notFound(ResponseInterface $r): void
-    {
-        $this->http->saveResponse($r->withStatus(404));
-        $this->http->sendResponse();
-        $this->http->close();
+        parent::__construct($http, $response_builder, $fallback_response_builder, $isolation);
     }
 
     public function attached(
@@ -116,6 +107,12 @@ final class StreamDelivery extends BaseDelivery
 
     public function deliverFromToken(string $token): never
     {
+        $r = $this->http->response();
+
+        if (!$this->isRequestHostAllowed()) {
+            $this->notFound($r);
+        }
+
         // check if $token has a sub-request, such as .../index.html
         $parts = explode(self::SUBREQUEST_SEPARATOR, $token);
         $sub_request = null;
@@ -124,7 +121,6 @@ final class StreamDelivery extends BaseDelivery
             $sub_request = implode('/', array_slice($parts, 1));
         }
 
-        $r = $this->http->response();
         $payload = $this->data_signer->verifyStreamToken($token);
 
         switch (true) {

--- a/components/ILIAS/FileDelivery/src/Init.php
+++ b/components/ILIAS/FileDelivery/src/Init.php
@@ -30,6 +30,7 @@ use ILIAS\FileDelivery\Delivery\ResponseBuilder\XSendFileResponseBuilder;
 use ILIAS\FileDelivery\Delivery\ResponseBuilder\PHPResponseBuilder;
 use ILIAS\FileDelivery\Delivery\ResponseBuilder\ResponseBuilder;
 use ILIAS\FileDelivery\Setup\DeliveryMethodObjective;
+use ILIAS\FileDelivery\Isolation\IsolationConfig;
 use ILIAS\FileDelivery\Delivery\LegacyDelivery;
 use ILIAS\FileDelivery\Delivery\ResponseBuilder\XAccelResponseBuilder;
 
@@ -53,6 +54,10 @@ class Init
         };
 
         $c['file_delivery.fallback_response_builder'] = (static fn(): ResponseBuilder => new PHPResponseBuilder());
+
+        // Both the content domain and the ILIAS domain (derived from http_path)
+        // are baked into the artefact at setup time, so no ini read is needed.
+        $c['file_delivery.isolation'] = static fn(): IsolationConfig => IsolationConfig::fromArtefact();
 
         $c['file_delivery.data_signer'] = static function (): DataSigner {
             $keys = array_map(static fn(string $key): SecretKey => new SecretKey($key), (require KeyRotationObjective::PATH()) ?? []);
@@ -78,7 +83,8 @@ class Init
                 $c['file_delivery.data_signer'],
                 $c['http'],
                 $c['file_delivery.response_builder'],
-                $c['file_delivery.fallback_response_builder']
+                $c['file_delivery.fallback_response_builder'],
+                $c['file_delivery.isolation']
             );
         };
 
@@ -92,7 +98,8 @@ class Init
             return new LegacyDelivery(
                 $c['http'],
                 $c['file_delivery.response_builder'],
-                $c['file_delivery.fallback_response_builder']
+                $c['file_delivery.fallback_response_builder'],
+                $c['file_delivery.isolation']
             );
         };
 
@@ -100,7 +107,8 @@ class Init
             $c['file_delivery.delivery'],
             $c['file_delivery.legacy_delivery'],
             $c['file_delivery.data_signer'],
-            $c['http']
+            $c['http'],
+            $c['file_delivery.isolation']
         ));
     }
 }

--- a/components/ILIAS/FileDelivery/src/Isolation/IsolationConfig.php
+++ b/components/ILIAS/FileDelivery/src/Isolation/IsolationConfig.php
@@ -1,0 +1,244 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Isolation;
+
+use ILIAS\FileDelivery\Setup\IsolationObjective;
+
+/**
+ * Read-only configuration of the IRSS User Content Isolation feature.
+ *
+ * Loaded from a static PHP artefact written by the setup so that the
+ * FileDelivery service can decide whether to deliver content via a
+ * dedicated content domain — without any DB dependency.
+ *
+ * Both the content domain (admin-configured) and the ILIAS domain (derived
+ * from the installed http_path at setup time) are baked into the artefact.
+ * The runtime therefore never has to read ilias.ini.php to learn either value.
+ *
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+final readonly class IsolationConfig
+{
+    public const KEY_ACTIVATED = 'activated';
+    public const KEY_CONTENT_DOMAIN = 'content_domain';
+    public const KEY_ILIAS_DOMAIN = 'ilias_domain';
+
+    public function __construct(
+        private bool $activated,
+        private ?string $content_domain,
+        private ?string $ilias_domain,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $activated = (bool) ($data[self::KEY_ACTIVATED] ?? false);
+        $content = self::normalizeUrl($data[self::KEY_CONTENT_DOMAIN] ?? null);
+        $ilias = self::normalizeUrl($data[self::KEY_ILIAS_DOMAIN] ?? null);
+
+        // Only the content domain is mandatory for isolation; without a separate
+        // origin to deliver from there is nothing to isolate, so it stays off.
+        if ($activated && $content === null) {
+            $activated = false;
+        }
+
+        return new self($activated, $content, $ilias);
+    }
+
+    public static function disabled(): self
+    {
+        return new self(false, null, null);
+    }
+
+    /**
+     * Load the configuration from the static artefact written by the setup.
+     *
+     * A missing, unreadable or malformed artefact keeps the feature off, so an
+     * installation that never ran the FileDelivery setup behaves as before.
+     *
+     * @param string|null $path only passed in tests; defaults to the artefact
+     *                          location the setup writes to
+     */
+    public static function fromArtefact(?string $path = null): self
+    {
+        $path ??= IsolationObjective::PATH();
+        if (!is_file($path)) {
+            return self::disabled();
+        }
+
+        $data = @include $path;
+
+        return self::fromArray(is_array($data) ? $data : []);
+    }
+
+    /**
+     * Validate and normalize a configured domain to a bare origin
+     * ("scheme://host[:port]"), or null if it is not a usable http/https origin.
+     *
+     * Shared with the setup layer so that the setup and the runtime enforce one
+     * identical set of rules for what a content/ILIAS domain may look like.
+     */
+    public static function normalizeOrigin(mixed $value): ?string
+    {
+        return self::normalizeUrl($value);
+    }
+
+    public function isActivated(): bool
+    {
+        return $this->activated;
+    }
+
+    public function getContentDomain(): ?string
+    {
+        return $this->content_domain;
+    }
+
+    public function getIliasDomain(): ?string
+    {
+        return $this->ilias_domain;
+    }
+
+    public function getContentHost(): ?string
+    {
+        return $this->extractHost($this->content_domain);
+    }
+
+    public function getIliasHost(): ?string
+    {
+        return $this->extractHost($this->ilias_domain);
+    }
+
+    private function extractHost(?string $url): ?string
+    {
+        if ($url === null) {
+            return null;
+        }
+        $host = parse_url($url, PHP_URL_HOST);
+        return is_string($host) && $host !== '' ? $host : null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            self::KEY_ACTIVATED => $this->activated,
+            self::KEY_CONTENT_DOMAIN => $this->content_domain,
+            self::KEY_ILIAS_DOMAIN => $this->ilias_domain,
+        ];
+    }
+
+    /**
+     * Normalize the configured value to a bare origin: "scheme://host[:port]".
+     *
+     * Security: the result is used both as the base for asset URLs and as the
+     * value of the Access-Control-Allow-Origin response header. It must therefore
+     * be a clean origin only — any scheme other than http/https, and any userinfo,
+     * path, query or fragment, makes the value unusable (returns null, which keeps
+     * isolation disabled). The setup layer rejects such input loudly; this is the
+     * runtime safety net.
+     */
+    private static function normalizeUrl(mixed $value): ?string
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+        $value = trim($value);
+        if ($value === '') {
+            return null;
+        }
+        // accept either a full URL ("https://host[:port]") or a bare hostname ("host.example.org")
+        if (!preg_match('#^[a-z][a-z0-9+.\-]*://#i', $value)) {
+            $value = 'https://' . ltrim($value, '/');
+        }
+
+        $parts = parse_url($value);
+        if (!is_array($parts) || !isset($parts['host']) || $parts['host'] === '') {
+            return null;
+        }
+
+        $scheme = strtolower($parts['scheme'] ?? '');
+        if ($scheme !== 'http' && $scheme !== 'https') {
+            return null;
+        }
+
+        // reject anything that is more than a bare origin
+        if (isset($parts['user']) || isset($parts['pass'])
+            || isset($parts['query']) || isset($parts['fragment'])
+            || (isset($parts['path']) && $parts['path'] !== '' && $parts['path'] !== '/')
+        ) {
+            return null;
+        }
+
+        $origin = $scheme . '://' . strtolower($parts['host']);
+        if (isset($parts['port'])) {
+            $origin .= ':' . $parts['port'];
+        }
+
+        return $origin;
+    }
+
+    /**
+     * Reduce a (trusted) application URL to its bare origin "scheme://host[:port]".
+     *
+     * Unlike {@see self::normalizeOrigin()} this tolerates a path/query/fragment and
+     * simply discards them, because the source is the internally configured ILIAS
+     * http_path (which may carry a sub-directory) rather than admin-provided config.
+     * The result is only ever used as a CORS allow-origin, which must be an origin.
+     *
+     * Used by the setup layer to derive the ILIAS domain from http_path at build
+     * time so the value can be baked into the artefact.
+     */
+    public static function originFromUrl(mixed $value): ?string
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+        $value = trim($value);
+        if ($value === '') {
+            return null;
+        }
+        if (!preg_match('#^[a-z][a-z0-9+.\-]*://#i', $value)) {
+            $value = 'https://' . ltrim($value, '/');
+        }
+
+        $parts = parse_url($value);
+        if (!is_array($parts) || !isset($parts['host']) || $parts['host'] === '') {
+            return null;
+        }
+
+        $scheme = strtolower($parts['scheme'] ?? '');
+        if ($scheme !== 'http' && $scheme !== 'https') {
+            return null;
+        }
+
+        $origin = $scheme . '://' . strtolower($parts['host']);
+        if (isset($parts['port'])) {
+            $origin .= ':' . $parts['port'];
+        }
+
+        return $origin;
+    }
+}

--- a/components/ILIAS/FileDelivery/src/Services.php
+++ b/components/ILIAS/FileDelivery/src/Services.php
@@ -25,6 +25,7 @@ use ILIAS\FileDelivery\Token\DataSigner;
 use ILIAS\Filesystem\Stream\FileStream;
 use ILIAS\FileDelivery\Delivery\Disposition;
 use ILIAS\FileDelivery\Delivery\LegacyDelivery;
+use ILIAS\FileDelivery\Isolation\IsolationConfig;
 use ILIAS\Data\URI;
 
 /**
@@ -40,7 +41,8 @@ class Services
         private StreamDelivery $delivery,
         private LegacyDelivery $legacy_delivery,
         private DataSigner $data_signer,
-        private \ILIAS\HTTP\Services $http
+        private \ILIAS\HTTP\Services $http,
+        private IsolationConfig $isolation = new IsolationConfig(false, null, null),
     ) {
     }
 
@@ -90,11 +92,22 @@ class Services
 
     protected function getBaseURI(): string
     {
-        return $this->base_uri ?? $this->base_uri = rtrim(
-            $this->http->request()->getUri()->getScheme()
-            . '://' . $this->http->request()->getUri()->getHost()
-            . ($this->http->request()->getUri()->getPort() ? ':' . $this->http->request()->getUri()->getPort() : '')
-            . dirname($this->http->request()->getUri()->getPath()),
+        if ($this->base_uri !== null) {
+            return $this->base_uri;
+        }
+
+        $request_uri = $this->http->request()->getUri();
+        $path = rtrim(dirname($request_uri->getPath()), "/");
+
+        if ($this->isolation->isActivated() && ($content_domain = $this->isolation->getContentDomain()) !== null) {
+            return $this->base_uri = rtrim($content_domain, "/") . $path;
+        }
+
+        return $this->base_uri = rtrim(
+            $request_uri->getScheme()
+            . '://' . $request_uri->getHost()
+            . ($request_uri->getPort() ? ':' . $request_uri->getPort() : '')
+            . $path,
             "/"
         );
     }

--- a/components/ILIAS/FileDelivery/src/Setup/Agent.php
+++ b/components/ILIAS/FileDelivery/src/Setup/Agent.php
@@ -25,14 +25,25 @@ use ILIAS\Setup\ObjectiveCollection;
 use ILIAS\Setup\Metrics\Storage;
 use ILIAS\Setup;
 use ILIAS\Setup\Objective;
+use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\Refinery\Transformation;
 use ILIAS\Setup\Config;
 
 /**
  * @author Fabian Schmid <fabian@sr.solutions>
  */
-class Agent implements Setup\Agent
+class Agent implements Setup\NamedAgent
 {
+    public function __construct(
+        private readonly Refinery $refinery,
+    ) {
+    }
+
+    public function getAgentName(): string
+    {
+        return 'content_isolation';
+    }
+
     public function getBuildObjective(): Objective
     {
         return new NullObjective();
@@ -45,12 +56,23 @@ class Agent implements Setup\Agent
 
     public function hasConfig(): bool
     {
-        return false;
+        return true;
     }
 
     public function getArrayToConfigTransformation(): Transformation
     {
-        throw new LogicException("No Config");
+        return $this->refinery->custom()->transformation(
+            static function (?array $data): FileDeliverySetupConfig {
+                $data ??= [];
+
+                return new FileDeliverySetupConfig(
+                    (bool) ($data['activated'] ?? false),
+                    isset($data['content_domain']) && $data['content_domain'] !== ''
+                        ? (string) $data['content_domain']
+                        : null,
+                );
+            }
+        );
     }
 
     public function getInstallObjective(?Config $config = null): Objective
@@ -60,7 +82,8 @@ class Agent implements Setup\Agent
             true,
             new KeyRotationObjective(),
             new DeliveryMethodObjective(),
-            new BaseDirObjective()
+            new BaseDirObjective(),
+            $this->buildIsolationObjective($config),
         );
     }
 
@@ -71,7 +94,8 @@ class Agent implements Setup\Agent
             true,
             new KeyRotationObjective(),
             new DeliveryMethodObjective(),
-            new BaseDirObjective()
+            new BaseDirObjective(),
+            $this->buildIsolationObjective($config),
         );
     }
 
@@ -83,5 +107,17 @@ class Agent implements Setup\Agent
     public function getMigrations(): array
     {
         return [];
+    }
+
+    private function buildIsolationObjective(?Config $config): Objective
+    {
+        if (!$config instanceof FileDeliverySetupConfig) {
+            return new IsolationObjective();
+        }
+
+        return new IsolationObjective(
+            $config->isIsolationActivated(),
+            $config->getIsolationContentDomain(),
+        );
     }
 }

--- a/components/ILIAS/FileDelivery/src/Setup/FileDeliverySetupConfig.php
+++ b/components/ILIAS/FileDelivery/src/Setup/FileDeliverySetupConfig.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Setup;
+
+use ILIAS\FileDelivery\Isolation\IsolationConfig;
+use ILIAS\Setup\Config;
+
+/**
+ * Setup configuration for the FileDelivery component.
+ *
+ * Currently used to enable the IRSS User Content Isolation feature
+ * (delivery of user content via a dedicated content domain) at install
+ * or update time. The values are written to a static PHP artefact and
+ * read at runtime without DB access.
+ *
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+final readonly class FileDeliverySetupConfig implements Config
+{
+    private bool $isolation_activated;
+    private ?string $isolation_content_domain;
+
+    public function __construct(
+        bool $isolation_activated = false,
+        ?string $isolation_content_domain = null,
+    ) {
+        // normalize to a bare origin using the same rules the runtime enforces
+        $content = IsolationConfig::normalizeOrigin($isolation_content_domain);
+
+        // The ILIAS domain is no longer configured here: it is derived from the
+        // installed http_path at build time (see IsolationObjective). Only the
+        // content domain is admin-provided and therefore validated here.
+        if ($isolation_activated && $content === null) {
+            throw new \InvalidArgumentException(
+                'IRSS User Content Isolation requires a valid content domain '
+                . '(a bare host like "content.example.org" or a "scheme://host[:port]" '
+                . 'origin, no userinfo/path/query). Given: '
+                . var_export($isolation_content_domain, true)
+            );
+        }
+
+        $this->isolation_activated = $isolation_activated;
+        $this->isolation_content_domain = $content;
+    }
+
+    public function isIsolationActivated(): bool
+    {
+        return $this->isolation_activated;
+    }
+
+    public function getIsolationContentDomain(): ?string
+    {
+        return $this->isolation_content_domain;
+    }
+}

--- a/components/ILIAS/FileDelivery/src/Setup/IsolationObjective.php
+++ b/components/ILIAS/FileDelivery/src/Setup/IsolationObjective.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Setup;
+
+use ILIAS\Setup\Artifact;
+use ILIAS\Setup\Artifact\ArrayArtifact;
+use ILIAS\Setup\Environment;
+use ILIAS\Setup\UnachievableException;
+use ILIAS\FileDelivery\Isolation\IsolationConfig;
+
+/**
+ * Writes the IRSS User Content Isolation settings to a static PHP artefact
+ * so the FileDelivery runtime can read them without a DB connection.
+ *
+ * The ILIAS domain is not part of the admin config: it is derived from the
+ * installed http_path at build time and baked into the artefact. The runtime
+ * therefore never reads ilias.ini.php to obtain it.
+ *
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class IsolationObjective extends BuildStaticConfigStoredObjective
+{
+    public function __construct(
+        private readonly bool $activated = false,
+        private readonly ?string $content_domain = null,
+    ) {
+    }
+
+    public function getArtifactName(): string
+    {
+        return 'isolation';
+    }
+
+    #[\Override]
+    public function getPreconditions(Environment $environment): array
+    {
+        // ilias.ini.php must be loaded as a resource so we can read http_path;
+        // and http_path must have been written into it before we read it.
+        $preconditions = [new \ilIniFilesLoadedObjective()];
+        if ($environment->hasConfigFor('http')) {
+            $preconditions[] = new \ilHttpConfigStoredObjective($environment->getConfigFor('http'));
+        }
+        return $preconditions;
+    }
+
+    #[\Override]
+    public function buildIn(Environment $env): Artifact
+    {
+        $ilias_domain = $this->readIliasDomain($env);
+
+        if ($this->activated
+            && $this->content_domain !== null
+            && $ilias_domain !== null
+            && strcasecmp(
+                (string) parse_url($this->content_domain, PHP_URL_HOST),
+                (string) parse_url($ilias_domain, PHP_URL_HOST)
+            ) === 0
+        ) {
+            throw new UnachievableException(
+                'IRSS User Content Isolation requires the content domain to differ from the '
+                . 'ILIAS domain (http_path); serving user content from the same host defeats '
+                . 'the isolation.'
+            );
+        }
+
+        return new ArrayArtifact([
+            IsolationConfig::KEY_ACTIVATED => $this->activated,
+            IsolationConfig::KEY_CONTENT_DOMAIN => $this->content_domain,
+            IsolationConfig::KEY_ILIAS_DOMAIN => $ilias_domain,
+        ]);
+    }
+
+    public function build(): Artifact
+    {
+        // Used only when no Environment is available (e.g. tests). The ILIAS
+        // domain is resolved in buildIn() from http_path, so it stays null here.
+        return new ArrayArtifact([
+            IsolationConfig::KEY_ACTIVATED => $this->activated,
+            IsolationConfig::KEY_CONTENT_DOMAIN => $this->content_domain,
+            IsolationConfig::KEY_ILIAS_DOMAIN => null,
+        ]);
+    }
+
+    /**
+     * Read the installed http_path from ilias.ini.php and reduce it to a bare
+     * origin to be used as the CORS allow-origin of asset responses.
+     */
+    private function readIliasDomain(Environment $env): ?string
+    {
+        $ini = $env->getResource(Environment::RESOURCE_ILIAS_INI);
+        if (!$ini instanceof \ilIniFile) {
+            return null;
+        }
+
+        return IsolationConfig::originFromUrl(
+            $ini->readVariable('server', 'http_path') ?: null
+        );
+    }
+}

--- a/components/ILIAS/FileDelivery/tests/Delivery/BaseDeliveryIsolationTest.php
+++ b/components/ILIAS/FileDelivery/tests/Delivery/BaseDeliveryIsolationTest.php
@@ -1,0 +1,196 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Tests\FileDelivery\Delivery;
+
+use GuzzleHttp\Psr7\Response;
+use ILIAS\FileDelivery\Delivery\BaseDelivery;
+use ILIAS\FileDelivery\Delivery\Disposition;
+use ILIAS\FileDelivery\Delivery\ResponseBuilder\ResponseBuilder;
+use ILIAS\FileDelivery\Isolation\IsolationConfig;
+use ILIAS\HTTP\Services as HttpServices;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+final class BaseDeliveryIsolationTest extends TestCase
+{
+    private function delivery(IsolationConfig $isolation, string $request_host = 'app.example.org'): BaseDelivery
+    {
+        $uri = $this->createStub(UriInterface::class);
+        $uri->method('getHost')->willReturn($request_host);
+
+        $request = $this->createStub(ServerRequestInterface::class);
+        $request->method('getUri')->willReturn($uri);
+
+        $http = $this->createStub(HttpServices::class);
+        $http->method('request')->willReturn($request);
+
+        $rb = $this->createStub(ResponseBuilder::class);
+
+        return new class ($http, $rb, $rb, $isolation) extends BaseDelivery {
+            public function exposedHostAllowed(): bool
+            {
+                return $this->isRequestHostAllowed();
+            }
+
+            public function exposedOnContentHost(): bool
+            {
+                return $this->isRequestOnContentHost();
+            }
+
+            public function exposedIsolationHeaders(ResponseInterface $r): ResponseInterface
+            {
+                return $this->applyIsolationHeaders($r);
+            }
+
+            public function exposedGeneralHeaders(ResponseInterface $r): ResponseInterface
+            {
+                return $this->setGeneralHeaders(
+                    $r,
+                    '/tmp/user_content.txt',
+                    'text/plain',
+                    'user_content.txt',
+                    Disposition::INLINE
+                );
+            }
+        };
+    }
+
+    private function activeConfig(): IsolationConfig
+    {
+        return IsolationConfig::fromArray([
+            IsolationConfig::KEY_ACTIVATED => true,
+            IsolationConfig::KEY_CONTENT_DOMAIN => 'https://content.example.org',
+            IsolationConfig::KEY_ILIAS_DOMAIN => 'https://app.example.org',
+        ]);
+    }
+
+    public function testHostAllowedWhenIsolationDisabled(): void
+    {
+        $delivery = $this->delivery(IsolationConfig::disabled(), 'anything.example.org');
+        $this->assertTrue($delivery->exposedHostAllowed());
+    }
+
+    public function testHostAllowedWhenRequestHitsContentHost(): void
+    {
+        $delivery = $this->delivery($this->activeConfig(), 'content.example.org');
+        $this->assertTrue($delivery->exposedHostAllowed());
+    }
+
+    public function testHostAllowedIsCaseInsensitive(): void
+    {
+        $delivery = $this->delivery($this->activeConfig(), 'Content.Example.ORG');
+        $this->assertTrue($delivery->exposedHostAllowed());
+    }
+
+    public function testHostRejectedWhenRequestHitsIliasHost(): void
+    {
+        $delivery = $this->delivery($this->activeConfig(), 'app.example.org');
+        $this->assertFalse($delivery->exposedHostAllowed());
+    }
+
+    public function testNotOnContentHostWhenIsolationDisabled(): void
+    {
+        $delivery = $this->delivery(IsolationConfig::disabled(), 'content.example.org');
+        $this->assertFalse($delivery->exposedOnContentHost());
+    }
+
+    public function testOnContentHostWhenRequestHitsContentHost(): void
+    {
+        $delivery = $this->delivery($this->activeConfig(), 'content.example.org');
+        $this->assertTrue($delivery->exposedOnContentHost());
+    }
+
+    public function testOnContentHostIsCaseInsensitive(): void
+    {
+        $delivery = $this->delivery($this->activeConfig(), 'CONTENT.example.org');
+        $this->assertTrue($delivery->exposedOnContentHost());
+    }
+
+    public function testNotOnContentHostWhenRequestHitsIliasHost(): void
+    {
+        $delivery = $this->delivery($this->activeConfig(), 'app.example.org');
+        $this->assertFalse($delivery->exposedOnContentHost());
+    }
+
+    public function testNoIsolationHeadersWhenDisabled(): void
+    {
+        $delivery = $this->delivery(IsolationConfig::disabled());
+        $r = $delivery->exposedIsolationHeaders(new Response());
+
+        $this->assertFalse($r->hasHeader('X-Content-Type-Options'));
+        $this->assertFalse($r->hasHeader('Cross-Origin-Resource-Policy'));
+        $this->assertFalse($r->hasHeader('Referrer-Policy'));
+        $this->assertFalse($r->hasHeader('Access-Control-Allow-Origin'));
+    }
+
+    public function testIsolationHeadersWhenActive(): void
+    {
+        $delivery = $this->delivery($this->activeConfig());
+        $r = $delivery->exposedIsolationHeaders(new Response());
+
+        $this->assertSame('nosniff', $r->getHeaderLine('X-Content-Type-Options'));
+        $this->assertSame('cross-origin', $r->getHeaderLine('Cross-Origin-Resource-Policy'));
+        $this->assertSame('no-referrer', $r->getHeaderLine('Referrer-Policy'));
+        $this->assertSame('https://app.example.org', $r->getHeaderLine('Access-Control-Allow-Origin'));
+        $this->assertSame('Origin', $r->getHeaderLine('Vary'));
+    }
+
+    public function testGeneralHeadersCarryIsolationHeadersWhenActive(): void
+    {
+        $delivery = $this->delivery($this->activeConfig());
+        $r = $delivery->exposedGeneralHeaders(new Response());
+
+        $this->assertSame('nosniff', $r->getHeaderLine('X-Content-Type-Options'));
+        $this->assertSame('cross-origin', $r->getHeaderLine('Cross-Origin-Resource-Policy'));
+        $this->assertSame('no-referrer', $r->getHeaderLine('Referrer-Policy'));
+        $this->assertSame('https://app.example.org', $r->getHeaderLine('Access-Control-Allow-Origin'));
+        $this->assertSame('Origin', $r->getHeaderLine('Vary'));
+    }
+
+    public function testGeneralHeadersKeepTheirRegularContentHeaders(): void
+    {
+        $delivery = $this->delivery($this->activeConfig());
+        $r = $delivery->exposedGeneralHeaders(new Response());
+
+        $this->assertSame('text/plain', $r->getHeaderLine('Content-Type'));
+        $this->assertSame(
+            'inline; filename="user_content.txt"',
+            $r->getHeaderLine('Content-Disposition')
+        );
+    }
+
+    public function testGeneralHeadersCarryNoIsolationHeadersWhenDisabled(): void
+    {
+        $delivery = $this->delivery(IsolationConfig::disabled());
+        $r = $delivery->exposedGeneralHeaders(new Response());
+
+        $this->assertSame('text/plain', $r->getHeaderLine('Content-Type'));
+        $this->assertFalse($r->hasHeader('X-Content-Type-Options'));
+        $this->assertFalse($r->hasHeader('Cross-Origin-Resource-Policy'));
+        $this->assertFalse($r->hasHeader('Referrer-Policy'));
+        $this->assertFalse($r->hasHeader('Access-Control-Allow-Origin'));
+    }
+}

--- a/components/ILIAS/FileDelivery/tests/Delivery/DeliveryTerminated.php
+++ b/components/ILIAS/FileDelivery/tests/Delivery/DeliveryTerminated.php
@@ -16,6 +16,17 @@
  *
  *********************************************************************/
 
-return  [
-  'delivery_method' => 'php',
-];
+declare(strict_types=1);
+
+namespace ILIAS\Tests\FileDelivery\Delivery;
+
+/**
+ * Marker thrown by the doubled \ILIAS\HTTP\Services::close() so that a
+ * delivery — which is declared `never` and would terminate the request —
+ * can be observed in a test instead of ending the process.
+ *
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+final class DeliveryTerminated extends \RuntimeException
+{
+}

--- a/components/ILIAS/FileDelivery/tests/Delivery/LegacyDeliveryIsolationTest.php
+++ b/components/ILIAS/FileDelivery/tests/Delivery/LegacyDeliveryIsolationTest.php
@@ -1,0 +1,167 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Tests\FileDelivery\Delivery;
+
+use GuzzleHttp\Psr7\Response;
+use ILIAS\FileDelivery\Delivery\LegacyDelivery;
+use ILIAS\FileDelivery\Delivery\ResponseBuilder\ResponseBuilder;
+use ILIAS\FileDelivery\Isolation\IsolationConfig;
+use ILIAS\HTTP\Services as HttpServices;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Covers the host guard in {@see LegacyDelivery}: the content domain is
+ * reserved for signed token delivery, so legacy delivery must answer 404
+ * there instead of serving the file.
+ *
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+final class LegacyDeliveryIsolationTest extends TestCase
+{
+    private string $file;
+    private ?ResponseInterface $saved = null;
+
+    protected function setUp(): void
+    {
+        $this->file = (string) tempnam(sys_get_temp_dir(), 'fd_iso_');
+        file_put_contents($this->file, 'legacy content');
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->file)) {
+            unlink($this->file);
+        }
+    }
+
+    private function http(string $request_host): HttpServices
+    {
+        $uri = $this->createStub(UriInterface::class);
+        $uri->method('getHost')->willReturn($request_host);
+
+        $request = $this->createStub(ServerRequestInterface::class);
+        $request->method('getUri')->willReturn($uri);
+
+        $http = $this->createStub(HttpServices::class);
+        $http->method('request')->willReturn($request);
+        $http->method('response')->willReturn(new Response());
+        $http->method('saveResponse')->willReturnCallback(
+            function (ResponseInterface $r): void {
+                $this->saved = $r;
+            }
+        );
+        // deliveries are declared `never`; the doubled close() ends them observably
+        $http->method('close')->willThrowException(new DeliveryTerminated());
+
+        return $http;
+    }
+
+    private function activeConfig(): IsolationConfig
+    {
+        return IsolationConfig::fromArray([
+            IsolationConfig::KEY_ACTIVATED => true,
+            IsolationConfig::KEY_CONTENT_DOMAIN => 'https://content.example.org',
+            IsolationConfig::KEY_ILIAS_DOMAIN => 'https://app.example.org',
+        ]);
+    }
+
+    private function deliverInline(
+        IsolationConfig $isolation,
+        string $request_host,
+        ResponseBuilder $response_builder
+    ): void {
+        $delivery = new LegacyDelivery(
+            $this->http($request_host),
+            $response_builder,
+            $response_builder,
+            $isolation
+        );
+
+        try {
+            $delivery->inline($this->file);
+            $this->fail('delivery did not terminate');
+        } catch (DeliveryTerminated) {
+            // expected: the delivery ran to its end and closed the request
+        }
+    }
+
+    private function neverBuilding(): ResponseBuilder
+    {
+        $rb = $this->createMock(ResponseBuilder::class);
+        $rb->expects($this->never())->method('buildForStream');
+        return $rb;
+    }
+
+    private function building(): ResponseBuilder
+    {
+        $rb = $this->createMock(ResponseBuilder::class);
+        $rb->method('getName')->willReturn('PHP');
+        $rb->expects($this->once())
+           ->method('buildForStream')
+           ->willReturnCallback(
+               static fn(ServerRequestInterface $request, ResponseInterface $r): ResponseInterface => $r
+           );
+        return $rb;
+    }
+
+    public function testLegacyDeliveryIsRefusedOnTheContentHost(): void
+    {
+        $this->deliverInline($this->activeConfig(), 'content.example.org', $this->neverBuilding());
+
+        $this->assertNotNull($this->saved);
+        $this->assertSame(404, $this->saved->getStatusCode());
+    }
+
+    public function testLegacyDeliveryIsRefusedOnTheContentHostRegardlessOfCase(): void
+    {
+        $this->deliverInline($this->activeConfig(), 'CONTENT.Example.ORG', $this->neverBuilding());
+
+        $this->assertNotNull($this->saved);
+        $this->assertSame(404, $this->saved->getStatusCode());
+    }
+
+    public function testLegacyDeliveryIsServedOnTheIliasHost(): void
+    {
+        $this->deliverInline($this->activeConfig(), 'app.example.org', $this->building());
+
+        $this->assertNotNull($this->saved);
+        $this->assertSame(200, $this->saved->getStatusCode());
+        // the delivered response carries the isolation headers
+        $this->assertSame('nosniff', $this->saved->getHeaderLine('X-Content-Type-Options'));
+        $this->assertSame(
+            'https://app.example.org',
+            $this->saved->getHeaderLine('Access-Control-Allow-Origin')
+        );
+    }
+
+    public function testLegacyDeliveryIsServedOnAnyHostWhenIsolationIsDisabled(): void
+    {
+        $this->deliverInline(IsolationConfig::disabled(), 'content.example.org', $this->building());
+
+        $this->assertNotNull($this->saved);
+        $this->assertSame(200, $this->saved->getStatusCode());
+        $this->assertFalse($this->saved->hasHeader('X-Content-Type-Options'));
+        $this->assertFalse($this->saved->hasHeader('Access-Control-Allow-Origin'));
+    }
+}

--- a/components/ILIAS/FileDelivery/tests/Delivery/StreamDeliveryIsolationTest.php
+++ b/components/ILIAS/FileDelivery/tests/Delivery/StreamDeliveryIsolationTest.php
@@ -1,0 +1,191 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Tests\FileDelivery\Delivery;
+
+use GuzzleHttp\Psr7\Response;
+use ILIAS\FileDelivery\Delivery\Disposition;
+use ILIAS\FileDelivery\Delivery\ResponseBuilder\ResponseBuilder;
+use ILIAS\FileDelivery\Delivery\StreamDelivery;
+use ILIAS\FileDelivery\Isolation\IsolationConfig;
+use ILIAS\FileDelivery\Token\DataSigner;
+use ILIAS\FileDelivery\Token\Signer\Algorithm\SHA1;
+use ILIAS\FileDelivery\Token\Signer\Key\Secret\SecretKey;
+use ILIAS\FileDelivery\Token\Signer\Key\Secret\SecretKeyRotation;
+use ILIAS\Filesystem\Stream\Streams;
+use ILIAS\HTTP\Services as HttpServices;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Covers the host guard in {@see StreamDelivery::deliverFromToken()}: with a
+ * *valid* token, delivery must still be refused with 404 unless the request
+ * reached the configured content domain.
+ *
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+final class StreamDeliveryIsolationTest extends TestCase
+{
+    private string $file;
+    private DataSigner $data_signer;
+    private ?ResponseInterface $saved = null;
+
+    protected function setUp(): void
+    {
+        $this->file = (string) tempnam(sys_get_temp_dir(), 'fd_iso_');
+        file_put_contents($this->file, 'user content');
+        $this->data_signer = new DataSigner(
+            new SecretKeyRotation(new SecretKey('test_key')),
+            new SHA1()
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->file)) {
+            unlink($this->file);
+        }
+    }
+
+    private function validToken(): string
+    {
+        return $this->data_signer->getSignedStreamToken(
+            Streams::ofResource(fopen($this->file, 'rb')),
+            basename($this->file),
+            Disposition::INLINE,
+            0
+        );
+    }
+
+    private function http(string $request_host): HttpServices
+    {
+        $uri = $this->createStub(UriInterface::class);
+        $uri->method('getHost')->willReturn($request_host);
+
+        $request = $this->createStub(ServerRequestInterface::class);
+        $request->method('getUri')->willReturn($uri);
+
+        $http = $this->createStub(HttpServices::class);
+        $http->method('request')->willReturn($request);
+        $http->method('response')->willReturn(new Response());
+        $http->method('saveResponse')->willReturnCallback(
+            function (ResponseInterface $r): void {
+                $this->saved = $r;
+            }
+        );
+        // deliveries are declared `never`; the doubled close() ends them observably
+        $http->method('close')->willThrowException(new DeliveryTerminated());
+
+        return $http;
+    }
+
+    private function activeConfig(): IsolationConfig
+    {
+        return IsolationConfig::fromArray([
+            IsolationConfig::KEY_ACTIVATED => true,
+            IsolationConfig::KEY_CONTENT_DOMAIN => 'https://content.example.org',
+            IsolationConfig::KEY_ILIAS_DOMAIN => 'https://app.example.org',
+        ]);
+    }
+
+    private function deliverFromToken(
+        IsolationConfig $isolation,
+        string $request_host,
+        ResponseBuilder $response_builder
+    ): void {
+        $delivery = new StreamDelivery(
+            $this->data_signer,
+            $this->http($request_host),
+            $response_builder,
+            $response_builder,
+            $isolation
+        );
+
+        try {
+            $delivery->deliverFromToken($this->validToken());
+            $this->fail('delivery did not terminate');
+        } catch (DeliveryTerminated) {
+            // expected: the delivery ran to its end and closed the request
+        }
+    }
+
+    private function neverBuilding(): ResponseBuilder
+    {
+        $rb = $this->createMock(ResponseBuilder::class);
+        $rb->expects($this->never())->method('buildForStream');
+        return $rb;
+    }
+
+    private function building(): ResponseBuilder
+    {
+        $rb = $this->createMock(ResponseBuilder::class);
+        $rb->method('getName')->willReturn('PHP');
+        $rb->expects($this->once())
+           ->method('buildForStream')
+           ->willReturnCallback(
+               static fn(ServerRequestInterface $request, ResponseInterface $r): ResponseInterface => $r
+           );
+        return $rb;
+    }
+
+    public function testValidTokenIsRefusedOnTheIliasHostWhenIsolationIsActive(): void
+    {
+        $this->deliverFromToken($this->activeConfig(), 'app.example.org', $this->neverBuilding());
+
+        $this->assertNotNull($this->saved);
+        $this->assertSame(404, $this->saved->getStatusCode());
+    }
+
+    public function testValidTokenIsRefusedOnAnyForeignHostWhenIsolationIsActive(): void
+    {
+        $this->deliverFromToken($this->activeConfig(), 'evil.example.org', $this->neverBuilding());
+
+        $this->assertNotNull($this->saved);
+        $this->assertSame(404, $this->saved->getStatusCode());
+    }
+
+    public function testValidTokenIsServedOnTheContentHost(): void
+    {
+        $this->deliverFromToken($this->activeConfig(), 'content.example.org', $this->building());
+
+        $this->assertNotNull($this->saved);
+        $this->assertSame(200, $this->saved->getStatusCode());
+        // the delivered response carries the isolation headers
+        $this->assertSame('nosniff', $this->saved->getHeaderLine('X-Content-Type-Options'));
+        $this->assertSame('cross-origin', $this->saved->getHeaderLine('Cross-Origin-Resource-Policy'));
+        $this->assertSame('no-referrer', $this->saved->getHeaderLine('Referrer-Policy'));
+        $this->assertSame(
+            'https://app.example.org',
+            $this->saved->getHeaderLine('Access-Control-Allow-Origin')
+        );
+    }
+
+    public function testValidTokenIsServedOnAnyHostWhenIsolationIsDisabled(): void
+    {
+        $this->deliverFromToken(IsolationConfig::disabled(), 'app.example.org', $this->building());
+
+        $this->assertNotNull($this->saved);
+        $this->assertSame(200, $this->saved->getStatusCode());
+        $this->assertFalse($this->saved->hasHeader('X-Content-Type-Options'));
+        $this->assertFalse($this->saved->hasHeader('Access-Control-Allow-Origin'));
+    }
+}

--- a/components/ILIAS/FileDelivery/tests/Isolation/IsolationConfigTest.php
+++ b/components/ILIAS/FileDelivery/tests/Isolation/IsolationConfigTest.php
@@ -1,0 +1,315 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Tests\FileDelivery\Isolation;
+
+use ILIAS\FileDelivery\Isolation\IsolationConfig;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+final class IsolationConfigTest extends TestCase
+{
+    /** @var list<string> */
+    private array $artefacts = [];
+
+    public function testDisabledFactory(): void
+    {
+        $config = IsolationConfig::disabled();
+
+        $this->assertFalse($config->isActivated());
+        $this->assertNull($config->getContentDomain());
+        $this->assertNull($config->getIliasDomain());
+        $this->assertNull($config->getContentHost());
+        $this->assertNull($config->getIliasHost());
+    }
+
+    public function testFromEmptyArrayIsDisabled(): void
+    {
+        $config = IsolationConfig::fromArray([]);
+
+        $this->assertFalse($config->isActivated());
+        $this->assertNull($config->getContentDomain());
+        $this->assertNull($config->getIliasDomain());
+    }
+
+    public function testFromArrayWithFullSpecExample(): void
+    {
+        // exact artefact shape from the feature spec
+        $config = IsolationConfig::fromArray([
+            IsolationConfig::KEY_ACTIVATED => true,
+            IsolationConfig::KEY_CONTENT_DOMAIN => 'https://test11.iliascontent.de',
+            IsolationConfig::KEY_ILIAS_DOMAIN => 'https://test11.ilias.de',
+        ]);
+
+        $this->assertTrue($config->isActivated());
+        $this->assertSame('https://test11.iliascontent.de', $config->getContentDomain());
+        $this->assertSame('https://test11.ilias.de', $config->getIliasDomain());
+        $this->assertSame('test11.iliascontent.de', $config->getContentHost());
+        $this->assertSame('test11.ilias.de', $config->getIliasHost());
+    }
+
+    public function testBareHostnamesGetHttpsScheme(): void
+    {
+        $config = IsolationConfig::fromArray([
+            IsolationConfig::KEY_ACTIVATED => true,
+            IsolationConfig::KEY_CONTENT_DOMAIN => 'content.example.org',
+            IsolationConfig::KEY_ILIAS_DOMAIN => 'app.example.org',
+        ]);
+
+        $this->assertSame('https://content.example.org', $config->getContentDomain());
+        $this->assertSame('https://app.example.org', $config->getIliasDomain());
+        $this->assertSame('content.example.org', $config->getContentHost());
+        $this->assertSame('app.example.org', $config->getIliasHost());
+    }
+
+    public function testTrailingSlashIsStripped(): void
+    {
+        $config = IsolationConfig::fromArray([
+            IsolationConfig::KEY_ACTIVATED => true,
+            IsolationConfig::KEY_CONTENT_DOMAIN => 'https://content.example.org/',
+            IsolationConfig::KEY_ILIAS_DOMAIN => 'https://app.example.org/',
+        ]);
+
+        $this->assertSame('https://content.example.org', $config->getContentDomain());
+        $this->assertSame('https://app.example.org', $config->getIliasDomain());
+    }
+
+    public function testActivatedWithoutContentDomainIsForcedOff(): void
+    {
+        $config = IsolationConfig::fromArray([
+            IsolationConfig::KEY_ACTIVATED => true,
+            IsolationConfig::KEY_ILIAS_DOMAIN => 'https://app.example.org',
+        ]);
+
+        $this->assertFalse($config->isActivated());
+    }
+
+    public function testActivatedWithoutIliasDomainStaysActiveWithNullIliasDomain(): void
+    {
+        // The ILIAS domain is optional in the artefact: when http_path could not
+        // be resolved at build time it is simply null (the CORS allow-origin
+        // header is then omitted), isolation stays on.
+        $config = IsolationConfig::fromArray([
+            IsolationConfig::KEY_ACTIVATED => true,
+            IsolationConfig::KEY_CONTENT_DOMAIN => 'https://content.example.org',
+        ]);
+
+        $this->assertTrue($config->isActivated());
+        $this->assertSame('https://content.example.org', $config->getContentDomain());
+        $this->assertNull($config->getIliasDomain());
+    }
+
+    public function testInactiveStillParsesDomains(): void
+    {
+        $config = IsolationConfig::fromArray([
+            IsolationConfig::KEY_ACTIVATED => false,
+            IsolationConfig::KEY_CONTENT_DOMAIN => 'https://content.example.org',
+            IsolationConfig::KEY_ILIAS_DOMAIN => 'https://app.example.org',
+        ]);
+
+        $this->assertFalse($config->isActivated());
+        $this->assertSame('https://content.example.org', $config->getContentDomain());
+        $this->assertSame('https://app.example.org', $config->getIliasDomain());
+    }
+
+    #[DataProvider('unusableDomainProvider')]
+    public function testUnusableDomainsNormalizeToNull(mixed $value): void
+    {
+        $config = IsolationConfig::fromArray([
+            IsolationConfig::KEY_ACTIVATED => true,
+            IsolationConfig::KEY_CONTENT_DOMAIN => $value,
+            IsolationConfig::KEY_ILIAS_DOMAIN => 'https://app.example.org',
+        ]);
+
+        // unusable content domain -> null -> isolation forced off
+        $this->assertNull($config->getContentDomain());
+        $this->assertFalse($config->isActivated());
+    }
+
+    public static function unusableDomainProvider(): \Iterator
+    {
+        yield 'empty string' => [''];
+        yield 'whitespace only' => ['   '];
+        yield 'scheme without host' => ['https://'];
+        yield 'non-string int' => [123];
+        yield 'non-string bool' => [true];
+        yield 'null' => [null];
+        yield 'array' => [['x']];
+    }
+
+    public function testToArrayUsesSpecKeys(): void
+    {
+        $config = IsolationConfig::fromArray([
+            IsolationConfig::KEY_ACTIVATED => true,
+            IsolationConfig::KEY_CONTENT_DOMAIN => 'https://content.example.org',
+            IsolationConfig::KEY_ILIAS_DOMAIN => 'https://app.example.org',
+        ]);
+
+        $this->assertSame([
+            IsolationConfig::KEY_ACTIVATED => true,
+            IsolationConfig::KEY_CONTENT_DOMAIN => 'https://content.example.org',
+            IsolationConfig::KEY_ILIAS_DOMAIN => 'https://app.example.org',
+        ], $config->toArray());
+    }
+
+    public function testFromArrayToArrayRoundtripIsStable(): void
+    {
+        $source = [
+            IsolationConfig::KEY_ACTIVATED => true,
+            IsolationConfig::KEY_CONTENT_DOMAIN => 'content.example.org',
+            IsolationConfig::KEY_ILIAS_DOMAIN => 'app.example.org',
+        ];
+
+        $once = IsolationConfig::fromArray($source)->toArray();
+        $twice = IsolationConfig::fromArray($once)->toArray();
+
+        $this->assertSame($once, $twice);
+    }
+
+    #[DataProvider('originNormalizationProvider')]
+    public function testValidValuesNormalizeToBareOrigin(
+        string $input,
+        string $expected_domain,
+        string $expected_host
+    ): void {
+        $config = IsolationConfig::fromArray([
+            IsolationConfig::KEY_ACTIVATED => false,
+            IsolationConfig::KEY_CONTENT_DOMAIN => $input,
+            IsolationConfig::KEY_ILIAS_DOMAIN => 'https://app.example.org',
+        ]);
+
+        $this->assertSame($expected_domain, $config->getContentDomain());
+        $this->assertSame($expected_host, $config->getContentHost());
+    }
+
+    public static function originNormalizationProvider(): \Iterator
+    {
+        yield 'bare host gets https' => ['content.example.org', 'https://content.example.org', 'content.example.org'];
+        yield 'https kept' => ['https://content.example.org', 'https://content.example.org', 'content.example.org'];
+        yield 'http kept' => ['http://localhost', 'http://localhost', 'localhost'];
+        yield 'port preserved' => ['https://content.example.org:8443', 'https://content.example.org:8443', 'content.example.org'];
+        yield 'host lowercased' => ['https://Content.Example.ORG', 'https://content.example.org', 'content.example.org'];
+        yield 'root slash stripped' => ['https://content.example.org/', 'https://content.example.org', 'content.example.org'];
+    }
+
+    #[DataProvider('rejectedOriginProvider')]
+    public function testNonBareOriginsAreRejected(string $input): void
+    {
+        $config = IsolationConfig::fromArray([
+            IsolationConfig::KEY_ACTIVATED => false,
+            IsolationConfig::KEY_CONTENT_DOMAIN => $input,
+            IsolationConfig::KEY_ILIAS_DOMAIN => 'https://app.example.org',
+        ]);
+
+        $this->assertNull($config->getContentDomain());
+        $this->assertNull($config->getContentHost());
+    }
+
+    public static function rejectedOriginProvider(): \Iterator
+    {
+        yield 'with path' => ['https://content.example.org/foo'];
+        yield 'with userinfo' => ['https://user:pass@content.example.org'];
+        yield 'with query' => ['https://content.example.org/?a=b'];
+        yield 'with fragment' => ['https://content.example.org/#x'];
+        yield 'ftp scheme' => ['ftp://content.example.org'];
+        yield 'file scheme' => ['file:///etc/passwd'];
+        yield 'javascript scheme' => ['javascript:alert(1)'];
+    }
+
+    #[DataProvider('trustedOriginProvider')]
+    public function testOriginFromUrlReducesTrustedAppUrlToBareOrigin(?string $input, ?string $expected): void
+    {
+        // originFromUrl is used at build time to derive the ILIAS domain from
+        // http_path, which may carry a sub-directory path that must be discarded.
+        $this->assertSame($expected, IsolationConfig::originFromUrl($input));
+    }
+
+    public static function trustedOriginProvider(): \Iterator
+    {
+        yield 'bare origin' => ['https://app.example.org', 'https://app.example.org'];
+        yield 'path discarded' => ['https://app.example.org/ilias/index.php', 'https://app.example.org'];
+        yield 'query discarded' => ['https://app.example.org/?a=b', 'https://app.example.org'];
+        yield 'bare host gets https' => ['app.example.org', 'https://app.example.org'];
+        yield 'http kept' => ['http://localhost/sub', 'http://localhost'];
+        yield 'port preserved' => ['https://app.example.org:8443/sub', 'https://app.example.org:8443'];
+        yield 'empty stays null' => ['', null];
+        yield 'null stays null' => [null, null];
+        yield 'non-http scheme rejected' => ['ftp://app.example.org', null];
+    }
+
+    private function artefact(string $php): string
+    {
+        $path = (string) tempnam(sys_get_temp_dir(), 'iso_artefact_') . '.php';
+        file_put_contents($path, $php);
+        $this->artefacts[] = $path;
+        return $path;
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->artefacts as $path) {
+            if (is_file($path)) {
+                unlink($path);
+            }
+        }
+        $this->artefacts = [];
+    }
+
+    public function testFromArtefactWithoutFileIsDisabled(): void
+    {
+        $config = IsolationConfig::fromArtefact(sys_get_temp_dir() . '/does_not_exist_isolation.php');
+
+        $this->assertFalse($config->isActivated());
+        $this->assertNull($config->getContentDomain());
+        $this->assertNull($config->getIliasDomain());
+    }
+
+    public function testFromArtefactReadsTheStoredSettings(): void
+    {
+        $path = $this->artefact(
+            "<?php return ['activated' => true, 'content_domain' => 'content.example.org',"
+            . " 'ilias_domain' => 'https://app.example.org'];"
+        );
+        $config = IsolationConfig::fromArtefact($path);
+
+        $this->assertTrue($config->isActivated());
+        $this->assertSame('https://content.example.org', $config->getContentDomain());
+        $this->assertSame('https://app.example.org', $config->getIliasDomain());
+    }
+
+    public function testFromArtefactWithNonArrayContentIsDisabled(): void
+    {
+        $config = IsolationConfig::fromArtefact($this->artefact('<?php return "nonsense";'));
+
+        $this->assertFalse($config->isActivated());
+        $this->assertNull($config->getContentDomain());
+    }
+
+    public function testFromArtefactWithoutReturnValueIsDisabled(): void
+    {
+        $config = IsolationConfig::fromArtefact($this->artefact('<?php // nothing returned'));
+
+        $this->assertFalse($config->isActivated());
+        $this->assertNull($config->getContentDomain());
+    }
+}

--- a/components/ILIAS/FileDelivery/tests/ServicesBaseUriTest.php
+++ b/components/ILIAS/FileDelivery/tests/ServicesBaseUriTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Tests\FileDelivery;
+
+use ILIAS\FileDelivery\Delivery\LegacyDelivery;
+use ILIAS\FileDelivery\Delivery\ResponseBuilder\ResponseBuilder;
+use ILIAS\FileDelivery\Delivery\StreamDelivery;
+use ILIAS\FileDelivery\Isolation\IsolationConfig;
+use ILIAS\FileDelivery\Services;
+use ILIAS\FileDelivery\Token\DataSigner;
+use ILIAS\FileDelivery\Token\Signer\Algorithm\SHA1;
+use ILIAS\FileDelivery\Token\Signer\Key\Secret\SecretKey;
+use ILIAS\FileDelivery\Token\Signer\Key\Secret\SecretKeyRotation;
+use ILIAS\HTTP\Services as HttpServices;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+final class ServicesBaseUriTest extends TestCase
+{
+    private function services(
+        IsolationConfig $isolation,
+        string $scheme = 'https',
+        string $host = 'app.example.org',
+        ?int $port = null,
+        string $path = '/data/deliver.php'
+    ): object {
+        $uri = $this->createStub(UriInterface::class);
+        $uri->method('getScheme')->willReturn($scheme);
+        $uri->method('getHost')->willReturn($host);
+        $uri->method('getPort')->willReturn($port);
+        $uri->method('getPath')->willReturn($path);
+
+        $request = $this->createStub(ServerRequestInterface::class);
+        $request->method('getUri')->willReturn($uri);
+
+        $http = $this->createStub(HttpServices::class);
+        $http->method('request')->willReturn($request);
+
+        $data_signer = new DataSigner(new SecretKeyRotation(new SecretKey('test_key')), new SHA1());
+        $rb = $this->createStub(ResponseBuilder::class);
+
+        // the inner deliveries are required by the constructor but unused by getBaseURI
+        $stream = new StreamDelivery($data_signer, $http, $rb, $rb, IsolationConfig::disabled());
+        $legacy = new LegacyDelivery($http, $rb, $rb, IsolationConfig::disabled());
+
+        return new class ($stream, $legacy, $data_signer, $http, $isolation) extends Services {
+            public function exposedBaseURI(): string
+            {
+                return $this->getBaseURI();
+            }
+        };
+    }
+
+    private function activeConfig(): IsolationConfig
+    {
+        return IsolationConfig::fromArray([
+            IsolationConfig::KEY_ACTIVATED => true,
+            IsolationConfig::KEY_CONTENT_DOMAIN => 'https://content.example.org',
+            IsolationConfig::KEY_ILIAS_DOMAIN => 'https://app.example.org',
+        ]);
+    }
+
+    public function testUsesRequestHostWhenIsolationDisabled(): void
+    {
+        $services = $this->services(IsolationConfig::disabled());
+        $this->assertSame('https://app.example.org/data', $services->exposedBaseURI());
+    }
+
+    public function testKeepsPortWhenIsolationDisabled(): void
+    {
+        $services = $this->services(IsolationConfig::disabled(), 'https', 'app.example.org', 8443);
+        $this->assertSame('https://app.example.org:8443/data', $services->exposedBaseURI());
+    }
+
+    public function testRewritesToContentDomainWhenIsolationActive(): void
+    {
+        $services = $this->services($this->activeConfig());
+        $this->assertSame('https://content.example.org/data', $services->exposedBaseURI());
+    }
+
+    public function testContentDomainRewriteIgnoresRequestHostAndPort(): void
+    {
+        // even if the request arrives on a different host/port, the content
+        // domain is authoritative for the asset base URI
+        $services = $this->services($this->activeConfig(), 'http', 'whatever.example.org', 1234);
+        $this->assertSame('https://content.example.org/data', $services->exposedBaseURI());
+    }
+}

--- a/components/ILIAS/FileDelivery/tests/Setup/AgentTest.php
+++ b/components/ILIAS/FileDelivery/tests/Setup/AgentTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Tests\FileDelivery\Setup;
+
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\FileDelivery\Setup\Agent;
+use ILIAS\FileDelivery\Setup\FileDeliverySetupConfig;
+use ILIAS\Language\Language;
+use ILIAS\Refinery\Factory as Refinery;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+final class AgentTest extends TestCase
+{
+    private function agent(): Agent
+    {
+        $refinery = new Refinery(new DataFactory(), $this->createStub(Language::class));
+        return new Agent($refinery);
+    }
+
+    public function testHasConfig(): void
+    {
+        $this->assertTrue($this->agent()->hasConfig());
+    }
+
+    public function testAgentNameIsContentIsolation(): void
+    {
+        // the agent name is the top-level key for this agent in config.json
+        $this->assertSame('content_isolation', $this->agent()->getAgentName());
+    }
+
+    public function testTransformsActivatedConfig(): void
+    {
+        $config = $this->agent()->getArrayToConfigTransformation()->transform([
+            'activated' => true,
+            'content_domain' => 'https://content.example.org',
+        ]);
+
+        $this->assertInstanceOf(FileDeliverySetupConfig::class, $config);
+        $this->assertTrue($config->isIsolationActivated());
+        $this->assertSame('https://content.example.org', $config->getIsolationContentDomain());
+    }
+
+    public function testTransformsNullToDisabledConfig(): void
+    {
+        $config = $this->agent()->getArrayToConfigTransformation()->transform(null);
+
+        $this->assertInstanceOf(FileDeliverySetupConfig::class, $config);
+        $this->assertFalse($config->isIsolationActivated());
+        $this->assertNull($config->getIsolationContentDomain());
+    }
+
+    public function testTransformsEmptyArrayToDisabledConfig(): void
+    {
+        $config = $this->agent()->getArrayToConfigTransformation()->transform([]);
+
+        $this->assertFalse($config->isIsolationActivated());
+    }
+
+    public function testEmptyStringDomainTreatedAsNull(): void
+    {
+        $config = $this->agent()->getArrayToConfigTransformation()->transform([
+            'activated' => false,
+            'content_domain' => '',
+        ]);
+
+        $this->assertFalse($config->isIsolationActivated());
+        $this->assertNull($config->getIsolationContentDomain());
+    }
+
+    public function testActivatedWithoutDomainThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->agent()->getArrayToConfigTransformation()->transform([
+            'activated' => true,
+        ]);
+    }
+}

--- a/components/ILIAS/FileDelivery/tests/Setup/FileDeliverySetupConfigTest.php
+++ b/components/ILIAS/FileDelivery/tests/Setup/FileDeliverySetupConfigTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Tests\FileDelivery\Setup;
+
+use ILIAS\FileDelivery\Setup\FileDeliverySetupConfig;
+use ILIAS\Setup\Config;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+final class FileDeliverySetupConfigTest extends TestCase
+{
+    public function testDefaultIsDisabled(): void
+    {
+        $config = new FileDeliverySetupConfig();
+
+        $this->assertInstanceOf(Config::class, $config);
+        $this->assertFalse($config->isIsolationActivated());
+        $this->assertNull($config->getIsolationContentDomain());
+    }
+
+    public function testActivatedWithContentDomain(): void
+    {
+        $config = new FileDeliverySetupConfig(
+            true,
+            'https://content.example.org',
+        );
+
+        $this->assertTrue($config->isIsolationActivated());
+        $this->assertSame('https://content.example.org', $config->getIsolationContentDomain());
+    }
+
+    public function testInactiveWithNullDomainIsAllowed(): void
+    {
+        $config = new FileDeliverySetupConfig(false);
+
+        $this->assertFalse($config->isIsolationActivated());
+    }
+
+    public function testActivatedWithoutContentDomainThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new FileDeliverySetupConfig(true, null);
+    }
+
+    public function testActivatedWithoutAnyDomainThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new FileDeliverySetupConfig(true);
+    }
+
+    public function testStoresNormalizedBareOrigin(): void
+    {
+        $config = new FileDeliverySetupConfig(true, 'content.example.org');
+
+        $this->assertSame('https://content.example.org', $config->getIsolationContentDomain());
+    }
+
+    public function testActivatedWithContentPathThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new FileDeliverySetupConfig(true, 'https://content.example.org/assets');
+    }
+
+    public function testActivatedWithNonHttpSchemeThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new FileDeliverySetupConfig(true, 'ftp://content.example.org');
+    }
+
+    public function testInactiveDoesNotValidateAndDropsUnusableDomain(): void
+    {
+        $config = new FileDeliverySetupConfig(false, 'https://content.example.org/path');
+
+        $this->assertFalse($config->isIsolationActivated());
+        $this->assertNull($config->getIsolationContentDomain());
+    }
+}

--- a/components/ILIAS/FileDelivery/tests/Setup/IsolationObjectiveTest.php
+++ b/components/ILIAS/FileDelivery/tests/Setup/IsolationObjectiveTest.php
@@ -1,0 +1,171 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Tests\FileDelivery\Setup;
+
+use ILIAS\FileDelivery\Isolation\IsolationConfig;
+use ILIAS\FileDelivery\Setup\IsolationObjective;
+use ILIAS\Setup\Artifact;
+use ILIAS\Setup\Environment;
+use ILIAS\Setup\UnachievableException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+final class IsolationObjectiveTest extends TestCase
+{
+    public function testArtifactName(): void
+    {
+        $this->assertSame('isolation', (new IsolationObjective())->getArtifactName());
+    }
+
+    public function testBuildProducesContentDomainWithNullIliasDomain(): void
+    {
+        // build() has no Environment, so the ILIAS domain (derived from http_path)
+        // stays null; it is filled in by buildIn().
+        $objective = new IsolationObjective(
+            true,
+            'https://content.example.org',
+        );
+
+        $artifact = $objective->build();
+        $this->assertInstanceOf(Artifact::class, $artifact);
+
+        $value = $this->evaluateArtifact($artifact);
+
+        $this->assertSame([
+            IsolationConfig::KEY_ACTIVATED => true,
+            IsolationConfig::KEY_CONTENT_DOMAIN => 'https://content.example.org',
+            IsolationConfig::KEY_ILIAS_DOMAIN => null,
+        ], $value);
+    }
+
+    public function testDefaultBuildIsDisabledArtifact(): void
+    {
+        $value = $this->evaluateArtifact((new IsolationObjective())->build());
+
+        $this->assertSame([
+            IsolationConfig::KEY_ACTIVATED => false,
+            IsolationConfig::KEY_CONTENT_DOMAIN => null,
+            IsolationConfig::KEY_ILIAS_DOMAIN => null,
+        ], $value);
+    }
+
+    public function testBuildInDerivesIliasDomainFromHttpPath(): void
+    {
+        // http_path may carry a sub-directory; it is reduced to a bare origin.
+        $env = $this->environmentWithHttpPath('https://app.example.org/ilias/index.php');
+
+        $objective = new IsolationObjective(true, 'https://content.example.org');
+        $value = $this->evaluateArtifact($objective->buildIn($env));
+
+        $this->assertSame([
+            IsolationConfig::KEY_ACTIVATED => true,
+            IsolationConfig::KEY_CONTENT_DOMAIN => 'https://content.example.org',
+            IsolationConfig::KEY_ILIAS_DOMAIN => 'https://app.example.org',
+        ], $value);
+    }
+
+    public function testBuildInWithoutIniResourceLeavesIliasDomainNull(): void
+    {
+        $env = $this->createStub(Environment::class);
+        $env->method('getResource')->willReturn(null);
+
+        $objective = new IsolationObjective(true, 'https://content.example.org');
+        $value = $this->evaluateArtifact($objective->buildIn($env));
+
+        $this->assertNull($value[IsolationConfig::KEY_ILIAS_DOMAIN]);
+        $this->assertTrue($value[IsolationConfig::KEY_ACTIVATED]);
+    }
+
+    public function testBuildInThrowsWhenContentHostEqualsIliasHost(): void
+    {
+        $env = $this->environmentWithHttpPath('https://same.example.org');
+
+        $objective = new IsolationObjective(true, 'https://same.example.org');
+
+        $this->expectException(UnachievableException::class);
+        $objective->buildIn($env);
+    }
+
+    public function testBuildInDoesNotThrowForSameHostWhenInactive(): void
+    {
+        $env = $this->environmentWithHttpPath('https://same.example.org');
+
+        $objective = new IsolationObjective(false, 'https://same.example.org');
+        $value = $this->evaluateArtifact($objective->buildIn($env));
+
+        $this->assertFalse($value[IsolationConfig::KEY_ACTIVATED]);
+    }
+
+    /**
+     * Regression for the review concern that a generated PHP artefact could
+     * allow code injection via an unescaped string. var_export() must escape
+     * the value so the malicious payload survives as a literal string and is
+     * never executed.
+     */
+    public function testMaliciousDomainIsEscapedAndNotExecuted(): void
+    {
+        $marker = sys_get_temp_dir() . '/isolation_injection_' . getmypid();
+        @unlink($marker);
+
+        $payload = "https://evil.example.org' . file_put_contents('" . $marker . "', 'pwned') . '";
+
+        $objective = new IsolationObjective(true, $payload);
+        $value = $this->evaluateArtifact($objective->build());
+
+        // payload preserved verbatim, no code executed
+        $this->assertSame($payload, $value[IsolationConfig::KEY_CONTENT_DOMAIN]);
+        $this->assertFileDoesNotExist($marker);
+    }
+
+    private function environmentWithHttpPath(string $http_path): Environment
+    {
+        $ini = $this->createStub(\ilIniFile::class);
+        $ini->method('readVariable')->willReturn($http_path);
+
+        $env = $this->createStub(Environment::class);
+        $env->method('getResource')->willReturn($ini);
+
+        return $env;
+    }
+
+    /**
+     * Execute the serialized artefact exactly the way the runtime loads it
+     * (`include $path`) and return the produced array.
+     *
+     * @return array<string, mixed>
+     */
+    private function evaluateArtifact(Artifact $artifact): array
+    {
+        $file = tempnam(sys_get_temp_dir(), 'isolation_artifact_') . '.php';
+        file_put_contents($file, $artifact->serialize());
+
+        try {
+            $value = include $file;
+        } finally {
+            @unlink($file);
+        }
+
+        $this->assertIsArray($value);
+        return $value;
+    }
+}

--- a/components/ILIAS/Init/classes/class.ilInitialisation.php
+++ b/components/ILIAS/Init/classes/class.ilInitialisation.php
@@ -371,7 +371,8 @@ class ilInitialisation
                 $DIC->settings(),
                 $DIC['https'],
                 $DIC['ilIliasIniFile'],
-                $_SERVER
+                $_SERVER,
+                \ILIAS\FileDelivery\Isolation\IsolationConfig::fromArtefact()
             ))->build()->getBaseURI()
         );
     }

--- a/components/ILIAS/Init/src/Environment/HttpPathBuilder.php
+++ b/components/ILIAS/Init/src/Environment/HttpPathBuilder.php
@@ -20,6 +20,8 @@ declare(strict_types=1);
 
 namespace ILIAS\Init\Environment;
 
+use ILIAS\FileDelivery\Isolation\IsolationConfig;
+
 final class HttpPathBuilder
 {
     /**
@@ -30,7 +32,8 @@ final class HttpPathBuilder
         private readonly \ilSetting $settings,
         private readonly \ilHTTPS $https,
         private readonly \ilIniFile $ini,
-        private readonly array|\ArrayAccess $server_data
+        private readonly array|\ArrayAccess $server_data,
+        private readonly ?IsolationConfig $isolation = null,
     ) {
     }
 
@@ -99,6 +102,19 @@ final class HttpPathBuilder
 
         if (!\in_array($uri->getHost(), $allowed_hosts, true)) {
             throw new \RuntimeException('Request rejected, the given HTTP host is not in the "allowed_hosts" list');
+        }
+
+        // IRSS User Content Isolation: when active, the content domain is
+        // reserved for asset delivery via deliver.php and must not be used
+        // to access the regular ILIAS application.
+        if ($this->isolation !== null
+            && $this->isolation->isActivated()
+            && ($content_host = $this->isolation->getContentHost()) !== null
+            && strcasecmp($uri->getHost(), $content_host) === 0
+        ) {
+            throw new \RuntimeException(
+                'Request rejected, the configured content domain is reserved for asset delivery.'
+            );
         }
 
         return $uri;

--- a/components/ILIAS/Init/tests/HttpPathBuilderTest.php
+++ b/components/ILIAS/Init/tests/HttpPathBuilderTest.php
@@ -15,11 +15,12 @@
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-class HttpPathBuilderTest extends TestCase
+final class HttpPathBuilderTest extends TestCase
 {
     /**
      * @return Generator<string, array{
@@ -109,6 +110,71 @@ class HttpPathBuilderTest extends TestCase
         );
 
         $path_builder->build();
+    }
+
+    public function testContentDomainIsRejectedAsApplicationHostWhenIsolationActive(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('reserved for asset delivery');
+
+        $path_builder = new \ILIAS\Init\Environment\HttpPathBuilder(
+            new \ILIAS\Data\Factory(),
+            // content host added to allowed_hosts so we reach the isolation check
+            $this->getSettingsMock('https://app.ilias.de/soap/server.php?wsdl=1', 'content.ilias.de'),
+            $this->getHttpsMock(),
+            $this->getIniMock('https://app.ilias.de'),
+            [
+                'HTTP_HOST' => 'content.ilias.de',
+                'REQUEST_URI' => '/login.php',
+            ],
+            \ILIAS\FileDelivery\Isolation\IsolationConfig::fromArray([
+                \ILIAS\FileDelivery\Isolation\IsolationConfig::KEY_ACTIVATED => true,
+                \ILIAS\FileDelivery\Isolation\IsolationConfig::KEY_CONTENT_DOMAIN => 'https://content.ilias.de',
+                \ILIAS\FileDelivery\Isolation\IsolationConfig::KEY_ILIAS_DOMAIN => 'https://app.ilias.de',
+            ])
+        );
+
+        $path_builder->build();
+    }
+
+    public function testApplicationHostStillAllowedWhenIsolationActive(): void
+    {
+        $path_builder = new \ILIAS\Init\Environment\HttpPathBuilder(
+            new \ILIAS\Data\Factory(),
+            $this->getSettingsMock('https://app.ilias.de/soap/server.php?wsdl=1', ''),
+            $this->getHttpsMock(),
+            $this->getIniMock('https://app.ilias.de'),
+            [
+                'HTTP_HOST' => 'app.ilias.de',
+                'REQUEST_URI' => '/login.php',
+            ],
+            \ILIAS\FileDelivery\Isolation\IsolationConfig::fromArray([
+                \ILIAS\FileDelivery\Isolation\IsolationConfig::KEY_ACTIVATED => true,
+                \ILIAS\FileDelivery\Isolation\IsolationConfig::KEY_CONTENT_DOMAIN => 'https://content.ilias.de',
+                \ILIAS\FileDelivery\Isolation\IsolationConfig::KEY_ILIAS_DOMAIN => 'https://app.ilias.de',
+            ])
+        );
+
+        $this->assertSame('app.ilias.de', $path_builder->build()->getHost());
+    }
+
+    public function testContentDomainNotRejectedWhenIsolationInactive(): void
+    {
+        // isolation disabled -> the content host is treated like any other host;
+        // since it is in allowed_hosts here, build() must succeed
+        $path_builder = new \ILIAS\Init\Environment\HttpPathBuilder(
+            new \ILIAS\Data\Factory(),
+            $this->getSettingsMock('https://app.ilias.de/soap/server.php?wsdl=1', 'content.ilias.de'),
+            $this->getHttpsMock(),
+            $this->getIniMock('https://app.ilias.de'),
+            [
+                'HTTP_HOST' => 'content.ilias.de',
+                'REQUEST_URI' => '/login.php',
+            ],
+            \ILIAS\FileDelivery\Isolation\IsolationConfig::disabled()
+        );
+
+        $this->assertSame('content.ilias.de', $path_builder->build()->getHost());
     }
 
     private function getSettingsMock(

--- a/components/ILIAS/Setup/src/ImplementationOfAgentFinder.php
+++ b/components/ILIAS/Setup/src/ImplementationOfAgentFinder.php
@@ -72,10 +72,10 @@ class ImplementationOfAgentFinder implements AgentFinder
         $agents = new AgentCollection($this->refinery, []);
 
         foreach ($this->component_agents as $agent) {
-            $agents = $agents->withAdditionalAgent(
-                $this->getAgentNameByClassName(get_class($agent)),
-                $agent
-            );
+            $name = $agent instanceof NamedAgent
+                ? $agent->getAgentName()
+                : $this->getAgentNameByClassName(get_class($agent));
+            $agents = $agents->withAdditionalAgent($name, $agent);
         }
 
         $this->component_agents = $agents;

--- a/components/ILIAS/Setup/src/NamedAgent.php
+++ b/components/ILIAS/Setup/src/NamedAgent.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Setup;
+
+/**
+ * An agent that declares its own name in the agent collection.
+ *
+ * By default the agent finder derives an agent's name from its class name
+ * (legacy "ilXYZSetupAgent" => "xyz", or the full class name otherwise). A
+ * namespaced agent that wants a stable, semantic name — which is in particular
+ * the top-level key used for it in the setup config.json — implements this
+ * interface to override that derivation.
+ */
+interface NamedAgent extends Agent
+{
+    /**
+     * The name under which this agent is registered in the agent collection,
+     * and therefore the top-level key used for its configuration in config.json.
+     *
+     * Should be a short, lowercase, snake_case identifier (e.g. "content_isolation").
+     */
+    public function getAgentName(): string;
+}

--- a/components/ILIAS/Setup/tests/ImplementationOfAgentFinderTest.php
+++ b/components/ILIAS/Setup/tests/ImplementationOfAgentFinderTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Tests\Setup;
+
+use ILIAS\Setup\Agent;
+use ILIAS\Setup\NamedAgent;
+use ILIAS\Setup\ImplementationOfAgentFinder;
+use ILIAS\Setup\ImplementationOfInterfaceFinder;
+use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Language\Language;
+use PHPUnit\Framework\TestCase;
+
+class ImplementationOfAgentFinderTest extends TestCase
+{
+    private function finder(array $component_agents): ImplementationOfAgentFinder
+    {
+        $refinery = new Refinery(new DataFactory(), $this->createStub(Language::class));
+
+        return new ImplementationOfAgentFinder(
+            $refinery,
+            new DataFactory(),
+            $this->createStub(Language::class),
+            $this->createStub(ImplementationOfInterfaceFinder::class),
+            $component_agents
+        );
+    }
+
+    public function testNamedAgentIsKeyedByItsDeclaredName(): void
+    {
+        $named = $this->createStub(NamedAgent::class);
+        $named->method('getAgentName')->willReturn('content_isolation');
+
+        $collection = $this->finder([$named])->getComponentAgents();
+
+        $this->assertSame($named, $collection->getAgent('content_isolation'));
+    }
+
+    public function testPlainAgentFallsBackToClassNameKeying(): void
+    {
+        $plain = $this->createStub(Agent::class);
+
+        $collection = $this->finder([$plain])->getComponentAgents();
+
+        // no semantic name -> not reachable under one, but reachable by class name
+        $this->assertNull($collection->getAgent('content_isolation'));
+        $this->assertSame($plain, $collection->getAgent($plain::class));
+    }
+}

--- a/components/ILIAS/Test/tests/ilTestBaseTestCaseTrait.php
+++ b/components/ILIAS/Test/tests/ilTestBaseTestCaseTrait.php
@@ -441,20 +441,24 @@ trait ilTestBaseTestCaseTrait
         );
         $http_mock = $this->createMock(HTTPServices::class);
         $response_builder_mock = $this->createMock(\ILIAS\FileDelivery\Delivery\ResponseBuilder\ResponseBuilder::class);
+        $isolation = \ILIAS\FileDelivery\Isolation\IsolationConfig::disabled();
         return new \ILIAS\FileDelivery\Services(
             new ILIAS\FileDelivery\Delivery\StreamDelivery(
                 $data_signer,
                 $http_mock,
                 $response_builder_mock,
-                $response_builder_mock
+                $response_builder_mock,
+                $isolation
             ),
             new \ILIAS\FileDelivery\Delivery\LegacyDelivery(
                 $http_mock,
                 $response_builder_mock,
-                $response_builder_mock
+                $response_builder_mock,
+                $isolation
             ),
             $data_signer,
-            $http_mock
+            $http_mock,
+            $isolation
         );
     }
 

--- a/docs/configuration/secure.md
+++ b/docs/configuration/secure.md
@@ -23,6 +23,7 @@
     + [Deny Access to local Git-Directory](#deny-access-to-local-git-directory)
   * [Integrity check of ILIAS code in docroot](#integrity-check-of-ilias-code-in-docroot)
   * [Use WebAccessChecker](#use-webaccesschecker)
+  * [Serve user content from a separate domain (User Content Isolation)](#serve-user-content-from-a-separate-domain-user-content-isolation)
   * [Use secure passwords](#use-secure-passwords)
   * [Report security issues](#report-security-issues)
 
@@ -703,6 +704,14 @@ to
 ```
 %DOCROOT%/components/ILIAS/FileDelivery/classes/override.php
 ```
+
+## Serve user content from a separate domain (User Content Isolation)
+
+User-uploaded files (and derived files such as previews) can contain active markup (SVG, HTML, …). Serving them from the same origin as the application allows attacks such as stored XSS or canvas exfiltration against the logged-in session. ILIAS can therefore deliver all files stored in the Resource Storage Service from a dedicated, cookie-less **content domain**, while the application itself keeps running on the ILIAS domain.
+
+The content domain points at the *same* ILIAS installation — you only need an additional DNS record, a TLS certificate covering the extra host name and the host name added to your existing vhost. The isolation itself is enforced by ILIAS in PHP. The feature is configured through the Setup (`content_isolation` in `config.json`), it is deactivated by default.
+
+For the configuration, the guarantees ILIAS enforces and an example web server setup see the [FileDelivery documentation](../../components/ILIAS/FileDelivery/README.md#irss-user-content-isolation).
 
 ## Use secure passwords
 


### PR DESCRIPTION
Funded by Martin Luther University Halle-Wittenberg

Serve user-generated content from a separate content domain so that uploaded files can no longer run in the security context of the ILIAS host.

FileDelivery:
- IsolationConfig holds the activated flag, the content domain and the derived ILIAS domain; it is built from the isolation.php artefact and therefore needs no ini/DB access at runtime.
- BaseDelivery/StreamDelivery/LegacyDelivery emit the isolation headers and CORS allow-origin for the ILIAS domain; Services builds delivery URIs against the content domain.
- IsolationObjective derives the ILIAS domain from the installed http_path at build time and bakes it into the artefact. It declares ilHttpConfigStoredObjective as a precondition and throws an UnachievableException when the content domain equals the ILIAS host.
- FileDeliverySetupConfig accepts content_domain / ilias_domain as a bare host or a full http(s) origin.
- The stale tracked artefact src/artifacts/delivery_method.php is removed; the setup generates it into public/data.

Setup:
- New optional NamedAgent interface lets a namespaced agent declare its own name, i.e. the top-level key used for its configuration in config.json. The FileDelivery agent uses "content_isolation". ImplementationOfAgentFinder falls back to the previous class-name derivation, so existing agents are unaffected.

Documentation:
- FileDelivery README describes the setup including a web server vhost example; docs/configuration/secure.md links to it.