### PR TITLE
Streamline Logging in a bunch of components

### DIFF
--- a/components/ILIAS/AccessControl/service.xml
+++ b/components/ILIAS/AccessControl/service.xml
@@ -17,9 +17,8 @@
 			checkbox="1" inherit="0" translate="0" rbac="0">
 		</object>
 	</objects>
-	<events>		
+	<events>
 		<event type="raise" id="assignUser" />
 		<event type="raise" id="deassignUser" />
 	</events>
-	<logging />
 </service>

--- a/components/ILIAS/Administration/classes/class.ilAdministrationGUI.php
+++ b/components/ILIAS/Administration/classes/class.ilAdministrationGUI.php
@@ -87,7 +87,7 @@ class ilAdministrationGUI implements ilCtrlBaseClassInterface
         global $DIC;
 
         $this->help = $DIC["ilHelp"];
-        $this->logger = $DIC->logger()->root();
+        $this->logger = $DIC->logger()->forComponent('adms');
         $this->lng = $DIC->language();
         $this->tpl = $DIC->ui()->mainTemplate();
         $this->tree = $DIC->repositoryTree();

--- a/components/ILIAS/Administration/service.xml
+++ b/components/ILIAS/Administration/service.xml
@@ -23,5 +23,4 @@
 			<parent id="adm" max="1">adm</parent>
 		</object>
 	</objects>
-	<logging />
 </service>

--- a/components/ILIAS/AdministrativeNotification/service.xml
+++ b/components/ILIAS/AdministrativeNotification/service.xml
@@ -1,7 +1,6 @@
 <?xml version = "1.0" encoding = "UTF-8"?>
 <service xmlns="http://www.w3.org" version="$Id$" id="adn">
 	<baseclasses />
-	<logging />
 	<objects>
 		<object id="adn" class_name="AdministrativeNotification" dir="classes" checkbox="0" inherit="0" translate="sys" rbac="1" system="1" administration="1">
 			<parent id="adm" max="1">adm</parent>

--- a/components/ILIAS/AdvancedMetaData/classes/class.ilAdvancedMDValues.php
+++ b/components/ILIAS/AdvancedMetaData/classes/class.ilAdvancedMDValues.php
@@ -426,9 +426,9 @@ class ilAdvancedMDValues
         }
 
         if (!$has_cloned) {
-            $ilLog->write(__METHOD__ . ': No advanced meta data found.');
+            $ilLog->info('No advanced meta data found.');
         } else {
-            $ilLog->write(__METHOD__ . ': Start cloning advanced meta data.');
+            $ilLog->info('Start cloning advanced meta data.');
         }
     }
 

--- a/components/ILIAS/AdvancedMetaData/service.xml
+++ b/components/ILIAS/AdvancedMetaData/service.xml
@@ -8,5 +8,4 @@
 	<pluginslots>
 		<pluginslot id="amdc" name="AdvancedMDClaiming" />
 	</pluginslots>
-	<logging/>
 </service>

--- a/components/ILIAS/AuthShibboleth/classes/class.ilShibbolethRoleAssignmentRules.php
+++ b/components/ILIAS/AuthShibboleth/classes/class.ilShibbolethRoleAssignmentRules.php
@@ -64,7 +64,7 @@ class ilShibbolethRoleAssignmentRules
         $db = $DIC->database();
         $rbac_admin = $DIC->rbac()->admin();
         $rbac_review = $DIC->rbac()->review();
-        $logger = $DIC->logger()->root();
+        $logger = $DIC->logger()->forComponent('shiba');
         $query = "SELECT rule_id,add_on_update,remove_on_update FROM shib_role_assignment " . "WHERE add_on_update = 1 OR remove_on_update = 1";
         $res = $db->query($query);
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
@@ -95,7 +95,7 @@ class ilShibbolethRoleAssignmentRules
         global $DIC;
         $db = $DIC->database();
         $rbac_admin = $DIC->rbac()->admin();
-        $logger = $DIC->logger()->root();
+        $logger = $DIC->logger()->forComponent('shiba');
         $query = "SELECT rule_id,add_on_update FROM shib_role_assignment WHERE add_on_update = 1";
         $num_matches = 0;
         $res = $db->query($query);

--- a/components/ILIAS/AuthShibboleth/classes/class.ilShibbolethRoleAssignmentRules.php
+++ b/components/ILIAS/AuthShibboleth/classes/class.ilShibbolethRoleAssignmentRules.php
@@ -71,11 +71,11 @@ class ilShibbolethRoleAssignmentRules
             $rule = new ilShibbolethRoleAssignmentRule($row->rule_id);
             //			$matches = $rule->matches($a_data);
             if ($row->add_on_update && $rule->doesMatch($a_data)) {
-                $logger->write(__METHOD__ . ': Assigned to role ' . ilObject::_lookupTitle($rule->getRoleId()));
+                $logger->info('Assigned to role ' . ilObject::_lookupTitle($rule->getRoleId()));
                 $rbac_admin->assignUser($rule->getRoleId(), $a_usr_id);
             }
             if ($row->remove_on_update && !$rule->doesMatch($a_data)) {
-                $logger->write(__METHOD__ . ': Deassigned from role ' . ilObject::_lookupTitle($rule->getRoleId()));
+                $logger->info('Deassigned from role ' . ilObject::_lookupTitle($rule->getRoleId()));
                 $rbac_admin->deassignUser($rule->getRoleId(), $a_usr_id);
             }
         }
@@ -83,7 +83,7 @@ class ilShibbolethRoleAssignmentRules
         if (!array_intersect($rbac_review->assignedRoles($a_usr_id), $rbac_review->getGlobalRoles())) {
             $settings = new ilShibbolethSettings();
             $default_role = $settings->getDefaultRole();
-            $logger->write(__METHOD__ . ': Assigned to default role ' . ilObject::_lookupTitle($default_role));
+            $logger->info('Assigned to default role ' . ilObject::_lookupTitle($default_role));
             $rbac_admin->assignUser($default_role, $a_usr_id);
         }
 
@@ -103,7 +103,7 @@ class ilShibbolethRoleAssignmentRules
             $rule = new ilShibbolethRoleAssignmentRule($row->rule_id);
             if ($rule->doesMatch($a_data)) {
                 $num_matches++;
-                $logger->write(__METHOD__ . ': Assigned to role ' . ilObject::_lookupTitle($rule->getRoleId()));
+                $logger->info(__METHOD__ . ': Assigned to role ' . ilObject::_lookupTitle($rule->getRoleId()));
                 $rbac_admin->assignUser($rule->getRoleId(), $a_usr_id);
             }
         }
@@ -111,7 +111,7 @@ class ilShibbolethRoleAssignmentRules
         if ($num_matches === 0) {
             $settings = new ilShibbolethSettings();
             $default_role = $settings->getDefaultRole();
-            $logger->write(__METHOD__ . ': Assigned to default role ' . ilObject::_lookupTitle($default_role));
+            $logger->info(__METHOD__ . ': Assigned to default role ' . ilObject::_lookupTitle($default_role));
             $rbac_admin->assignUser($default_role, $a_usr_id);
         }
 

--- a/components/ILIAS/Authentication/service.xml
+++ b/components/ILIAS/Authentication/service.xml
@@ -9,7 +9,7 @@
 			<parent id="adm" max="1">adm</parent>
 		</object>
 	</objects>
-	<events>		
+	<events>
 		<event type="raise" id="afterLogin" />
 		<event type="raise" id="beforeLogout" />
 		<event type="raise" id="afterLogout" />
@@ -22,7 +22,6 @@
 	<pluginslots>
 		<pluginslot id="authhk" name="AuthenticationHook" />
 	</pluginslots>
-	<logging />
 	<crons>
 		<cron id="auth_destroy_expired_sessions" class="ilAuthDestroyExpiredSessionsCron" />
 	</crons>

--- a/components/ILIAS/Awareness/service.xml
+++ b/components/ILIAS/Awareness/service.xml
@@ -10,5 +10,4 @@
 			<parent id="adm" max="1">adm</parent>
 		</object>
 	</objects>
-	<logging />
 </service>

--- a/components/ILIAS/BackgroundTasks/src/Dependencies/DependencyMap/BaseDependencyMap.php
+++ b/components/ILIAS/BackgroundTasks/src/Dependencies/DependencyMap/BaseDependencyMap.php
@@ -65,7 +65,7 @@ class BaseDependencyMap extends EmptyDependencyMap
             case \ilLoggerFactory::class:
                 return $DIC["ilLoggerFactory"];
             case \ilLogger::class:
-                return $DIC->logger()->root();
+                return $DIC->logger()->forComponent('bgtk');
             case \ilToolbarGUI::class:
                 return $DIC->toolbar();
             case \ilTabsGUI::class:

--- a/components/ILIAS/BackgroundTasks_/service.xml
+++ b/components/ILIAS/BackgroundTasks_/service.xml
@@ -7,6 +7,4 @@
 	<gsproviders>
 		<gsprovider class_name="ilBTGSProvider" purpose="meta_bar_static"/>
 	</gsproviders>
-
-	<logging />
 </service>

--- a/components/ILIAS/Badge/classes/class.ilBadge.php
+++ b/components/ILIAS/Badge/classes/class.ilBadge.php
@@ -51,7 +51,7 @@ class ilBadge
 
         $this->db = $container->database();
         $this->resource_storage = $container->resourceStorage();
-        $this->log = $container->logger()->root();
+        $this->log = $container->logger()->forComponent('badge');
         if ($a_id) {
             $this->read($a_id);
         }

--- a/components/ILIAS/Benchmark/service.xml
+++ b/components/ILIAS/Benchmark/service.xml
@@ -7,5 +7,4 @@
             <parent id="adm" max="1">adm</parent>
         </object>
     </objects>
-    <logging />
 </service>

--- a/components/ILIAS/BookingManager/module.xml
+++ b/components/ILIAS/BookingManager/module.xml
@@ -26,5 +26,4 @@
 		<cron id="book_notification" class="ilBookCronNotification" />
 		<cron id="book_pref_book" class="ilBookingPrefBookCron" />
 	</crons>
-	<logging />
 </module>

--- a/components/ILIAS/COPage/classes/class.ilPageQuestionProcessor.php
+++ b/components/ILIAS/COPage/classes/class.ilPageQuestionProcessor.php
@@ -37,14 +37,14 @@ class ilPageQuestionProcessor
         $ilUser = $DIC->user();
         $ilLog = $DIC["ilLog"];
         $ilDB = $DIC->database();
-        $ilLog->write($a_type);
-        $ilLog->write($a_id);
-        $ilLog->write($a_answer);
+        $ilLog->info($a_type);
+        $ilLog->info($a_id);
+        $ilLog->info($a_answer);
         $answer = json_decode($a_answer, false, 512, JSON_THROW_ON_ERROR);
         $passed = $answer->passed;
         $choice = $answer->choice ?? [];
         $points = self::calculatePoints($a_type, $a_id, $choice);
-        $ilLog->write("Points: " . $points);
+        $ilLog->info("Points: " . $points);
 
         $set = $ilDB->query(
             "SELECT * FROM page_qst_answer WHERE " .

--- a/components/ILIAS/COPage/service.xml
+++ b/components/ILIAS/COPage/service.xml
@@ -37,7 +37,6 @@
 		<pagecontent pc_type="map" name="Map" directory="PC/Map" int_links="0" style_classes="0" xsl="0" def_enabled="0" top_item="1" order_nr="280"/>
 		<pageobject parent_type="stys" class_name="ilPageLayoutPage" directory="Layout/classes"/>
 	</copage>
-	<logging />
 	<crons>
 		<cron id="copg_history_cleanup" class="ilCleanCOPageHistoryCronjob" path="Services/COPage/Cron" />
 	</crons>

--- a/components/ILIAS/Calendar/classes/iCal/class.ilICalParser.php
+++ b/components/ILIAS/Calendar/classes/iCal/class.ilICalParser.php
@@ -205,7 +205,7 @@ class ilICalParser
 
         // Return if there are no values
         if (!count($items)) {
-            $this->log->write(__METHOD__ . ': Cannot parse parameter: ' . $a_param_part . ', value: ' . $a_value_part);
+            $this->log->info('Cannot parse parameter: ' . $a_param_part . ', value: ' . $a_value_part);
             return;
         }
 

--- a/components/ILIAS/Calendar/service.xml
+++ b/components/ILIAS/Calendar/service.xml
@@ -9,7 +9,7 @@
 			<parent id="adm" max="1">adm</parent>
 		</object>
 	</objects>
-	<events>		
+	<events>
 		<event type="listen" id="components/ILIAS/Group" />
 		<event type="listen" id="components/ILIAS/Session" />
 		<event type="listen" id="components/ILIAS/Course" />
@@ -24,5 +24,4 @@
 		<pluginslot id="capm" name="AppointmentCustomModal" />
 		<pluginslot id="capg" name="AppointmentCustomGrid" />
 	</pluginslots>
-	<logging />
 </service>

--- a/components/ILIAS/Category/Export/class.ilCategoryExporter.php
+++ b/components/ILIAS/Category/Export/class.ilCategoryExporter.php
@@ -77,7 +77,7 @@ class ilCategoryExporter extends ilXmlExporter
         $category = ilObjectFactory::getInstanceByRefId($cat_ref_id, false);
 
         if (!$category instanceof ilObjCategory) {
-            $GLOBALS['ilLog']->write(__METHOD__ . $a_id . ' is not instance of type category!');
+            $GLOBALS['ilLog']->info($a_id . ' is not instance of type category!');
             return '';
         }
 

--- a/components/ILIAS/Category/Export/class.ilCategoryImporter.php
+++ b/components/ILIAS/Category/Export/class.ilCategoryImporter.php
@@ -60,7 +60,7 @@ class ilCategoryImporter extends ilXmlImporter
             $parser->startParsing();
             $a_mapping->addMapping('components/ILIAS/Category', 'cat', $a_id, (string) $this->category->getId());
         } catch (ilSaxParserException | Exception $e) {
-            $GLOBALS['ilLog']->write(__METHOD__ . ': Parsing failed with message, "' . $e->getMessage() . '".');
+            $GLOBALS['ilLog']->info('Parsing failed with message, "' . $e->getMessage() . '".');
         }
 
         foreach ($a_mapping->getMappingsOfEntity('components/ILIAS/Container', 'objs') as $old => $new) {

--- a/components/ILIAS/Category/module.xml
+++ b/components/ILIAS/Category/module.xml
@@ -15,8 +15,7 @@
 			<parent id="root">root</parent>
 		</object>
 	</objects>
-	<events>		
+	<events>
 		<event type="raise" id="delete" />
 	</events>
-	<logging/>
 </module>

--- a/components/ILIAS/Certificate/classes/class.ilObjCertificateSettingsGUI.php
+++ b/components/ILIAS/Certificate/classes/class.ilObjCertificateSettingsGUI.php
@@ -61,7 +61,7 @@ class ilObjCertificateSettingsGUI extends ilObjectGUI
 
         $this->httpState = $DIC->http();
         $this->upload = $DIC->upload();
-        $this->logger = $DIC->logger()->root();
+        $this->logger = $DIC->logger()->forComponent('cert');
         $this->type = 'cert';
         $this->lng->loadLanguageModule('certificate');
         $this->lng->loadLanguageModule('cert');

--- a/components/ILIAS/Certificate/service.xml
+++ b/components/ILIAS/Certificate/service.xml
@@ -17,5 +17,4 @@
 	<crons>
 		<cron id="certificate" class="ilCertificateCron" />
 	</crons>
-	<logging />
 </service>

--- a/components/ILIAS/Chatroom/classes/class.ilChatroomExporter.php
+++ b/components/ILIAS/Chatroom/classes/class.ilChatroomExporter.php
@@ -31,7 +31,7 @@ class ilChatroomExporter extends ilXmlExporter
     {
         $chat = ilObjectFactory::getInstanceByObjId((int) $a_id, false);
         if (!($chat instanceof ilObjChatroom)) {
-            $GLOBALS['DIC']->logger()->root()->warning(
+            $GLOBALS['DIC']->logger()->forComponent('chtr')->warning(
                 $a_id . ' is not id of chatroom instance. Skipped generation of export XML.'
             );
             return '';

--- a/components/ILIAS/Chatroom/module.xml
+++ b/components/ILIAS/Chatroom/module.xml
@@ -22,7 +22,6 @@
 	<events>
 		<event type="listen" id="components/ILIAS/User" />
 	</events>
-	<logging />
 	<web_access_checker>
 		<secure_path path="chatroom" checking-class="ilObjChatroomAccess" />
 	</web_access_checker>

--- a/components/ILIAS/CmiXapi/classes/Verification/class.ilCmiXapiVerificationTableGUI.php
+++ b/components/ILIAS/CmiXapi/classes/Verification/class.ilCmiXapiVerificationTableGUI.php
@@ -59,7 +59,7 @@ class ilCmiXapiVerificationTableGUI extends ilTable2GUI
 
         $userCertificateRepository = new ilUserCertificateRepository(
             $DIC->database(),
-            $DIC->logger()->root()
+            $DIC->logger()->forComponent('cmix')
         );
 
         $certificateArray = $userCertificateRepository->fetchActiveCertificatesByTypeForPresentation(

--- a/components/ILIAS/CmiXapi/classes/Verification/class.ilObjCmiXapiVerificationGUI.php
+++ b/components/ILIAS/CmiXapi/classes/Verification/class.ilObjCmiXapiVerificationGUI.php
@@ -63,7 +63,7 @@ class ilObjCmiXapiVerificationGUI extends ilObject2GUI
             $certificateVerificationFileService = new ilCertificateVerificationFileService(
                 $DIC->language(),
                 $DIC->database(),
-                $DIC->logger()->root(),
+                $DIC->logger()->forComponent('cmix'),
                 new ilCertificateVerificationClassMap()
             );
 

--- a/components/ILIAS/CmiXapi/classes/class.ilCmiXapiDataSet.php
+++ b/components/ILIAS/CmiXapi/classes/class.ilCmiXapiDataSet.php
@@ -164,7 +164,7 @@ class ilCmiXapiDataSet extends ilDataSet
         global $DIC;
         /** @var \ILIAS\DI\Container $DIC */
 
-        $GLOBALS["ilLog"]->write(json_encode($this->getTypes("cmix", "5.1.0"), JSON_PRETTY_PRINT));
+        $GLOBALS["ilLog"]->info(json_encode($this->getTypes("cmix", "5.1.0"), JSON_PRETTY_PRINT));
 
         $this->dircnt = 1;
 

--- a/components/ILIAS/CmiXapi/classes/class.ilCmiXapiSettingsGUI.php
+++ b/components/ILIAS/CmiXapi/classes/class.ilCmiXapiSettingsGUI.php
@@ -692,7 +692,7 @@ class ilCmiXapiSettingsGUI
 
         $repository = new ilUserCertificateRepository();
 
-        $certLogger = $this->dic->logger()->root();//->cert();
+        $certLogger = $this->dic->logger()->forComponent('cmix');//->cert();
         $pdfGenerator = new ilPdfGenerator($repository);
 
         $pdfAction = new ilCertificatePdfAction(

--- a/components/ILIAS/CmiXapi/module.xml
+++ b/components/ILIAS/CmiXapi/module.xml
@@ -37,7 +37,6 @@
 	</crons>
 	<copage />
 	<web_access_checker />
-	<logging />
 	<mailtemplates>
 		<context id="cmix_context_notification_mail" class="ilCmiXapiNotificationMailTemplateContext" />
 	</mailtemplates>

--- a/components/ILIAS/Contact/service.xml
+++ b/components/ILIAS/Contact/service.xml
@@ -14,5 +14,4 @@
 		<event type="raise" id="relationLinked" />
 		<event type="raise" id="relationUnlinked" />
 	</events>
-	<logging />
 </service>

--- a/components/ILIAS/Container/Export/class.ilContainerExporter.php
+++ b/components/ILIAS/Container/Export/class.ilContainerExporter.php
@@ -124,7 +124,7 @@ class ilContainerExporter extends ilXmlExporter
     {
         global $DIC;
 
-        $log = $DIC->logger()->root();
+        $log = $DIC->logger()->forComponent('exp');
         if ($a_entity === 'struct') {
             $log->debug(__METHOD__ . ': Received id = ' . $a_id);
             $ref_ids = ilObject::_getAllReferences((int) $a_id);

--- a/components/ILIAS/Container/StartObjects/Objects/class.ilContainerStartObjects.php
+++ b/components/ILIAS/Container/StartObjects/Objects/class.ilContainerStartObjects.php
@@ -239,7 +239,7 @@ class ilContainerStartObjects
         $ilObjDataCache = $this->obj_data_cache;
         $ilLog = $this->log;
 
-        $ilLog->write(__METHOD__ . ': Begin course start objects...');
+        $ilLog->info('Begin course start objects...');
 
         $new_obj_id = $ilObjDataCache->lookupObjId($a_target_id);
         $start = new self($a_target_id, $new_obj_id);
@@ -249,13 +249,13 @@ class ilContainerStartObjects
         foreach ($this->getStartObjects() as $data) {
             $item_ref_id = $data['item_ref_id'];
             if (isset($mappings[$item_ref_id]) && $mappings[$item_ref_id]) {
-                $ilLog->write(__METHOD__ . ': Clone start object nr. ' . $item_ref_id);
+                $ilLog->info('Clone start object nr. ' . $item_ref_id);
                 $start->add($mappings[$item_ref_id]);
             } else {
-                $ilLog->write(__METHOD__ . ': No mapping found for start object nr. ' . $item_ref_id);
+                $ilLog->info('No mapping found for start object nr. ' . $item_ref_id);
             }
         }
-        $ilLog->write(__METHOD__ . ': ... end course start objects');
+        $ilLog->info('... end course start objects');
     }
 
     public static function isStartObject(

--- a/components/ILIAS/Container/classes/class.ilContainer.php
+++ b/components/ILIAS/Container/classes/class.ilContainer.php
@@ -554,7 +554,7 @@ class ilContainer extends ilObject
         $soap_client->setResponseTimeout($soap_client->getResponseTimeout());
         $soap_client->enableWSDL(true);
 
-        $ilLog->write(__METHOD__ . ': Trying to call Soap client...');
+        $ilLog->info('Trying to call Soap client...');
         if ($soap_client->init()) {
             ilLoggerFactory::getLogger('obj')->info('Calling soap clone method');
             $res = $soap_client->call('ilClone', [$new_session_id . '::' . $client_id, $copy_id]);

--- a/components/ILIAS/Container/classes/class.ilContainerGUI.php
+++ b/components/ILIAS/Container/classes/class.ilContainerGUI.php
@@ -1383,7 +1383,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         }
 
         // log pasteObject call
-        $ilLog->write(__METHOD__ . ", cmd: " . $command);
+        $ilLog->info("cmd: " . $command);
 
         ////////////////////////////////////////////////////////
         // everything ok: now paste the objects to new location
@@ -1514,7 +1514,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                     // END PATCH ChangeEvent: Record link event.
                 }
 
-                $ilLog->write(__METHOD__ . ', link finished');
+                $ilLog->info('link finished');
             }
 
             $links = [];
@@ -1718,7 +1718,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         }
 
         // log pasteObject call
-        $ilLog->write("ilObjectGUI::pasteObject(), cmd: " . $this->clipboard->getCmd());
+        $ilLog->info("cmd: " . $this->clipboard->getCmd());
 
         ////////////////////////////////////////////////////////
         // everything ok: now paste the objects to new location
@@ -1743,7 +1743,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             }
             $ilCtrl->redirectByClass("ilobjectcopygui", "saveTarget");
 
-            $ilLog->write("ilObjectGUI::pasteObject(), copy finished");
+            $ilLog->info("copy finished");
         }
         // END WebDAV: Support a Copy command in the repository
 
@@ -1809,7 +1809,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                 // END PATCH ChangeEvent: Record link event.
             }
 
-            $ilLog->write("ilObjectGUI::pasteObject(), link finished");
+            $ilLog->info("link finished");
         } // END LINK
 
 
@@ -1844,8 +1844,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 
         // function should not be called if clipboard is empty
         if (!$this->clipboard->hasEntries()) {
-            $message = sprintf('%s::clipboardObject(): Illegal access. Clipboard variable is empty!', get_class($this));
-            $ilLog->write($message, $ilLog->FATAL);
+            $ilLog->fatal('Illegal access. Clipboard variable is empty!');
             $ilErr->raiseError($this->lng->txt("permission_denied"), $ilErr->WARNING);
         }
 

--- a/components/ILIAS/Container/service.xml
+++ b/components/ILIAS/Container/service.xml
@@ -5,7 +5,6 @@
 		<pageobject parent_type="cont" class_name="ilContainerPage" directory="Page"/>
 		<pageobject parent_type="cstr" class_name="ilContainerStartObjectsPage" directory="StartObjects"/>
 	</copage>
-	<logging />
 	<web_access_checker>
 		<secure_path path="container_data" checking-class="ilContainerAccess" />
 	</web_access_checker>

--- a/components/ILIAS/ContainerReference/classes/class.ilContainerReferenceAppEventListener.php
+++ b/components/ILIAS/ContainerReference/classes/class.ilContainerReferenceAppEventListener.php
@@ -38,7 +38,7 @@ class ilContainerReferenceAppEventListener implements ilAppEventListener
             case 'components/ILIAS/StudyProgramme':
                 switch ($a_event) {
                     case 'delete':
-                        $ilLog->write(__METHOD__ . ': Handling delete event.');
+                        $ilLog->info('Handling delete event.');
                         self::deleteReferences((int) $a_parameter['obj_id']);
                         break;
                 }
@@ -69,7 +69,7 @@ class ilContainerReferenceAppEventListener implements ilAppEventListener
                 case 'prgr':
                     $parent_id = $tree->getParentId($ref_id);
                     $instance->delete();
-                    $ilLog->write(__METHOD__ . ': Deleted reference object of type ' . $instance->getType() . ' with Id ' . $instance->getId());
+                    $ilLog->info('Deleted reference object of type ' . $instance->getType() . ' with Id ' . $instance->getId());
                     $ilAppEventHandler->raise(
                         'components/ILIAS/ContainerReference',
                         'deleteReference',
@@ -82,7 +82,7 @@ class ilContainerReferenceAppEventListener implements ilAppEventListener
                     break;
 
                 default:
-                    $ilLog->write(__METHOD__ . ': Unexpected object type ' . $instance->getType() . ' with Id ' . $instance->getId());
+                    $ilLog->info('Unexpected object type ' . $instance->getType() . ' with Id ' . $instance->getId());
                     break;
             }
         }

--- a/components/ILIAS/ContainerReference/classes/class.ilContainerReferenceExporter.php
+++ b/components/ILIAS/ContainerReference/classes/class.ilContainerReferenceExporter.php
@@ -29,7 +29,7 @@ abstract class ilContainerReferenceExporter extends ilXmlExporter
     {
         global $DIC;
 
-        $log = $DIC->logger()->root();
+        $log = $DIC->logger()->forComponent('cont');
 
         $eo = ilExportOptions::getInstance();
 
@@ -57,7 +57,7 @@ abstract class ilContainerReferenceExporter extends ilXmlExporter
     {
         global $DIC;
 
-        $log = $DIC->logger()->root();
+        $log = $DIC->logger()->forComponent('cont');
 
         $refs = ilObject::_getAllReferences((int) $a_id);
         $ref_ref_id = end($refs);

--- a/components/ILIAS/ContainerReference/classes/class.ilContainerReferenceImporter.php
+++ b/components/ILIAS/ContainerReference/classes/class.ilContainerReferenceImporter.php
@@ -59,7 +59,7 @@ abstract class ilContainerReferenceImporter extends ilXmlImporter
         global $DIC;
 
         $objDefinition = $DIC["objDefinition"];
-        $log = $DIC->logger()->root();
+        $log = $DIC->logger()->forComponent('cntr');
 
         if ($new_id = $a_mapping->getMapping('components/ILIAS/Container', 'objs', $a_id)) {
             $refs = ilObject::_getAllReferences((int) $new_id);

--- a/components/ILIAS/Course/classes/Objectives/class.ilCourseObjectivesGUI.php
+++ b/components/ILIAS/Course/classes/Objectives/class.ilCourseObjectivesGUI.php
@@ -1044,7 +1044,7 @@ class ilCourseObjectivesGUI
         $limit = 0;
 
         foreach ($tests as $test) {
-            $GLOBALS['DIC']['ilLog']->write(__METHOD__ . ': ' . print_r($test, true));
+            $GLOBALS['DIC']['ilLog']->info(print_r($test, true));
 
             $limit = $test['limit'];
 

--- a/components/ILIAS/Course/classes/Objectives/class.ilLOTestQuestionAdapter.php
+++ b/components/ILIAS/Course/classes/Objectives/class.ilLOTestQuestionAdapter.php
@@ -355,7 +355,7 @@ class ilLOTestQuestionAdapter
     {
         foreach ($this->run as $run) {
             if ($run->questionExists($qst->getId())) {
-                $GLOBALS['DIC']['ilLog']->write(__METHOD__ . ': reached points are ' . $qst->getReachedPoints(
+                $GLOBALS['DIC']['ilLog']->info('reached points are ' . $qst->getReachedPoints(
                     $session->getActiveId(),
                     $session->getPass()
                 ));

--- a/components/ILIAS/Course/classes/Verification/class.ilCourseVerificationTableGUI.php
+++ b/components/ILIAS/Course/classes/Verification/class.ilCourseVerificationTableGUI.php
@@ -39,7 +39,7 @@ class ilCourseVerificationTableGUI extends ilTable2GUI
 
         $this->dic = $DIC;
         $database = $DIC->database();
-        $logger = $DIC->logger()->root();
+        $logger = $DIC->logger()->forComponent('crs');
 
         if (null === $userCertificateRepository) {
             $userCertificateRepository = new ilUserCertificateRepository($database, $logger);

--- a/components/ILIAS/Course/classes/Verification/class.ilObjCourseVerificationGUI.php
+++ b/components/ILIAS/Course/classes/Verification/class.ilObjCourseVerificationGUI.php
@@ -69,7 +69,7 @@ class ilObjCourseVerificationGUI extends ilObject2GUI
             $certificateVerificationFileService = new ilCertificateVerificationFileService(
                 $this->dic->language(),
                 $this->dic->database(),
-                $this->dic->logger()->root(),
+                $this->dic->logger()->forComponent('crs'),
                 new ilCertificateVerificationClassMap()
             );
 

--- a/components/ILIAS/Course/classes/class.ilCourseXMLParser.php
+++ b/components/ILIAS/Course/classes/class.ilCourseXMLParser.php
@@ -101,7 +101,7 @@ class ilCourseXMLParser extends ilSaxParser implements ilSaxSubsetParser
         switch ($a_name) {
             case 'Course':
                 if (strlen($a_attribs['importId'] ?? '')) {
-                    $this->log->write("CourseXMLParser: importId = " . $a_attribs['importId']);
+                    $this->log->info("importId = " . $a_attribs['importId']);
                     $this->course_obj->setImportId($a_attribs['importId']);
                     ilObject::_writeImportId($this->course_obj->getId(), $a_attribs['importId']);
                 }
@@ -482,7 +482,7 @@ class ilCourseXMLParser extends ilSaxParser implements ilSaxSubsetParser
         switch ($a_name) {
             case 'Course':
 
-                $this->log->write('CourseXMLParser: import_id = ' . $this->course_obj->getImportId());
+                $this->log->info('import_id = ' . $this->course_obj->getImportId());
 
                 $this->course_obj->readContainerSettings();
                 // see #26169

--- a/components/ILIAS/Course/classes/class.ilFSStorageCourse.php
+++ b/components/ILIAS/Course/classes/class.ilFSStorageCourse.php
@@ -77,7 +77,7 @@ class ilFSStorageCourse extends ilFileSystemAbstractionStorage
     {
         $this->initMemberExportDirectory();
         if (!$this->writeToFile($a_data, $this->getMemberExportDirectory() . '/' . $a_rel_name)) {
-            $this->logger->write('Cannot write to file: ' . $this->getMemberExportDirectory() . '/' . $a_rel_name);
+            $this->logger->info('Cannot write to file: ' . $this->getMemberExportDirectory() . '/' . $a_rel_name);
             return false;
         }
 

--- a/components/ILIAS/Course/module.xml
+++ b/components/ILIAS/Course/module.xml
@@ -51,6 +51,5 @@
 		<context id="crs_context_tutor_manual" class="ilCourseMailTemplateTutorContext" />
 		<context id="crs_context_member_manual" class="ilCourseMailTemplateMemberContext" />
 	</mailtemplates>
-	<logging />
 	<badges />
 </module>

--- a/components/ILIAS/CourseReference/module.xml
+++ b/components/ILIAS/CourseReference/module.xml
@@ -17,5 +17,4 @@
 	<events>
 		<event type="listen" id="components/ILIAS/AccessControl" />
 	</events>
-	<logging />
 </module>

--- a/components/ILIAS/Cron/service.xml
+++ b/components/ILIAS/Cron/service.xml
@@ -12,5 +12,4 @@
 	<pluginslots>
 		<pluginslot id="crnhk" name="CronHook" />
 	</pluginslots>
-	<logging />
 </service>

--- a/components/ILIAS/DI/src/LoggingServices.php
+++ b/components/ILIAS/DI/src/LoggingServices.php
@@ -30,13 +30,9 @@ class LoggingServices
         $this->container = $container;
     }
 
-    /**
-     * Get interface to the global logger.
-     * @return \ilLogger
-     */
-    public function root()
+    public function forComponent(string $component_id): \ilLogger
     {
-        return $this->container["ilLoggerFactory"]->getRootLogger();
+        return $this->container["ilLoggerFactory"]->getComponentLogger($component_id);
     }
 
     /**

--- a/components/ILIAS/Dashboard/Block/classes/class.ilDashboardBlockGUI.php
+++ b/components/ILIAS/Dashboard/Block/classes/class.ilDashboardBlockGUI.php
@@ -57,7 +57,7 @@ abstract class ilDashboardBlockGUI extends ilBlockGUI implements ilDesktopItemHa
         global $DIC;
         $this->http = $DIC->http();
         $this->refinery = $DIC->refinery();
-        $this->logging = $DIC->logger()->root();
+        $this->logging = $DIC->logger()->forComponent('dash');
         $this->settings = $DIC->settings();
         $this->object_cache = $DIC['ilObjDataCache'];
         $this->tree = $DIC->repositoryTree();

--- a/components/ILIAS/DataCollection/classes/Content/class.ilDclContentExporter.php
+++ b/components/ILIAS/DataCollection/classes/Content/class.ilDclContentExporter.php
@@ -172,15 +172,15 @@ class ilDclContentExporter
         $soap_client->setResponseTimeout(5);
         $soap_client->enableWSDL(true);
 
-        $DIC->logger()->root()->info('Trying to call Soap client...');
+        $DIC->logger()->forComponent('dcl')->info('Trying to call Soap client...');
 
         array_unshift($soap_params, $new_session_id . '::' . $client_id);
 
         if ($soap_client->init()) {
-            $DIC->logger()->root()->info('Calling soap ' . $method . ' method with params ' . print_r($soap_params, true));
+            $DIC->logger()->forComponent('dcl')->info('Calling soap ' . $method . ' method with params ' . print_r($soap_params, true));
             $res = $soap_client->call($method, $soap_params);
         } else {
-            $DIC->logger()->root()->warning('SOAP clone call failed. Calling clone method manually');
+            $DIC->logger()->forComponent('dcl')->warning('SOAP clone call failed. Calling clone method manually');
             if (method_exists('ilSoapFunctions', $method)) {
                 $res = ilSoapFunctions::$method(
                     $new_session_id . '::' . $client_id,

--- a/components/ILIAS/DataCollection/classes/Content/class.ilDclContentExporter.php
+++ b/components/ILIAS/DataCollection/classes/Content/class.ilDclContentExporter.php
@@ -172,7 +172,7 @@ class ilDclContentExporter
         $soap_client->setResponseTimeout(5);
         $soap_client->enableWSDL(true);
 
-        $DIC->logger()->root()->write(__METHOD__ . ': Trying to call Soap client...');
+        $DIC->logger()->root()->info('Trying to call Soap client...');
 
         array_unshift($soap_params, $new_session_id . '::' . $client_id);
 

--- a/components/ILIAS/DataCollection/classes/Fields/Base/class.ilDclStandardField.php
+++ b/components/ILIAS/DataCollection/classes/Fields/Base/class.ilDclStandardField.php
@@ -35,7 +35,7 @@ class ilDclStandardField extends ilDclBaseFieldModel
         $ilLog = $DIC['ilLog'];
         $message = "Standard fields cannot be read from DB";
         $this->main_tpl->setOnScreenMessage('failure', $message);
-        $ilLog->write("[ilDclStandardField] " . $message);
+        $ilLog->info("[ilDclStandardField] " . $message);
     }
 
     public function doCreate(): void
@@ -44,7 +44,7 @@ class ilDclStandardField extends ilDclBaseFieldModel
         $ilLog = $DIC['ilLog'];
         $message = "Standard fields cannot be written to DB";
         $this->main_tpl->setOnScreenMessage('failure', $message);
-        $ilLog->write("[ilDclStandardField] " . $message);
+        $ilLog->info("[ilDclStandardField] " . $message);
     }
 
     public function doUpdate(): void

--- a/components/ILIAS/DataProtection/service.xml
+++ b/components/ILIAS/DataProtection/service.xml
@@ -7,5 +7,4 @@
       <parent id="adm" max="1">adm</parent>
     </object>
   </objects>
-  <logging />
 </service>

--- a/components/ILIAS/Database/classes/ilDBGenerator.php
+++ b/components/ILIAS/Database/classes/ilDBGenerator.php
@@ -488,7 +488,7 @@ class ilDBGenerator
     public function buildInsertStatement(string $a_table, string $a_basedir): bool
     {
         global $DIC;
-        $ilLogger = $DIC->logger()->root();
+        $ilLogger = $DIC->logger()->forComponent('db');
 
         $ilLogger->log('Starting export of:' . $a_table);
 
@@ -581,7 +581,7 @@ class ilDBGenerator
     protected function shortenText(string $table, string $field, string $a_value, int $a_size): string
     {
         global $DIC;
-        $ilLogger = $DIC->logger()->root();
+        $ilLogger = $DIC->logger()->forComponent('db');
 
         if ($this->getTargetEncoding() === 'UTF-8') {
             return $a_value;

--- a/components/ILIAS/Database/service.xml
+++ b/components/ILIAS/Database/service.xml
@@ -1,4 +1,3 @@
 <?xml version = "1.0" encoding = "UTF-8"?>
-<service xmlns="http://www.w3.org" version="$Id$" id="db">	
-	<logging />
+<service xmlns="http://www.w3.org" version="$Id$" id="db">
 </service>

--- a/components/ILIAS/DidacticTemplate/service.xml
+++ b/components/ILIAS/DidacticTemplate/service.xml
@@ -6,5 +6,4 @@
             <parent id="adm" max="1">adm</parent>
         </object>
     </objects>
-    <logging/>
 </service>

--- a/components/ILIAS/EventHandling/service.xml
+++ b/components/ILIAS/EventHandling/service.xml
@@ -8,7 +8,6 @@
 	<pluginslots>
 		<pluginslot id="evhk" name="EventHook" />
 	</pluginslots>
-	<logging />
 	<events>
 		<event type="listen" id="components/ILIAS/EventHandling" />
 	</events>

--- a/components/ILIAS/Exercise/classes/class.ilExerciseVerificationTableGUI.php
+++ b/components/ILIAS/Exercise/classes/class.ilExerciseVerificationTableGUI.php
@@ -37,7 +37,7 @@ class ilExerciseVerificationTableGUI extends ilTable2GUI
 
         $this->user = $DIC->user();
         $database = $DIC->database();
-        $logger = $DIC->logger()->root();
+        $logger = $DIC->logger()->forComponent('exc');
         $ilCtrl = $DIC->ctrl();
 
         if (null === $userCertificateRepository) {

--- a/components/ILIAS/Exercise/classes/class.ilObjExerciseGUI.php
+++ b/components/ILIAS/Exercise/classes/class.ilObjExerciseGUI.php
@@ -1000,7 +1000,7 @@ class ilObjExerciseGUI extends ilObjectGUI
         global $DIC;
 
         $database = $DIC->database();
-        $logger = $DIC->logger()->root();
+        $logger = $DIC->logger()->forComponent('exc');
 
         $ilUser = $this->user;
 

--- a/components/ILIAS/Exercise/classes/class.ilObjExerciseVerificationGUI.php
+++ b/components/ILIAS/Exercise/classes/class.ilObjExerciseVerificationGUI.php
@@ -60,7 +60,7 @@ class ilObjExerciseVerificationGUI extends ilObject2GUI
             $certificateVerificationFileService = new ilCertificateVerificationFileService(
                 $DIC->language(),
                 $DIC->database(),
-                $DIC->logger()->root(),
+                $DIC->logger()->forComponent('exc'),
                 new ilCertificateVerificationClassMap()
             );
 

--- a/components/ILIAS/Exercise/module.xml
+++ b/components/ILIAS/Exercise/module.xml
@@ -34,15 +34,14 @@
 		<context id="exc_context_grade_rmd" class="ilExcMailTemplateGradeReminderContext" />
 		<context id="exc_context_peer_rmd" class="ilExcMailTemplatePeerReminderContext" />
 	</mailtemplates>
-	<events>				
+	<events>
 		<event type="raise" id="createAssignment" />
 		<event type="raise" id="updateAssignment" />
-		<event type="raise" id="deleteAssignment" />		
+		<event type="raise" id="deleteAssignment" />
 		<event type="raise" id="delete" />
 		<event type="listen" id="Services/User" />
 	</events>
 	<web_access_checker>
 		<secure_path path="ilExercise" checking-class="ilObjExerciseAccess" />
 	</web_access_checker>
-	<logging />
 </module>

--- a/components/ILIAS/Export/classes/ImportHandler/Factory.php
+++ b/components/ILIAS/Export/classes/ImportHandler/Factory.php
@@ -50,7 +50,7 @@ class Factory implements ImportHandlerFactoryInterface
     public function __construct()
     {
         global $DIC;
-        $this->logger = $DIC->logger()->root();
+        $this->logger = $DIC->logger()->forComponent('exp');
         $this->lng = $DIC->language();
         $this->lng->loadLanguageModule("exp");
         $this->import_status_factory = new ImportStatusFactory();

--- a/components/ILIAS/Export/service.xml
+++ b/components/ILIAS/Export/service.xml
@@ -1,5 +1,4 @@
 <?xml version = "1.0" encoding = "UTF-8"?>
 <service xmlns="http://www.w3.org" version="$Id$"
 		 id="exp">
-	<logging />
 </service>

--- a/components/ILIAS/File/classes/class.ilFileXMLParser.php
+++ b/components/ILIAS/File/classes/class.ilFileXMLParser.php
@@ -205,7 +205,7 @@ class ilFileXMLParser extends ilSaxParser
     {
         $this->cdata = trim($this->cdata ?? '');
 
-        $GLOBALS['DIC']['ilLog']->write(__METHOD__ . ': ' . $this->cdata);
+        $GLOBALS['DIC']['ilLog']->info($this->cdata);
 
         switch ($a_name) {
             case 'File':

--- a/components/ILIAS/File/module.xml
+++ b/components/ILIAS/File/module.xml
@@ -24,7 +24,6 @@
             <parent id="adm" max="1">adm</parent>
         </object>
     </objects>
-    <logging/>
 
     <web_access_checker>
         <secure_path path="previews" checking-class="ilObjFileAccess" in-sec-folder='0'/>

--- a/components/ILIAS/FileServices/service.xml
+++ b/components/ILIAS/FileServices/service.xml
@@ -1,7 +1,6 @@
 <?xml version = "1.0" encoding = "UTF-8"?>
 <service xmlns="http://www.w3.org" version="$Id$" id="fils">
 	<baseclasses />
-	<logging />
 	<objects>
 		<object id="fils" class_name="FileServices" dir="classes" checkbox="0" inherit="0" translate="sys" rbac="1" system="1" administration="1">
 			<parent id="adm" max="1">adm</parent>

--- a/components/ILIAS/Filesystem/classes/class.ilFileSystemCleanTempDirCron.php
+++ b/components/ILIAS/Filesystem/classes/class.ilFileSystemCleanTempDirCron.php
@@ -52,7 +52,7 @@ class ilFileSystemCleanTempDirCron extends CronJob
             $this->filesystem = $DIC->filesystem()->temp();
         }
         if ($DIC->offsetExists('ilLoggerFactory')) {
-            $this->logger = $DIC->logger()->root();
+            $this->logger = $DIC->logger()->forComponent('filesys');
         }
     }
 

--- a/components/ILIAS/Folder/classes/class.ilFolderExporter.php
+++ b/components/ILIAS/Folder/classes/class.ilFolderExporter.php
@@ -49,7 +49,7 @@ class ilFolderExporter extends ilXmlExporter
             $writer->write();
             return $writer->xmlDumpMem(false);
         } catch (UnexpectedValueException $e) {
-            $GLOBALS['ilLog']->write("Caught error: " . $e->getMessage());
+            $GLOBALS['ilLog']->info("Caught error: " . $e->getMessage());
             return '';
         }
     }

--- a/components/ILIAS/Folder/classes/class.ilFolderImporter.php
+++ b/components/ILIAS/Folder/classes/class.ilFolderImporter.php
@@ -48,7 +48,7 @@ class ilFolderImporter extends ilXmlImporter
             $parser->start();
             $a_mapping->addMapping('components/ILIAS/Folder', 'fold', $a_id, (string) $this->folder->getId());
         } catch (ilSaxParserException $e) {
-            $GLOBALS['ilLog']->write(__METHOD__ . ': Parsing failed with message, "' . $e->getMessage() . '".');
+            $GLOBALS['ilLog']->info(__METHOD__ . ': Parsing failed with message, "' . $e->getMessage() . '".');
         }
     }
 }

--- a/components/ILIAS/Folder/classes/class.ilFolderXmlParser.php
+++ b/components/ILIAS/Folder/classes/class.ilFolderXmlParser.php
@@ -92,7 +92,7 @@ class ilFolderXmlParser extends ilContainerBaseXmlParser
      */
     public function handlerEndTag($a_xml_parser, string $a_name): void
     {
-        $GLOBALS['ilLog']->write(__METHOD__ . ': Called ' . $a_name);
+        $GLOBALS['ilLog']->info(__METHOD__ . ': Called ' . $a_name);
 
         switch ($a_name) {
             case 'Folder':

--- a/components/ILIAS/Forum/classes/class.ilObjForum.php
+++ b/components/ILIAS/Forum/classes/class.ilObjForum.php
@@ -473,7 +473,7 @@ class ilObjForum extends ilObject
             0 === $this->getRefId() ||
             0 === $new_obj->getRefId()
         ) {
-            $this->logger->write(__METHOD__ . ' : Error cloning auto generated role: il_frm_moderator');
+            $this->logger->info('Error cloning auto generated role: il_frm_moderator');
         }
 
         $this->rbac->admin()->copyRolePermissions(
@@ -484,7 +484,7 @@ class ilObjForum extends ilObject
             true
         );
 
-        $this->logger->write(__METHOD__ . ' : Finished copying of role il_frm_moderator.');
+        $this->logger->info('Finished copying of role il_frm_moderator.');
 
         $moderators = new ilForumModerators($this->getRefId());
         $src_moderator_usr_ids = $moderators->getCurrentModerators();

--- a/components/ILIAS/Forum/classes/class.ilObjForum.php
+++ b/components/ILIAS/Forum/classes/class.ilObjForum.php
@@ -46,7 +46,7 @@ class ilObjForum extends ilObject
         parent::__construct($a_id, $a_call_by_reference);
 
         $this->rbac = $DIC->rbac();
-        $this->logger = $DIC->logger()->root();
+        $this->logger = $DIC->logger()->forComponent('frm');
 
         $this->settings = $DIC->settings();
         $this->Forum = new ilForum();

--- a/components/ILIAS/Forum/module.xml
+++ b/components/ILIAS/Forum/module.xml
@@ -18,7 +18,7 @@
 			<parent id="adm" max="1">adm</parent>
 		</object>
 	</objects>
-	<events>		
+	<events>
 		<event type="listen" id="components/ILIAS/News" />
 		<event type="listen" id="components/ILIAS/Course" />
 		<event type="listen" id="components/ILIAS/Group" />
@@ -32,10 +32,9 @@
 		<event type="raise" id="mergedThreads" />
 		<event type="raise" id="movedThreads" />
 	</events>
-	<crons>		
+	<crons>
 		<cron id="frm_notification" class="ilForumCronNotification" />
 	</crons>
-	<logging />
 	<gsproviders>
 		<gsprovider purpose="tools" class_name="ilForumGlobalScreenToolsProvider" />
 	</gsproviders>

--- a/components/ILIAS/GlobalScreen/service.xml
+++ b/components/ILIAS/GlobalScreen/service.xml
@@ -8,5 +8,4 @@
             <parent id="adm" max="1">adm</parent>
         </object>
     </objects>
-    <logging/>
 </service>

--- a/components/ILIAS/Glossary/Export/class.ilGlossaryImporter.php
+++ b/components/ILIAS/Glossary/Export/class.ilGlossaryImporter.php
@@ -47,7 +47,7 @@ class ilGlossaryImporter extends ilXmlImporter
             // in the new version (5.1)  we are also here, but the following file should not exist
             // if being exported with 5.1 or higher
             $xml_file = $this->getImportDirectory() . '/' . basename($this->getImportDirectory()) . '.xml';
-            $GLOBALS['ilLog']->write(__METHOD__ . ': Using XML file ' . $xml_file);
+            $GLOBALS['ilLog']->info('Using XML file ' . $xml_file);
 
             // old school import
             if (file_exists($xml_file)) {

--- a/components/ILIAS/Glossary/module.xml
+++ b/components/ILIAS/Glossary/module.xml
@@ -23,7 +23,6 @@
 	<copage>
 		<pageobject parent_type="term" class_name="ilGlossaryDefPage" directory="classes"/>
 	</copage>
-	<logging />
 	<events>
 		<event type="listen" id="components/ILIAS/ILIASObject" />
 		<event type="raise" id="deleteTerm" />

--- a/components/ILIAS/Group/classes/class.ilGroupParticipantsTableGUI.php
+++ b/components/ILIAS/Group/classes/class.ilGroupParticipantsTableGUI.php
@@ -352,8 +352,6 @@ class ilGroupParticipantsTableGUI extends ilParticipantTableGUI
 
         // Custom user data fields
         if ($udf_ids) {
-            global $DIC;
-            $DIC->logger()->root()->dump($filtered_user_ids);
             $a_user_data = array_reduce(
                 iterator_to_array($this->profile->getDataForMultiple($filtered_user_ids)),
                 function (array $c, ProfileData $v) use ($udf_ids): array {

--- a/components/ILIAS/Group/module.xml
+++ b/components/ILIAS/Group/module.xml
@@ -23,7 +23,7 @@
 			<parent id="adm" max="1">adm</parent>
 		</object>
 	</objects>
-	<events>	
+	<events>
 		<event type="listen" id="components/ILIAS/AccessControl" />
 		<event type="raise" id="create" />
 		<event type="raise" id="update" />
@@ -33,5 +33,4 @@
 		<event type="raise" id="addToWaitingList" />
 		<event type="raise" id="addSubscriber" />
 	</events>
-	<logging id="grp" />
 </module>

--- a/components/ILIAS/ILIASObject/classes/class.ilObject.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObject.php
@@ -244,7 +244,7 @@ class ilObject
                 $obj["type"]
             );
 
-            $this->log->write($message);
+            $this->log->info($message);
             throw new ilObjectTypeMismatchException($message);
         }
 
@@ -558,7 +558,7 @@ class ilObject
             $this->error->raiseError($message, $this->error->WARNING);
         }
 
-        $this->log->write("ilObject::create(), start");
+        $this->log->info("start");
 
         // determine owner
         $owner = 0;
@@ -620,9 +620,9 @@ class ilObject
         $this->setOwner($owner);
 
         // write log entry
-        $this->log->write(
+        $this->log->info(
             sprintf(
-                "ilObject::create(), finished, obj_id: %s, type: %s, title: %s",
+                "finished, obj_id: %s, type: %s, title: %s",
                 $this->getId(),
                 $this->getType(),
                 $this->getTitle()
@@ -1189,7 +1189,7 @@ class ilObject
         $this->handleAutoRating();
 
         $log_entry = sprintf(
-            "ilObject::putInTree(), parent_ref: %s, ref_id: %s, obj_id: %s, type: %s, title: %s",
+            "parent_ref: %s, ref_id: %s, obj_id: %s, type: %s, title: %s",
             $parent_ref_id,
             $this->getRefId(),
             $this->getId(),
@@ -1197,7 +1197,7 @@ class ilObject
             $this->getTitle()
         );
 
-        $this->log->write($log_entry);
+        $this->log->info($log_entry);
 
         $this->app_event_handler->raise(
             'components/ILIAS/ILIASObject',
@@ -1307,13 +1307,13 @@ class ilObject
             $type = ilObject::_lookupType($this->getId());
             if ($this->type != $type) {
                 $log_entry = sprintf(
-                    "ilObject::delete(): Type mismatch. Object with obj_id: %s was instantiated by type '%s'. DB type is: %s",
+                    "Type mismatch. Object with obj_id: %s was instantiated by type '%s'. DB type is: %s",
                     $this->id,
                     $this->type,
                     $type
                 );
 
-                $this->log->write($log_entry);
+                $this->log->info($log_entry);
                 $this->error->raiseError(
                     sprintf("ilObject::delete(): Type mismatch. (%s/%s)", $this->type, $this->id),
                     $this->error->WARNING
@@ -1336,9 +1336,9 @@ class ilObject
             ;
             $this->db->manipulate($sql);
 
-            $this->log->write(
+            $this->log->info(
                 sprintf(
-                    "ilObject::delete(), deleted object, obj_id: %s, type: %s, title: %s",
+                    "deleted object, obj_id: %s, type: %s, title: %s",
                     $this->getId(),
                     $this->getType(),
                     $this->getTitle()
@@ -1369,9 +1369,9 @@ class ilObject
 
             $remove = true;
         } else {
-            $this->log->write(
+            $this->log->info(
                 sprintf(
-                    "ilObject::delete(), object not deleted, number of references: %s, obj_id: %s, type: %s, title: %s",
+                    "object not deleted, number of references: %s, obj_id: %s, type: %s, title: %s",
                     $this->countReferences(),
                     $this->getId(),
                     $this->getType(),
@@ -1392,9 +1392,9 @@ class ilObject
             ;
             $this->db->manipulate($sql);
 
-            $this->log->write(
+            $this->log->info(
                 sprintf(
-                    "ilObject::delete(), reference deleted, ref_id: %s, obj_id: %s, type: %s, title: %s",
+                    "reference deleted, ref_id: %s, obj_id: %s, type: %s, title: %s",
                     $this->getRefId(),
                     $this->getId(),
                     $this->getType(),

--- a/components/ILIAS/ILIASObject/classes/class.ilObjectActivation.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObjectActivation.php
@@ -421,17 +421,17 @@ class ilObjectActivation
 
         $ilLog = $DIC["ilLog"];
 
-        $ilLog->write(__METHOD__ . ': Begin course items...' . $ref_id);
+        $ilLog->info('Begin course items...' . $ref_id);
 
         $items = self::getItems($ref_id, false);
         if (!$items) {
-            $ilLog->write(__METHOD__ . ': No course items found.');
+            $ilLog->info('No course items found.');
             return;
         }
 
         // new course item object
         if (!is_object(ilObjectFactory::getInstanceByRefId($target_id, false))) {
-            $ilLog->write(__METHOD__ . ': Cannot create target object.');
+            $ilLog->info('Cannot create target object.');
             return;
         }
 
@@ -440,11 +440,11 @@ class ilObjectActivation
 
         foreach ($items as $item) {
             if (!isset($mappings[$item['parent_id']]) or !$mappings[$item['parent_id']]) {
-                $ilLog->write(__METHOD__ . ': No mapping for parent nr. ' . $item['parent_id']);
+                $ilLog->info('No mapping for parent nr. ' . $item['parent_id']);
                 continue;
             }
             if (!isset($mappings[$item['obj_id']]) or !$mappings[$item['obj_id']]) {
-                $ilLog->write(__METHOD__ . ': No mapping for item nr. ' . $item['obj_id']);
+                $ilLog->info('No mapping for item nr. ' . $item['obj_id']);
                 continue;
             }
             $new_item_id = $mappings[$item['obj_id']];

--- a/components/ILIAS/ILIASObject/service.xml
+++ b/components/ILIAS/ILIASObject/service.xml
@@ -17,7 +17,6 @@
 		<event type="raise" id="undelete" />
 		<event type="listen" id="components/ILIAS/ILIASObject" />
 	</events>
-	<logging />
 	<web_access_checker>
 		<secure_path path="custom_icons" checking-class="ilObjectAccess" />
 	</web_access_checker>

--- a/components/ILIAS/Init/classes/class.ilErrorHandling.php
+++ b/components/ILIAS/Init/classes/class.ilErrorHandling.php
@@ -170,13 +170,13 @@ class ilErrorHandling implements ErrorHandling\Application\ContextErrorHandlerPr
             $m = 'Fatal Error: Called raise error two times.<br>' .
                 'First error: ' . $session_failure . '<br>' .
                 'Last Error:' . $message;
-            $log->write($m);
+            $log->info($m);
             ilSession::clear('failure');
             die($m);
         }
 
         if ($log instanceof ilLogger) {
-            $log->write($message);
+            $log->info($message);
         }
         if ($code === $this->FATAL) {
             throw new RuntimeException(stripslashes($message));
@@ -298,7 +298,7 @@ class ilErrorHandling implements ErrorHandling\Application\ContextErrorHandlerPr
                 // fallthrough
             default:
                 if ((!defined('ERROR_HANDLER') || ERROR_HANDLER !== 'PRETTY_PAGE') && $ilLog) {
-                    $ilLog->write(
+                    $ilLog->info(
                         "Unknown or undefined error handler '" . ERROR_HANDLER . "'. " .
                         'Falling back to PrettyPageHandler.'
                     );
@@ -407,7 +407,7 @@ class ilErrorHandling implements ErrorHandling\Application\ContextErrorHandlerPr
                 if ($level >= E_USER_NOTICE) {
                     if ($ilLog) {
                         $severity = Whoops\Util\Misc::translateErrorCode($level);
-                        $ilLog->write("\n\n" . $severity . ' - ' . $message . "\n" . $file . ' - line ' . $line . "\n");
+                        $ilLog->info("\n\n" . $severity . ' - ' . $message . "\n" . $file . ' - line ' . $line . "\n");
                     }
 
                     return true;
@@ -417,7 +417,7 @@ class ilErrorHandling implements ErrorHandling\Application\ContextErrorHandlerPr
             if ($level === E_USER_DEPRECATED) {
                 if ($ilLog) {
                     $severity = Whoops\Util\Misc::translateErrorCode($level);
-                    $ilLog->write("\n\n" . $severity . ' - ' . $message . "\n" . $file . ' - line ' . $line . "\n");
+                    $ilLog->info("\n\n" . $severity . ' - ' . $message . "\n" . $file . ' - line ' . $line . "\n");
                 }
 
                 return true;

--- a/components/ILIAS/Init/classes/class.ilInitialisation.php
+++ b/components/ILIAS/Init/classes/class.ilInitialisation.php
@@ -1112,7 +1112,7 @@ class ilInitialisation
     protected static function abortAndDie(string $a_message): void
     {
         if (isset($GLOBALS['ilLog'])) {
-            $GLOBALS['ilLog']->write("Fatal Error: ilInitialisation - " . $a_message);
+            $GLOBALS['ilLog']->info("Fatal Error: ilInitialisation - " . $a_message);
             $GLOBALS['ilLog']->logStack();
         }
         die($a_message);

--- a/components/ILIAS/Init/classes/class.ilInitialisation.php
+++ b/components/ILIAS/Init/classes/class.ilInitialisation.php
@@ -1075,7 +1075,7 @@ class ilInitialisation
      */
     protected static function initLog(): void
     {
-        $log = ilLoggerFactory::getRootLogger();
+        $log = ilLoggerFactory::getLogger('legacy_root');
 
         self::initGlobal("ilLog", $log);
         // deprecated

--- a/components/ILIAS/Init/resources/ilias.master.ini.php
+++ b/components/ILIAS/Init/resources/ilias.master.ini.php
@@ -35,13 +35,13 @@
 [server]
 http_path =
 absolute_path =
-presetting = 
+presetting =
 
 [clients]
 path = public/data
 inifile = client.ini.php
-datadir = 
-default = 
+datadir =
+default =
 list = 0
 
 [setup]
@@ -49,17 +49,17 @@ pass =
 
 [tools]
 convert =
-zip = 
-unzip = 
-java = 
-ffmpeg = 
+zip =
+unzip =
+java =
+ffmpeg =
 
 [log]
-path = 
-file = 
+path =
+file =
 enabled = 1
-level = WARNING
-error_path = 
+default_level = INFO
+error_path =
 
 [debian]
 data_dir = /var/opt/ilias
@@ -67,26 +67,26 @@ log = /var/log/ilias/ilias.log
 convert = /usr/bin/convert
 zip = /usr/bin/zip
 unzip = /usr/bin/unzip
-java = 
+java =
 ffmpeg = /usr/bin/ffmpeg
 
 [redhat]
-data_dir = 
-log = 
-convert = 
-zip = 
-unzip = 
-java = 
+data_dir =
+log =
+convert =
+zip =
+unzip =
+java =
 
 [suse]
-data_dir = 
-log = 
-convert = 
-zip = 
-unzip = 
-java = 
+data_dir =
+log =
+convert =
+zip =
+unzip =
+java =
 
 [https]
 auto_https_detect_enabled = 0
-auto_https_detect_header_name = 
+auto_https_detect_header_name =
 auto_https_detect_header_value =

--- a/components/ILIAS/Init/resources/ilias.php
+++ b/components/ILIAS/Init/resources/ilias.php
@@ -42,8 +42,8 @@ try {
         throw $e;
     }
 
-    $DIC->logger()->root()->error($e->getMessage());
-    $DIC->logger()->root()->error($e->getTraceAsString());
+    $DIC->logger()->forComponent('init')->error($e->getMessage());
+    $DIC->logger()->forComponent('init')->error($e->getTraceAsString());
 
     $DIC->language()->loadLanguageModule('error');
     $df = new DataFactory();

--- a/components/ILIAS/Init/service.xml
+++ b/components/ILIAS/Init/service.xml
@@ -4,5 +4,4 @@
 	<baseclasses>
 		<baseclass name="ilStartUpGUI" dir="classes" />
 	</baseclasses>
-        <logging />
 </service>

--- a/components/ILIAS/ItemGroup/classes/class.ilItemGroupItems.php
+++ b/components/ILIAS/ItemGroup/classes/class.ilItemGroupItems.php
@@ -194,7 +194,7 @@ class ilItemGroupItems
     ): void {
         $ilLog = $this->log;
 
-        $ilLog->write(__METHOD__ . ': Begin cloning item group materials ... -' . $a_source_id . '-');
+        $ilLog->info('Begin cloning item group materials ... -' . $a_source_id . '-');
 
         $cwo = ilCopyWizardOptions::_getInstance($a_copy_id);
         $mappings = $cwo->getMappings();
@@ -204,15 +204,15 @@ class ilItemGroupItems
         $source_ig = new ilItemGroupItems($a_source_id);
         foreach ($source_ig->getItems() as $item_ref_id) {
             if (isset($mappings[$item_ref_id]) and $mappings[$item_ref_id]) {
-                $ilLog->write(__METHOD__ . ': Clone item group item nr. ' . $item_ref_id);
+                $ilLog->info('Clone item group item nr. ' . $item_ref_id);
                 $new_items[] = $mappings[$item_ref_id];
             } else {
-                $ilLog->write(__METHOD__ . ': No mapping found for item group item nr. ' . $item_ref_id);
+                $ilLog->info('No mapping found for item group item nr. ' . $item_ref_id);
             }
         }
         $this->setItems($new_items);
         $this->update();
-        $ilLog->write(__METHOD__ . ': Finished cloning item group items ...');
+        $ilLog->info('Finished cloning item group items ...');
     }
 
     public static function _getItemsOfContainer(int $a_ref_id): array

--- a/components/ILIAS/ItemGroup/classes/class.ilObjItemGroup.php
+++ b/components/ILIAS/ItemGroup/classes/class.ilObjItemGroup.php
@@ -215,23 +215,23 @@ class ilObjItemGroup extends ilObject2
 
         $ilLog = $DIC["ilLog"];
 
-        $ilLog->write(__METHOD__ . ': Fix item group references in ' . $a_source_container->getType());
+        $ilLog->info('Fix item group references in ' . $a_source_container->getType());
 
         $cwo = ilCopyWizardOptions::_getInstance($a_copy_id);
         $mappings = $cwo->getMappings();
 
         $new_container_ref_id = $mappings[$a_source_container->getRefId()];
-        $ilLog->write(__METHOD__ . ': 2-' . $new_container_ref_id . '-');
+        $ilLog->info('2-' . $new_container_ref_id . '-');
         $new_container_obj_id = ilObject::_lookupObjId($new_container_ref_id);
 
-        $ilLog->write(__METHOD__ . ': 3' . $new_container_obj_id . '-');
+        $ilLog->info('3' . $new_container_obj_id . '-');
         if (ilPageObject::_exists("cont", $new_container_obj_id)) {
-            $ilLog->write(__METHOD__ . ': 4');
+            $ilLog->info('4');
             $new_page = new ilContainerPage($new_container_obj_id);
             $new_page->buildDom();
             ilPCResources::modifyItemGroupRefIdsByMapping($new_page, $mappings);
             $new_page->update();
         }
-        $ilLog->write(__METHOD__ . ': 5');
+        $ilLog->info('5');
     }
 }

--- a/components/ILIAS/LDAP/classes/class.ilLDAPRoleGroupMapping.php
+++ b/components/ILIAS/LDAP/classes/class.ilLDAPRoleGroupMapping.php
@@ -105,10 +105,10 @@ class ilLDAPRoleGroupMapping
             return false;
         }
         if (!$this->isHandledUser($a_usr_id)) {
-            $this->log->write('LDAP assign: User ID: ' . $a_usr_id . ' has no LDAP account');
+            $this->log->info('LDAP assign: User ID: ' . $a_usr_id . ' has no LDAP account');
             return false;
         }
-        $this->log->write('LDAP assign: User ID: ' . $a_usr_id . ' Role Id: ' . $a_role_id);
+        $this->log->info('LDAP assign: User ID: ' . $a_usr_id . ' Role Id: ' . $a_role_id);
         $this->assignToGroup($a_role_id, $a_usr_id);
 
         return true;
@@ -157,7 +157,7 @@ class ilLDAPRoleGroupMapping
         if (!$this->isHandledUser($a_usr_id)) {
             return false;
         }
-        $this->log->write('LDAP deassign: User ID: ' . $a_usr_id . ' Role Id: ' . $a_role_id);
+        $this->log->info('LDAP deassign: User ID: ' . $a_usr_id . ' Role Id: ' . $a_role_id);
         $this->deassignFromGroup($a_role_id, $a_usr_id);
 
         return true;
@@ -262,10 +262,10 @@ class ilLDAPRoleGroupMapping
                     // Add user
                     $query_obj = $this->getLDAPQueryInstance($data['server_id'], $data['url']);
                     $query_obj->modAdd($data['dn'], array($data['member'] => $external_account));
-                    $this->log->write('LDAP assign: Assigned ' . $external_account . ' to group ' . $data['dn']);
+                    $this->log->info('LDAP assign: Assigned ' . $external_account . ' to group ' . $data['dn']);
                 }
             } catch (ilLDAPQueryException $exc) {
-                $this->log->write($exc->getMessage());
+                $this->log->info($exc->getMessage());
                 // try next mapping
                 continue;
             }
@@ -291,7 +291,7 @@ class ilLDAPRoleGroupMapping
 
                 // Check for other role membership
                 if ($role_id = $this->checkOtherMembership($a_usr_id, $a_role_id, $data)) {
-                    $this->log->write('LDAP deassign: User is still assigned to role "' . $role_id . '".');
+                    $this->log->info('LDAP deassign: User is still assigned to role "' . $role_id . '".');
                     continue;
                 }
                 /*
@@ -304,7 +304,7 @@ class ilLDAPRoleGroupMapping
                 // Deassign user
                 $query_obj = $this->getLDAPQueryInstance($data['server_id'], $data['url']);
                 $query_obj->modDelete($data['dn'], array($data['member'] => $external_account));
-                $this->log->write('LDAP deassign: Deassigned ' . $external_account . ' from group ' . $data['dn']);
+                $this->log->info('LDAP deassign: Deassigned ' . $external_account . ' from group ' . $data['dn']);
 
                 // Delete from cache
                 if (is_array($this->mapping_members[$data['mapping_id']])) {
@@ -314,7 +314,7 @@ class ilLDAPRoleGroupMapping
                     }
                 }
             } catch (ilLDAPQueryException $exc) {
-                $this->log->write($exc->getMessage());
+                $this->log->info($exc->getMessage());
                 // try next mapping
                 continue;
             }

--- a/components/ILIAS/LTIConsumer/classes/Verification/class.ilLTIConsumerVerificationTableGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/Verification/class.ilLTIConsumerVerificationTableGUI.php
@@ -61,7 +61,7 @@ class ilLTIConsumerVerificationTableGUI extends ilTable2GUI
 
         $userCertificateRepository = new ilUserCertificateRepository(
             $DIC->database(),
-            $DIC->logger()->root()
+            $DIC->logger()->forComponent('lti')
         );
 
         $certificateArray = $userCertificateRepository->fetchActiveCertificatesByTypeForPresentation(

--- a/components/ILIAS/LTIConsumer/classes/Verification/class.ilObjLTIConsumerVerificationGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/Verification/class.ilObjLTIConsumerVerificationGUI.php
@@ -64,7 +64,7 @@ class ilObjLTIConsumerVerificationGUI extends ilObject2GUI
             $certificateVerificationFileService = new ilCertificateVerificationFileService(
                 $DIC->language(),
                 $DIC->database(),
-                $DIC->logger()->root(),
+                $DIC->logger()->forComponent('lti'),
                 new ilCertificateVerificationClassMap()
             );
 

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceScores.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceScores.php
@@ -137,7 +137,7 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
     {
         global $DIC; /* @var \ILIAS\DI\Container $DIC */
 
-        $logger = $DIC->logger()->root();
+        $logger = $DIC->logger()->forComponent('lti');
 
         $logger->info('checkScore');
         $score = json_decode($requestData);

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResult.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResult.php
@@ -81,7 +81,7 @@ class ilLTIConsumerResult
     {
         global $DIC;
 
-        $logger = $DIC->logger()->root();
+        $logger = $DIC->logger()->forComponent('lti');
         $logger->info('getByKeys: ' . $a_obj_id . ' ' . $a_usr_id);
 
         $query = 'SELECT * FROM lti_consumer_results'
@@ -125,7 +125,7 @@ class ilLTIConsumerResult
     {
         global $DIC; /* @var \ILIAS\DI\Container $DIC */
 
-        $logger = $DIC->logger()->root();
+        $logger = $DIC->logger()->forComponent('lti');
 
         $logger->info('save: ' . $this->obj_id . ' ' . $this->usr_id);
 
@@ -136,7 +136,7 @@ class ilLTIConsumerResult
             $this->id = $DIC->database()->nextId('lti_consumer_results');
         }
 
-        $logger = $DIC->logger()->root();
+        $logger = $DIC->logger()->forComponent('lti');
 
         $logger->info('save 2: ' . $this->obj_id . ' ' . $this->usr_id);
 

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResultService.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResultService.php
@@ -100,7 +100,7 @@ class ilLTIConsumerResultService
         try {
 
             global $DIC;
-            $logger = $DIC->logger()->root();
+            $logger = $DIC->logger()->forComponent('lti');
             $logger->info('LTI Consumer Result Service: Incoming request');
             // get the request as xml
             $xml = simplexml_load_file('php://input');
@@ -195,7 +195,7 @@ class ilLTIConsumerResultService
     protected function replaceResult(\SimpleXMLElement $request): void
     {
         global $DIC;
-        $logger = $DIC->logger()->root();
+        $logger = $DIC->logger()->forComponent('lti');
 
         $result = (string) $request->resultRecord->result->resultScore->textString;
         $logger->info('LTI Consumer Result Service: Replace result. Result: ' . $result);

--- a/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumer.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumer.php
@@ -1285,7 +1285,7 @@ class ilObjLTIConsumer extends ilObject2
     {
         global $DIC;
 
-        $logger = $DIC->logger()->root();
+        $logger = $DIC->logger()->forComponent('lti');
         $f = new \ILIAS\Data\Factory();
 
         if (!ilContext::usesHTTP() || !isset($_SERVER['HTTP_HOST'], $_SERVER['REQUEST_URI'])) {

--- a/components/ILIAS/LTIConsumer/module.xml
+++ b/components/ILIAS/LTIConsumer/module.xml
@@ -25,5 +25,4 @@
 	<crons />
 	<copage />
 	<web_access_checker />
-	<logging />
 </module>

--- a/components/ILIAS/LTIProvider/classes/Screen/CustomBreadcrumbPagePartProvider.php
+++ b/components/ILIAS/LTIProvider/classes/Screen/CustomBreadcrumbPagePartProvider.php
@@ -32,7 +32,7 @@ class CustomBreadcrumbPagePartProvider implements PagePartProvider
         global $DIC;
         $this->refinery = $DIC->refinery();
         $this->original = $original;
-        $this->logger = $DIC->logger()->root();
+        $this->logger = $DIC->logger()->forComponent('ltis');
     }
 
     public function getTitle(): string

--- a/components/ILIAS/LTIProvider/classes/class.ilLTIAppEventListener.php
+++ b/components/ILIAS/LTIProvider/classes/class.ilLTIAppEventListener.php
@@ -133,7 +133,7 @@ class ilLTIAppEventListener
     protected function definePercentageByObjectId(int|null $status, string $obj_id, int|null $percentage): int
     {
         global $DIC;
-        $logger = $DIC->logger()->root();
+        $logger = $DIC->logger()->forComponent('ltis');
         $logger->debug('definePercentageByObjectId');
         $indentifier = ilObjectFactory::getInstanceByRefId((int) $obj_id)->getType();
         $logger->info('Object type: ' . $indentifier . " for object id: " . $obj_id);

--- a/components/ILIAS/LTIProvider/service.xml
+++ b/components/ILIAS/LTIProvider/service.xml
@@ -16,5 +16,4 @@
     <crons>
         <cron id="lti_outcome" class="ilLTICronOutcomeService" />
     </crons>
-    <logging />
 </service>

--- a/components/ILIAS/Language/classes/Setup/class.ilSetupLanguage.php
+++ b/components/ILIAS/Language/classes/Setup/class.ilSetupLanguage.php
@@ -83,7 +83,7 @@ class ilSetupLanguage extends ilLanguage
         }
 
         if ($translation === "") {
-            $log->writeLanguageLog($a_topic, $this->lang_key);
+            $log->debug("Language (" . $this->lang_key . "): topic -" . $a_topic . "- not present");
             return "-" . $a_topic . "-";
         }
 

--- a/components/ILIAS/Language/classes/class.ilLanguage.php
+++ b/components/ILIAS/Language/classes/class.ilLanguage.php
@@ -75,7 +75,7 @@ class ilLanguage implements \ILIAS\Language\Language
         global $DIC;
         $client_ini = $DIC->clientIni();
 
-        $this->log = $DIC->logger()->root();
+        $this->log = $DIC->logger()->forComponent('lang');
 
         $this->lang_key = $a_lang_key;
 

--- a/components/ILIAS/Language/classes/class.ilObjLanguageExt.php
+++ b/components/ILIAS/Language/classes/class.ilObjLanguageExt.php
@@ -456,7 +456,7 @@ class ilObjLanguageExt extends ilObjLanguage
             ));
             $row = $ilDB->fetchAssoc($set);
             if (!$row) {
-                $DIC->logger()->root()->warning("Language module '{$module}' not found for language {$a_lang_key}.");
+                $DIC->logger()->forComponent('lang')->warning("Language module '{$module}' not found for language {$a_lang_key}.");
                 continue;
             }
 

--- a/components/ILIAS/Language/service.xml
+++ b/components/ILIAS/Language/service.xml
@@ -13,5 +13,4 @@
 			checkbox="1" translate="0" rbac="0">
 		</object>
 	</objects>
-	<logging />
 </service>

--- a/components/ILIAS/LearningHistory/service.xml
+++ b/components/ILIAS/LearningHistory/service.xml
@@ -1,6 +1,5 @@
 <?xml version = "1.0" encoding = "UTF-8"?>
 <service xmlns="http://www.w3.org" version="$Id$" id="lhist">
-	<logging />
 	<copage>
 		<pagecontent pc_type="lhist" name="LearningHistory" directory="classes" int_links="0" style_classes="0" xsl="0" def_enabled="0" top_item="1" order_nr="136"/>
 	</copage>

--- a/components/ILIAS/LearningModule/classes/class.ilLMObject.php
+++ b/components/ILIAS/LearningModule/classes/class.ilLMObject.php
@@ -620,7 +620,7 @@ class ilLMObject
         }
 
         if ($tree->isInTree($parent_id) && !$tree->isInTree($a_obj->getId())) {
-            $ilLog->write("LMObject::putInTree: insertNode, ID: " . $a_obj->getId() .
+            $ilLog->info("insertNode, ID: " . $a_obj->getId() .
                 "Parent ID: " . $parent_id . ", Target: " . $target);
 
             $tree->insertNode($a_obj->getId(), $parent_id, $target);
@@ -761,7 +761,7 @@ class ilLMObject
             $item = new ilLMPageObject($lm_obj, $a_item_id);
         }
 
-        $ilLog->write("Getting from clipboard type " . $item_type . ", " .
+        $ilLog->info("Getting from clipboard type " . $item_type . ", " .
             "Item ID: " . $a_item_id . ", of original LM: " . $item_lm_id);
 
         if ($item_lm_id != $a_target_lm->getId() && !$a_as_copy) {
@@ -795,7 +795,7 @@ class ilLMObject
             $target_item = $item;
         }
 
-        $ilLog->write("Putting into tree type " . $target_item->getType() .
+        $ilLog->info("Putting into tree type " . $target_item->getType() .
             "Item ID: " . $target_item->getId() . ", Parent: " . $a_parent_id . ", " .
             "Target: " . $a_target . ", Item LM:" . $target_item->getContentObject()->getId());
 

--- a/components/ILIAS/LearningModule/module.xml
+++ b/components/ILIAS/LearningModule/module.xml
@@ -30,5 +30,4 @@
 	<web_access_checker>
 		<secure_path path="lm_data" checking-class="ilObjLearningModuleAccess" />
 	</web_access_checker>
-	<logging />
 </module>

--- a/components/ILIAS/LearningSequence/classes/Members/class.ilLearningSequenceParticipants.php
+++ b/components/ILIAS/LearningSequence/classes/Members/class.ilLearningSequenceParticipants.php
@@ -50,7 +50,7 @@ class ilLearningSequenceParticipants extends ilParticipants
     {
         global $DIC;
 
-        $logger = $DIC["ilLoggerFactory"]->getRootLogger();
+        $logger = $DIC["ilLoggerFactory"]->getComponentLogger('lso');
         $app_event_handler = $DIC['ilAppEventHandler'];
         $settings = $DIC["ilSetting"];
 

--- a/components/ILIAS/LearningSequence/classes/class.ilLSLocalDI.php
+++ b/components/ILIAS/LearningSequence/classes/class.ilLSLocalDI.php
@@ -247,7 +247,7 @@ class ilLSLocalDI extends Container
         $this["participants"] = function ($c) use ($dic): ilLearningSequenceParticipants {
             return new ilLearningSequenceParticipants(
                 $c["obj.obj_id"],
-                $dic["ilLoggerFactory"]->getRootLogger(),
+                $dic["ilLoggerFactory"]->getComponentLogger('lso'),
                 $dic["ilAppEventHandler"],
                 $dic["ilSetting"]
             );

--- a/components/ILIAS/LearningSequence/classes/class.ilLearningSequenceImporter.php
+++ b/components/ILIAS/LearningSequence/classes/class.ilLearningSequenceImporter.php
@@ -31,7 +31,7 @@ class ilLearningSequenceImporter extends ilXmlImporter
         global $DIC;
         $this->user = $DIC["ilUser"];
         $this->rbac_admin = $DIC["rbacadmin"];
-        $this->log = $DIC["ilLoggerFactory"]->getRootLogger();
+        $this->log = $DIC["ilLoggerFactory"]->getComponentLogger('lso');
     }
 
     public function importXmlRepresentation(string $a_entity, string $a_id, string $a_xml, ilImportMapping $a_mapping): void

--- a/components/ILIAS/LearningSequence/classes/class.ilObjLearningSequence.php
+++ b/components/ILIAS/LearningSequence/classes/class.ilObjLearningSequence.php
@@ -215,21 +215,21 @@ class ilObjLearningSequence extends ilContainer
         $new_admin = $new_obj->getDefaultAdminRole();
 
         if (!$admin || !$new_admin || !$this->getRefId() || !$new_obj->getRefId()) {
-            $this->log->write(__METHOD__ . ' : Error cloning auto generated role: il_lso_admin');
+            $this->log->info('Error cloning auto generated role: il_lso_admin');
         }
 
         $this->rbac_admin->copyRolePermissions($admin, $this->getRefId(), $new_obj->getRefId(), $new_admin, true);
-        $this->log->write(__METHOD__ . ' : Finished copying of role lso_admin.');
+        $this->log->info('Finished copying of role lso_admin.');
 
         $member = $this->getDefaultMemberRole();
         $new_member = $new_obj->getDefaultMemberRole();
 
         if (!$member || !$new_member) {
-            $this->log->write(__METHOD__ . ' : Error cloning auto generated role: il_lso_member');
+            $this->log->info('Error cloning auto generated role: il_lso_member');
         }
 
         $this->rbac_admin->copyRolePermissions($member, $this->getRefId(), $new_obj->getRefId(), $new_member, true);
-        $this->log->write(__METHOD__ . ' : Finished copying of role lso_member.');
+        $this->log->info('Finished copying of role lso_member.');
 
         return true;
     }

--- a/components/ILIAS/LearningSequence/classes/class.ilObjLearningSequence.php
+++ b/components/ILIAS/LearningSequence/classes/class.ilObjLearningSequence.php
@@ -61,7 +61,7 @@ class ilObjLearningSequence extends ilContainer
         $this->ctrl = $DIC['ilCtrl'];
         $this->user = $DIC['ilUser'];
         $this->tree = $DIC['tree'];
-        $this->log = $DIC["ilLoggerFactory"]->getRootLogger();
+        $this->log = $DIC["ilLoggerFactory"]->getComponentLogger('lso');
         $this->app_event_handler = $DIC['ilAppEventHandler'];
         $this->il_news = $DIC->news();
         $this->il_condition_handler = new ilConditionHandler();

--- a/components/ILIAS/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
+++ b/components/ILIAS/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
@@ -219,7 +219,7 @@ class ilObjLearningSequenceGUI extends ilContainerGUI implements ilCtrlBaseClass
         $this->ui_renderer = $DIC['ui.renderer'];
         $this->request = $DIC->http()->request();
 
-        $this->log = $DIC["ilLoggerFactory"]->getRootLogger();
+        $this->log = $DIC["ilLoggerFactory"]->getComponentLogger('lso');
         $this->app_event_handler = $DIC['ilAppEventHandler'];
         $this->navigation_history = $DIC['ilNavigationHistory'];
         $this->obj_definition = $DIC['objDefinition'];

--- a/components/ILIAS/LegalDocuments/service.xml
+++ b/components/ILIAS/LegalDocuments/service.xml
@@ -3,5 +3,4 @@
   <events>
     <event type="listen" id="components/ILIAS/Authentication" />
   </events>
-  <logging />
 </service>

--- a/components/ILIAS/Logging/classes/NullLogger.php
+++ b/components/ILIAS/Logging/classes/NullLogger.php
@@ -85,14 +85,6 @@ class NullLogger extends ilLogger
         throw new Exception('Can not return monolog logger from a null logger.');
     }
 
-    public function write(string $message, $level = ilLogLevel::INFO, array $context = []): void
-    {
-    }
-
-    public function writeLanguageLog(string $topic, string $lang_key): void
-    {
-    }
-
     public function logStack(?int $level = null, string $message = '', array $context = []): void
     {
     }

--- a/components/ILIAS/Logging/classes/class.ilLogger.php
+++ b/components/ILIAS/Logging/classes/class.ilLogger.php
@@ -100,28 +100,6 @@ abstract class ilLogger
         return $this->logger;
     }
 
-    /**
-     * write log message
-     * @deprecated since version 5.1
-     * @see ilLogger->info(), ilLogger()->debug(), ...
-     */
-    public function write(string $message, $level = ilLogLevel::INFO, array $context = []): void
-    {
-        if (!in_array($level, ilLogLevel::getLevels())) {
-            $level = ilLogLevel::INFO;
-        }
-        $this->getLogger()->log((int) $level, $message, $context);
-    }
-
-    /**
-     * Write language log
-     * @deprecated since version 5.1
-     */
-    public function writeLanguageLog(string $topic, string $lang_key): void
-    {
-        $this->getLogger()->debug("Language (" . $lang_key . "): topic -" . $topic . "- not present");
-    }
-
     public function logStack(?int $level = null, string $message = '', array $context = []): void
     {
         if (is_null($level)) {

--- a/components/ILIAS/Logging/classes/public/class.ilLoggerFactory.php
+++ b/components/ILIAS/Logging/classes/public/class.ilLoggerFactory.php
@@ -62,15 +62,6 @@ class ilLoggerFactory
         return $factory->getComponentLogger($a_component_id);
     }
 
-    /**
-     * The unique root logger has a fixed error level
-     */
-    public static function getRootLogger(): ilLogger
-    {
-        $factory = self::getInstance();
-        return $factory->getComponentLogger('root');
-    }
-
 
     /**
      * Init user specific log options

--- a/components/ILIAS/Logging/service.xml
+++ b/components/ILIAS/Logging/service.xml
@@ -12,5 +12,4 @@
 	<crons>
 		<cron id="log_error_file_cleanup" class="ilLoggerCronCleanErrorFiles" path="Services/Logging/classes/error/" />
 	</crons>
-	<logging id="log" />
 </service>

--- a/components/ILIAS/Logging/src/Setup/Config.php
+++ b/components/ILIAS/Logging/src/Setup/Config.php
@@ -42,7 +42,7 @@ class Config implements ConfigInterface
                 "Expected a path to the logfile, if logging is enabled."
             );
         }
-        $level = $level === null ? null : ILIASLogLevel::tryFromString($level);
+        $level = $level === null ? null : ILIASLogLevel::tryFromString(strtoupper($level));
         if ($enabled && !$level) {
             throw new InvalidArgumentException(
                 "Expected a valid default log level, if logging is enabled."

--- a/components/ILIAS/Mail/service.xml
+++ b/components/ILIAS/Mail/service.xml
@@ -23,5 +23,4 @@
 		<event type="raise" id="sentInternalMail" />
 		<event type="listen" id="components/ILIAS/User" />
 	</events>
-	<logging />
 </service>

--- a/components/ILIAS/MainMenu/service.xml
+++ b/components/ILIAS/MainMenu/service.xml
@@ -1,7 +1,6 @@
 <?xml version = "1.0" encoding = "UTF-8"?>
 <service xmlns="http://www.w3.org" version="$Id$" id="mme">
 	<baseclasses />
-	<logging />
 	<objects>
 		<object id="mme" class_name="MainMenu" dir="classes" checkbox="0" inherit="0" translate="sys" rbac="1" system="1" administration="1">
 			<parent id="adm" max="1">adm</parent>

--- a/components/ILIAS/Maps/service.xml
+++ b/components/ILIAS/Maps/service.xml
@@ -7,5 +7,4 @@
       <parent id="adm" max="1">adm</parent>
     </object>
   </objects>
-  <logging />
 </service>

--- a/components/ILIAS/MediaCast/classes/class.ilObjMediaCastGUI.php
+++ b/components/ILIAS/MediaCast/classes/class.ilObjMediaCastGUI.php
@@ -769,7 +769,7 @@ EOT;
             foreach (ilObjMediaCast::$purposes as $purpose) {
                 if ($this->form_gui->getInput("delete_" . $purpose)) {
                     $mob->removeMediaItem($purpose);
-                    $ilLog->write("Mcst: deleting purpose $purpose");
+                    $ilLog->info("Mcst: deleting purpose $purpose");
                     continue;
                 }
                 $media_item = $mob->getMediaItem($purpose);

--- a/components/ILIAS/MediaCast/module.xml
+++ b/components/ILIAS/MediaCast/module.xml
@@ -19,5 +19,4 @@
 			<parent id="adm" max="1">adm</parent>
 		</object>
 	</objects>
-	<logging />
 </module>

--- a/components/ILIAS/MediaObjects/service.xml
+++ b/components/ILIAS/MediaObjects/service.xml
@@ -13,5 +13,4 @@
 		<secure_path path="mobs" checking-class="ilObjMediaObjectAccess" />
 		<secure_path path="thumbs" checking-class="ilObjMediaObjectAccess" />
 	</web_access_checker>
-	<logging />
 </service>

--- a/components/ILIAS/MediaPool/module.xml
+++ b/components/ILIAS/MediaPool/module.xml
@@ -17,11 +17,10 @@
 			<sub_type id="mpg" amet="1" />
 		</object>
 	</objects>
-	<events>		
+	<events>
 		<event type="listen" id="components/ILIAS/ILIASObject" />
 	</events>
 	<copage>
 		<pageobject parent_type="mep" class_name="ilMediaPoolPage" directory="classes"/>
 	</copage>
-	<logging />
 </module>

--- a/components/ILIAS/Membership/service.xml
+++ b/components/ILIAS/Membership/service.xml
@@ -7,5 +7,4 @@
 		<cron id="mem_notification" class="ilMembershipCronNotifications" path="Services/Membership/classes/Cron" />
 		<cron id="mem_min_members" class="ilMembershipCronMinMembers" path="Services/Membership/classes/Cron" />
 	</crons>
-	<logging />
 </service>

--- a/components/ILIAS/MetaData/service.xml
+++ b/components/ILIAS/MetaData/service.xml
@@ -12,5 +12,4 @@
 	<crons>
 		<cron id="meta_oer_harvester" class="ilCronOerHarvester" />
 	</crons>
-	<logging/>
 </service>

--- a/components/ILIAS/Migration/DBUpdate_3560/classes/class.ilDBUpdateNewObjectType.php
+++ b/components/ILIAS/Migration/DBUpdate_3560/classes/class.ilDBUpdateNewObjectType.php
@@ -257,7 +257,7 @@ class ilDBUpdateNewObjectType
             . "WHERE typ_id = " . $ilDB->quote($type_id, "integer") . PHP_EOL
             . "AND ops_id = " . $ilDB->quote($ops_id, "integer") . PHP_EOL
         ;
-        $GLOBALS['ilLog']->write(__METHOD__ . ': ' . $sql);
+        $GLOBALS['ilLog']->info($sql);
         $ilDB->manipulate($sql);
 
         self::deleteRBACTemplateOperation($type, $ops_id);
@@ -281,7 +281,7 @@ class ilDBUpdateNewObjectType
             . "WHERE type = " . $ilDB->quote($type, "text") . PHP_EOL
             . "ops_id = " . $ilDB->quote($ops_id, "integer") . PHP_EOL
         ;
-        $GLOBALS['ilLog']->write(__METHOD__ . ': ' . $sql);
+        $GLOBALS['ilLog']->info($sql);
         $ilDB->manipulate($sql);
     }
 

--- a/components/ILIAS/News/service.xml
+++ b/components/ILIAS/News/service.xml
@@ -9,9 +9,8 @@
 			<parent id="adm" max="1">adm</parent>
 		</object>
 	</objects>
-	<events>		
+	<events>
 		<event type="raise" id="readNews" />
 		<event type="raise" id="unreadNews" />
 	</events>
-	<logging />
 </service>

--- a/components/ILIAS/Notes/service.xml
+++ b/components/ILIAS/Notes/service.xml
@@ -10,5 +10,4 @@
 			<parent id="adm" max="1">adm</parent>
 		</object>
 	</objects>
-	<logging />
 </service>

--- a/components/ILIAS/Notification/service.xml
+++ b/components/ILIAS/Notification/service.xml
@@ -3,5 +3,4 @@
 	<events>
 		<event type="listen" id="Service/Object" />
 	</events>
-	<logging />
 </service>

--- a/components/ILIAS/Notifications/classes/ilNotificationPushHandler.php
+++ b/components/ILIAS/Notifications/classes/ilNotificationPushHandler.php
@@ -57,7 +57,7 @@ class ilNotificationPushHandler extends ilNotificationHandler
     {
         global $DIC;
         $this->provider = $provider;
-        $this->logger = $DIC->logger()->root();
+        $this->logger = $DIC->logger()->forComponent('noti');
         $this->sub = $DIC->settings()->get('admin_email');
         $this->subscription_repo = new PushRepository($DIC->database(), $DIC->user());
         $settings = new ilSetting('notifications');

--- a/components/ILIAS/Notifications/service.xml
+++ b/components/ILIAS/Notifications/service.xml
@@ -9,7 +9,6 @@
 			<parent id="adm" max="1">adm</parent>
 		</object>
 	</objects>
-	<logging />
 	<events>
 		<event type="listen" id="Services/User" />
 	</events>

--- a/components/ILIAS/OnScreenChat/service.xml
+++ b/components/ILIAS/OnScreenChat/service.xml
@@ -6,5 +6,4 @@
 	<events>
 		<event type="listen" id="components/ILIAS/Chatroom" />
 	</events>
-	<logging />
 </service>

--- a/components/ILIAS/OrgUnit/classes/LocalUser/class.ilLocalUserGUI.php
+++ b/components/ILIAS/OrgUnit/classes/LocalUser/class.ilLocalUserGUI.php
@@ -190,7 +190,7 @@ class ilLocalUserGUI
         $this->checkPermission("cat_administrate_users");
         foreach ($_POST['user_ids'] as $user_id) {
             if (!in_array($user_id, ilLocalUser::_getAllUserIds($this->getRefId()))) {
-                $this->logger->write(__FILE__ . ":" . __LINE__ . " User with id $user_id could not be found.");
+                $this->logger->info("User with id $user_id could not be found.");
                 $this->tpl->setOnScreenMessage('failure', $this->lng->txt('user_not_found_to_delete'));
             }
             if (!$tmp_obj = ilObjectFactory::getInstanceByObjId((int) $user_id, false)) {

--- a/components/ILIAS/OrgUnit/classes/SimpleImport/class.ilOrgUnitSimpleImport.php
+++ b/components/ILIAS/OrgUnit/classes/SimpleImport/class.ilOrgUnitSimpleImport.php
@@ -171,7 +171,7 @@ class ilOrgUnitSimpleImport extends ilOrgUnitImporter
                 global $DIC;
                 $ilLog = $DIC['ilLog'];
                 $this->addWarning("not_movable", $ou_id ? $ou_id : $external_id, "update");
-                $ilLog->write($e->getMessage() . "\\n" . $e->getTraceAsString());
+                $ilLog->info($e->getMessage() . "\\n" . $e->getTraceAsString());
                 error_log($e->getMessage() . "\\n" . $e->getTraceAsString());
             }
         }

--- a/components/ILIAS/OrgUnit/classes/SimpleImport/class.ilOrgUnitSimpleImportGUI.php
+++ b/components/ILIAS/OrgUnit/classes/SimpleImport/class.ilOrgUnitSimpleImportGUI.php
@@ -171,7 +171,7 @@ class ilOrgUnitSimpleImportGUI
 
                 $importer->simpleImport($file_path);
             } catch (Exception $e) {
-                $this->ilLog->write($e->getMessage() . " - " . $e->getTraceAsString());
+                $this->ilLog->info($e->getMessage() . " - " . $e->getTraceAsString());
                 $this->tpl->setOnScreenMessage('failure', $this->lng->txt("import_failed"), true);
                 $this->ctrl->redirect($this, "render");
             }

--- a/components/ILIAS/OrgUnit/classes/SimpleUserImport/class.ilOrgUnitSimpleUserImportGUI.php
+++ b/components/ILIAS/OrgUnit/classes/SimpleUserImport/class.ilOrgUnitSimpleUserImportGUI.php
@@ -104,7 +104,7 @@ class ilOrgUnitSimpleUserImportGUI
             try {
                 $importer->simpleUserImport($file['tmp_name']);
             } catch (Exception $e) {
-                $this->ilLog->write($e->getMessage() . ' - ' . $e->getTraceAsString());
+                $this->ilLog->info($e->getMessage() . ' - ' . $e->getTraceAsString());
                 $this->tpl->setOnScreenMessage('failure', $this->lng->txt('import_failed'), true);
                 $this->ctrl->redirect($this, 'render');
             }

--- a/components/ILIAS/PersonalWorkspace/service.xml
+++ b/components/ILIAS/PersonalWorkspace/service.xml
@@ -8,5 +8,4 @@
 			checkbox="0" inherit="0" translate="sys" rbac="1" system="1" administration="1">
 		<parent id="adm" max="1">adm</parent>
 	</object>
-	<logging />
 </service>

--- a/components/ILIAS/Repository/Deletion/EventStandardAdapter.php
+++ b/components/ILIAS/Repository/Deletion/EventStandardAdapter.php
@@ -43,7 +43,7 @@ class EventStandardAdapter implements EventInterface
 
     public function afterMoveToTrash(int $ref_id, int $old_parent_ref_id): void
     {
-        $this->log->write("ilObjectGUI::confirmedDeleteObject(), moved ref_id " . $ref_id .
+        $this->log->info("moved ref_id " . $ref_id .
             " to trash");
 
         $this->event_handler->raise(

--- a/components/ILIAS/Repository/Deletion/EventStandardAdapter.php
+++ b/components/ILIAS/Repository/Deletion/EventStandardAdapter.php
@@ -31,7 +31,7 @@ class EventStandardAdapter implements EventInterface
         protected InternalDomainService $domain,
     ) {
         $this->event_handler = $domain->event();
-        $this->log = $domain->logger()->root();
+        $this->log = $domain->logger()->forComponent('rep');
     }
 
     public function beforeMoveToTrash(int $ref_id, array $subnodes): void

--- a/components/ILIAS/Repository/TreeValidator/class.ilValidator.php
+++ b/components/ILIAS/Repository/TreeValidator/class.ilValidator.php
@@ -898,11 +898,7 @@ class ilValidator
         removal starts here
         ********************/
 
-        $message = sprintf(
-            '%s::removeInvalidReferences(): Started...',
-            get_class($this)
-        );
-        $ilLog->write($message, $ilLog->WARNING);
+        $ilLog->warning('Started...');
 
         // to make sure
         $this->filterWorkspaceObjects($a_invalid_refs);
@@ -913,11 +909,10 @@ class ilValidator
             $res = $ilDB->manipulate($query);
 
             $message = sprintf(
-                '%s::removeInvalidReferences(): Reference %s removed',
-                get_class($this),
+                'Reference %s removed',
                 $entry["ref_id"]
             );
-            $ilLog->write($message, $ilLog->WARNING);
+            $ilLog->warning($message);
 
             $this->writeScanLogLine("Entry " . $entry["ref_id"] . " removed");
         }
@@ -962,22 +957,17 @@ class ilValidator
         removal starts here
         ********************/
 
-        $message = sprintf(
-            '%s::removeInvalidChilds(): Started...',
-            get_class($this)
-        );
-        $ilLog->write($message, $ilLog->WARNING);
+        $ilLog->warning('Started...');
 
         foreach ($a_invalid_childs as $entry) {
             $q = "DELETE FROM tree WHERE child='" . $entry["child"] . "'";
             $this->db->query($q);
 
             $message = sprintf(
-                '%s::removeInvalidChilds(): Entry child=%s removed',
-                get_class($this),
+                'Entry child=%s removed',
                 $entry["child"]
             );
-            $ilLog->write($message, $ilLog->WARNING);
+            $ilLog->warning($message);
 
             $this->writeScanLogLine("Entry " . $entry["child"] . " removed");
         }
@@ -1025,11 +1015,7 @@ class ilValidator
 
         $removed = false;
 
-        $message = sprintf(
-            '%s::removeInvalidRolefolders(): Started...',
-            get_class($this)
-        );
-        $ilLog->write($message, $ilLog->WARNING);
+        $ilLog->warning('Started...');
 
         // to make sure
         $this->filterWorkspaceObjects($a_invalid_rolefolders);
@@ -1096,11 +1082,7 @@ class ilValidator
 
         $restored = false;
 
-        $message = sprintf(
-            '%s::restoreMissingObjects(): Started...',
-            get_class($this)
-        );
-        $ilLog->write($message, $ilLog->WARNING);
+        $ilLog->warning('Started...');
 
         // to make sure
         $this->filterWorkspaceObjects($a_missing_objects);
@@ -1153,12 +1135,11 @@ class ilValidator
         $res = $ilDB->manipulate($query);
 
         $message = sprintf(
-            '%s::restoreReference(): new reference %s for obj_id %s created',
-            get_class($this),
+            'new reference %s for obj_id %s created',
             $next_id,
             $a_obj_id
         );
-        $ilLog->write($message, $ilLog->WARNING);
+        $ilLog->warning($message);
 
         return $next_id;
     }
@@ -1190,11 +1171,7 @@ class ilValidator
             return false;
         }
 
-        $message = sprintf(
-            '%s::restoreUnboundObjects(): Started...',
-            get_class($this)
-        );
-        $ilLog->write($message, $ilLog->WARNING);
+        $ilLog->warning('Started...');
 
         // start restore process
         return $this->restoreSubTrees($a_unbound_objects);
@@ -1228,11 +1205,7 @@ class ilValidator
             return false;
         }
 
-        $message = sprintf(
-            '%s::restoreTrash(): Started...',
-            get_class($this)
-        );
-        $ilLog->write($message, $ilLog->WARNING);
+        $ilLog->warning('Started...');
 
         // start restore process
         $restored = $this->restoreDeletedObjects($a_deleted_objects);
@@ -1241,11 +1214,7 @@ class ilValidator
             $q = "DELETE FROM tree WHERE tree!=1";
             $this->db->query($q);
 
-            $message = sprintf(
-                '%s::restoreTrash(): Removed all trees with tree id <> 1',
-                get_class($this)
-            );
-            $ilLog->write($message, $ilLog->WARNING);
+            $ilLog->warning('Removed all trees with tree id <> 1');
 
             $this->writeScanLogLine("Old tree entries removed");
         }
@@ -1279,11 +1248,7 @@ class ilValidator
             return false;
         }
 
-        $message = sprintf(
-            '%s::restoreDeletedObjects()): Started...',
-            get_class($this)
-        );
-        $ilLog->write($message, $ilLog->WARNING);
+        $ilLog->warning('Started...');
 
         // first delete all rolefolders
         // don't save rolefolders, remove them
@@ -1344,11 +1309,7 @@ class ilValidator
         $subnodes = [];
         $topnode = [];
 
-        $message = sprintf(
-            '%s::restoreSubTrees(): Started...',
-            get_class($this)
-        );
-        $ilLog->write($message, $ilLog->WARNING);
+        $ilLog->warning('Started...');
 
         // process move subtree
         foreach ($a_nodes as $node) {
@@ -1425,11 +1386,7 @@ class ilValidator
         if ($a_nodes === null && isset($this->deleted_objects)) {
             $a_nodes = $this->deleted_objects;
         }
-        $message = sprintf(
-            '%s::purgeTrash(): Started...',
-            get_class($this)
-        );
-        $ilLog->write($message, $ilLog->WARNING);
+        $ilLog->warning('Started...');
 
         // start purge process
         return $this->purgeObjects($a_nodes);
@@ -1456,11 +1413,7 @@ class ilValidator
             $a_nodes = $this->unbound_objects;
         }
 
-        $message = sprintf(
-            '%s::purgeUnboundObjects(): Started...',
-            get_class($this)
-        );
-        $ilLog->write($message, $ilLog->WARNING);
+        $ilLog->warning('Started...');
 
         // start purge process
         return $this->purgeObjects($a_nodes);
@@ -1487,11 +1440,7 @@ class ilValidator
             $a_nodes = $this->missing_objects;
         }
 
-        $message = sprintf(
-            '%s::purgeMissingObjects(): Started...',
-            get_class($this)
-        );
-        $ilLog->write($message, $ilLog->WARNING);
+        $ilLog->warning('Started...');
 
         // start purge process
         return $this->purgeObjects($a_nodes);
@@ -1564,12 +1513,11 @@ class ilValidator
             }
 
             $message = sprintf(
-                '%s::purgeObjects(): Removing object (id:%s ref:%s)',
-                get_class($this),
+                'Removing object (id:%s ref:%s)',
                 $ref_id,
                 $node_obj->getId()
             );
-            $ilLog->write($message, $ilLog->WARNING);
+            $ilLog->warning($message);
 
             $startTime = microtime(true);
             $node_obj->delete();
@@ -1601,11 +1549,7 @@ class ilValidator
         $tree = $this->tree;
         $ilLog = $this->log;
 
-        $message = sprintf(
-            '%s::initGapsInTree(): Started...',
-            get_class($this)
-        );
-        $ilLog->write($message, $ilLog->WARNING);
+        $ilLog->warning('Started...');
 
         // check mode: clean
         if ($this->mode["clean"] !== true) {

--- a/components/ILIAS/Repository/service.xml
+++ b/components/ILIAS/Repository/service.xml
@@ -14,7 +14,6 @@
 	<pluginslots>
 		<pluginslot id="robj" name="RepositoryObject" />
 	</pluginslots>
-	<logging />
 	<events>
 		<event type="listen" id="components/ILIAS/ILIASObject" />
 	</events>

--- a/components/ILIAS/ResourceStorage/service.xml
+++ b/components/ILIAS/ResourceStorage/service.xml
@@ -3,5 +3,4 @@
     <web_access_checker>
         <secure_path path="rs" checking-class="ilWACSignedResourceStorage" in-sec-folder='1'/>
     </web_access_checker>
-    <logging />
 </service>

--- a/components/ILIAS/Scorm2004/classes/class.ilObjSCORM2004LearningModule.php
+++ b/components/ILIAS/Scorm2004/classes/class.ilObjSCORM2004LearningModule.php
@@ -274,7 +274,7 @@ class ilObjSCORM2004LearningModule extends ilObjSCORMLearningModule
 
         //transform manifest file
         $this->totransform = $doc;
-        $ilLog->write("SCORM: about to transform to SCORM 2004");
+        $ilLog->info("SCORM: about to transform to SCORM 2004");
 
         $xsl = new DOMDocument();
         //        $xsl->async = false;
@@ -284,7 +284,7 @@ class ilObjSCORM2004LearningModule extends ilObjSCORMLearningModule
 
         file_put_contents($this->imsmanifestFile, $prc->transformToXML($this->totransform));
 
-        $ilLog->write("SCORM: Transformation completed");
+        $ilLog->info("SCORM: Transformation completed");
     }
 
     /**

--- a/components/ILIAS/Scorm2004/classes/class.ilSCORM2004StoreData.php
+++ b/components/ILIAS/Scorm2004/classes/class.ilSCORM2004StoreData.php
@@ -659,7 +659,7 @@ class ilSCORM2004StoreData
         $ilDB = $DIC->database();
         $ilLog = $DIC["ilLog"];
         $saved_global_status = $data->saved_global_status;
-        $ilLog->write("saved_global_status=" . $saved_global_status);
+        $ilLog->info("saved_global_status=" . $saved_global_status);
 
         //update percentage_completed, sco_total_time_sec,status in sahs_user
         $totalTime = (int) $data->totalTimeCentisec;

--- a/components/ILIAS/Scorm2004/module.xml
+++ b/components/ILIAS/Scorm2004/module.xml
@@ -4,5 +4,4 @@
 	<copage>
 		<pageobject parent_type="sahs" class_name="ilSCORM2004Page" directory="classes"/>
 	</copage>
-	<logging/>
 </module>

--- a/components/ILIAS/ScormAicc/classes/SCORM/class.ilObjSCORMTracking.php
+++ b/components/ILIAS/ScormAicc/classes/SCORM/class.ilObjSCORMTracking.php
@@ -75,7 +75,7 @@ class ilObjSCORMTracking
         }
 
         if ($obj_id <= 1) {
-            $ilLog->write("ScormAicc: storeJsApi: Error: No valid obj_id given.");
+            $ilLog->info("ScormAicc: storeJsApi: Error: No valid obj_id given.");
         } else {
             foreach ($aa_data as $a_data) {
                 $set = $ilDB->queryF(
@@ -155,7 +155,7 @@ class ilObjSCORMTracking
         $ilDB = $DIC->database();
         $ilLog = ilLoggerFactory::getLogger('sahs');
         $saved_global_status = $data->saved_global_status;
-        $ilLog->write("saved_global_status=" . $saved_global_status);
+        $ilLog->info("saved_global_status=" . $saved_global_status);
 
         // get attempts
         if (!isset($data->packageAttempts)) {
@@ -580,7 +580,7 @@ class ilObjSCORMTracking
         $ref_id = $DIC->http()->wrapper()->query()->retrieve('ref_id', $DIC->refinery()->kindlyTo()->int());
         $obj_id = $DIC->http()->wrapper()->query()->retrieve('package_id', $DIC->refinery()->kindlyTo()->int());
         if ($obj_id <= 1) {
-            $GLOBALS['DIC']['ilLog']->write(__METHOD__ . ' no valid obj_id');
+            $GLOBALS['DIC']['ilLog']->info('no valid obj_id');
         } else {
             $last_visited = "";
             if ($DIC->http()->wrapper()->query()->has('last_visited')) {

--- a/components/ILIAS/ScormAicc/classes/SCORM/class.ilSCORMItem.php
+++ b/components/ILIAS/ScormAicc/classes/SCORM/class.ilSCORMItem.php
@@ -308,7 +308,7 @@ class ilSCORMItem extends ilSCORMObject
             array($this->getId())
         );
 
-        $ilLog->write("SAHS Delete(ScormItem): " .
+        $ilLog->info("SAHS Delete(ScormItem): " .
             'DELETE FROM scorm_tracking WHERE sco_id = ' . $this->getId() . ' AND obj_id = ' . $this->getSLMId());
         $ilDB->manipulateF(
             'DELETE FROM scorm_tracking WHERE sco_id = %s AND obj_id = %s',

--- a/components/ILIAS/ScormAicc/classes/SCORM/class.ilSCORMPresentationGUI.php
+++ b/components/ILIAS/ScormAicc/classes/SCORM/class.ilSCORMPresentationGUI.php
@@ -508,7 +508,7 @@ class ilSCORMPresentationGUI
         $certValidator = new ilCertificateDownloadValidator();
         $allowed = $certValidator->isCertificateDownloadable($ilUser->getId(), $obj_id);
         if ($allowed) {
-            $certificateLogger = $DIC->logger()->root();
+            $certificateLogger = $DIC->logger()->forComponent('sahs');
 
             $ilUserCertificateRepository = new ilUserCertificateRepository();
             $pdfGenerator = new ilPdfGenerator($ilUserCertificateRepository);

--- a/components/ILIAS/ScormAicc/classes/Verification/class.ilObjSCORMVerificationGUI.php
+++ b/components/ILIAS/ScormAicc/classes/Verification/class.ilObjSCORMVerificationGUI.php
@@ -65,7 +65,7 @@ class ilObjSCORMVerificationGUI extends ilObject2GUI
             $certificateVerificationFileService = new ilCertificateVerificationFileService(
                 $DIC->language(),
                 $DIC->database(),
-                $DIC->logger()->root(),
+                $DIC->logger()->forComponent('sahs'),
                 new ilCertificateVerificationClassMap()
             );
 

--- a/components/ILIAS/ScormAicc/classes/Verification/class.ilSCORMVerificationTableGUI.php
+++ b/components/ILIAS/ScormAicc/classes/Verification/class.ilSCORMVerificationTableGUI.php
@@ -38,7 +38,7 @@ class ilSCORMVerificationTableGUI extends ilTable2GUI
 
         $ilCtrl = $DIC->ctrl();
         $database = $DIC->database();
-        $logger = $DIC->logger()->root();
+        $logger = $DIC->logger()->forComponent('sahs');
 
         if (null === $userCertificateRepository) {
             $userCertificateRepository = new ilUserCertificateRepository($database, $logger);

--- a/components/ILIAS/ScormAicc/classes/class.ilObjSAHSLearningModule.php
+++ b/components/ILIAS/ScormAicc/classes/class.ilObjSAHSLearningModule.php
@@ -1085,7 +1085,7 @@ class ilObjSAHSLearningModule extends ilObject
         }
 
         $q_log = "DELETE FROM scorm_tracking WHERE obj_id = " . $ilDB->quote($this->getId());
-        $ilLog->write("SAHS Delete(SAHSLM): " . $q_log);
+        $ilLog->info("SAHS Delete(SAHSLM): " . $q_log);
 
         $ilDB->manipulateF(
             'DELETE FROM scorm_tracking WHERE obj_id = %s',
@@ -1094,7 +1094,7 @@ class ilObjSAHSLearningModule extends ilObject
         );
 
         $q_log = "DELETE FROM sahs_user WHERE obj_id = " . $ilDB->quote($this->getId());
-        $ilLog->write("SAHS Delete(SAHSLM): " . $q_log);
+        $ilLog->info("SAHS Delete(SAHSLM): " . $q_log);
 
         $ilDB->manipulateF(
             'DELETE FROM sahs_user WHERE obj_id = %s',

--- a/components/ILIAS/ScormAicc/classes/class.ilScormAiccDataSet.php
+++ b/components/ILIAS/ScormAicc/classes/class.ilScormAiccDataSet.php
@@ -155,7 +155,7 @@ class ilScormAiccDataSet extends ilDataSet
                 }
             }
         } else {
-            $ilLog->write("no module properties for imported object");
+            $ilLog->info("no module properties for imported object");
         }
     }
 
@@ -175,7 +175,7 @@ class ilScormAiccDataSet extends ilDataSet
         global $DIC;
         $ilLog = ilLoggerFactory::getLogger('sahs');
 
-        $ilLog->write(json_encode($this->getTypes("sahs", "5.1.0"), JSON_PRETTY_PRINT));
+        $ilLog->info(json_encode($this->getTypes("sahs", "5.1.0"), JSON_PRETTY_PRINT));
 
         $this->dircnt = 1;
 

--- a/components/ILIAS/Search/service.xml
+++ b/components/ILIAS/Search/service.xml
@@ -17,5 +17,4 @@
 	<crons>
 		<cron id="src_lucene_indexer" class="ilLuceneIndexer" path="Services/Search/classes/Lucene/" />
 	</crons>
-	<logging />
 </service>

--- a/components/ILIAS/Session/module.xml
+++ b/components/ILIAS/Session/module.xml
@@ -26,5 +26,4 @@
 	<mailtemplates>
 		<context id="sess_context_participant_manual" class="ilSessionMailTemplateParticipantContext" />
 	</mailtemplates>
-	<logging />
 </module>

--- a/components/ILIAS/Setup/README.md
+++ b/components/ILIAS/Setup/README.md
@@ -585,11 +585,13 @@ are printed bold**, all other fields might be omitted. A minimal example is
 	"logging" : {
 		"enable" : true,
 		"path_to_logfile" : "/var/log/ilias_test7.log",
+        "default_level" : "INFO"
 		"errorlog_dir" : "/var/log/ilias_errorlogs/"
 	},
     ```
   * *enable* (type: boolean) the logging, defaults to `false`
   * *path_to_logfile* (type: string) to be used for logging
+  * *default_level* (type: string) default log level, possible values: `DEBUG`, `INFO`, `NOTICE`, `WARNING`, `ERROR`, `CRITICAL`, `ALERT`, `EMERGENCY`
   * *errorlog_dir* (type: string) to put error logs in
 * *preview* (type: object) contains settings for ILIAS/Preview
     ```

--- a/components/ILIAS/Skill/Node/class.SkillTreeNodeManager.php
+++ b/components/ILIAS/Skill/Node/class.SkillTreeNodeManager.php
@@ -285,7 +285,7 @@ class SkillTreeNodeManager
             $item = new \ilSkillTemplateCategory($a_item_id);
         }
 
-        $ilLog->write("Getting from clipboard type " . $item_type . ", " .
+        $ilLog->info("Getting from clipboard type " . $item_type . ", " .
             "Item ID: " . $a_item_id);
 
         if ($a_as_copy) {
@@ -299,7 +299,7 @@ class SkillTreeNodeManager
             $target_item = $item;
         }
 
-        $ilLog->write("Putting into skill tree type " . $target_item->getType() .
+        $ilLog->info("Putting into skill tree type " . $target_item->getType() .
             "Item ID: " . $target_item->getId() . ", Parent: " . $a_parent_id . ", " .
             "Target: " . $a_target);
 

--- a/components/ILIAS/Skill/service.xml
+++ b/components/ILIAS/Skill/service.xml
@@ -13,7 +13,6 @@
 			<parent id="skmg" max="1">skmg</parent>
 		</object>
 	</objects>
-	<logging />
 	<events>
 		<event type="listen" id="components/ILIAS/Tracking" />
 		<event type="listen" id="components/ILIAS/ILIASObject" />

--- a/components/ILIAS/StudyProgramme/classes/Mail/class.ilPRGMail.php
+++ b/components/ILIAS/StudyProgramme/classes/Mail/class.ilPRGMail.php
@@ -99,7 +99,7 @@ class ilPRGMail
             $mail->enqueue($login, '', '', $subject, $body, []);
             return true;
         } catch (Exception $e) {
-            $this->log->write($e->getMessage());
+            $this->log->info($e->getMessage());
             return false;
         }
     }
@@ -109,7 +109,7 @@ class ilPRGMail
         list($ass, $prg) = $this->getAssignmentAndProgramme($assignment_id, $root_prg_id);
 
         if (! $prg->getSettings()->getAutoMailSettings()->getReminderNotRestartedByUserDays() > 0) {
-            $this->log->write("Send info to re-assign mail is deactivated in study programme settings");
+            $this->log->info("Send info to re-assign mail is deactivated in study programme settings");
             return;
         }
 
@@ -138,7 +138,7 @@ class ilPRGMail
         list($ass, $prg) = $this->getAssignmentAndProgramme($assignment_id, $root_prg_id);
 
         if (! $prg->getSettings()->getAutoMailSettings()->getProcessingEndsNotSuccessfulDays() > 0) {
-            $this->log->write("Send risky to fail mail is deactivated in study programme settings");
+            $this->log->info("Send risky to fail mail is deactivated in study programme settings");
             return;
         }
 
@@ -167,7 +167,7 @@ class ilPRGMail
         list($ass, $prg) = $this->getAssignmentAndProgramme($assignment_id, $root_prg_id);
 
         if (! $prg->getSettings()->getAutoMailSettings()->getSendReAssignedMail()) {
-            $this->log->write("Send re assign mail is deactivated in study programme settings");
+            $this->log->info("Send re assign mail is deactivated in study programme settings");
             return false;
         }
 

--- a/components/ILIAS/StudyProgramme/classes/class.ilPrgInvalidateExpiredProgressesCronJob.php
+++ b/components/ILIAS/StudyProgramme/classes/class.ilPrgInvalidateExpiredProgressesCronJob.php
@@ -100,7 +100,7 @@ class ilPrgInvalidateExpiredProgressesCronJob extends CronJob
                 $assignment = $assignment->invalidate($this->settings_repo);
                 $this->assignment_repo->store($assignment);
             } catch (ilException $e) {
-                $this->log->write('an error occured: ' . $e->getMessage());
+                $this->log->info('an error occured: ' . $e->getMessage());
                 $result->setStatus(JobResult::STATUS_FAIL);
                 return $result;
             }

--- a/components/ILIAS/StudyProgramme/classes/class.ilPrgRestartAssignmentsCronJob.php
+++ b/components/ILIAS/StudyProgramme/classes/class.ilPrgRestartAssignmentsCronJob.php
@@ -159,6 +159,6 @@ class ilPrgRestartAssignmentsCronJob extends CronJob
 
     protected function log(string $msg): void
     {
-        $this->log->write($msg);
+        $this->log->info($msg);
     }
 }

--- a/components/ILIAS/StudyProgramme/classes/class.ilPrgUserNotRestartedCronJob.php
+++ b/components/ILIAS/StudyProgramme/classes/class.ilPrgUserNotRestartedCronJob.php
@@ -128,6 +128,6 @@ class ilPrgUserNotRestartedCronJob extends CronJob
 
     protected function log(string $msg): void
     {
-        $this->log->write($msg);
+        $this->log->info($msg);
     }
 }

--- a/components/ILIAS/StudyProgramme/classes/class.ilPrgUserRiskyToFailCronJob.php
+++ b/components/ILIAS/StudyProgramme/classes/class.ilPrgUserRiskyToFailCronJob.php
@@ -129,6 +129,6 @@ class ilPrgUserRiskyToFailCronJob extends CronJob
 
     protected function log(string $msg): void
     {
-        $this->log->write($msg);
+        $this->log->info($msg);
     }
 }

--- a/components/ILIAS/StudyProgramme/classes/memberexport/ilFSStoragePRG.php
+++ b/components/ILIAS/StudyProgramme/classes/memberexport/ilFSStoragePRG.php
@@ -106,7 +106,7 @@ class ilFSStoragePRG extends ilFileSystemAbstractionStorage
     {
         $this->initMemberExportDirectory();
         if (!$this->writeToFile($a_data, $this->getMemberExportDirectory() . '/' . $a_rel_name)) {
-            $this->logger->write('Cannot write to file: ' . $this->getMemberExportDirectory() . '/' . $a_rel_name);
+            $this->logger->info('Cannot write to file: ' . $this->getMemberExportDirectory() . '/' . $a_rel_name);
             return false;
         }
 

--- a/components/ILIAS/Style/service.xml
+++ b/components/ILIAS/Style/service.xml
@@ -13,7 +13,6 @@
 			<parent id="adm" max="1">adm</parent>
 		</object>
 	</objects>
-	<logging />
 	<web_access_checker>
 		<secure_path path="css" checking-class="ilContentStyleWAC" />
 	</web_access_checker>

--- a/components/ILIAS/Survey/Export/class.ilSurveyExporter.php
+++ b/components/ILIAS/Survey/Export/class.ilSurveyExporter.php
@@ -62,7 +62,7 @@ class ilSurveyExporter extends ilXmlExporter
             // here: svy_data/svy_301/export/1698817474__0__svy_301
             //       svy_301/export/1698817474__0__svy_301/Modules/Survey/set_1
             //       svy_data/svy_301/export/1698817474__0__svy_301.zip
-            $GLOBALS['ilLog']->write(__METHOD__ . ': Created zip file ' . $zip);
+            $GLOBALS['ilLog']->info('Created zip file ' . $zip);
             return "";
         } else {
             return $this->ds->getXmlRepresentation($a_entity, $a_schema_version, [$a_id], "", true, true);

--- a/components/ILIAS/Survey/Export/class.ilSurveyImporter.php
+++ b/components/ILIAS/Survey/Export/class.ilSurveyImporter.php
@@ -97,10 +97,10 @@ class ilSurveyImporter extends ilXmlImporter
             [$xml_file] = $this->parseXmlFileNames();
 
             if (!file_exists($xml_file)) {
-                $GLOBALS['ilLog']->write(__METHOD__ . ': Cannot find xml definition: ' . $xml_file);
+                $GLOBALS['ilLog']->info('Cannot find xml definition: ' . $xml_file);
                 return;
             }
-            $GLOBALS['ilLog']->write("getQuestionPoolID = " . $this->getImport()->getConfig("components/ILIAS/Survey")->getQuestionPoolID());
+            $GLOBALS['ilLog']->info("getQuestionPoolID = " . $this->getImport()->getConfig("components/ILIAS/Survey")->getQuestionPoolID());
 
             $import = new SurveyImportParser(
                 $this->getImport()->getConfig("components/ILIAS/Survey")->getQuestionPoolID(),
@@ -136,7 +136,7 @@ class ilSurveyImporter extends ilXmlImporter
      */
     protected function parseXmlFileNames(): array
     {
-        $GLOBALS['ilLog']->write(__METHOD__ . ': ' . $this->getImportDirectory());
+        $GLOBALS['ilLog']->info($this->getImportDirectory());
 
         $basename = basename($this->getImportDirectory());
         $xml = $this->getImportDirectory() . '/' . $basename . '.xml';

--- a/components/ILIAS/Survey/Participants/class.ilSurveyParticipantsGUI.php
+++ b/components/ILIAS/Survey/Participants/class.ilSurveyParticipantsGUI.php
@@ -822,7 +822,7 @@ class ilSurveyParticipantsGUI
             }
         } catch (Exception $e) {
             $ilLog = $this->log;
-            $ilLog->write('Error: ' . $e->getMessage());
+            $ilLog->info('Error: ' . $e->getMessage());
         }
         $this->tpl->setVariable("ADM_CONTENT", $form_gui->getHTML());
     }
@@ -845,7 +845,7 @@ class ilSurveyParticipantsGUI
             }
         } catch (Exception $e) {
             $ilLog = $this->log;
-            $ilLog->write('Error: ' . $e->getMessage());
+            $ilLog->info('Error: ' . $e->getMessage());
         }
         $this->tpl->setVariable("ADM_CONTENT", $form_gui->getHTML());
     }

--- a/components/ILIAS/Survey/module.xml
+++ b/components/ILIAS/Survey/module.xml
@@ -28,7 +28,6 @@
 		<context id="svy_context_rmd" class="ilSurveyMailTemplateReminderContext" />
 		<context id="svy_rater_inv" class="ilSurveyMailTemplateRaterInvitationContext" />
 	</mailtemplates>
-	<logging />
 	<events>
 		<event type="listen" id="components/ILIAS/Skill" />
 	</events>

--- a/components/ILIAS/SurveyQuestionPool/Export/class.ilSurveyQuestionPoolImporter.php
+++ b/components/ILIAS/SurveyQuestionPool/Export/class.ilSurveyQuestionPoolImporter.php
@@ -39,7 +39,7 @@ class ilSurveyQuestionPoolImporter extends ilXmlImporter
         # Try legacy import
         $xml_file = $this->getXmlFileName();
         if (file_exists($xml_file)) {
-            $GLOBALS['ilLog']->write(__METHOD__ . ': Cannot find xml definition: ' . $xml_file);
+            $GLOBALS['ilLog']->info('Cannot find xml definition: ' . $xml_file);
             // import qti data
             $newObj->importObject($xml_file);
         }

--- a/components/ILIAS/SurveyQuestionPool/module.xml
+++ b/components/ILIAS/SurveyQuestionPool/module.xml
@@ -15,5 +15,4 @@
 			<parent id="root">root</parent>
 		</object>
 	</objects>
-	<logging />
 </module>

--- a/components/ILIAS/SystemCheck/service.xml
+++ b/components/ILIAS/SystemCheck/service.xml
@@ -7,8 +7,7 @@
 			<parent id="adm" max="1">adm</parent>
 		</object>
 	</objects>
-	<crons>		
+	<crons>
 		<cron id="sysc_trash" class="ilSCCronTrash" />
 	</crons>
-	<logging />
 </service>

--- a/components/ILIAS/TermsOfService/service.xml
+++ b/components/ILIAS/TermsOfService/service.xml
@@ -11,5 +11,4 @@
 		<event type="listen" id="components/ILIAS/User" />
 		<event type="raise" id="ilTermsOfServiceEventWithdrawn" />
 	</events>
-	<logging />
 </service>

--- a/components/ILIAS/Test/classes/class.ilObjTest.php
+++ b/components/ILIAS/Test/classes/class.ilObjTest.php
@@ -5579,7 +5579,7 @@ class ilObjTest extends ilObject
             $row = $ilDB->fetchAssoc($result);
             $row['feedback'] = ilRTE::_replaceMediaObjectImageSrc($row['feedback'] ?? '', 1);
         } elseif ($ilDB->numRows($result) > 1) {
-            $DIC->logger()->root()->warning(
+            $DIC->logger()->forComponent('tst')->warning(
                 "WARNING: Multiple feedback entries on tst_manual_fb for " .
                 "active_fi = $active_id , question_fi = $question_id and pass = $pass"
             );

--- a/components/ILIAS/Test/classes/class.ilObjTestVerificationGUI.php
+++ b/components/ILIAS/Test/classes/class.ilObjTestVerificationGUI.php
@@ -59,7 +59,7 @@ class ilObjTestVerificationGUI extends ilObject2GUI
             $this->ctrl->getLinkTarget($this, "cancel")
         );
 
-        $table = new ilTestVerificationTableGUI($this, 'create', $this->db, $this->user, $this->logger->root());
+        $table = new ilTestVerificationTableGUI($this, 'create', $this->db, $this->user, $this->logger->forComponent('tst'));
         $this->tpl->setContent($table->getHTML());
     }
 
@@ -70,7 +70,7 @@ class ilObjTestVerificationGUI extends ilObject2GUI
             $certificateVerificationFileService = new ilCertificateVerificationFileService(
                 $this->lng,
                 $this->db,
-                $this->logger->root(),
+                $this->logger->forComponent('tst'),
                 new ilCertificateVerificationClassMap()
             );
 

--- a/components/ILIAS/TestQuestionPool/classes/class.assImagemapQuestion.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assImagemapQuestion.php
@@ -319,7 +319,7 @@ class assImagemapQuestion extends assQuestion implements ilObjQuestionScoringAdj
                 $this->tpl->setOnScreenMessage('failure', 'The image could not be uploaded!');
                 return;
             }
-            $this->log->write('gespeichert: ' . $imagepath . $image_filename);
+            $this->log->info('gespeichert: ' . $imagepath . $image_filename);
         }
     }
 

--- a/components/ILIAS/TestQuestionPool/classes/class.assImagemapQuestion.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assImagemapQuestion.php
@@ -206,7 +206,7 @@ class assImagemapQuestion extends assQuestion implements ilObjQuestionScoringAdj
         }
 
         if (!file_exists($image_source_path) || !is_readable($image_source_path)) {
-            $this->log->root()->alert(
+            $this->log->forComponent('qpl')->alert(
                 "Could not copy imagemap question files: Source path '{$image_source_path}' does not exist or is not readable.",
                 [
                     'source_question_id' => $source_question_id,

--- a/components/ILIAS/TestQuestionPool/classes/class.assMatchingQuestion.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assMatchingQuestion.php
@@ -350,7 +350,7 @@ class assMatchingQuestion extends assQuestion implements ilObjQuestionScoringAdj
             $filename = $term->getPicture();
             if (!file_exists($image_source_path . $filename)
                 || !copy($image_source_path . $filename, $image_target_path . $filename)) {
-                $this->log->root()->warning('matching question image could not be copied: '
+                $this->log->forComponent('qpl')->warning('matching question image could not be copied: '
                     . $image_source_path . $filename);
             }
             if (!file_exists($image_source_path . $this->getThumbPrefix() . $filename)
@@ -358,7 +358,7 @@ class assMatchingQuestion extends assQuestion implements ilObjQuestionScoringAdj
                     $image_source_path . $this->getThumbPrefix() . $filename,
                     $image_target_path . $this->getThumbPrefix() . $filename
                 )) {
-                $this->log->root()->warning('matching question image thumbnail could not be copied: '
+                $this->log->forComponent('qpl')->warning('matching question image thumbnail could not be copied: '
                     . $image_source_path . $this->getThumbPrefix() . $filename);
             }
         }
@@ -370,7 +370,7 @@ class assMatchingQuestion extends assQuestion implements ilObjQuestionScoringAdj
 
             if (!file_exists($image_source_path . $filename)
                 || !copy($image_source_path . $filename, $image_target_path . $filename)) {
-                $this->log->root()->warning('matching question image could not be copied: '
+                $this->log->forComponent('qpl')->warning('matching question image could not be copied: '
                     . $image_source_path . $filename);
             }
 
@@ -379,7 +379,7 @@ class assMatchingQuestion extends assQuestion implements ilObjQuestionScoringAdj
                     $image_source_path . $this->getThumbPrefix() . $filename,
                     $image_target_path . $this->getThumbPrefix() . $filename
                 )) {
-                $this->log->root()->warning('matching question image thumbnail could not be copied: '
+                $this->log->forComponent('qpl')->warning('matching question image thumbnail could not be copied: '
                     . $image_source_path . $this->getThumbPrefix() . $filename);
             }
         }

--- a/components/ILIAS/TestQuestionPool/classes/class.assOrderingQuestion.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assOrderingQuestion.php
@@ -199,11 +199,11 @@ class assOrderingQuestion extends assQuestion implements ilObjQuestionScoringAdj
 
             if (!file_exists($image_source_path . $filename)
                 || !copy($image_source_path . $filename, $image_target_path . $filename)) {
-                $this->log->root()->warning('Image could not be cloned for object for question: ' . $target_question_id);
+                $this->log->forComponent('qpl')->warning('Image could not be cloned for object for question: ' . $target_question_id);
             }
             if (!file_exists($image_source_path . $this->getThumbPrefix() . $filename)
                 || !copy($image_source_path . $this->getThumbPrefix() . $filename, $image_target_path . $this->getThumbPrefix() . $filename)) {
-                $this->log->root()->warning('Image thumbnails could not be cloned for object for question: ' . $target_question_id);
+                $this->log->forComponent('qpl')->warning('Image thumbnails could not be cloned for object for question: ' . $target_question_id);
             }
         }
     }

--- a/components/ILIAS/TestQuestionPool/classes/class.assQuestion.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assQuestion.php
@@ -856,7 +856,7 @@ abstract class assQuestion implements Question
         try {
             $this->deletePageOfQuestion($question_id);
         } catch (Exception $e) {
-            $this->log->root()->error("EXCEPTION: Could not delete page of question $question_id: $e");
+            $this->log->forComponent('qpl')->error("EXCEPTION: Could not delete page of question $question_id: $e");
             return;
         }
 
@@ -875,7 +875,7 @@ abstract class assQuestion implements Question
             $this->feedbackOBJ->deleteGenericFeedbacks($question_id, $this->isAdditionalContentEditingModePageObject());
             $this->feedbackOBJ->deleteSpecificAnswerFeedbacks($question_id, $this->isAdditionalContentEditingModePageObject());
         } catch (Exception $e) {
-            $this->log->root()->error("EXCEPTION: Could not delete additional table data of question {$question_id}: {$e}");
+            $this->log->forComponent('qpl')->error("EXCEPTION: Could not delete additional table data of question {$question_id}: {$e}");
         }
 
         try {
@@ -886,13 +886,13 @@ abstract class assQuestion implements Question
                 [$question_id]
             );
         } catch (Exception $e) {
-            $this->log->root()->error("EXCEPTION: Could not delete delete question {$question_id} from a test: {$e}");
+            $this->log->forComponent('qpl')->error("EXCEPTION: Could not delete delete question {$question_id} from a test: {$e}");
         }
 
         try {
             $this->getSuggestedSolutionsRepo()->deleteForQuestion($question_id);
         } catch (Exception $e) {
-            $this->log->root()->error("EXCEPTION: Could not delete suggested solutions of question {$question_id}: {$e}");
+            $this->log->forComponent('qpl')->error("EXCEPTION: Could not delete suggested solutions of question {$question_id}: {$e}");
         }
 
         $directory = CLIENT_WEB_DIR . "/assessment/" . $obj_id . "/$question_id";
@@ -901,7 +901,7 @@ abstract class assQuestion implements Question
                 ilFileUtils::delDir($directory);
             }
         } catch (Exception $e) {
-            $this->log->root()->error("EXCEPTION: Could not delete question file directory {$directory} of question {$question_id}: {$e}");
+            $this->log->forComponent('qpl')->error("EXCEPTION: Could not delete question file directory {$directory} of question {$question_id}: {$e}");
         }
 
         try {
@@ -918,7 +918,7 @@ abstract class assQuestion implements Question
                 }
             }
         } catch (Exception $e) {
-            $this->log->root()->error("EXCEPTION: Error deleting the media objects of question {$question_id}: {$e}");
+            $this->log->forComponent('qpl')->error("EXCEPTION: Error deleting the media objects of question {$question_id}: {$e}");
         }
         $assignmentList = new ilAssQuestionSkillAssignmentList($this->db);
         $assignmentList->setParentObjId($obj_id);
@@ -944,7 +944,7 @@ abstract class assQuestion implements Question
         try {
             ilObjQuestionPool::_updateQuestionCount($this->getObjId());
         } catch (Exception $e) {
-            $this->log->root()->error(
+            $this->log->forComponent('qpl')->error(
                 "EXCEPTION: Error updating the question pool question count of"
                 . " question pool {$this->getObjId()} when deleting question {$question_id}: {$e}"
             );
@@ -1560,8 +1560,8 @@ abstract class assQuestion implements Question
             }
             if (!is_file($filepath_original . $solution->getFilename())
                 || !copy($filepath_original . $solution->getFilename(), $filepath . $solution->getFilename())) {
-                $this->log->root()->error('File for suggested solutions could not be duplicated:');
-                $this->log->root()->error("Question-Id: {$this->id}; Question-Title: {$this->title}; File: {$filepath_original}{$solution->getFilename()}");
+                $this->log->forComponent('qpl')->error('File for suggested solutions could not be duplicated:');
+                $this->log->forComponent('qpl')->error("Question-Id: {$this->id}; Question-Title: {$this->title}; File: {$filepath_original}{$solution->getFilename()}");
             }
         }
     }
@@ -1585,8 +1585,8 @@ abstract class assQuestion implements Question
 
             if (!is_file($filepath_original . $solution->getFilename())
                 || copy($filepath_target . $solution->getFilename(), $filepath_target . $solution->getFilename())) {
-                $this->log->root()->error('File for suggested solutions could not be cloned:');
-                $this->log->root()->error("Question-Id: {$this->id}; Question-Title: {$this->title}; File: {$filepath_original}{$solution->getFilename()}");
+                $this->log->forComponent('qpl')->error('File for suggested solutions could not be cloned:');
+                $this->log->forComponent('qpl')->error("Question-Id: {$this->id}; Question-Title: {$this->title}; File: {$filepath_original}{$solution->getFilename()}");
             }
         }
     }

--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssFileUploadUploadsExporter.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssFileUploadUploadsExporter.php
@@ -261,7 +261,7 @@ class ilAssFileUploadUploadsExporter
         try {
             ilFileUtils::rename($this->tempZipFilePath, $this->finalZipFilePath);
         } catch (\ilFileUtilsException $e) {
-            \ilLoggerFactory::getRootLogger()->error($e->getMessage());
+            \ilLoggerFactory::getLogger('tst')->error($e->getMessage());
         }
     }
 

--- a/components/ILIAS/TestQuestionPool/classes/class.ilImagemapPreview.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilImagemapPreview.php
@@ -236,7 +236,7 @@ class ilImagemapPreview
         }
         exec($cmd, $arr);
 
-        $DIC->logger()->root()->debug("ilUtil::execQuoted: " . $cmd . ".");
+        $DIC->logger()->forComponent('qpl')->debug("ilUtil::execQuoted: " . $cmd . ".");
 
         return $arr;
     }

--- a/components/ILIAS/TestQuestionPool/classes/class.ilQuestionPageParser.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilQuestionPageParser.php
@@ -147,7 +147,7 @@ class ilQuestionPageParser extends ilSaxParser
                     switch ($pg['type']) {
                         case 'pg_alias':
                             if ($this->pg_mapping[$pg['id']] == '') {
-                                $ilLog->write('LM Import: No PageObject for PageAlias ' .
+                                $ilLog->info('LM Import: No PageObject for PageAlias ' .
                                               $pg['id'] . ' found! (Please update export installation to ILIAS 3.3.0)');
 
                                 // Jump two levels up. First level is switch

--- a/components/ILIAS/TestQuestionPool/classes/class.ilTestQuestionPoolExporter.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilTestQuestionPoolExporter.php
@@ -65,7 +65,7 @@ class ilTestQuestionPoolExporter extends ilXmlExporter
         $qpl_exp->buildExportFile();
 
         global $DIC; /* @var ILIAS\DI\Container $DIC */
-        $DIC['ilLog']->write(__METHOD__ . ': Created zip file');
+        $DIC['ilLog']->info(': Created zip file');
         return ''; // sagt mjansen
     }
 

--- a/components/ILIAS/TestQuestionPool/classes/class.ilTestQuestionPoolImporter.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilTestQuestionPoolImporter.php
@@ -71,16 +71,16 @@ class ilTestQuestionPoolImporter extends ilXmlImporter
             ilSession::clear('qpl_import_selected_questions');
         } else {
             // Shouldn't happen
-            $DIC['ilLog']->write(__METHOD__ . ': non container and no tax mapping, perhaps old qpl export');
+            $DIC['ilLog']->info('non container and no tax mapping, perhaps old qpl export');
             return;
         }
 
         if (!file_exists($xmlfile)) {
-            $DIC['ilLog']->write(__METHOD__ . ': Cannot find xml definition: ' . $xmlfile);
+            $DIC['ilLog']->info('Cannot find xml definition: ' . $xmlfile);
             return;
         }
         if (!file_exists($qtifile)) {
-            $DIC['ilLog']->write(__METHOD__ . ': Cannot find qti definition: ' . $qtifile);
+            $DIC['ilLog']->info('Cannot find qti definition: ' . $qtifile);
             return;
         }
 
@@ -102,7 +102,7 @@ class ilTestQuestionPoolImporter extends ilXmlImporter
         // TODO: move all logic to ilObjQuestionPoolGUI::importVerifiedFile and call
         // this method from ilObjQuestionPoolGUI and ilTestImporter
 
-        $DIC['ilLog']->write(__METHOD__ . ': xml file: ' . $xmlfile . ', qti file:' . $qtifile);
+        $DIC['ilLog']->info('xml file: ' . $xmlfile . ', qti file:' . $qtifile);
 
         $qtiParser = new ilQTIParser(
             $importdir,

--- a/components/ILIAS/TestQuestionPool/classes/import/qti12/class.assClozeTestImport.php
+++ b/components/ILIAS/TestQuestionPool/classes/import/qti12/class.assClozeTestImport.php
@@ -328,7 +328,7 @@ class assClozeTestImport extends assQuestionImport
             foreach (ilSession::get('import_mob_xhtml') as $mob) {
                 $importfile = $importdirectory . DIRECTORY_SEPARATOR . $mob['uri'];
                 global $DIC;
-                $DIC['ilLog']->write(__METHOD__ . ': import mob from dir: ' . $importfile);
+                $DIC['ilLog']->info('import mob from dir: ' . $importfile);
 
                 $media_object = ilObjMediaObject::_saveTempFileAsMediaObject(basename($importfile), $importfile, false);
                 $questiontext = str_replace('src="' . $mob['mob'] . '"', 'src="' . 'il_' . IL_INST_ID . '_mob_' . $media_object->getId() . '"', $questiontext);

--- a/components/ILIAS/TestQuestionPool/classes/import/qti12/class.assErrorTextImport.php
+++ b/components/ILIAS/TestQuestionPool/classes/import/qti12/class.assErrorTextImport.php
@@ -76,7 +76,7 @@ class assErrorTextImport extends assQuestionImport
             foreach (ilSession::get("import_mob_xhtml") as $mob) {
                 $importfile = $importdirectory . DIRECTORY_SEPARATOR . $mob["uri"];
                 global $DIC; /* @var ILIAS\DI\Container $DIC */
-                $DIC['ilLog']->write(__METHOD__ . ': import mob from dir: ' . $importfile);
+                $DIC['ilLog']->info('import mob from dir: ' . $importfile);
 
                 $media_object = ilObjMediaObject::_saveTempFileAsMediaObject(basename($importfile), $importfile, false);
                 ilObjMediaObject::_saveUsage($media_object->getId(), "qpl:html", $this->object->getId());

--- a/components/ILIAS/TestQuestionPool/classes/import/qti12/class.assFileUploadImport.php
+++ b/components/ILIAS/TestQuestionPool/classes/import/qti12/class.assFileUploadImport.php
@@ -64,7 +64,7 @@ class assFileUploadImport extends assQuestionImport
                 $importfile = $importdirectory . DIRECTORY_SEPARATOR . $mob["uri"];
 
                 global $DIC; /* @var ILIAS\DI\Container $DIC */
-                $DIC['ilLog']->write(__METHOD__ . ': import mob from dir: ' . $importfile);
+                $DIC['ilLog']->info('import mob from dir: ' . $importfile);
 
                 $media_object = ilObjMediaObject::_saveTempFileAsMediaObject(basename($importfile), $importfile, false);
                 ilObjMediaObject::_saveUsage($media_object->getId(), "qpl:html", $this->object->getId());

--- a/components/ILIAS/TestQuestionPool/classes/import/qti12/class.assImagemapQuestionImport.php
+++ b/components/ILIAS/TestQuestionPool/classes/import/qti12/class.assImagemapQuestionImport.php
@@ -225,7 +225,7 @@ class assImagemapQuestionImport extends assQuestionImport
                 $importfile = $importdirectory . DIRECTORY_SEPARATOR . $mob["uri"];
 
                 global $DIC; /* @var ILIAS\DI\Container $DIC */
-                $DIC['ilLog']->write(__METHOD__ . ': import mob from dir: ' . $importfile);
+                $DIC['ilLog']->info('import mob from dir: ' . $importfile);
 
                 $media_object = ilObjMediaObject::_saveTempFileAsMediaObject(basename($importfile), $importfile, false);
                 ilObjMediaObject::_saveUsage($media_object->getId(), "qpl:html", $this->object->getId());

--- a/components/ILIAS/TestQuestionPool/classes/import/qti12/class.assKprimChoiceImport.php
+++ b/components/ILIAS/TestQuestionPool/classes/import/qti12/class.assKprimChoiceImport.php
@@ -262,7 +262,7 @@ class assKprimChoiceImport extends assQuestionImport
                 $importfile = $importdirectory . DIRECTORY_SEPARATOR . $mob["uri"];
 
                 global $DIC; /* @var ILIAS\DI\Container $DIC */
-                $DIC['ilLog']->write(__METHOD__ . ': import mob from dir: ' . $importfile);
+                $DIC['ilLog']->info('import mob from dir: ' . $importfile);
 
                 $media_object = ilObjMediaObject::_saveTempFileAsMediaObject(basename($importfile), $importfile, false);
                 ilObjMediaObject::_saveUsage($media_object->getId(), "qpl:html", $this->object->getId());

--- a/components/ILIAS/TestQuestionPool/classes/import/qti12/class.assLongMenuImport.php
+++ b/components/ILIAS/TestQuestionPool/classes/import/qti12/class.assLongMenuImport.php
@@ -60,7 +60,7 @@ class assLongMenuImport extends assQuestionImport
                 $importfile = $importdirectory . DIRECTORY_SEPARATOR . $mob["uri"];
 
                 global $DIC; /* @var ILIAS\DI\Container $DIC */
-                $DIC['ilLog']->write(__METHOD__ . ': import mob from dir: ' . $importfile);
+                $DIC['ilLog']->info('import mob from dir: ' . $importfile);
 
                 $media_object = ilObjMediaObject::_saveTempFileAsMediaObject(basename($importfile), $importfile, false);
                 ilObjMediaObject::_saveUsage($media_object->getId(), "qpl:html", $this->object->getId());

--- a/components/ILIAS/TestQuestionPool/classes/import/qti12/class.assMatchingQuestionImport.php
+++ b/components/ILIAS/TestQuestionPool/classes/import/qti12/class.assMatchingQuestionImport.php
@@ -263,7 +263,7 @@ class assMatchingQuestionImport extends assQuestionImport
                 $importfile = $importdirectory . DIRECTORY_SEPARATOR . $mob["uri"];
 
                 global $DIC; /* @var ILIAS\DI\Container $DIC */
-                $DIC['ilLog']->write(__METHOD__ . ': import mob from dir: ' . $importfile);
+                $DIC['ilLog']->info('import mob from dir: ' . $importfile);
 
                 $media_object = ilObjMediaObject::_saveTempFileAsMediaObject(basename($importfile), $importfile, false);
                 ilObjMediaObject::_saveUsage($media_object->getId(), "qpl:html", $this->object->getId());

--- a/components/ILIAS/TestQuestionPool/classes/import/qti12/class.assMultipleChoiceImport.php
+++ b/components/ILIAS/TestQuestionPool/classes/import/qti12/class.assMultipleChoiceImport.php
@@ -270,7 +270,7 @@ class assMultipleChoiceImport extends assQuestionImport
                 $importfile = $importdirectory . DIRECTORY_SEPARATOR . $mob["uri"];
 
                 global $DIC; /* @var ILIAS\DI\Container $DIC */
-                $DIC['ilLog']->write(__METHOD__ . ': import mob from dir: ' . $importfile);
+                $DIC['ilLog']->info('import mob from dir: ' . $importfile);
 
                 $media_object = ilObjMediaObject::_saveTempFileAsMediaObject(basename($importfile), $importfile, false);
                 ilObjMediaObject::_saveUsage($media_object->getId(), "qpl:html", $this->object->getId());

--- a/components/ILIAS/TestQuestionPool/classes/import/qti12/class.assNumericImport.php
+++ b/components/ILIAS/TestQuestionPool/classes/import/qti12/class.assNumericImport.php
@@ -151,7 +151,7 @@ class assNumericImport extends assQuestionImport
                 $importfile = $importdirectory . DIRECTORY_SEPARATOR . $mob["uri"];
 
                 global $DIC; /* @var ILIAS\DI\Container $DIC */
-                $DIC['ilLog']->write(__METHOD__ . ': import mob from dir: ' . $importfile);
+                $DIC['ilLog']->info('import mob from dir: ' . $importfile);
 
                 $media_object = ilObjMediaObject::_saveTempFileAsMediaObject(basename($importfile), $importfile, false);
                 ilObjMediaObject::_saveUsage($media_object->getId(), "qpl:html", $this->object->getId());

--- a/components/ILIAS/TestQuestionPool/classes/import/qti12/class.assOrderingHorizontalImport.php
+++ b/components/ILIAS/TestQuestionPool/classes/import/qti12/class.assOrderingHorizontalImport.php
@@ -72,7 +72,7 @@ class assOrderingHorizontalImport extends assQuestionImport
                 $importfile = $importdirectory . DIRECTORY_SEPARATOR . $mob["uri"];
 
                 global $DIC; /* @var ILIAS\DI\Container $DIC */
-                $DIC['ilLog']->write(__METHOD__ . ': import mob from dir: ' . $importfile);
+                $DIC['ilLog']->info('import mob from dir: ' . $importfile);
 
                 $media_object = ilObjMediaObject::_saveTempFileAsMediaObject(basename($importfile), $importfile, false);
                 ilObjMediaObject::_saveUsage($media_object->getId(), "qpl:html", $this->object->getId());

--- a/components/ILIAS/TestQuestionPool/classes/import/qti12/class.assOrderingQuestionImport.php
+++ b/components/ILIAS/TestQuestionPool/classes/import/qti12/class.assOrderingQuestionImport.php
@@ -256,7 +256,7 @@ class assOrderingQuestionImport extends assQuestionImport
                 $importfile = $importdirectory . DIRECTORY_SEPARATOR . $mob['uri'];
 
                 global $DIC; /* @var ILIAS\DI\Container $DIC */
-                $DIC['ilLog']->write(__METHOD__ . ': import mob from dir: ' . $importfile);
+                $DIC['ilLog']->info('import mob from dir: ' . $importfile);
 
                 $media_object = ilObjMediaObject::_saveTempFileAsMediaObject(basename($importfile), $importfile, false);
                 ilObjMediaObject::_saveUsage($media_object->getId(), "qpl:html", $this->object->getId());

--- a/components/ILIAS/TestQuestionPool/classes/import/qti12/class.assSingleChoiceImport.php
+++ b/components/ILIAS/TestQuestionPool/classes/import/qti12/class.assSingleChoiceImport.php
@@ -266,7 +266,7 @@ class assSingleChoiceImport extends assQuestionImport
                 $importfile = $importdirectory . DIRECTORY_SEPARATOR . $mob["uri"];
 
                 global $DIC; /* @var ILIAS\DI\Container $DIC */
-                $DIC['ilLog']->write(__METHOD__ . ': import mob from dir: ' . $importfile);
+                $DIC['ilLog']->info('import mob from dir: ' . $importfile);
 
                 $media_object = ilObjMediaObject::_saveTempFileAsMediaObject(basename($importfile), $importfile, false);
                 ilObjMediaObject::_saveUsage($media_object->getId(), 'qpl:html', $this->object->getId());

--- a/components/ILIAS/TestQuestionPool/classes/import/qti12/class.assTextQuestionImport.php
+++ b/components/ILIAS/TestQuestionPool/classes/import/qti12/class.assTextQuestionImport.php
@@ -176,7 +176,7 @@ class assTextQuestionImport extends assQuestionImport
                 $importfile = $importdirectory . DIRECTORY_SEPARATOR . $mob["uri"];
 
                 global $DIC; /* @var ILIAS\DI\Container $DIC */
-                $DIC['ilLog']->write(__METHOD__ . ': import mob from dir: ' . $importfile);
+                $DIC['ilLog']->info('import mob from dir: ' . $importfile);
 
                 $media_object = ilObjMediaObject::_saveTempFileAsMediaObject(basename($importfile), $importfile, false);
                 ilObjMediaObject::_saveUsage($media_object->getId(), "qpl:html", $this->object->getId());

--- a/components/ILIAS/TestQuestionPool/classes/import/qti12/class.assTextSubsetImport.php
+++ b/components/ILIAS/TestQuestionPool/classes/import/qti12/class.assTextSubsetImport.php
@@ -169,7 +169,7 @@ class assTextSubsetImport extends assQuestionImport
                 $importfile = $importdirectory . DIRECTORY_SEPARATOR . $mob["uri"];
 
                 global $DIC; /* @var ILIAS\DI\Container $DIC */
-                $DIC['ilLog']->write(__METHOD__ . ': import mob from dir: ' . $importfile);
+                $DIC['ilLog']->info('import mob from dir: ' . $importfile);
 
                 $media_object = ilObjMediaObject::_saveTempFileAsMediaObject(basename($importfile), $importfile, false);
                 ilObjMediaObject::_saveUsage($media_object->getId(), "qpl:html", $this->object->getId());

--- a/components/ILIAS/TestQuestionPool/src/ManipulateImagesInChoiceQuestionsTrait.php
+++ b/components/ILIAS/TestQuestionPool/src/ManipulateImagesInChoiceQuestionsTrait.php
@@ -59,11 +59,11 @@ trait ManipulateImagesInChoiceQuestionsTrait
 
             if (!file_exists($image_source_path . $filename)
                 || !copy($image_source_path . $filename, $image_target_path . $filename)) {
-                $this->log->root()->warning('Image could not be cloned for object for question: ' . $target_question_id);
+                $this->log->forComponent('qpl')->warning('Image could not be cloned for object for question: ' . $target_question_id);
             }
             if (!file_exists($image_source_path . $this->getThumbPrefix() . $filename)
                 || !copy($image_source_path . $this->getThumbPrefix() . $filename, $image_target_path . $this->getThumbPrefix() . $filename)) {
-                $this->log->root()->warning('Image thumbnail could not be cloned for object for question: ' . $target_question_id);
+                $this->log->forComponent('qpl')->warning('Image thumbnail could not be cloned for object for question: ' . $target_question_id);
             }
         }
     }

--- a/components/ILIAS/Tracking/service.xml
+++ b/components/ILIAS/Tracking/service.xml
@@ -9,8 +9,8 @@
 			<parent id="adm" max="1">adm</parent>
 		</object>
 	</objects>
-	<events>		
-		<event type="raise" id="updateStatus" />	
+	<events>
+		<event type="raise" id="updateStatus" />
 		<event type="listen" id="components/ILIAS/ILIASObject" />
 		<event type="listen" id="components/ILIAS/Tree" />
 		<event type="listen" id="components/ILIAS/Course" />
@@ -20,5 +20,4 @@
 	<crons>
 		<cron id="lp_object_statistics" class="ilLPCronObjectStatistics" />
 	</crons>
-	<logging />
 </service>

--- a/components/ILIAS/Tree/service.xml
+++ b/components/ILIAS/Tree/service.xml
@@ -8,9 +8,8 @@
 		<systemcheck_task identifier="missing_tree" />
 		<systemcheck_task identifier="missing_reference" />
 		<systemcheck_task identifier="duplicates" />
-	</systemcheck> 
+	</systemcheck>
 	<events>
 		<event type="raise" id="deleteNode" />
 	</events>
-	<logging />
 </service>

--- a/components/ILIAS/User/classes/Cron/class.ilCronDeleteInactiveUserAccounts.php
+++ b/components/ILIAS/User/classes/Cron/class.ilCronDeleteInactiveUserAccounts.php
@@ -236,7 +236,7 @@ class ilCronDeleteInactiveUserAccounts extends CronJob
         }
 
         $this->cron_delete_reminder_mail->removeEntriesFromTableIfLastLoginIsNewer();
-        $this->log->write(
+        $this->log->info(
             'CRON - ilCronDeleteInactiveUserAccounts::run(), deleted '
             . "=> {$counters[self::ACTION_USER_DELETED]} User(s), sent reminder "
             . "mail to {$counters[self::ACTION_USER_REMINDER_MAIL_SENT]} User(s)"

--- a/components/ILIAS/User/classes/Cron/class.ilUserCronCheckAccounts.php
+++ b/components/ILIAS/User/classes/Cron/class.ilUserCronCheckAccounts.php
@@ -142,7 +142,7 @@ class ilUserCronCheckAccounts extends CronJob
             $this->db->query($query);
 
             // Send log message
-            $this->log->write('Cron: (checkUserAccounts()) sent message to ' . $login . '.');
+            $this->log->info('Cron: (checkUserAccounts()) sent message to ' . $login . '.');
 
             $this->counter++;
         }

--- a/components/ILIAS/User/service.xml
+++ b/components/ILIAS/User/service.xml
@@ -28,6 +28,5 @@
 	<web_access_checker>
 		<secure_path path="usr_images" checking-class="ilObjUserAccess" />
 	</web_access_checker>
-	<logging />
 	<badges />
 </service>

--- a/components/ILIAS/User/src/Account/class.DeleteAccountGUI.php
+++ b/components/ILIAS/User/src/Account/class.DeleteAccountGUI.php
@@ -220,7 +220,7 @@ class DeleteAccountGUI
             $mmail->Send();
         }
 
-        $this->log->root()->log(
+        $this->log->forComponent('usr')->log(
             'Account deleted: ' . $this->current_user->getLogin()
                 . ' (' . $this->current_user->getId() . ')'
         );

--- a/components/ILIAS/Utilities/classes/class.ilShellUtil.php
+++ b/components/ILIAS/Utilities/classes/class.ilShellUtil.php
@@ -130,7 +130,7 @@ class ilShellUtil
         }
         $arr = [];
         exec($cmd, $arr);
-        $DIC->logger()->root()->debug("ilUtil::execQuoted: " . $cmd . ".");
+        $DIC->logger()->forComponent('util')->debug("ilUtil::execQuoted: " . $cmd . ".");
         return $arr;
     }
 

--- a/components/ILIAS/Utilities/classes/class.ilUtil.php
+++ b/components/ILIAS/Utilities/classes/class.ilUtil.php
@@ -667,7 +667,7 @@ class ilUtil
                 $a_str
             );
             if ($old_str == $a_str) {
-                $ilLog->write(
+                $ilLog->info(
                     "ilUtil::maskA-" . htmlentities($old_str) . " == " .
                     htmlentities($a_str)
                 );
@@ -700,7 +700,7 @@ class ilUtil
                 $a_str
             );
             if ($old_str == $a_str) {
-                $ilLog->write(
+                $ilLog->info(
                     "ilUtil::unmaskA-" . htmlentities($old_str) . " == " .
                     htmlentities($a_str)
                 );

--- a/components/ILIAS/VirusScanner/classes/class.ilVirusScanner.php
+++ b/components/ILIAS/VirusScanner/classes/class.ilVirusScanner.php
@@ -55,7 +55,7 @@ class ilVirusScanner
         global $DIC;
         $error = $DIC['ilErr'];
         $lng = $DIC->language();
-        $log = $DIC->logger()->root();
+        $log = $DIC->logger()->forComponent('virusscanner');
 
         $this->error = $error;
         $this->lng = $lng;

--- a/components/ILIAS/VirusScanner/classes/class.ilVirusScanner.php
+++ b/components/ILIAS/VirusScanner/classes/class.ilVirusScanner.php
@@ -152,7 +152,7 @@ class ilVirusScanner
         }
         $mess .= ': ' . preg_replace('/[\r\n]+/', '; ', $this->scanResult);
 
-        $this->log->write($mess);
+        $this->log->info($mess);
     }
 
     protected function removeBufferFile(string $bufferFile): void
@@ -188,7 +188,7 @@ class ilVirusScanner
         }
         $mess .= ': ' . preg_replace('/[\r\n]+/', '; ', $this->cleanResult);
 
-        $this->log->write($mess);
+        $this->log->info($mess);
     }
 
     public function fileCleaned(): bool

--- a/components/ILIAS/VirusScanner/classes/class.ilVirusScannerClamAV.php
+++ b/components/ILIAS/VirusScanner/classes/class.ilVirusScannerClamAV.php
@@ -137,7 +137,7 @@ class ilVirusScannerClamAV extends ilVirusScanner
         $return_error = 'ERROR (Virus Scanner failed): '
             . $this->scanResult
             . '; Path=' . $a_filepath;
-        $this->log->write($return_error);
+        $this->log->info($return_error);
         return $return_error;
     }
 }

--- a/components/ILIAS/VirusScanner/classes/class.ilVirusScannerFactory.php
+++ b/components/ILIAS/VirusScanner/classes/class.ilVirusScannerFactory.php
@@ -38,7 +38,7 @@ class ilVirusScannerFactory
 
                 case 'AntiVir':
                     global $DIC;
-                    $DIC->logger()->root()->error('AntiVir is deprecated, please install and use a different virus scanner.');
+                    $DIC->logger()->forComponent('virusscanner')->error('AntiVir is deprecated, please install and use a different virus scanner.');
                     $vs = new ilVirusScannerAntiVir(IL_VIRUS_SCAN_COMMAND, IL_VIRUS_CLEAN_COMMAND);
                     break;
 

--- a/components/ILIAS/VirusScanner/classes/class.ilVirusScannerSophos.php
+++ b/components/ILIAS/VirusScanner/classes/class.ilVirusScannerSophos.php
@@ -54,7 +54,7 @@ class ilVirusScannerSophos extends ilVirusScanner
         }
 
         // sophie has failed (probably the daemon doesn't run)
-        $this->log->write(
+        $this->log->info(
             'ERROR (Virus Scanner failed): '
             . $this->scanResult
             . '; COMMAMD=' . $cmd

--- a/components/ILIAS/WOPI/service.xml
+++ b/components/ILIAS/WOPI/service.xml
@@ -3,5 +3,4 @@
     <crons>
         <cron id="wopi_crawler" class="ilWOPICrawler"/>
     </crons>
-    <logging/>
 </service>

--- a/components/ILIAS/WebDAV/service.xml
+++ b/components/ILIAS/WebDAV/service.xml
@@ -1,7 +1,6 @@
 <?xml version = "1.0" encoding = "UTF-8"?>
 <service xmlns="http://www.w3.org" version="$Id$" name="WebDAV" short="trac" dir="Services/WebDAV" id="wbdv">
     <baseclasses/>
-    <logging/>
     <objects>
         <object id="wbdv" class_name="WebDAV" dir="classes" checkbox="0" inherit="0" translate="sys" rbac="1" system="1"
                 administration="1">

--- a/components/ILIAS/WebDAV/src/Log/Log.php
+++ b/components/ILIAS/WebDAV/src/Log/Log.php
@@ -71,12 +71,12 @@ class Log extends ServerPlugin
 
         $called_by = $e->getTrace()[0] ?? null;
         if ($called_by && isset($called_by['class'], $called_by['function'])) {
-            $this->logger->write(
+            $this->logger->info(
                 'WEBDAV: Exception in ' . $called_by['class'] . '::' . $called_by['function'] . ' - ' . $e->getMessage(
                 ),
             );
         } else {
-            $this->logger->write(
+            $this->logger->info(
                 'WEBDAV: Uncaught exception - ' . $e->getMessage(),
             );
         }

--- a/components/ILIAS/WebResource/module.xml
+++ b/components/ILIAS/WebResource/module.xml
@@ -22,5 +22,4 @@
 			<parent id="adm" max="1">adm</parent>
 		</object>
 	</objects>
-	<logging />
 </module>

--- a/components/ILIAS/WebServices/ECS/classes/class.ilECSCategoryMapping.php
+++ b/components/ILIAS/WebServices/ECS/classes/class.ilECSCategoryMapping.php
@@ -90,16 +90,16 @@ class ilECSCategoryMapping
                 $exists = true;
             }
         }
-        $logger->info(__METHOD__ . ': Creating/Deleting references...');
+        $logger->info('Creating/Deleting references...');
 
         if (!$exists) {
-            $logger->info(__METHOD__ . ': Add new reference. STEP 1');
+            $logger->info('Add new reference. STEP 1');
 
             if ($obj_data = ilObjectFactory::getInstanceByRefId($a_ref_id, false)) {
                 $obj_data->createReference();
                 $obj_data->putInTree($cat);
                 $obj_data->setPermissions($cat);
-                $logger->info(__METHOD__ . ': Add new reference.');
+                $logger->info('Add new reference.');
             }
         }
         // Now delete old references
@@ -113,7 +113,7 @@ class ilECSCategoryMapping
             }
             if ($to_delete = ilObjectFactory::getInstanceByRefId($ref_id)) {
                 $to_delete->delete();
-                $logger->write(__METHOD__ . ': Deleted deprecated reference.');
+                $logger->info('Deleted deprecated reference.');
             }
         }
         return true;

--- a/components/ILIAS/WebServices/service.xml
+++ b/components/ILIAS/WebServices/service.xml
@@ -8,7 +8,7 @@
 			<parent id="adm" max="1">adm</parent>
 		</object>
 	</objects>
-	<events>		
+	<events>
 		<event type="listen" id="components/ILIAS/Course" component="Services/WebServices/ECS" />
 		<event type="listen" id="components/ILIAS/Group" component="Services/WebServices/ECS" />
 		<event type="listen" id="components/ILIAS/User" component="Services/WebServices/ECS" />
@@ -21,5 +21,4 @@
 	<pluginslots>
 		<pluginslot id="soaphk" name="SoapHook" />
 	</pluginslots>
-	<logging />
 </service>

--- a/components/ILIAS/Wiki/module.xml
+++ b/components/ILIAS/Wiki/module.xml
@@ -27,5 +27,4 @@
 		<pageobject parent_type="wpg" class_name="ilWikiPage" directory="classes"/>
 		<pagecontent pc_type="amdpl" name="AMDPageList" directory="classes" int_links="0" style_classes="0" xsl="0" def_enabled="0" top_item="1" order_nr="240"/>
 	</copage>
-	<logging />
 </module>

--- a/components/ILIAS/soap/classes/class.ilSoapCourseAdministration.php
+++ b/components/ILIAS/soap/classes/class.ilSoapCourseAdministration.php
@@ -122,7 +122,7 @@ class ilSoapCourseAdministration extends ilSoapAdministration
             return $this->raiseError('Node already deleted', 'Client');
         }
 
-        $log->write("SOAP ilObjectGUI::confirmedDeleteObject(), moved ref_id " . $course_id . " to trash");
+        $log->info("SOAP ilObjectGUI::confirmedDeleteObject(), moved ref_id " . $course_id . " to trash");
         return true;
     }
 

--- a/components/ILIAS/soap/classes/class.ilSoapFileAdministration.php
+++ b/components/ILIAS/soap/classes/class.ilSoapFileAdministration.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -76,7 +77,7 @@ class ilSoapFileAdministration extends ilSoapAdministration
 
                 $ilLog = $DIC['ilLog'];
 
-                $ilLog->write(__METHOD__ . ': File type: ' . $file->getFileType());
+                $ilLog->info('File type: ' . $file->getFileType());
 
                 $file->create();
                 $file->createReference();

--- a/components/ILIAS/soap/classes/class.ilSoapLearningProgressAdministration.php
+++ b/components/ILIAS/soap/classes/class.ilSoapLearningProgressAdministration.php
@@ -426,21 +426,21 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
         }
 
         if (!$filter || in_array(self::PROGRESS_FILTER_ALL, $filter)) {
-            $GLOBALS['DIC']['log']->write(__METHOD__ . ': Deleting all progress data');
+            $GLOBALS['DIC']['log']->info('Deleting all progress data');
             return $all_users;
         }
 
         $filter_users = array();
         if (in_array(self::PROGRESS_FILTER_IN_PROGRESS, $filter)) {
-            $GLOBALS['DIC']['log']->write(__METHOD__ . ': Filtering  in progress.');
+            $GLOBALS['DIC']['log']->info('Filtering  in progress.');
             $filter_users = array_merge($filter, ilLPStatusWrapper::_getInProgress($obj_id));
         }
         if (in_array(self::PROGRESS_FILTER_COMPLETED, $filter)) {
-            $GLOBALS['DIC']['log']->write(__METHOD__ . ': Filtering  completed.');
+            $GLOBALS['DIC']['log']->info('Filtering  completed.');
             $filter_users = array_merge($filter, ilLPStatusWrapper::_getCompleted($obj_id));
         }
         if (in_array(self::PROGRESS_FILTER_FAILED, $filter)) {
-            $GLOBALS['DIC']['log']->write(__METHOD__ . ': Filtering  failed.');
+            $GLOBALS['DIC']['log']->info('Filtering  failed.');
             $filter_users = array_merge($filter, ilLPStatusWrapper::_getFailed($obj_id));
         }
 

--- a/components/ILIAS/soap/classes/class.ilSoapObjectAdministration.php
+++ b/components/ILIAS/soap/classes/class.ilSoapObjectAdministration.php
@@ -47,7 +47,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
 
         $ilLog = $DIC['ilLog'];
         $obj_id = ilObject::_lookupObjIdByImportId($import_id);
-        $ilLog->write("SOAP getObjIdByImportId(): import_id = " . $import_id . ' obj_id = ' . $obj_id);
+        $ilLog->info("SOAP getObjIdByImportId(): import_id = " . $import_id . ' obj_id = ' . $obj_id);
         return $obj_id ?: "0";
     }
 
@@ -883,7 +883,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
             $subtree_nodes = $tree->getSubtree($node_data);
 
             foreach ($subtree_nodes as $node) {
-                $ilLog->write('Soap: removeFromSystemByImportId(). Deleting object with title id: ' . $node['title']);
+                $ilLog->info('Soap: removeFromSystemByImportId(). Deleting object with title id: ' . $node['title']);
                 $tmp_obj = ilObjectFactory::getInstanceByRefId($node['ref_id']);
                 if (!is_object($tmp_obj)) {
                     return $this->raiseError(
@@ -1371,17 +1371,17 @@ class ilSoapObjectAdministration extends ilSoapAdministration
 
                 switch ($ref_data['time_target']['timing_type']) {
                     case ilObjectXMLWriter::TIMING_DEACTIVATED:
-                        $ilLog->write(__METHOD__ . ilObjectActivation::TIMINGS_DEACTIVATED . ' ' . $ref_data['time_target']['timing_type']);
+                        $ilLog->info(ilObjectActivation::TIMINGS_DEACTIVATED . ' ' . $ref_data['time_target']['timing_type']);
                         $items->setTimingType(ilObjectActivation::TIMINGS_DEACTIVATED);
                         break;
 
                     case ilObjectXMLWriter::TIMING_TEMPORARILY_AVAILABLE:
-                        $ilLog->write(__METHOD__ . ilObjectActivation::TIMINGS_ACTIVATION . ' ' . $ref_data['time_target']['timing_type']);
+                        $ilLog->info(ilObjectActivation::TIMINGS_ACTIVATION . ' ' . $ref_data['time_target']['timing_type']);
                         $items->setTimingType(ilObjectActivation::TIMINGS_ACTIVATION);
                         break;
 
                     case ilObjectXMLWriter::TIMING_PRESETTING:
-                        $ilLog->write(__METHOD__ . ilObjectActivation::TIMINGS_PRESETTING . ' ' . $ref_data['time_target']['timing_type']);
+                        $ilLog->info(ilObjectActivation::TIMINGS_PRESETTING . ' ' . $ref_data['time_target']['timing_type']);
                         $items->setTimingType(ilObjectActivation::TIMINGS_PRESETTING);
                         break;
                 }
@@ -1429,17 +1429,17 @@ class ilSoapObjectAdministration extends ilSoapAdministration
 
                 switch ($ref_data['time_target']['timing_type']) {
                     case ilObjectXMLWriter::TIMING_DEACTIVATED:
-                        $ilLog->write(__METHOD__ . ilObjectActivation::TIMINGS_DEACTIVATED . ' ' . $ref_data['time_target']['timing_type']);
+                        $ilLog->info(ilObjectActivation::TIMINGS_DEACTIVATED . ' ' . $ref_data['time_target']['timing_type']);
                         $items->setTimingType(ilObjectActivation::TIMINGS_DEACTIVATED);
                         break;
 
                     case ilObjectXMLWriter::TIMING_TEMPORARILY_AVAILABLE:
-                        $ilLog->write(__METHOD__ . ilObjectActivation::TIMINGS_ACTIVATION . ' ' . $ref_data['time_target']['timing_type']);
+                        $ilLog->info(ilObjectActivation::TIMINGS_ACTIVATION . ' ' . $ref_data['time_target']['timing_type']);
                         $items->setTimingType(ilObjectActivation::TIMINGS_ACTIVATION);
                         break;
 
                     case ilObjectXMLWriter::TIMING_PRESETTING:
-                        $ilLog->write(__METHOD__ . ilObjectActivation::TIMINGS_PRESETTING . ' ' . $ref_data['time_target']['timing_type']);
+                        $ilLog->info(ilObjectActivation::TIMINGS_PRESETTING . ' ' . $ref_data['time_target']['timing_type']);
                         $items->setTimingType(ilObjectActivation::TIMINGS_PRESETTING);
                         break;
                 }

--- a/components/ILIAS/soap/classes/class.ilSoapUserAdministration.php
+++ b/components/ILIAS/soap/classes/class.ilSoapUserAdministration.php
@@ -348,37 +348,37 @@ class ilSoapUserAdministration extends ilSoapAdministration
 
         // global role
         if ($location == ROLE_FOLDER_ID) {
-            $ilLog->write(__METHOD__ . ': Check global role');
+            $ilLog->info('Check global role');
             // check assignment permission if called from local admin
 
             if ($a_folder !== self::USER_FOLDER_ID && $a_folder !== 0) {
-                $ilLog->write(__METHOD__ . ': ' . $a_folder);
+                $ilLog->info($a_folder);
                 if (!ilObjRole::_getAssignUsersStatus($a_role)) {
-                    $ilLog->write(__METHOD__ . ': No assignment allowed');
+                    $ilLog->info('No assignment allowed');
                     $checked_roles[$a_role] = false;
                     return false;
                 }
             }
             // exclude anonymous role from list
             if ($a_role === ANONYMOUS_ROLE_ID) {
-                $ilLog->write(__METHOD__ . ': Anonymous role chosen.');
+                $ilLog->info('Anonymous role chosen.');
                 $checked_roles[$a_role] = false;
                 return false;
             }
             // do not allow to assign users to administrator role if current user does not has SYSTEM_ROLE_ID
             if ($a_role === SYSTEM_ROLE_ID &&
                 !in_array(SYSTEM_ROLE_ID, $rbacreview->assignedRoles($ilUser->getId()), true)) {
-                $ilLog->write(__METHOD__ . ': System role assignment forbidden.');
+                $ilLog->info('System role assignment forbidden.');
                 $checked_roles[$a_role] = false;
                 return false;
             }
 
             // Global role assignment ok
-            $ilLog->write(__METHOD__ . ': Assignment allowed.');
+            $ilLog->info('Assignment allowed.');
             $checked_roles[$a_role] = true;
             return true;
         } elseif ($location) {
-            $ilLog->write(__METHOD__ . ': Check local role.');
+            $ilLog->info('Check local role.');
 
             // It's a local role
             $rolfs = $rbacreview->getFoldersAssignedToRole($a_role, true);
@@ -390,7 +390,7 @@ class ilSoapUserAdministration extends ilSoapAdministration
             // (The ROLE_FOLDER_ID folder contains the global roles).
             if ($rbacreview->isDeleted($rolf)
                 || !$rbacsystem->checkAccess('edit_permission', $rolf)) {
-                $ilLog->write(__METHOD__ . ': Role deleted or no permission.');
+                $ilLog->info('Role deleted or no permission.');
                 $checked_roles[$a_role] = false;
                 return false;
             }
@@ -403,11 +403,11 @@ class ilSoapUserAdministration extends ilSoapAdministration
             // with false, and only set to true if we find the object id of the
             // locally administrated category in the tree path to the local role.
             if ($a_folder !== self::USER_FOLDER_ID && $a_folder !== 0 && !$tree->isGrandChild($a_folder, $rolf)) {
-                $ilLog->write(__METHOD__ . ': Not in path of category.');
+                $ilLog->info('Not in path of category.');
                 $checked_roles[$a_role] = false;
                 return false;
             }
-            $ilLog->write(__METHOD__ . ': Assignment allowed.');
+            $ilLog->info('Assignment allowed.');
             $checked_roles[$a_role] = true;
             return true;
         }

--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -368,6 +368,7 @@ A typical configuration might look like this afterwards:
         "logging" : {
                 "enable" : true,
                 "path_to_logfile" : "/var/www/logs/ilias.log",
+                "default_level" : "INFO",
                 "errorlog_dir" : "/var/www/logs/"
     	},
         "http" : {

--- a/docs/configuration/settings/ini-file.md
+++ b/docs/configuration/settings/ini-file.md
@@ -39,7 +39,7 @@ to the webserver. These files are located here:
 | path                            | "/var/iliasdata"                   |             |
 | file                            | "ilias.log"                        |             |
 | enabled                         | "1"                                |             |
-| level                           | "WARNING"                          |             |
+| default_level                   | "WARNING"                          |             |
 | error_path                      | "/var/iliasdata"                   |             |
 | [debian]                        |                                    |             |
 | data_dir                        | "/var/opt/ilias"                   |             |


### PR DESCRIPTION
The Logging component was recently refactored and cleaned up as described in [Streamline Logging](https://docu.ilias.de/go/wiki/wpage_8981_1357). This PR contains the changes required to properly conclude the implementation of that feature:

- The docs related to installation and configuration of ILIAS are updated to include the new `default_level` field in the `ilias.ini.php`. Also for the `master.ini.php`. (ping @thibsy, @chfsx, @acgruber)
- All components and plugins now automatically get a configurable log level, so the `logging` tag is removed from all `service.xml`s and `module.xml`s.
- The long deprecated `ilLogger::write` and `ilLogger::writeLanguageLog` have been removed, and its usages replaced (mostly with `ilLogger::info`). This makes the public interface of the now deprecated `ilLogger` match the new `LoggerInterface`.
- (Almost) all usages of the root logger have been replaced with the logger of the appropriate component. The exception is the logger exposed through an ancient global `ilLog` \ `log`. This is still used by a handful of components, most crucially Init\ErrorHandling, but tracking down all usages exactly is tricky. That logger identifies itself now as `legacy_root` in the log, and only uses the default log level.

Especially the last two sets of changes should be understood as transitional. In the long run, only the new `LoggerInterface` should be used, but the new infrastructure will only be directly available to other components when the Component revision is a bit further along (see #11430). Until then, this is a step in the right direction, and will ease the transition later on.