### PR TITLE
[Fix] LegalDocuments #0048204: Avoid MySQL error 1093 when deleting documents

### DIFF
--- a/components/ILIAS/LegalDocuments/classes/Repository/DatabaseDocumentRepository.php
+++ b/components/ILIAS/LegalDocuments/classes/Repository/DatabaseDocumentRepository.php
@@ -335,7 +335,10 @@ class DatabaseDocumentRepository implements DocumentRepository, DocumentReposito
     private function deleteEntry(string $table, int $id, string $doc_field, bool $cleanup = false): void
     {
         $id = $this->database->quote($id, ilDBConstants::T_INTEGER);
-        $this->database->manipulate("DELETE FROM $table WHERE id = $id AND " . $this->exists($table . '.' . $doc_field));
+        $belongs_to_provider = $table === $this->documentTable()
+            ? 'provider = ' . $this->database->quote($this->id, ilDBConstants::T_TEXT)
+            : $this->exists($table . '.' . $doc_field);
+        $this->database->manipulate("DELETE FROM $table WHERE id = $id AND " . $belongs_to_provider);
         if ($cleanup) {
             $this->cleanupCriteria();
         }


### PR DESCRIPTION
## Bug
Documents that are added via **Terms of Service** or **Declaration of Data Protection** cannot be deleted afterwards. The request fails with an internal error:
ilDatabaseException SQLSTATE[HY000]: General error: 1093 You can't specify target table 'ldoc_documents' for update in FROM clause

DELETE FROM ldoc_documents WHERE id = 9 AND EXISTS ( SELECT 1 FROM ldoc_documents AS t29 WHERE t29.id = ldoc_documents.id AND t29.provider = 'dpro' )
`provider = 'dpro'` is Data Protection; Terms of Service uses `'tos'`. Both hit the same delete path.

## Why it is easy to miss

The query is generated in `DatabaseDocumentRepository::deleteEntry()`. It appends `exists()`, which always subselects `ldoc_documents`.

On **MariaDB** this DELETE is legal. On **Oracle MySQL 8** it is not (error 1093). ILIAS 10 still supports MySQL > 8.0.21; the reference system is MariaDB, so local tests often never see the failure.

The same `deleteEntry()` implementation is still present on **release_11** and **trunk**. Those branches still support MySQL (8.0.x / 8.4.x). Error 1093 is unchanged there, so the fix should be applied to 10, 11, and trunk.

Mantis: https://mantis.ilias.de/view.php?id=48204

## Fix

When deleting from `ldoc_documents`, restrict with `provider = ...` instead of `EXISTS` on the same table:

```sql
DELETE FROM ldoc_documents WHERE id = 9 AND provider = 'dpro'