### PR TITLE
fix: Adapt alt text at the course sessions

### DIFF
--- a/components/ILIAS/ILIASObject/classes/class.ilObjectListGUI.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObjectListGUI.php
@@ -380,6 +380,11 @@ class ilObjectListGUI
     {
         return $this->is_expanded;
     }
+
+    protected function getExpandAltTextKey(): string
+    {
+        return 'expand';
+    }
     /**
      * @param string	$field_index e.g. '[crs][34]'
      * @param string	$position_value	e.g. '2.0'
@@ -2632,7 +2637,7 @@ class ilObjectListGUI
                 $this->tpl->setVariable('EXP_HREF', $this->ctrl->getLinkTarget($this->container_obj, 'view', $this->getUniqueItemId(true)));
                 $this->ctrl->clearParameters($this->container_obj);
                 $this->tpl->setVariable('EXP_IMG', ilUtil::getImagePath('nav/tree_col.svg'));
-                $this->tpl->setVariable('EXP_ALT', $this->lng->txt($this->type === 'sess' ? 'open_link' : 'expand'));
+                $this->tpl->setVariable('EXP_ALT', $this->lng->txt($this->getExpandAltTextKey()));
             }
 
             $this->tpl->parseCurrentBlock();

--- a/components/ILIAS/ILIASObject/classes/class.ilObjectListGUI.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObjectListGUI.php
@@ -2632,7 +2632,7 @@ class ilObjectListGUI
                 $this->tpl->setVariable('EXP_HREF', $this->ctrl->getLinkTarget($this->container_obj, 'view', $this->getUniqueItemId(true)));
                 $this->ctrl->clearParameters($this->container_obj);
                 $this->tpl->setVariable('EXP_IMG', ilUtil::getImagePath('nav/tree_col.svg'));
-                $this->tpl->setVariable('EXP_ALT', $this->lng->txt('expand'));
+                $this->tpl->setVariable('EXP_ALT', $this->lng->txt($this->type === 'sess' ? 'open_link' : 'expand'));
             }
 
             $this->tpl->parseCurrentBlock();

--- a/components/ILIAS/Session/classes/class.ilObjSessionListGUI.php
+++ b/components/ILIAS/Session/classes/class.ilObjSessionListGUI.php
@@ -104,6 +104,11 @@ class ilObjSessionListGUI extends ilObjectListGUI
         return parent::checkCommandAccess($a_permission, $a_cmd, $a_ref_id, $a_type, $a_obj_id);
     }
 
+    protected function getExpandAltTextKey(): string
+    {
+        return 'open_link';
+    }
+
     public function getProperties(): array
     {
         $app_info = $this->getAppointmentInfo();

--- a/lang/ilias_ar.lang
+++ b/lang/ilias_ar.lang
@@ -5273,6 +5273,7 @@ common#:#online_time#:# (DD:HH:MM:SS) وقت التواجد
 common#:#only_active#:#Only Active###07 02 2020 new variable
 common#:#only_inactive#:#Only Inactive###07 02 2020 new variable
 common#:#open#:#Open###10 11 2018 new variable
+common#:#open_link#:#Open link###05 08 2026 new variable
 common#:#operation#:#عملية
 common#:#optimize#:#Optimize
 common#:#option#:#Option

--- a/lang/ilias_bg.lang
+++ b/lang/ilias_bg.lang
@@ -5273,6 +5273,7 @@ common#:#online_time#:#Time online (DD:HH:MM:SS)###25 02 2007 new variable
 common#:#only_active#:#Only Active###07 02 2020 new variable
 common#:#only_inactive#:#Only Inactive###07 02 2020 new variable
 common#:#open#:#Open###10 11 2018 new variable
+common#:#open_link#:#Open link###05 08 2026 new variable
 common#:#operation#:#Операция
 common#:#optimize#:#Оптимизиране
 common#:#option#:#Option###26 03 2010 new variable

--- a/lang/ilias_cs.lang
+++ b/lang/ilias_cs.lang
@@ -5273,6 +5273,7 @@ common#:#online_time#:#Čas připojení (DD:HH:MM:SS)
 common#:#only_active#:#Only Active
 common#:#only_inactive#:#Only Inactive
 common#:#open#:#Otevřít
+common#:#open_link#:#Open link###05 08 2026 new variable
 common#:#operation#:#Operace
 common#:#optimize#:#Optimalizovat
 common#:#option#:#Volba

--- a/lang/ilias_da.lang
+++ b/lang/ilias_da.lang
@@ -5273,6 +5273,7 @@ common#:#online_time#:#Time online (DD:HH:MM:SS)
 common#:#only_active#:#Only Active###07 02 2020 new variable
 common#:#only_inactive#:#Only Inactive###07 02 2020 new variable
 common#:#open#:#Open###10 11 2018 new variable
+common#:#open_link#:#Open link###05 08 2026 new variable
 common#:#operation#:#Operation
 common#:#optimize#:#Optimer
 common#:#option#:#Mulighed

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -5273,6 +5273,7 @@ common#:#online_time#:#Gesamtzeit Online (DD:HH:MM:SS)
 common#:#only_active#:#Nur aktive
 common#:#only_inactive#:#Nur inaktive
 common#:#open#:#Öffnen
+common#:#open_link#:#Link öffnen
 common#:#operation#:#Operation
 common#:#optimize#:#Optimieren
 common#:#option#:#Option

--- a/lang/ilias_el.lang
+++ b/lang/ilias_el.lang
@@ -5274,6 +5274,7 @@ common#:#online_time#:#Χρόνος σε σύνδεση (DD:HH:MM:SS)
 common#:#only_active#:#Only Active###07 02 2020 new variable
 common#:#only_inactive#:#Only Inactive###07 02 2020 new variable
 common#:#open#:#Open###10 11 2018 new variable
+common#:#open_link#:#Open link###05 08 2026 new variable
 common#:#operation#:#Λειτουργία
 common#:#optimize#:#Βελτιστοποίηση
 common#:#option#:#Option###26 03 2010 new variable

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -5274,6 +5274,7 @@ common#:#online_time#:#Time online (DD:HH:MM:SS)
 common#:#only_active#:#Only Active
 common#:#only_inactive#:#Only Inactive
 common#:#open#:#Open
+common#:#open_link#:#Open link
 common#:#operation#:#Operation
 common#:#optimize#:#Optimize
 common#:#option#:#Option

--- a/lang/ilias_es.lang
+++ b/lang/ilias_es.lang
@@ -5277,6 +5277,7 @@ common#:#online_time#:#Tiempo en línea (DD:HH:MM:SS)
 common#:#only_active#:#Solo activos
 common#:#only_inactive#:#Solo inactivos
 common#:#open#:#Abrir
+common#:#open_link#:#Abrir enlace
 common#:#operation#:#Operación
 common#:#optimize#:#Optimizar
 common#:#option#:#Opción

--- a/lang/ilias_et.lang
+++ b/lang/ilias_et.lang
@@ -5273,6 +5273,7 @@ common#:#online_time#:#Kasutamisaeg (PP:TT:MM:SS)
 common#:#only_active#:#Only Active###07 02 2020 new variable
 common#:#only_inactive#:#Only Inactive###07 02 2020 new variable
 common#:#open#:#Open###10 11 2018 new variable
+common#:#open_link#:#Open link###05 08 2026 new variable
 common#:#operation#:#Operation
 common#:#optimize#:#Optimeeri
 common#:#option#:#Valik

--- a/lang/ilias_fa.lang
+++ b/lang/ilias_fa.lang
@@ -5273,6 +5273,7 @@ common#:#online_time#:#زمان آنلاین (DD:HH:MM:SS)
 common#:#only_active#:#Only Active###07 02 2020 new variable
 common#:#only_inactive#:#Only Inactive###07 02 2020 new variable
 common#:#open#:#Open###10 11 2018 new variable
+common#:#open_link#:#Open link###05 08 2026 new variable
 common#:#operation#:#عملیات
 common#:#optimize#:#بهینه سازی
 common#:#option#:#گزینه

--- a/lang/ilias_fr.lang
+++ b/lang/ilias_fr.lang
@@ -5258,6 +5258,7 @@ common#:#online_time#:#Temps en-ligne (JJ:HH:MM:SS)
 common#:#only_active#:#Only Active
 common#:#only_inactive#:#Only Inactive
 common#:#open#:#Open
+common#:#open_link#:#Open link###05 08 2026 new variable
 common#:#operation#:#Opération
 common#:#optimize#:#Optimiser
 common#:#option#:#Option

--- a/lang/ilias_hr.lang
+++ b/lang/ilias_hr.lang
@@ -5273,6 +5273,7 @@ common#:#online_time#:#Ukupno vrijeme na mreži (online) (DD: SS: MM: SS)
 common#:#only_active#:#Samo aktivni
 common#:#only_inactive#:#Samo neaktivni
 common#:#open#:#Otvori
+common#:#open_link#:#Open link###05 08 2026 new variable
 common#:#operation#:#Operacija
 common#:#optimize#:#Optimiziraj
 common#:#option#:#Opcija

--- a/lang/ilias_hu.lang
+++ b/lang/ilias_hu.lang
@@ -5273,6 +5273,7 @@ common#:#online_time#:#Online töltött idő (NN:ÓÓ:PP:MM)
 common#:#only_active#:#Csak aktív
 common#:#only_inactive#:#Csak inaktív
 common#:#open#:#Kinyitni
+common#:#open_link#:#Link megnyitása
 common#:#operation#:#Művelet
 common#:#optimize#:#Optimalizálás
 common#:#option#:#Beállítás

--- a/lang/ilias_it.lang
+++ b/lang/ilias_it.lang
@@ -5272,6 +5272,7 @@ common#:#online_time#:#Tempo online (DD:HH:MM:SS)
 common#:#only_active#:#Solo attivo
 common#:#only_inactive#:#Solo inattivo
 common#:#open#:#Aperto
+common#:#open_link#:#Open link###05 08 2026 new variable
 common#:#operation#:#Operazione
 common#:#optimize#:#Ottimizza
 common#:#option#:#Opzioni

--- a/lang/ilias_ja.lang
+++ b/lang/ilias_ja.lang
@@ -5273,6 +5273,7 @@ common#:#online_time#:#オンライン時間(DD:HH:MM:SS)
 common#:#only_active#:#Only Active
 common#:#only_inactive#:#Only Inactive
 common#:#open#:#Open
+common#:#open_link#:#リンクを開く
 common#:#operation#:#操作
 common#:#optimize#:#最適化
 common#:#option#:#オプション

--- a/lang/ilias_ka.lang
+++ b/lang/ilias_ka.lang
@@ -5273,6 +5273,7 @@ common#:#online_time#:#MM
 common#:#only_active#:#Only Active###07 02 2020 new variable
 common#:#only_inactive#:#Only Inactive###07 02 2020 new variable
 common#:#open#:#Open###10 11 2018 new variable
+common#:#open_link#:#Open link###05 08 2026 new variable
 common#:#operation#:#ოპერაცია
 common#:#optimize#:#ოპტიმიზაცია
 common#:#option#:#არჩევა

--- a/lang/ilias_lt.lang
+++ b/lang/ilias_lt.lang
@@ -5273,6 +5273,7 @@ common#:#online_time#:#Laikas online (DD:HH:MM:SS)
 common#:#only_active#:#Only Active###07 02 2020 new variable
 common#:#only_inactive#:#Only Inactive###07 02 2020 new variable
 common#:#open#:#Open###10 11 2018 new variable
+common#:#open_link#:#Open link###05 08 2026 new variable
 common#:#operation#:#Operacija
 common#:#optimize#:#Optimizuoti
 common#:#option#:#Option###26 03 2010 new variable

--- a/lang/ilias_nl.lang
+++ b/lang/ilias_nl.lang
@@ -5273,6 +5273,7 @@ common#:#online_time#:#Tijd online (DD:UU:MM:SS)
 common#:#only_active#:#Only Active###07 02 2020 new variable
 common#:#only_inactive#:#Only Inactive###07 02 2020 new variable
 common#:#open#:#Open###10 11 2018 new variable
+common#:#open_link#:#Open link###05 08 2026 new variable
 common#:#operation#:#Operatie
 common#:#optimize#:#Optimaliseren
 common#:#option#:#Optie

--- a/lang/ilias_pl.lang
+++ b/lang/ilias_pl.lang
@@ -5273,6 +5273,7 @@ common#:#online_time#:#Czas online (DD:HH:MM:SS)
 common#:#only_active#:#Only Active###07 02 2020 new variable
 common#:#only_inactive#:#Only Inactive###07 02 2020 new variable
 common#:#open#:#Open
+common#:#open_link#:#Open link###05 08 2026 new variable
 common#:#operation#:#Operacja
 common#:#optimize#:#Optymalizuj
 common#:#option#:#Opcja

--- a/lang/ilias_pt.lang
+++ b/lang/ilias_pt.lang
@@ -5273,6 +5273,7 @@ common#:#online_time#:#Remetente
 common#:#only_active#:#Enviar mensagem
 common#:#only_inactive#:#Enviado
 common#:#open#:#Sequência
+common#:#open_link#:#Open link###05 08 2026 new variable
 common#:#operation#:#Sequências
 common#:#optimize#:#Servidor
 common#:#option#:#Opção

--- a/lang/ilias_ro.lang
+++ b/lang/ilias_ro.lang
@@ -5273,6 +5273,7 @@ common#:#online_time#:#Time online (DD:HH:MM:SS)###10 Jul 2006 new variable
 common#:#only_active#:#Only Active###07 02 2020 new variable
 common#:#only_inactive#:#Only Inactive###07 02 2020 new variable
 common#:#open#:#Open###10 11 2018 new variable
+common#:#open_link#:#Open link###05 08 2026 new variable
 common#:#operation#:#Operatie
 common#:#optimize#:#Optimizati
 common#:#option#:#Option###26 03 2010 new variable

--- a/lang/ilias_ru.lang
+++ b/lang/ilias_ru.lang
@@ -5273,6 +5273,7 @@ common#:#online_time#:#Время в сети (DD:HH:MM:SS)
 common#:#only_active#:#Only Active###07 02 2020 new variable
 common#:#only_inactive#:#Only Inactive###07 02 2020 new variable
 common#:#open#:#Open###10 11 2018 new variable
+common#:#open_link#:#Open link###05 08 2026 new variable
 common#:#operation#:#Операция
 common#:#optimize#:#Оптимизация
 common#:#option#:#Вариант

--- a/lang/ilias_sk.lang
+++ b/lang/ilias_sk.lang
@@ -5273,6 +5273,7 @@ common#:#online_time#:#Čas připojení (DD:HH:MM:SS)
 common#:#only_active#:#Only Active###07 02 2020 new variable
 common#:#only_inactive#:#Only Inactive###07 02 2020 new variable
 common#:#open#:#Open###10 11 2018 new variable
+common#:#open_link#:#Open link###05 08 2026 new variable
 common#:#operation#:#Operace
 common#:#optimize#:#Optimalizovat
 common#:#option#:#Volba

--- a/lang/ilias_sl.lang
+++ b/lang/ilias_sl.lang
@@ -5273,6 +5273,7 @@ common#:#online_time#:#Skupni čas na spletu (DD:UU:MM:SS)
 common#:#only_active#:#Samo aktivni
 common#:#only_inactive#:#Samo neaktivni
 common#:#open#:#Odpri
+common#:#open_link#:#Open link###05 08 2026 new variable
 common#:#operation#:#Operacija
 common#:#optimize#:#Optimiziraj
 common#:#option#:#Možnost

--- a/lang/ilias_sq.lang
+++ b/lang/ilias_sq.lang
@@ -5273,6 +5273,7 @@ common#:#online_time#:#Time online (DD:HH:MM:SS)###10 Jul 2006 new variable
 common#:#only_active#:#Only Active###07 02 2020 new variable
 common#:#only_inactive#:#Only Inactive###07 02 2020 new variable
 common#:#open#:#Open###10 11 2018 new variable
+common#:#open_link#:#Open link###05 08 2026 new variable
 common#:#operation#:#Operacion
 common#:#optimize#:#Optimizim
 common#:#option#:#Option###26 03 2010 new variable

--- a/lang/ilias_sr.lang
+++ b/lang/ilias_sr.lang
@@ -5273,6 +5273,7 @@ common#:#online_time#:#Time online (DD:HH:MM:SS)###10 Jul 2006 new variable
 common#:#only_active#:#Only Active###07 02 2020 new variable
 common#:#only_inactive#:#Only Inactive###07 02 2020 new variable
 common#:#open#:#Open###10 11 2018 new variable
+common#:#open_link#:#Open link###05 08 2026 new variable
 common#:#operation#:#Operacija
 common#:#optimize#:#poboljšanje programa
 common#:#option#:#Option###26 03 2010 new variable

--- a/lang/ilias_sv.lang
+++ b/lang/ilias_sv.lang
@@ -5273,6 +5273,7 @@ common#:#online_time#:#Total tid online (DD
 common#:#only_active#:#Endast aktiv
 common#:#only_inactive#:#Endast inaktiv
 common#:#open#:#Öppen
+common#:#open_link#:#Open link###05 08 2026 new variable
 common#:#operation#:#Operation
 common#:#optimize#:#Optimise
 common#:#option#:#Alternativ

--- a/lang/ilias_tr.lang
+++ b/lang/ilias_tr.lang
@@ -5273,6 +5273,7 @@ common#:#online_time#:#Çevrimiçi süre (DD: SS: DD: SS)
 common#:#only_active#:#Only Active###07 02 2020 new variable
 common#:#only_inactive#:#Only Inactive###07 02 2020 new variable
 common#:#open#:#Open###10 11 2018 new variable
+common#:#open_link#:#Open link###05 08 2026 new variable
 common#:#operation#:#Operasyon
 common#:#optimize#:#Optimize
 common#:#option#:#Seçenek

--- a/lang/ilias_uk.lang
+++ b/lang/ilias_uk.lang
@@ -5273,6 +5273,7 @@ common#:#online_time#:#Time online (DD:HH:MM:SS)###25 02 2007 new variable
 common#:#only_active#:#Only Active###07 02 2020 new variable
 common#:#only_inactive#:#Only Inactive###07 02 2020 new variable
 common#:#open#:#Open###10 11 2018 new variable
+common#:#open_link#:#Open link###05 08 2026 new variable
 common#:#operation#:#Операція
 common#:#optimize#:#Оптимізувати
 common#:#option#:#Option###26 03 2010 new variable

--- a/lang/ilias_vi.lang
+++ b/lang/ilias_vi.lang
@@ -5275,6 +5275,7 @@ common#:#online_time#:#Time online (DD:HH:MM:SS)###25 02 2007 new variable
 common#:#only_active#:#Only Active###07 02 2020 new variable
 common#:#only_inactive#:#Only Inactive###07 02 2020 new variable
 common#:#open#:#Open###10 11 2018 new variable
+common#:#open_link#:#Open link###05 08 2026 new variable
 common#:#operation#:#Thao tác
 common#:#optimize#:#Lạc quan
 common#:#option#:#Option###26 03 2010 new variable

--- a/lang/ilias_zh.lang
+++ b/lang/ilias_zh.lang
@@ -5272,6 +5272,7 @@ common#:#online_time#:#在线时间(DD:HH:MM:SS)
 common#:#only_active#:#Only Active###07 02 2020 new variable
 common#:#only_inactive#:#Only Inactive###07 02 2020 new variable
 common#:#open#:#Open###10 11 2018 new variable
+common#:#open_link#:#Open link###05 08 2026 new variable
 common#:#operation#:#操作
 common#:#optimize#:#优化
 common#:#option#:#选项


### PR DESCRIPTION
Hi everyone!

This PR addresses the following ticket: https://mantis.ilias.de/view.php?id=41480

I replaced the language variable used for the session button’s alt text with a new one and translated it into most of the languages supported by ILIAS.

Best,
Abraham