### PR TITLE
[FIX] #21693 changed the tab-context while removing calendar 

### DIFF
--- a/components/ILIAS/Calendar/classes/class.ilCalendarCategoryGUI.php
+++ b/components/ILIAS/Calendar/classes/class.ilCalendarCategoryGUI.php
@@ -129,6 +129,17 @@ class ilCalendarCategoryGUI
         return [];
     }
 
+    protected function initSelectedCategoryIdFromGet(): int
+    {
+        if ($this->http->wrapper()->query()->has('selected_cat_id')) {
+            return $this->http->wrapper()->query()->retrieve(
+                'selected_cat_id',
+                $this->refinery->kindlyTo()->int()
+            );
+        }
+        return 0;
+    }
+
     public function executeCommand(): void
     {
         $next_class = $this->ctrl->getNextClass($this);
@@ -334,15 +345,15 @@ class ilCalendarCategoryGUI
     protected function confirmDelete(): void
     {
         $cat_ids = $this->initSelectedCategoryIdsFromPost();
-        if (
-            !count($cat_ids) &&
-            $this->initCategoryIdFromQuery() > 0
-        ) {
-            $cat_ids = [$this->initCategoryIdFromQuery()];
+        $selected_cat_id = $this->initSelectedCategoryIdFromGet();
+
+        if (!count($cat_ids) && $selected_cat_id > 0) {
+            $cat_ids = [$selected_cat_id];
         }
         if (!count($cat_ids)) {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt('select_one'), true);
             $this->manage();
+            return;
         }
         $confirmation_gui = new ilConfirmationGUI();
         $confirmation_gui->setFormAction($this->ctrl->getFormAction($this));

--- a/components/ILIAS/Calendar/classes/class.ilCalendarManageTableGUI.php
+++ b/components/ILIAS/Calendar/classes/class.ilCalendarManageTableGUI.php
@@ -128,10 +128,14 @@ class ilCalendarManageTableGUI extends ilTable2GUI
                 $url
             );
         }
+        $this->ctrl->clearParameterByClass($this->getParentObject()::class, 'category_id');
 
         // delete
         if ($this->actions->checkDeleteCal($a_set['id'])) {
+            $this->ctrl->setParameter($this->getParentObject(), 'selected_cat_id', $a_set['id']);
             $url = $this->ctrl->getLinkTarget($this->getParentObject(), 'confirmDelete');
+            $this->ctrl->clearParameterByClass($this->getParentObject()::class, 'selected_cat_id');
+
             $dropDownItems[] = $this->ui_factory->button()->shy(
                 $this->lng->txt('delete'),
                 $url
@@ -141,8 +145,6 @@ class ilCalendarManageTableGUI extends ilTable2GUI
             $this->tpl->setVariable('VAL_ID', $a_set['id']);
             $this->tpl->parseCurrentBlock();
         }
-
-        $this->ctrl->setParameter($this->getParentObject(), 'category_id', '');
 
         switch ($a_set['type']) {
             case ilCalendarCategory::TYPE_GLOBAL:

--- a/components/ILIAS/Calendar/classes/class.ilCalendarPresentationGUI.php
+++ b/components/ILIAS/Calendar/classes/class.ilCalendarPresentationGUI.php
@@ -730,7 +730,7 @@ class ilCalendarPresentationGUI
 
             // delete action
             if ($this->actions->checkDeleteCal($this->category_id)) {
-                $ctrl->setParameterByClass("ilcalendarcategorygui", "category_id", $this->category_id);
+                $ctrl->setParameterByClass("ilcalendarcategorygui", "selected_cat_id", $this->category_id);
                 $dropDownItems[] = $this->ui_factory->button()->shy(
                     $this->lng->txt("cal_delete_cal"),
                     $ctrl->getLinkTargetByClass("ilcalendarcategorygui", "confirmDelete")


### PR DESCRIPTION
Bug ticket:  https://mantis.ilias.de/view.php?id=21693
Issue: the tab-context for delete confirmation changes from calendar management to calendar view while removing the calendar via drop down menu option.
Fixed the bug by using separate parameter for calendar id instead of category id as before.
Also fixed the possibility to access delete confirmation while trying to remove several calendars via remove button when no calendar checkbox is marked (0 calendars chosen).