### PR TITLE
[ABANDON] News: Remove Local Default Visibility Setting

### DIFF
--- a/components/ILIAS/Container/News/class.ilContainerNewsSettingsGUI.php
+++ b/components/ILIAS/Container/News/class.ilContainerNewsSettingsGUI.php
@@ -216,7 +216,6 @@ class ilContainerNewsSettingsGUI
                 //save contextblock settings
                 $context_block_settings = [
                     "public_feed" => $form->getInput("notifications_public_feed") ?? "",
-                    "default_visibility" => $form->getInput("default_visibility"),
                     "hide_news_per_date" => $form->getInput("hide_news_per_date"),
                     "hide_news_date" => $form->getInput("hide_news_date")
                 ];

--- a/components/ILIAS/Container/classes/class.ilContainerGUI.php
+++ b/components/ILIAS/Container/classes/class.ilContainerGUI.php
@@ -1910,7 +1910,6 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         if ($ilAccess->checkAccess("write", "", $this->object->getRefId())) {
             $column_gui->setBlockProperty("news", "settings", '1');
             //$column_gui->setBlockProperty("news", "public_notifications_option", true);
-            $column_gui->setBlockProperty("news", "default_visibility_option", '1');
             $column_gui->setBlockProperty("news", "hide_news_block_option", '1');
         }
 

--- a/components/ILIAS/Export/xml/il_news_5_4.xsd
+++ b/components/ILIAS/Export/xml/il_news_5_4.xsd
@@ -52,7 +52,7 @@
             <sequence>
                 <element ref='t:ObjId' minOccurs='1' maxOccurs='1'/>
                 <element ref='t:PublicFeed' minOccurs='1' maxOccurs='1'/>
-                <element ref='t:DefaultVisibility' minOccurs='1' maxOccurs='1'/>
+                <element ref='t:DefaultVisibility' minOccurs='0' maxOccurs='1'/>
                 <element ref='t:KeepRssMin' minOccurs='1' maxOccurs='1'/>
                 <element ref='t:HideNewsPerDate' minOccurs='1' maxOccurs='1'/>
                 <element ref='t:HideNewsDate' minOccurs='1' maxOccurs='1'/>

--- a/components/ILIAS/File/classes/trait.ilObjFileMetadata.php
+++ b/components/ILIAS/File/classes/trait.ilObjFileMetadata.php
@@ -60,7 +60,7 @@ trait ilObjFileMetadata
 
         // New Item
         if (isset($this->ref_id)) {
-            $default_visibility = ilNewsItem::_getDefaultVisibilityForRefId($this->ref_id);
+            $default_visibility = ilNewsItem::getDefaultVisibility();
             if ($default_visibility === "public") {
                 ilBlockSetting::_write("news", "public_notifications", 1, 0, $this->getId());
             }

--- a/components/ILIAS/Forum/classes/class.ilObjForum.php
+++ b/components/ILIAS/Forum/classes/class.ilObjForum.php
@@ -645,18 +645,8 @@ class ilObjForum extends ilObject
 
     public function createSettings(): void
     {
-        global $DIC;
-
-        $ref_id = 0;
-        if ($DIC->http()->wrapper()->query()->has('ref_id')) {
-            $ref_id = $DIC->http()->wrapper()->query()->retrieve(
-                'ref_id',
-                $DIC->refinery()->kindlyTo()->int()
-            );
-        }
-
         // news settings (public notifications yes/no)
-        $default_visibility = ilNewsItem::_getDefaultVisibilityForRefId($ref_id);
+        $default_visibility = ilNewsItem::getDefaultVisibility();
         if ($default_visibility === 'public') {
             ilBlockSetting::_write('news', 'public_notifications', '1', 0, $this->getId());
         }

--- a/components/ILIAS/News/News.php
+++ b/components/ILIAS/News/News.php
@@ -20,6 +20,8 @@ declare(strict_types=1);
 
 namespace ILIAS;
 
+use ILIAS\Setup\Agent as SetupAgent;
+
 class News implements Component\Component
 {
     public function init(
@@ -32,6 +34,7 @@ class News implements Component\Component
         array | \ArrayAccess &$pull,
         array | \ArrayAccess &$internal,
     ): void {
+        $contribute[SetupAgent::class] = static fn() => new \ilNewsSetupAgent($pull[\ILIAS\Refinery\Factory::class]);
         $contribute[Component\Resource\PublicAsset::class] = fn() =>
             new Component\Resource\ComponentJS($this, "Timeline.js");
         $contribute[Component\Resource\PublicAsset::class] = fn() =>

--- a/components/ILIAS/News/PRIVACY.md
+++ b/components/ILIAS/News/PRIVACY.md
@@ -16,7 +16,6 @@ or contribute a fix via [Pull Request](../../docs/development/contributing.md#pu
 **Repository Objects**
 
 - The News service can be **activated** on the level of repository objects using the service, e.g. courses.
-- The **default access** of single news entries, authenticated users or public via RSS, can be set on the repository object level. This overwrites the global setting.
 
 **Single New Entries**
 

--- a/components/ILIAS/News/classes/Setup/class.ilNewsDefaultVisibilityMigration.php
+++ b/components/ILIAS/News/classes/Setup/class.ilNewsDefaultVisibilityMigration.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\Setup\Environment;
+use ILIAS\Setup\Migration;
+
+class ilNewsDefaultVisibilityMigration implements Migration
+{
+    private ilDBInterface $db;
+
+    public function getLabel(): string
+    {
+        return 'Remove local default visibility settings for news';
+    }
+
+    public function getDefaultAmountOfStepsPerRun(): int
+    {
+        return Migration::INFINITE;
+    }
+
+    public function getPreconditions(Environment $environment): array
+    {
+        return [
+            new ilDatabaseInitializedObjective(),
+        ];
+    }
+
+    public function prepare(Environment $environment): void
+    {
+        $this->db = $environment->getResource(Environment::RESOURCE_DATABASE);
+    }
+
+    public function step(Environment $environment): void
+    {
+        $this->db->manipulateF(
+            'DELETE FROM il_block_setting WHERE type = %s AND setting = %s',
+            [ilDBConstants::T_TEXT, ilDBConstants::T_TEXT],
+            ['news', 'default_visibility']
+        );
+    }
+
+    public function getRemainingAmountOfSteps(): int
+    {
+        return (int) ($this->db->fetchAssoc(
+            $this->db->queryF(
+                'SELECT COUNT(*) AS count FROM il_block_setting WHERE type = %s AND setting = %s',
+                [ilDBConstants::T_TEXT, ilDBConstants::T_TEXT],
+                ['news', 'default_visibility']
+            )
+        )['count'] ?? 0);
+    }
+}

--- a/components/ILIAS/News/classes/Setup/class.ilNewsSetupAgent.php
+++ b/components/ILIAS/News/classes/Setup/class.ilNewsSetupAgent.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 use ILIAS\Setup\Agent\HasNoNamedObjective;
 use ILIAS\Setup\Agent\NullAgent;
+use ILIAS\Setup\Config;
 use ILIAS\Setup\Objective;
 
 class ilNewsSetupAgent extends NullAgent
@@ -29,5 +30,12 @@ class ilNewsSetupAgent extends NullAgent
     public function getUpdateObjective(?ILIAS\Setup\Config $config = null): Objective
     {
         return new ilDatabaseUpdateStepsExecutedObjective(new ilNewsDBUpdateSteps());
+    }
+
+    public function getMigrations(?Config $config = null): array
+    {
+        return [
+            new ilNewsDefaultVisibilityMigration(),
+        ];
     }
 }

--- a/components/ILIAS/News/classes/class.ilNewsDataSet.php
+++ b/components/ILIAS/News/classes/class.ilNewsDataSet.php
@@ -62,7 +62,6 @@ class ilNewsDataSet extends ilDataSet
                     return [
                         "ObjId" => "integer",
                         "PublicFeed" => "integer",
-                        "DefaultVisibility" => "text",
                         "KeepRssMin" => "integer",
                         "HideNewsPerDate" => "integer",
                         "HideNewsDate" => "text",
@@ -102,7 +101,6 @@ class ilNewsDataSet extends ilDataSet
                         $this->data[$obj_id]["ObjId"] = $obj_id;
                         $this->data[$obj_id]["PublicFeed"] = ilBlockSetting::_lookup("news", "public_feed", 0, $obj_id);
                         $this->data[$obj_id]["KeepRssMin"] = (int) ilBlockSetting::_lookup("news", "keep_rss_min", 0, $obj_id);
-                        $this->data[$obj_id]["DefaultVisibility"] = ilBlockSetting::_lookup("news", "default_visibility", 0, $obj_id);
                         $this->data[$obj_id]["HideNewsPerDate"] = (int) ilBlockSetting::_lookup("news", "hide_news_per_date", 0, $obj_id);
                         $this->data[$obj_id]["HideNewsDate"] = ilBlockSetting::_lookup("news", "hide_news_date", 0, $obj_id);
                         $this->data[$obj_id]["PublicNotifications"] = (int) ilBlockSetting::_lookup("news", "public_notifications", 0, $obj_id);
@@ -153,7 +151,6 @@ class ilNewsDataSet extends ilDataSet
                     foreach ([
                         "public_feed" => "PublicFeed",
                         "keep_rss_min" => "KeepRssMin",
-                        "default_visibility" => "DefaultVisibility",
                         "hide_news_per_date" => "HideNewsPerDate",
                         "hide_news_date" => "HideNewsDate",
                         "public_notifications" => "PublicNotifications"

--- a/components/ILIAS/News/classes/class.ilNewsForContextBlockGUI.php
+++ b/components/ILIAS/News/classes/class.ilNewsForContextBlockGUI.php
@@ -831,31 +831,6 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
             $this->settings_form->addItem($hnpd);
         }
 
-        // default visibility
-        if ($enable_internal_rss && $this->getProperty("default_visibility_option")) {
-            $default_visibility = ilBlockSetting::_lookup(
-                $this->getBlockType(),
-                "default_visibility",
-                0,
-                (int) $this->block_id
-            );
-            if ($default_visibility == "") {
-                $default_visibility =
-                    ilNewsItem::_getDefaultVisibilityForRefId($this->std_request->getRefId());
-            }
-
-            // Default Visibility
-            $radio_group = new ilRadioGroupInputGUI($lng->txt("news_default_visibility"), "default_visibility");
-            $radio_option = new ilRadioOption($lng->txt("news_visibility_users"), "users");
-            $radio_group->addOption($radio_option);
-            $radio_option = new ilRadioOption($lng->txt("news_visibility_public"), "public");
-            $radio_group->addOption($radio_option);
-            $radio_group->setInfo($lng->txt("news_news_item_visibility_info"));
-            $radio_group->setRequired(false);
-            $radio_group->setValue($default_visibility);
-            $this->settings_form->addItem($radio_group);
-        }
-
         // public notifications
         if ($enable_internal_rss && $this->getProperty("public_notifications_option")) {
             $ch = new ilCheckboxInputGUI(
@@ -890,11 +865,6 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
     {
         global $DIC;
 
-        $std_request = $DIC->news()
-            ->internal()
-            ->gui()
-            ->standardRequest();
-
         $lng = $DIC->language();
         $block_id = $DIC->ctrl()->getContextObjId();
 
@@ -907,20 +877,6 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
             0,
             $block_id
         );
-        $default_visibility = ilBlockSetting::_lookup(self::$block_type, "default_visibility", 0, $block_id);
-        if ($default_visibility == "") {
-            $default_visibility =
-                ilNewsItem::_getDefaultVisibilityForRefId($std_request->getRefId());
-        }
-        $radio_group = new ilRadioGroupInputGUI($lng->txt("news_default_visibility"), "default_visibility");
-        $radio_option = new ilRadioOption($lng->txt("news_visibility_users"), "users");
-        $radio_group->addOption($radio_option);
-        $radio_option = new ilRadioOption($lng->txt("news_visibility_public"), "public");
-        $radio_group->addOption($radio_option);
-        $radio_group->setInfo($lng->txt("news_news_item_visibility_info"));
-        $radio_group->setRequired(false);
-        $radio_group->setValue($default_visibility);
-        $a_input->addSubItem($radio_group);
 
         // extra rss feed
         if ($enable_internal_rss) {
@@ -973,13 +929,6 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
                     $this->getBlockType(),
                     "public_feed",
                     $form->getInput("notifications_public_feed"),
-                    0,
-                    (int) $this->block_id
-                );
-                ilBlockSetting::_write(
-                    $this->getBlockType(),
-                    "default_visibility",
-                    $form->getInput("default_visibility"),
                     0,
                     (int) $this->block_id
                 );

--- a/components/ILIAS/News/classes/class.ilNewsItem.php
+++ b/components/ILIAS/News/classes/class.ilNewsItem.php
@@ -1280,42 +1280,11 @@ class ilNewsItem
     }
 
     /**
-     * Get default visibility for reference id
-     * @deprecated will move to ilNewsData
+     * Get global default visibility for news items.
      */
-    public static function _getDefaultVisibilityForRefId(int $a_ref_id): string
+    public static function getDefaultVisibility(): string
     {
-        global $DIC;
-
-        $tree = $DIC->repositoryTree();
-
-        $news_set = new ilSetting("news");
-        $default_visibility = ($news_set->get("default_visibility") != "")
-                ? $news_set->get("default_visibility")
-                : "users";
-
-        if ($tree->isInTree($a_ref_id)) {
-            $path = $tree->getPathFull($a_ref_id);
-
-            foreach ($path as $key => $row) {
-                if (!in_array($row["type"], ["root", "cat", "crs", "fold", "grp"], true)) {
-                    continue;
-                }
-
-                $visibility = ilBlockSetting::_lookup(
-                    "news",
-                    "default_visibility",
-                    0,
-                    (int) $row["obj_id"]
-                );
-
-                if ($visibility != "") {
-                    $default_visibility = $visibility;
-                }
-            }
-        }
-
-        return $default_visibility;
+        return (new ilSetting('news'))->get('default_visibility', NEWS_USERS);
     }
 
 

--- a/components/ILIAS/News/classes/class.ilNewsItemGUI.php
+++ b/components/ILIAS/News/classes/class.ilNewsItemGUI.php
@@ -233,7 +233,7 @@ class ilNewsItemGUI
         $radio_group->addOption($radio_option);
         $radio_group->setInfo($lng->txt("news_news_item_visibility_info"));
         $radio_group->setRequired(false);
-        $radio_group->setValue("users");
+        $radio_group->setValue(ilNewsItem::getDefaultVisibility());
         $form->addItem($radio_group);
 
         // media
@@ -261,7 +261,7 @@ class ilNewsItemGUI
         } else {
             $nv = $form->getItemByPostVar("news_visibility");
             if (is_object($nv)) {
-                $nv->setValue(ilNewsItem::_getDefaultVisibilityForRefId($a_ref_id));
+                $nv->setValue(ilNewsItem::getDefaultVisibility());
             }
         }
 


### PR DESCRIPTION
See: https://docu.ilias.de/go/wiki/wpage_8961_1357

As part of abandoning the local default visibility feature, removed the repository-object override for news visibility. Dropped the related block settings UI and export handling, replaced
`_getDefaultVisibilityForRefId()` with global `getDefaultVisibility()`, and added a setup migration to delete existing `default_visibility` entries from `il_block_setting`.

/cc @thojou @oliversamoila 