### PR TITLE
[FEATURE] UI: deprecate `Modal\RoundTrip` and `Interruptive`

### DIFF
--- a/components/ILIAS/UI/src/Component/Modal/Factory.php
+++ b/components/ILIAS/UI/src/Component/Modal/Factory.php
@@ -72,6 +72,8 @@ interface Factory
      * @param string $message A plain string informing the user about the critical situation
      * @param string $form_action The URL where the modal posts its form data
      * @return \ILIAS\UI\Component\Modal\Interruptive
+     *
+     * @deprecated use {@see \ILIAS\UI\Component\Prompt\Prompt} instead
      */
     public function interruptive(string $title, string $message, string $form_action): Interruptive;
 
@@ -93,6 +95,8 @@ interface Factory
      *       An interruptive item MUST have an ID.
      * ---
      * @return \ILIAS\UI\Component\Modal\InterruptiveItem\Factory
+     *
+     * @deprecated use {@see \ILIAS\UI\Component\Prompt\State\Factory} instead
      */
     public function interruptiveItem(): InterruptiveItem\Factory;
 
@@ -148,6 +152,8 @@ interface Factory
      * @param Component\Input\Container\Form\FormInput[] $inputs
      * @param string|null $post_url
      * @return \ILIAS\UI\Component\Modal\RoundTrip
+     *
+     * @deprecated use {@see \ILIAS\UI\Component\Prompt\Prompt} instead
      */
     public function roundtrip(string $title, Component\Component|array|null $content, array $inputs = [], ?string $post_url = null): RoundTrip;
 

--- a/components/ILIAS/UI/src/Component/Modal/Interruptive.php
+++ b/components/ILIAS/UI/src/Component/Modal/Interruptive.php
@@ -25,7 +25,7 @@ use ILIAS\UI\Component\Modal\InterruptiveItem\InterruptiveItem;
 /**
  * Interface Interruptive
  *
- * @package ILIAS\UI\Component\Modal
+ * @deprecated use {@see \ILIAS\UI\Component\Prompt\Prompt} instead
  */
 interface Interruptive extends Modal
 {

--- a/components/ILIAS/UI/src/Component/Modal/InterruptiveItem/Factory.php
+++ b/components/ILIAS/UI/src/Component/Modal/InterruptiveItem/Factory.php
@@ -26,7 +26,7 @@ use ILIAS\UI\Component\Image\Image;
 /**
  * Interface Factory
  *
- * @package ILIAS\UI\Component\Modal
+ * @deprecated use {@see \ILIAS\UI\Component\Prompt\State\Factory} instead
  */
 interface Factory
 {
@@ -56,6 +56,8 @@ interface Factory
      * @param Image $icon
      * @param string $description
      * @return \ILIAS\UI\Component\Modal\InterruptiveItem\Standard
+     *
+     * @deprecated use {@see \ILIAS\UI\Component\Prompt\State\State} instead
      */
     public function standard(
         string $id,
@@ -93,6 +95,8 @@ interface Factory
      * @param string $key
      * @param string $value
      * @return \ILIAS\UI\Component\Modal\InterruptiveItem\KeyValue
+     *
+     * @deprecated use {@see \ILIAS\UI\Component\Prompt\State\State} instead
      */
     public function keyValue(
         string $id,

--- a/components/ILIAS/UI/src/Component/Modal/InterruptiveItem/InterruptiveItem.php
+++ b/components/ILIAS/UI/src/Component/Modal/InterruptiveItem/InterruptiveItem.php
@@ -26,6 +26,8 @@ use ILIAS\UI\Component\Component;
  * Interface InterruptiveItem
  *
  * Represents an item to be displayed inside an interruptive modal
+ *
+ * @deprecated use {@see \ILIAS\UI\Component\Prompt\State\State} instead
  */
 interface InterruptiveItem extends Component
 {

--- a/components/ILIAS/UI/src/Component/Modal/InterruptiveItem/KeyValue.php
+++ b/components/ILIAS/UI/src/Component/Modal/InterruptiveItem/KeyValue.php
@@ -24,6 +24,8 @@ namespace ILIAS\UI\Component\Modal\InterruptiveItem;
  * Interface InterruptiveItem
  *
  * Represents a key-value item to be displayed inside an interruptive modal
+ *
+ * @deprecated use {@see \ILIAS\UI\Component\Prompt\State\State} instead
  */
 interface KeyValue extends InterruptiveItem
 {

--- a/components/ILIAS/UI/src/Component/Modal/InterruptiveItem/Standard.php
+++ b/components/ILIAS/UI/src/Component/Modal/InterruptiveItem/Standard.php
@@ -26,6 +26,8 @@ use ILIAS\UI\Component\Image\Image;
  * Interface InterruptiveItem
  *
  * Represents an object to be displayed inside an interruptive modal
+ *
+ * @deprecated use {@see \ILIAS\UI\Component\Prompt\State\State} instead
  */
 interface Standard extends InterruptiveItem
 {

--- a/components/ILIAS/UI/src/Component/Modal/RoundTrip.php
+++ b/components/ILIAS/UI/src/Component/Modal/RoundTrip.php
@@ -24,7 +24,7 @@ use ILIAS\UI\Component\ReplaceSignal;
 use ILIAS\UI\Component\Input\Container\Form\Standard;
 
 /**
- * @package ILIAS\UI\Component\Modal
+ * @deprecated use {@see \ILIAS\UI\Component\Prompt\Prompt} instead
  */
 interface RoundTrip extends Modal, Standard
 {


### PR DESCRIPTION
The `UI\Component\Modal` component family is partially superseded by the `UI\Component\Prompt` components.

The deprecation should stop new developments from using the components. No specific deadline is set (yet).

We should only announce this at JF after #10031 is merged.