### PR TITLE
[FIX] Cron: Align cron job execution docs with current CLI

### DIFF
--- a/components/ILIAS/Cron/README.md
+++ b/components/ILIAS/Cron/README.md
@@ -22,8 +22,7 @@ described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
 To give more control of if and when cron-jobs are executed to administrators a 2nd implementation of cron-jobs
 has been added to ILIAS 4.4+. All existing cron-jobs have been migrated and thus moved to their respective modules
-and services. The top-level directory "cron/" will probably be kept because of cron.php but should otherwise be empty
-at some point.
+and services. The CLI entry point for executing cron-jobs is `cli/cron.php`.
 
 ### Providing a Cron-Job
 
@@ -176,11 +175,13 @@ So as mentioned above the cron-tab can safely be set to every few minutes.
 In order to execute the cron job manager, the following command MUST be used:
 
 ```shell
-/usr/bin/php [PATH_TO_ILIAS]/cron/cron.php run-jobs <user> <client_id> run-jobs
+/usr/bin/php [PATH_TO_ILIAS]/cli/cron.php run-jobs <user>
 ```
 
 The `<user>` MUST be a valid (but arbitrary) user account of the ILIAS installation.
-The `<client_id>` MUST be the client id of the ILIAS installation.
+
+The system crontab SHOULD invoke this command every few minutes. Individual cron-jobs
+are then executed according to their configured schedule.
 
 ## Permission Context
 

--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -692,16 +692,16 @@ We strongly recommend using MariaDB instead of MySQL due to performance, licensi
 ## Configure Cron Jobs
 
 This step configures the execution of the ILIAS Cron Jobs, which can be set to perform tasks, such as sending notifications.
-You can manage these jobs in the ILIAS Administration under "Administration > General Settings > Cron Jobs".
+You can manage these jobs in the ILIAS Administration under
+"Administration > System Settings and Maintenance > Cron Jobs".
 
 To test the execution of the Cron Jobs Executable `./cli/cron.php`, the following command can be used:
 
 ```shell
-php /var/www/ilias/cli/cron.php run-jobs <user> <client_id>
+php /var/www/ilias/cli/cron.php run-jobs <user>
 ```
 
 The `<user>` is a valid, arbitrary user account within the ILIAS installation.
-The `<client_id>` corresponds to the client ID of the ILIAS installation.
 
 To configure automated Cron Jobs in your system, you need to create a user in ILIAS, for example named `cron`.
 Then create a new file in the Linux Cron configuration for ILIAS at `/etc/cron.d/ilias`,
@@ -709,11 +709,11 @@ including a line to execute `./cli/cron.php` every 5 minutes.
 Other methods for executing Linux cron tasks, such as using the user crontab, can also be utilized.
 
 ```cron
-*/5 * * * * www-data /usr/bin/php /var/www/ilias/cli/cron.php run-jobs cron myilias > /dev/null 2>&1
+*/5 * * * * www-data /usr/bin/php /var/www/ilias/cli/cron.php run-jobs cron > /dev/null 2>&1
 ```
 
 You can verify the proper automatic execution in the ILIAS Administration section by checking the timestamp
-displayed at `Last Start of the Cron Job` after some time.
+displayed at `Last Automatic Execution of Cron Job Script` after some time.
 
 
 <a name="webdav-configuration"></a>


### PR DESCRIPTION
The cron job execution documentation was outdated after the move to `cli/cron.php` and the removal of the `client_id` CLI argument.

This updates:
* `components/ILIAS/Cron/README.md` – correct entry point/command and drop the obsolete `cron/` path note
* `docs/configuration/install.md` – same CLI usage, plus the current administration menu path and last-run label