### PR TITLE
[A11y] Asign aria-expanded to file controls

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/Renderer.php
@@ -66,6 +66,16 @@ class Renderer extends AbstractComponentRenderer
 
         $tpl = $this->renderLabel($component, $tpl);
 
+        if ($component->getType() === Component\Symbol\Glyph\Glyph::EXPAND
+            || $component->getType() === Component\Symbol\Glyph\Glyph::COLLAPSE) {
+            $tpl->setCurrentBlock("with_aria_expanded");
+            $tpl->setVariable(
+                "ARIA_EXPANDED",
+                $component->getType() === Component\Symbol\Glyph\Glyph::COLLAPSE ? "true" : "false"
+            );
+            $tpl->parseCurrentBlock();
+        }
+
         $id = $this->bindJavaScript($component);
 
         if ($id !== null) {

--- a/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/Renderer.php
@@ -66,8 +66,9 @@ class Renderer extends AbstractComponentRenderer
 
         $tpl = $this->renderLabel($component, $tpl);
 
-        if ($component->getType() === Component\Symbol\Glyph\Glyph::EXPAND
-            || $component->getType() === Component\Symbol\Glyph\Glyph::COLLAPSE) {
+        if (!$this instanceof ButtonContextRenderer
+            && ($component->getType() === Component\Symbol\Glyph\Glyph::EXPAND
+                || $component->getType() === Component\Symbol\Glyph\Glyph::COLLAPSE)) {
             $tpl->setCurrentBlock("with_aria_expanded");
             $tpl->setVariable(
                 "ARIA_EXPANDED",

--- a/components/ILIAS/UI/src/templates/default/Symbol/tpl.glyph.standard.html
+++ b/components/ILIAS/UI/src/templates/default/Symbol/tpl.glyph.standard.html
@@ -1,3 +1,3 @@
-<a <!-- BEGIN tabbable -->tabindex="0" <!-- END tabbable -->class="glyph<!-- BEGIN highlighted --> highlighted<!-- END highlighted --><!-- BEGIN disabled --> disabled<!-- END disabled -->"<!-- BEGIN with_action --> href="{ACTION}"<!-- END with_action --> aria-label="{LABEL}"<!-- BEGIN with_aria_disabled --> aria-disabled="{ARIA_DISABLED}"<!-- END with_aria_disabled --><!-- BEGIN with_id --> id="{ID}"<!-- END with_id -->>
+<a <!-- BEGIN tabbable -->tabindex="0" <!-- END tabbable -->class="glyph<!-- BEGIN highlighted --> highlighted<!-- END highlighted --><!-- BEGIN disabled --> disabled<!-- END disabled -->"<!-- BEGIN with_action --> href="{ACTION}"<!-- END with_action --> aria-label="{LABEL}"<!-- BEGIN with_aria_disabled --> aria-disabled="{ARIA_DISABLED}"<!-- END with_aria_disabled --><!-- BEGIN with_aria_expanded --> aria-expanded="{ARIA_EXPANDED}"<!-- END with_aria_expanded --><!-- BEGIN with_id --> id="{ID}"<!-- END with_id -->>
 {GLYPH}
 </a>

--- a/components/ILIAS/UI/tests/Component/Input/Field/FileInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/FileInputTest.php
@@ -294,12 +294,12 @@ class FileInputTest extends ILIAS_UI_TestBase
                     <div class="ui-input-file-input">
                         <div class="ui-input-file-info">
                             <span data-action="expand">
-                                <a tabindex="0" class="glyph" href="#" aria-label="expand_content">
+                                <a tabindex="0" class="glyph" href="#" aria-label="expand_content" aria-expanded="false">
                                     <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span>
                                 </a>
                             </span>
                             <span data-action="collapse">
-                                <a tabindex="0" class="glyph" href="#" aria-label="collapse_content">
+                                <a tabindex="0" class="glyph" href="#" aria-label="collapse_content" aria-expanded="true">
                                     <span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span>
                                 </a>
                             </span>
@@ -328,10 +328,10 @@ class FileInputTest extends ILIAS_UI_TestBase
                     <template>
                         <div class="ui-input-file-input">
                             <div class="ui-input-file-info"><span data-action="expand"><a tabindex="0" class="glyph"
-                                        href="#" aria-label="expand_content"><span
+                                        href="#" aria-label="expand_content" aria-expanded="false"><span
                                             class="glyphicon glyphicon-triangle-right"
                                             aria-hidden="true"></span></a></span><span data-action="collapse"><a
-                                        tabindex="0" class="glyph" href="#" aria-label="collapse_content"><span
+                                         tabindex="0" class="glyph" href="#" aria-label="collapse_content" aria-expanded="true"><span
                                             class="glyphicon glyphicon-triangle-bottom"
                                             aria-hidden="true"></span></a></span><span data-dz-name></span><span
                                     data-dz-size></span><span data-action="remove"><a tabindex="0" class="glyph" href="#"
@@ -401,12 +401,12 @@ class FileInputTest extends ILIAS_UI_TestBase
                     <div class="ui-input-file-input">
                         <div class="ui-input-file-info">
                             <span data-action="expand">
-                                <a tabindex="0" class="glyph" href="#" aria-label="expand_content">
+                                <a tabindex="0" class="glyph" href="#" aria-label="expand_content" aria-expanded="false">
                                     <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span>
                                 </a>
                             </span>
                             <span data-action="collapse">
-                                <a tabindex="0" class="glyph" href="#" aria-label="collapse_content">
+                                <a tabindex="0" class="glyph" href="#" aria-label="collapse_content" aria-expanded="true">
                                     <span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span>
                                 </a>
                             </span>
@@ -436,12 +436,12 @@ class FileInputTest extends ILIAS_UI_TestBase
                         <div class="ui-input-file-input">
                             <div class="ui-input-file-info">
                             <span data-action="expand">
-                                <a tabindex="0" class="glyph" href="#" aria-label="expand_content">
+                                <a tabindex="0" class="glyph" href="#" aria-label="expand_content" aria-expanded="false">
                                     <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span>
                                 </a>
                             </span>
                             <span data-action="collapse">
-                                <a tabindex="0" class="glyph" href="#" aria-label="collapse_content">
+                                <a tabindex="0" class="glyph" href="#" aria-label="collapse_content" aria-expanded="true">
                                     <span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span>
                                 </a>
                             </span>

--- a/components/ILIAS/UI/tests/Component/Symbol/Glyph/GlyphTest.php
+++ b/components/ILIAS/UI/tests/Component/Symbol/Glyph/GlyphTest.php
@@ -385,8 +385,9 @@ class GlyphTest extends ILIAS_UI_TestBase
 
         $css_classes = self::$canonical_css_classes[$type];
         $aria_label = self::$aria_labels[$type];
+        $aria_expanded = $this->getAriaExpandedAttribute($type);
 
-        $expected = '<a tabindex="0" class="glyph" href="http://www.ilias.de" aria-label="' . $aria_label . '"><span class="' . $css_classes . '" aria-hidden="true"></span></a>';
+        $expected = '<a tabindex="0" class="glyph" href="http://www.ilias.de" aria-label="' . $aria_label . '"' . $aria_expanded . '><span class="' . $css_classes . '" aria-hidden="true"></span></a>';
         $this->assertEquals($expected, $html);
     }
 
@@ -403,9 +404,10 @@ class GlyphTest extends ILIAS_UI_TestBase
 
         $css_classes = self::$canonical_css_classes[$type];
         $aria_label = self::$aria_labels[$type];
+        $aria_expanded = $this->getAriaExpandedAttribute($type);
 
         $expected = '
-        <a class="glyph disabled" aria-label="' . $aria_label . '" aria-disabled="true">
+        <a class="glyph disabled" aria-label="' . $aria_label . '" aria-disabled="true"' . $aria_expanded . '>
             <span class="' . $css_classes . '" aria-hidden="true"></span>
         </a>';
         $this->assertEquals($this->brutallyTrimHTML($expected), $this->brutallyTrimHTML($html));
@@ -495,9 +497,10 @@ class GlyphTest extends ILIAS_UI_TestBase
 
         $css_classes = self::$canonical_css_classes[$type];
         $aria_label = self::$aria_labels[$type];
+        $aria_expanded = $this->getAriaExpandedAttribute($type);
 
         $id = $ids[0];
-        $expected = "<a tabindex=\"0\" class=\"glyph\" href=\"http://www.ilias.de\" aria-label=\"$aria_label\" id=\"$id\"><span class=\"$css_classes\" aria-hidden=\"true\"></span></a>";
+        $expected = "<a tabindex=\"0\" class=\"glyph\" href=\"http://www.ilias.de\" aria-label=\"$aria_label\"$aria_expanded id=\"$id\"><span class=\"$css_classes\" aria-hidden=\"true\"></span></a>";
         $this->assertEquals($expected, $html);
     }
 
@@ -515,8 +518,9 @@ class GlyphTest extends ILIAS_UI_TestBase
 
         $css_classes = self::$canonical_css_classes[$type];
         $aria_label = self::$aria_labels[$type];
+        $aria_expanded = $this->getAriaExpandedAttribute($type);
 
-        $expected = "<a tabindex=\"0\" class=\"glyph\" href=\"http://www.ilias.de/open-source-lms-ilias/\" aria-label=\"$aria_label\"><span class=\"$css_classes\" aria-hidden=\"true\"></span></a>";
+        $expected = "<a tabindex=\"0\" class=\"glyph\" href=\"http://www.ilias.de/open-source-lms-ilias/\" aria-label=\"$aria_label\"$aria_expanded><span class=\"$css_classes\" aria-hidden=\"true\"></span></a>";
         $this->assertEquals($expected, $html);
     }
 
@@ -544,6 +548,15 @@ class GlyphTest extends ILIAS_UI_TestBase
         // Glyph with Action and Signal but Inactive
         $c = $f->user()->withAction("#")->withOnClick(new I\Signal("id_1", "click"))->withUnavailableAction();
         $this->assertFalse($c->isTabbable());
+    }
+
+    private function getAriaExpandedAttribute(string $type): string
+    {
+        return match ($type) {
+            G\Glyph::EXPAND => ' aria-expanded="false"',
+            G\Glyph::COLLAPSE => ' aria-expanded="true"',
+            default => '',
+        };
     }
 
     public function testTabbableGlyphRender(): void

--- a/components/ILIAS/UI/tests/Component/Table/PresentationTest.php
+++ b/components/ILIAS/UI/tests/Component/Table/PresentationTest.php
@@ -172,12 +172,12 @@ class PresentationTest extends TableTestBase
 
             <div class="il-table-presentation-row-controls col-lg-auto col-sm-12">
                 <div class="il-table-presentation-row-controls-expander inline">
-                    <a tabindex="0" class="glyph" href="#" aria-label="expand_content" id="id_5">
+                    <a tabindex="0" class="glyph" href="#" aria-label="expand_content" aria-expanded="false" id="id_5">
                         <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span>
                     </a>
                 </div>
                 <div class="il-table-presentation-row-controls-collapser">
-                    <a tabindex="0" class="glyph" href="#" aria-label="collapse_content" id="id_6">
+                    <a tabindex="0" class="glyph" href="#" aria-label="collapse_content" aria-expanded="true" id="id_6">
                         <span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span>
                     </a>
                 </div>
@@ -277,12 +277,12 @@ EXP;
 
             <div class="il-table-presentation-row-controls col-lg-auto col-sm-12">
                 <div class="il-table-presentation-row-controls-expander inline">
-                    <a tabindex="0" class="glyph" href="#" aria-label="expand_content" id="id_5">
+                    <a tabindex="0" class="glyph" href="#" aria-label="expand_content" aria-expanded="false" id="id_5">
                         <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span>
                     </a>
                 </div>
                 <div class="il-table-presentation-row-controls-collapser">
-                    <a tabindex="0" class="glyph" href="#" aria-label="collapse_content" id="id_6">
+                    <a tabindex="0" class="glyph" href="#" aria-label="collapse_content" aria-expanded="true" id="id_6">
                         <span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span>
                     </a>
                 </div>


### PR DESCRIPTION
Hello everyone!

This PR addresses the following ticket: [https://mantis.ilias.de/view.php?id=37177](https://mantis.ilias.de/view.php?id=37177)

It adds the `aria-expanded` attribute to the glyph icon to improve the accessibility of this view. As discussed in the Mantis ticket, I have applied the attribute to the `<a>` element.

I would appreciate a review from the Accessibility and UI Components teams, so I am forwarding this to you, @Annett7811 and @thibsy.

Thank you very much in advance for your time and feedback.

Best,
Abraham
