### PR TITLE
Fix the exam view (kiosk mode) fix from PR 11880

### DIFF
--- a/components/ILIAS/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -3058,7 +3058,7 @@ JS;
             // this is a placeholder solution with inline html tags to differentiate the different elements
             // should be removed when a title component with grouping and visual weighting is available
             // see:  https://github.com/ILIAS-eLearning/ILIAS/pull/7311
-            $pax_name_value = $this->ui_factory->legacy(
+            $pax_name_value = $this->ui_factory->legacy()->content(
                 sprintf(
                     "<span class='il-test-kiosk-head__participant-name'>%s</span>",
                     $this->refinery->encode()->htmlSpecialCharsAsEntities()->transform($this->user->getFullname())


### PR DESCRIPTION
We found that #11880, which has recently been merged to trunk and the release 11 branches, is unfortunately erroneous.

This pull request contains a suggested fix.

Please see the commit message for details.

We suggest to merge this to trunk and to cherry-pick it to `release_11`. Otherwise people upgrading to ILIAS 11.3 (like us) will be unhappy when they try to start a test in kiosk mode that shows a participant’s name.