### PR TITLE
[FIX] Database: replace deprecated `PDO::ATTR_USE_BUFFERED_QUERY`

### DIFF
--- a/components/ILIAS/Database/classes/PDO/ilDBPdo.php
+++ b/components/ILIAS/Database/classes/PDO/ilDBPdo.php
@@ -102,7 +102,7 @@ class ilDBPdo implements Internal
     {
         return [
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-            PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true,
+            PDO\Mysql::ATTR_USE_BUFFERED_QUERY => true,
             PDO::ATTR_TIMEOUT => 300 * 60,
         ];
     }


### PR DESCRIPTION
Use `PDO\Mysql::ATTR_USE_BUFFERED_QUERY` instead, see https://www.php.net/manual/en/migration85.deprecated.php