### PR TITLE
[FIX] UI: remove unintended `Prompt\IsPromptContent`

### DIFF
--- a/components/ILIAS/UI/src/Component/Modal/RoundTrip.php
+++ b/components/ILIAS/UI/src/Component/Modal/RoundTrip.php
@@ -21,12 +21,12 @@ namespace ILIAS\UI\Component\Modal;
 use ILIAS\UI\Component\Button;
 use ILIAS\UI\Component\Component;
 use ILIAS\UI\Component\ReplaceSignal;
-use ILIAS\UI\Component\Input\Container\Form\Standard;
+use ILIAS\UI\Component\Input\Container\Container;
 
 /**
  * @package ILIAS\UI\Component\Modal
  */
-interface RoundTrip extends Modal, Standard
+interface RoundTrip extends Modal, Container
 {
     /**
      * Get the title of the modal
@@ -65,6 +65,11 @@ interface RoundTrip extends Modal, Standard
      * The closing button has "Cancel" by default
      */
     public function withCancelButtonLabel(string $label): RoundTrip;
+
+    /**
+     * Get a modal like this with the provided submit button string.
+     */
+    public function withSubmitLabel(string $label): self;
 
     /**
      * Get the signal to replace the content of this modal.

--- a/components/ILIAS/UI/src/Implementation/Component/Dropzone/File/File.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Dropzone/File/File.php
@@ -191,13 +191,6 @@ abstract class File implements FileDropzone
         return $this->modal->getReplaceSignal();
     }
 
-    public function withAdditionalFormAction(string $action, string $label): static
-    {
-        $clone = clone $this;
-        $clone->modal = $clone->modal->withAdditionalFormAction($action, $label);
-        return $clone;
-    }
-
     public function getPostURL(): string
     {
         return $this->modal->getPostURL();
@@ -230,7 +223,7 @@ abstract class File implements FileDropzone
     public function withInput(InputData $input_data): self
     {
         $clone = clone $this;
-        $clone->modal = $clone->modal->withInput($request);
+        $clone->modal = $clone->modal->withInput($input_data);
         return $clone;
     }
 
@@ -280,21 +273,5 @@ abstract class File implements FileDropzone
     public function withDedicatedName(string $dedicated_name): self
     {
         return $this;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function getPromptButtons(): array
-    {
-        return $this->buttons;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function getPromptTitle(): string
-    {
-        return $this->type;
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Modal/RoundTrip.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Modal/RoundTrip.php
@@ -216,13 +216,6 @@ class RoundTrip extends Modal implements M\RoundTrip
         return $this->form->getError();
     }
 
-    public function withAdditionalFormAction(string $action, string $label): static
-    {
-        $clone = clone $this;
-        $clone->form = $clone->form->withAdditionalFormAction($action, $label);
-        return $clone;
-    }
-
     /**
      * @inheritDoc
      */
@@ -260,21 +253,5 @@ class RoundTrip extends Modal implements M\RoundTrip
     public function withDedicatedName(string $dedicated_name): self
     {
         return $this;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function getPromptButtons(): array
-    {
-        return $this->buttons;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function getPromptTitle(): string
-    {
-        return $this->type;
     }
 }


### PR DESCRIPTION
Hi all,

The `Modal\Roundtrip` and `Dropzone\File` components inherited `Prompt\IsPromptContent` unintendedly by `Form\Standard`, which was parent class of both.

To remove these components from being valid prompt content, the inheritance was changed from `Input\Container\Form\Standard` to `Input\Container\Container`. To minimise breaking changes, the `withSubmitLabel()` was added to the `Modal\RoundTrip` explicitly. This path was chosen to omit the `Prompt\IsPromptContent` from being inherited, while still offering the data processing options of an input container, as I believe they were more widely used.

There are four usages of `Modal\RoundTrip` used as `Prompt\IsPromptContent` inside `ILIAS\MetaData\OERHarvester\ControlCenter\ControlCenterGUI`. @schmitz-ilias, how would you like to proceed?

Kind regards,
@thibsy 