### PR TITLE
Test 48066: Fix Unescaped HTML In Kiosk View

### DIFF
--- a/components/ILIAS/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -3239,8 +3239,12 @@ JS;
             // this is a placeholder solution with inline html tags to differentiate the different elements
             // should be removed when a title component with grouping and visual weighting is available
             // see:  https://github.com/ILIAS-eLearning/ILIAS/pull/7311
-            $pax_name_value = "<span class='il-test-kiosk-head__participant-name'>"
-                . $this->user->getFullname() . "</span>";
+            $pax_name_value = $this->ui_factory->legacy(
+                sprintf(
+                    "<span class='il-test-kiosk-head__participant-name'>%s</span>",
+                    $this->refinery->encode()->htmlSpecialCharsAsEntities()->transform($this->user->getFullname())
+                )
+            );
             $title_content = $title_content->withProperty($pax_name_label, $pax_name_value, false);
         }
 


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=48066

The participant name in the test kiosk title was inserted as raw HTML, which could break rendering when the name contained special characters. The value is now escaped and passed via a legacy UI component.

/cc @thojou 