### PR TITLE
Trunk lti ags deeplinking

### DIFF
--- a/components/ILIAS/LTIConsumer/classes/Setup/class.ilLTIConsumerDatabaseUpdateSteps.php
+++ b/components/ILIAS/LTIConsumer/classes/Setup/class.ilLTIConsumerDatabaseUpdateSteps.php
@@ -236,4 +236,80 @@ class ilLTIConsumerDatabaseUpdateSteps implements ilDatabaseUpdateSteps
             $this->db->addIndex("lti_consumer_grades", array("obj_id","usr_id"), 'i1');
         }
     }
+
+    public function step_16(): void
+    {
+        if (!$this->db->tableColumnExists('lti_consumer_results', 'attended')) {
+            $this->db->addTableColumn('lti_consumer_results', 'attended', [
+                'type' => 'integer',
+                'notnull' => true,
+                'length' => 1,
+                'default' => 0
+            ]);
+
+            $query = /** @lang sql */
+                "
+                UPDATE lti_consumer_results
+                SET attended = 1
+                WHERE result IS NOT NULL AND result > 0
+            ";
+            $this->db->manipulate($query);
+        }
+    }
+
+    public function step_17(): void
+    {
+        if (!$this->db->tableColumnExists('lti_consumer_settings', 'score_maximum')) {
+            $this->db->addTableColumn('lti_consumer_settings', 'score_maximum', [
+                'type' => 'float',
+                'notnull' => false,
+                'default' => 1
+            ]);
+        }
+    }
+
+    public function step_18(): void
+    {
+        if (!$this->db->tableExists('lti_consumer_lineitems')) {
+            $values = [
+                'id' => ['type' => 'integer', 'length' => 4, 'notnull' => true],
+                'context_id' => ['type' => 'integer', 'length' => 4, 'notnull' => true],
+                'obj_id' => ['type' => 'integer', 'length' => 4, 'notnull' => false],
+                'client_id' => ['type' => 'text', 'length' => 255, 'notnull' => false],
+                'label' => ['type' => 'text', 'length' => 255, 'notnull' => false],
+                'score_maximum' => ['type' => 'float', 'notnull' => false, 'default' => 1],
+                'resource_id' => ['type' => 'text', 'length' => 255, 'notnull' => false],
+                'resource_link_id' => ['type' => 'text', 'length' => 255, 'notnull' => false],
+                'tag' => ['type' => 'text', 'length' => 255, 'notnull' => false],
+                'enabled' => ['type' => 'integer', 'length' => 1, 'notnull' => true, 'default' => 1]
+            ];
+            $this->db->createTable('lti_consumer_lineitems', $values);
+            $this->db->addPrimaryKey('lti_consumer_lineitems', ['id']);
+            $this->db->createSequence('lti_consumer_lineitems');
+        }
+    }
+
+    public function step_19(): void
+    {
+        if ($this->db->tableExists('lti_consumer_lineitems') &&
+            !$this->db->tableColumnExists('lti_consumer_lineitems', 'resource_link_id')) {
+            $this->db->addTableColumn('lti_consumer_lineitems', 'resource_link_id', [
+                'type' => 'text',
+                'length' => 255,
+                'notnull' => false
+            ]);
+        }
+    }
+
+    public function step_20(): void
+    {
+        if ($this->db->tableExists('lti_consumer_lineitems') &&
+            !$this->db->tableColumnExists('lti_consumer_lineitems', 'client_id')) {
+            $this->db->addTableColumn('lti_consumer_lineitems', 'client_id', [
+                'type' => 'text',
+                'length' => 255,
+                'notnull' => false
+            ]);
+        }
+    }
 }

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProvider.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProvider.php
@@ -174,6 +174,50 @@ class ilLTIConsumeProvider
         }
     }
 
+    private function preventClientIdInUrl(string $url): string
+    {
+        if (str_contains($url, ',')) {
+            return implode(',', array_map([$this, 'preventClientIdInUrl'], explode(',', $url)));
+        }
+
+        $parts = parse_url($url);
+        if ($parts === false || !isset($parts['query'])) {
+            return $url;
+        }
+
+        parse_str($parts['query'], $query);
+        unset($query['client_id']);
+
+        $result = '';
+        if (isset($parts['scheme'])) {
+            $result .= $parts['scheme'] . '://';
+        }
+        if (isset($parts['user'])) {
+            $result .= $parts['user'];
+            if (isset($parts['pass'])) {
+                $result .= ':' . $parts['pass'];
+            }
+            $result .= '@';
+        }
+        if (isset($parts['host'])) {
+            $result .= $parts['host'];
+        }
+        if (isset($parts['port'])) {
+            $result .= ':' . $parts['port'];
+        }
+        $result .= $parts['path'] ?? '';
+
+        $queryString = http_build_query($query, '', '&', PHP_QUERY_RFC3986);
+        if ($queryString !== '') {
+            $result .= '?' . $queryString;
+        }
+        if (isset($parts['fragment'])) {
+            $result .= '#' . $parts['fragment'];
+        }
+
+        return $result;
+    }
+
     /**
      * Inits class static
      * @throws IOException
@@ -255,12 +299,12 @@ class ilLTIConsumeProvider
 
     public function getProviderUrl(): string
     {
-        return $this->provider_url;
+        return $this->preventClientIdInUrl($this->provider_url);
     }
 
     public function setProviderUrl(string $provider_url): void
     {
-        $this->provider_url = $provider_url;
+        $this->provider_url = $this->preventClientIdInUrl($provider_url);
     }
 
     public function getProviderKey(): string
@@ -737,22 +781,22 @@ class ilLTIConsumeProvider
 
     public function getInitiateLogin(): string
     {
-        return $this->initiate_login;
+        return $this->preventClientIdInUrl($this->initiate_login);
     }
 
     public function setInitiateLogin(string $initiate_login): void
     {
-        $this->initiate_login = $initiate_login;
+        $this->initiate_login = $this->preventClientIdInUrl($initiate_login);
     }
 
     public function getRedirectionUris(): string
     {
-        return $this->redirection_uris;
+        return $this->preventClientIdInUrl($this->redirection_uris);
     }
 
     public function setRedirectionUris(string $redirection_uris): void
     {
-        $this->redirection_uris = $redirection_uris;
+        $this->redirection_uris = $this->preventClientIdInUrl($redirection_uris);
     }
 
     public function isContentItem(): bool
@@ -767,12 +811,12 @@ class ilLTIConsumeProvider
 
     public function getContentItemUrl(): string
     {
-        return $this->content_item_url;
+        return $this->preventClientIdInUrl($this->content_item_url);
     }
 
     public function setContentItemUrl(string $content_item_url): void
     {
-        $this->content_item_url = $content_item_url;
+        $this->content_item_url = $this->preventClientIdInUrl($content_item_url);
     }
 
     public function isGradeSynchronization(): bool
@@ -990,6 +1034,7 @@ class ilLTIConsumeProvider
      */
     protected function getInsertUpdateFields(): array
     {
+        // dump($this->getProviderUrl());exit();
         return array(
             'id' => array('integer', $this->getId()),
             'title' => array('text', $this->getTitle()),

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderFormGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderFormGUI.php
@@ -141,7 +141,8 @@ class ilLTIConsumeProviderFormGUI extends ilPropertyFormGUI
 
     public function initForm(string $formaction, string $saveCmd, string $cancelCmd): void
     {
-        global $DIC; /* @var \ILIAS\DI\Container $DIC */
+        global $DIC;
+        /* @var \ILIAS\DI\Container $DIC */
         $lng = $DIC->language();
 
         $this->setFormAction($formaction);
@@ -235,22 +236,22 @@ class ilLTIConsumeProviderFormGUI extends ilPropertyFormGUI
 
         //key_type
         $keyType = new ilRadioGroupInputGUI($lng->txt('lti_con_key_type'), 'key_type');
-        $keyType->setRequired(false);
+        $keyType->setRequired(true);
         //RSA
         $keyRsa = new ilRadioOption($lng->txt('lti_con_key_type_rsa'), 'RSA_KEY');
         $keyType->addOption($keyRsa);
         $publicKey = new ilTextAreaInputGUI($lng->txt('lti_con_key_type_rsa_public_key'), 'public_key');
         $publicKey->setRows(6);
         $publicKey->setValue($this->provider->getPublicKey());
-        $publicKey->setRequired(false);
         $publicKey->setInfo($lng->txt('lti_con_key_type_rsa_public_key_info'));
+        $publicKey->setRequired(true);
         $keyRsa->addSubItem($publicKey);
         //JWK
         $keyJwk = new ilRadioOption($lng->txt('lti_con_key_type_jwk'), 'JWK_KEYSET');
         $keyType->addOption($keyJwk);
         $keyset = new ilTextInputGUI($lng->txt('lti_con_key_type_jwk_url'), 'public_keyset');
         $keyset->setValue($this->provider->getPublicKeyset());
-        $keyset->setRequired(false);
+        $keyset->setRequired(true);
         $keyJwk->addSubItem($keyset);
 
         $keyType->setValue($this->provider->getKeyType());
@@ -540,7 +541,8 @@ class ilLTIConsumeProviderFormGUI extends ilPropertyFormGUI
 
     public function initToolConfigForm(string $formaction, string $saveCmd, string $cancelCmd): void
     {
-        global $DIC; /* @var \ILIAS\DI\Container $DIC */
+        global $DIC;
+        /* @var \ILIAS\DI\Container $DIC */
         $lng = $DIC->language();
 
         $this->setFormAction($formaction);
@@ -1021,7 +1023,8 @@ class ilLTIConsumeProviderFormGUI extends ilPropertyFormGUI
 
     public function initDynRegForm(string $formaction): void
     {
-        global $DIC; /* @var \ILIAS\DI\Container $DIC */
+        global $DIC;
+        /* @var \ILIAS\DI\Container $DIC */
         $lng = $DIC->language();
         $this->setFormAction($formaction);
         $this->clearCommandButtons();
@@ -1079,7 +1082,8 @@ class ilLTIConsumeProviderFormGUI extends ilPropertyFormGUI
 
     public function getDynRegError(): string
     {
-        global $DIC; /* @var \ILIAS\DI\Container $DIC */
+        global $DIC;
+        /* @var \ILIAS\DI\Container $DIC */
         $lng = $DIC->language();
         $this->removeItemByPostVar('lti_dyn_reg_url');
         $this->removeItemByPostVar('lti_dyn_reg_custom_params');

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderFormGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderFormGUI.php
@@ -60,7 +60,7 @@ class ilLTIConsumeProviderFormGUI extends ilPropertyFormGUI
     /**
      * Build the "Deep linking" UI (button + modal with iframe).
      *
-     * @param string $target_gui_class GUI class that has startDeepLinkingCmd()
+     * @param array $target_gui_class GUI class path that has startDeepLinkingCmd()
      * @param string $cmd command name, default 'startDeepLinking'
      * @return string                  rendered HTML to embed in a form/custom input
      */

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderFormGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderFormGUI.php
@@ -57,6 +57,88 @@ class ilLTIConsumeProviderFormGUI extends ilPropertyFormGUI
         $this->adminContext = $adminContext;
     }
 
+    /**
+     * Build the "Deep linking" UI (button + modal with iframe).
+     *
+     * @param string $target_gui_class GUI class that has startDeepLinkingCmd()
+     * @param string $cmd command name, default 'startDeepLinking'
+     * @return string                  rendered HTML to embed in a form/custom input
+     */
+    private function buildDlUiParts(
+        array $target_gui_class = [ilLTIConsumeProviderSettingsGUI::class],
+        string $cmd = 'startDeepLinking'
+    ): string {
+        global $DIC;
+
+        $factory = $DIC->ui()->factory();
+        $renderer = $DIC->ui()->renderer();
+        $ctrl = $DIC->ctrl();
+
+        if ($this->isAdminContext()) {
+            $target_gui_class = [
+                ilAdministrationGUI::class,
+                ilObjLTIConsumerGUI::class,
+                ilLTIConsumerSettingsGUI::class,
+                ilLTIConsumeProviderSettingsGUI::class
+            ];
+
+            $ctrl->setParameterByClass(ilLTIConsumerSettingsGUI::class, 'ref_id', ilObjLTIConsumer::getRefIdOfConsumerByDeploymentId((string)$this->getProvider()->getId()));
+        }
+
+        $iframe_url = $ctrl->getLinkTargetByClass(
+            $target_gui_class,
+            $cmd,
+            '',
+            true
+        );
+
+        $iframe_html = sprintf(
+            '<iframe src="%s" style="width:100%%;height:70vh;border:0;" allow="fullscreen"></iframe>',
+            htmlspecialchars($iframe_url, ENT_QUOTES)
+        );
+
+        $content = $factory->legacy()->content($iframe_html);
+
+        $modal = $factory
+            ->modal()
+            ->roundtrip($this->lng->txt('subtab_provider_settings'), $content);
+
+        $button = $factory
+            ->button()
+            ->standard($this->lng->txt('select'), '')
+            ->withOnClick($modal->getShowSignal());
+
+        $html = $renderer->render([$button, $modal]);
+
+        $html .= <<<HTML
+        <script>
+        function closeDialog() {
+            let dlg = document.querySelector('dialog.c-modal.il-modal-roundtrip[open], dialog.c-modal[open]');
+            if (dlg && typeof dlg.close === 'function') {
+                dlg.close();
+            }
+            let backdrop = document.querySelector('.c-modal__backdrop, dialog + .c-modal__backdrop');
+            if (backdrop) {
+                backdrop.remove();
+            }
+
+        }
+        document.addEventListener('click', function (e) {
+            closeDialog();
+           }, true);
+
+        window.onLtiDeepLinkDone = function (url) {
+            closeDialog();
+            if(url) {
+                window.location.href = url;
+            }
+        };
+        </script>
+        HTML;
+
+        return $html;
+    }
+
     public function initForm(string $formaction, string $saveCmd, string $cancelCmd): void
     {
         global $DIC; /* @var \ILIAS\DI\Container $DIC */
@@ -125,6 +207,15 @@ class ilLTIConsumeProviderFormGUI extends ilPropertyFormGUI
         if ($this->provider->getId() == 0) {
             $lti13->setInfo($lng->txt('lti_con_version_1.3_before_id'));
         }
+
+        if (!empty($this->provider->isContentItem())) {
+
+            $dl_html = $this->buildDlUiParts();
+            $dl_input = new ilCustomInputGUI($this->lng->txt('tab_content'));
+            $dl_input->setHTML($dl_html);
+            $lti13->addSubItem($dl_input);
+        }
+
         $versionInp->addOption($lti13);
         $providerUrlInp = new ilTextInputGUI($lng->txt('lti_con_tool_url'), 'provider_url13');
         $providerUrlInp->setValue($this->provider->getProviderUrl());

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderFormGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderFormGUI.php
@@ -82,7 +82,7 @@ class ilLTIConsumeProviderFormGUI extends ilPropertyFormGUI
                 ilLTIConsumeProviderSettingsGUI::class
             ];
 
-            $ctrl->setParameterByClass(ilLTIConsumerSettingsGUI::class, 'ref_id', ilObjLTIConsumer::getRefIdOfConsumerByDeploymentId((string)$this->getProvider()->getId()));
+            $ctrl->setParameterByClass(ilLTIConsumerSettingsGUI::class, 'ref_id', ilObjLTIConsumer::getRefIdOfConsumerByDeploymentId((string) $this->getProvider()->getId()));
         }
 
         $iframe_url = $ctrl->getLinkTargetByClass(

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderFormGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderFormGUI.php
@@ -974,7 +974,7 @@ class ilLTIConsumeProviderFormGUI extends ilPropertyFormGUI
             if (preg_match_all('/\S+/sm', $this->getInput('redirection_uris'), $redirect_uris_matches)) {
                 $provider->setRedirectionUris(implode(",", $redirect_uris_matches[0]));
             } else {
-                $provider->setRedirectionUris($this->provider->getInitiateLogin());
+                $provider->setRedirectionUris($this->provider->getRedirectionUris());
             }
             $provider->setKeyType($this->getInput('key_type'));
             if ($provider->getKeyType() == 'RSA_KEY') {

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderFormGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderFormGUI.php
@@ -1062,12 +1062,10 @@ class ilLTIConsumeProviderFormGUI extends ilPropertyFormGUI
         if (!empty($customParams)) {
             $regUrl .= "&custom_params=" . urlencode($customParams);
         }
-        $showToolConfigUrl = $DIC->ctrl()->getLinkTargetByClass([ilRepositoryGUI::class,ilObjLTIConsumerGUI::class], 'showToolConfig');
-        $regErrorUrl = $DIC->ctrl()->getLinkTargetByClass([ilRepositoryGUI::class,ilObjLTIConsumerGUI::class], 'addDynReg');
-        $this->getItemByPostVar('lti_dyn_reg_url')->setDisabled(true);
-        $this->getItemByPostVar('lti_dyn_reg_custom_params')->setDisabled(true);
+        $showToolConfigUrl = $DIC->ctrl()->getLinkTargetByClass([ilRepositoryGUI::class, ilObjLTIConsumerGUI::class], 'showToolConfig');
+        $regErrorUrl = $DIC->ctrl()->getLinkTargetByClass([ilRepositoryGUI::class, ilObjLTIConsumerGUI::class], 'addDynReg');
         $this->clearCommandButtons();
-        //$this->addCommandButton("cancelDynReg", $DIC->language()->txt('cancel'));
+        $this->addCommandButton("addDynReg", $DIC->language()->txt('save'));
         $template = new ilTemplate('tpl.lti_dyn_reg_request.html', true, true, "components/ILIAS/LTIConsumer");
         $template->setVariable('LTI_TOOL_REG_URL', $toolRegUrl);
         $template->setVariable('LTI_DYN_REG_URL', $regUrl);

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderSettingsGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderSettingsGUI.php
@@ -107,7 +107,7 @@ class ilLTIConsumeProviderSettingsGUI
 
         $platform_client_id = $provider->getClientId();
         $deployment_id = $provider->getId();
-        $user_id = ilCmiXapiUser::getIdentAsId($provider->getPrivacyIdent(), $DIC->user());                          // or whatever you used as login_hint
+        $user_id = ilObjLTIConsumer::getDeepLinkingUserIdentifier($provider, $DIC->user());                          // or whatever you used as login_hint
 
         $lti_message_hint = json_encode([
             'deployment_id' => $deployment_id,

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderSettingsGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderSettingsGUI.php
@@ -129,7 +129,7 @@ class ilLTIConsumeProviderSettingsGUI
         $join = (str_contains($provider->getInitiateLogin(), '?')) ? '&' : '?';
         $url = $provider->getInitiateLogin() . $join . http_build_query($params);
         $urlSafe = htmlspecialchars($url, ENT_QUOTES);
-        echo <<<HTML
+        $html = <<<HTML
         <!doctype html>
         <html>
           <body onload="window.location.href='{$urlSafe}'">
@@ -140,7 +140,10 @@ class ilLTIConsumeProviderSettingsGUI
           </body>
         </html>
         HTML;
-        exit;
+        $response = $DIC->http()->response()->withBody(ILIAS\Filesystem\Stream\Streams::ofString($html));
+        $DIC->http()->saveResponse($response);
+        $DIC->http()->sendResponse();
+        $DIC->http()->close();
 
     }
 

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderSettingsGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderSettingsGUI.php
@@ -100,7 +100,7 @@ class ilLTIConsumeProviderSettingsGUI
     }
 
 
-    protected function startDeepLinkingCmd()
+    protected function startDeepLinkingCmd(): never
     {
         global $DIC;
         $provider = $this->object->getProvider();

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderSettingsGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderSettingsGUI.php
@@ -99,6 +99,16 @@ class ilLTIConsumeProviderSettingsGUI
         $this->showSettingsCmd($form);
     }
 
+    private function getClientIdFromProviderUrl(string $providerUrl): string
+    {
+        $res = "";
+        $first = explode(".", $providerUrl)[0];
+        $secondSplit = explode("//", $first);
+        if (count($secondSplit) > 1) {
+            $res = $secondSplit[1];
+        }
+        return $res;
+    }
 
     protected function startDeepLinkingCmd(): never
     {
@@ -185,7 +195,6 @@ class ilLTIConsumeProviderSettingsGUI
     protected function buildForm(ilLTIConsumeProvider $provider): ilLTIConsumeProviderFormGUI
     {
         global $DIC; /* @var \ILIAS\DI\Container $DIC */
-
         $form = new ilLTIConsumeProviderFormGUI($provider);
         $form->initForm(
             $DIC->ctrl()->getFormAction($this),

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderSettingsGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderSettingsGUI.php
@@ -100,6 +100,50 @@ class ilLTIConsumeProviderSettingsGUI
     }
 
 
+    protected function startDeepLinkingCmd()
+    {
+        global $DIC;
+        $provider = $this->object->getProvider();
+
+        $platform_client_id = $provider->getClientId();
+        $deployment_id = $provider->getId();
+        $user_id = ilCmiXapiUser::getIdentAsId($provider->getPrivacyIdent(), $DIC->user());                          // or whatever you used as login_hint
+
+        $lti_message_hint = json_encode([
+            'deployment_id' => $deployment_id,
+        ]);
+        $state = bin2hex(random_bytes(16));
+
+
+        $params = [
+            'login_hint' => $user_id,
+            'iss' => ilObjLTIConsumer::getPlattformId(),
+            'lti_message_hint' => $lti_message_hint,
+            'target_link_uri' => $provider->getContentItemUrl(),
+            'id' => $platform_client_id, // Instead of client_id due to ILIAS redirection system
+            'lti_deployment_id' => $deployment_id,
+            'state' => $state,
+        ];
+
+
+        $join = (str_contains($provider->getInitiateLogin(), '?')) ? '&' : '?';
+        $url = $provider->getInitiateLogin() . $join . http_build_query($params);
+        $urlSafe = htmlspecialchars($url, ENT_QUOTES);
+        echo <<<HTML
+        <!doctype html>
+        <html>
+          <body onload="window.location.href='{$urlSafe}'">
+            <noscript>
+              <p>Continue to deep linking...</p>
+              <a href="{$urlSafe}">Continue</a>
+            </noscript>
+          </body>
+        </html>
+        HTML;
+        exit;
+
+    }
+
     /**
      * @throws ilMDServicesException
      */

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderSettingsGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderSettingsGUI.php
@@ -112,7 +112,15 @@ class ilLTIConsumeProviderSettingsGUI
         $lti_message_hint = json_encode([
             'deployment_id' => $deployment_id,
         ]);
-        $state = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(32));
+        $consumerRefId = ilObjLTIConsumer::getRefIdOfConsumerByDeploymentId((string) $deployment_id);
+        ilSession::set('lti13_deep_linking_state', [
+            'state' => $state,
+            'provider_id' => $deployment_id,
+            'ref_id' => $consumerRefId === null ? 0 : $DIC->repositoryTree()->getParentId($consumerRefId),
+            'flow' => 'content_selection',
+            'created_at' => time()
+        ]);
 
 
         $params = [

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerAccessToken.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerAccessToken.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+final class ilLTIConsumerAccessToken
+{
+    /** @param list<string> $scopes */
+    private function __construct(
+        private readonly string $client_id,
+        private readonly array $scopes
+    ) {
+    }
+
+    public static function fromVerifiedToken(object $token): ?self
+    {
+        $client_id = $token->sub ?? null;
+        if (!is_string($client_id) || $client_id === '') {
+            return null;
+        }
+
+        $scope = $token->{'imsglobal.org.security.scope'} ?? '';
+        if (is_string($scope)) {
+            $scopes = preg_split('/\s+/', trim($scope)) ?: [];
+        } elseif (is_array($scope) && array_is_list($scope)) {
+            $scopes = [];
+            foreach ($scope as $value) {
+                if (!is_string($value)) {
+                    return null;
+                }
+                $scopes[] = $value;
+            }
+        } else {
+            $scopes = [];
+        }
+
+        return new self($client_id, $scopes);
+    }
+
+    public function getClientId(): string
+    {
+        return $this->client_id;
+    }
+
+    /** @return list<string> */
+    public function getScopes(): array
+    {
+        return $this->scopes;
+    }
+}

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerAccessToken.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerAccessToken.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 declare(strict_types=1);
 
 final class ilLTIConsumerAccessToken

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerActivityProgress.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerActivityProgress.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+enum ilLTIConsumerActivityProgress: string
+{
+    case INITIALIZED = 'Initialized';
+    case STARTED = 'Started';
+    case IN_PROGRESS = 'InProgress';
+    case SUBMITTED = 'Submitted';
+    case COMPLETED = 'Completed';
+
+    public function isInProgress(): bool
+    {
+        return $this === self::STARTED || $this === self::IN_PROGRESS;
+    }
+
+    public function isSubmittedOrCompleted(): bool
+    {
+        return $this === self::SUBMITTED || $this === self::COMPLETED;
+    }
+}

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerActivityProgress.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerActivityProgress.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 declare(strict_types=1);
 
 enum ilLTIConsumerActivityProgress: string

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerContentGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerContentGUI.php
@@ -119,7 +119,8 @@ class ilLTIConsumerContentGUI
             return null;
         } else {
             $this->initCmixUser();
-            $params = $this->getLaunchParametersLTI13($loginData['redirect_uri'], $this->object->getProvider()->getClientId(), $this->object->getProvider()->getId(), $loginData['nonce']);
+            $targetLinkUri = $loginData['target_link_uri'] ?? $this->getTargetLinkUri();
+            $params = $this->getLaunchParametersLTI13($targetLinkUri, $this->object->getProvider()->getClientId(), $this->object->getProvider()->getId(), $loginData['nonce']);
             if (isset($loginData['state'])) {
                 $params['state'] = $loginData['state'];
             }
@@ -242,7 +243,7 @@ class ilLTIConsumerContentGUI
         $output = '<form id="lti_launch_form" name="lti_launch_form" action="' . $this->object->getProvider()->getInitiateLogin() . '" method="post" target="' . $target . '" encType="application/x-www-form-urlencoded">';
 
         $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'iss', ilObjLTIConsumer::getIliasHttpPath()) . "\n";
-        $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'target_link_uri', $this->object->getProvider()->getProviderUrl()) . "\n";
+        $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'target_link_uri', htmlspecialchars($this->getTargetLinkUri(), ENT_QUOTES)) . "\n";
         $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'login_hint', $user_ident) . "\n";
         $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'lti_message_hint', $ltiMessageHint) . "\n";
         $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'client_id', $this->object->getProvider()->getClientId()) . "\n";
@@ -279,7 +280,7 @@ class ilLTIConsumerContentGUI
         ilSession::set('lti_message_hint', $ltiMessageHint);
         $output = '<form id="lti_launch_form" name="lti_launch_form" action="' . $this->object->getProvider()->getInitiateLogin() . '" method="post" target="' . $target . '" encType="application/x-www-form-urlencoded">';
         $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'iss', ilObjLTIConsumer::getIliasHttpPath()) . "\n";
-        $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'target_link_uri', $this->object->getProvider()->getProviderUrl()) . "\n";
+        $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'target_link_uri', htmlspecialchars($this->getTargetLinkUri(), ENT_QUOTES)) . "\n";
         $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'login_hint', $user_ident) . "\n";
         $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'lti_message_hint', $ltiMessageHint) . "\n";
         $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'client_id', $this->object->getProvider()->getClientId()) . "\n";
@@ -382,6 +383,18 @@ class ilLTIConsumerContentGUI
             $launchContextId,
             $launchContextTitle
         );
+    }
+
+    private function getTargetLinkUri(): string
+    {
+        foreach (explode(';', $this->object->getCustomParams()) as $param) {
+            $parts = explode('=', $param, 2);
+            if (count($parts) === 2 && trim($parts[0]) === 'target_link_uri') {
+                return trim($parts[1]);
+            }
+        }
+
+        return $this->object->getProvider()->getProviderUrl();
     }
 
     public static function isEmbeddedLaunchRequest(): bool

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerContentGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerContentGUI.php
@@ -65,6 +65,17 @@ class ilLTIConsumerContentGUI
         $this->{$command}();
     }
 
+    public function getJwtForContentSelection(string $redirectUri, string $clientId, int $deploymentId, string $nonce, ?array $additionalArguments = null): string
+    {
+        $jwt = "";
+        $this->initCmixUser();
+        $jwtArray = $this->getLaunchParametersLTI13($redirectUri, $clientId, $deploymentId, $nonce, $additionalArguments);
+        if (isset($jwtArray['id_token'])) {
+            $jwt = $jwtArray['id_token'];
+        }
+        return $jwt;
+    }
+
     /**
      * @throws ilCtrlException
      * @throws ilTemplateException
@@ -83,7 +94,6 @@ class ilLTIConsumerContentGUI
                 $this->dic->toolbar()->addText($this->getStartButtonTxt11());
             }
         } else {
-
             if ($this->object->isLaunchMethodEmbedded() && (ilSession::get('lti13_login_data') == null)) {
                 $tpl = new ilTemplate('tpl.lti_content.html', true, true, 'components/ILIAS/LTIConsumer');
                 $tpl->setVariable("EMBEDDED_IFRAME_SRC", $this->dic->ctrl()->getLinkTarget(
@@ -195,7 +205,11 @@ class ilLTIConsumerContentGUI
         $button = '<input class="btn btn-default ilPre" type="button" onClick="ltilaunch()" value = "' . $this->lng->txt("show_content") . '" />';
         $output = '<form id="lti_launch_form" name="lti_launch_form" action="' . $this->object->getProvider()->getProviderUrl() . '" method="post" target="' . $target . '" encType="application/x-www-form-urlencoded">';
         foreach ($launchParameters as $field => $value) {
-            $output .= sprintf('<input type="hidden" name="%s" value="%s" />', $field, $value) . "\n";
+            $output .= sprintf(
+                '<input type="hidden" name="%s" value="%s" />',
+                htmlspecialchars((string) $field, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
+                htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
+            ) . "\n";
         }
         $output .= $button;
         $output .= '</form>';
@@ -260,7 +274,6 @@ class ilLTIConsumerContentGUI
             document.getElementById("lti_launch_form").style.display = "none";
             document.getElementById("lti_launched").style.display = "inline";
         }</script>';
-        //dump($output);exit();
         return($output);
     }
 
@@ -309,8 +322,8 @@ class ilLTIConsumerContentGUI
             $tpl = new ilTemplate('tpl.lti_embedded.html', true, true, 'components/ILIAS/LTIConsumer');
             foreach ($this->getLaunchParameters() as $field => $value) {
                 $tpl->setCurrentBlock('launch_parameter');
-                $tpl->setVariable('LAUNCH_PARAMETER', $field);
-                $tpl->setVariable('LAUNCH_PARAM_VALUE', $value);
+                $tpl->setVariable('LAUNCH_PARAMETER', htmlspecialchars((string) $field, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'));
+                $tpl->setVariable('LAUNCH_PARAM_VALUE', htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'));
                 $tpl->parseCurrentBlock();
             }
 
@@ -358,7 +371,7 @@ class ilLTIConsumerContentGUI
         );
     }
 
-    protected function getLaunchParametersLTI13(string $endpoint, string $clientId, int $deploymentId, string $nonce): ?array
+    protected function getLaunchParametersLTI13(string $endpoint, string $clientId, int $deploymentId, string $nonce, ?array $additionalArguments = null): ?array
     {
         $ilLTIConsumerLaunch = new ilLTIConsumerLaunch($this->object->getRefId());
         $launchContext = $ilLTIConsumerLaunch->getContext();
@@ -372,6 +385,11 @@ class ilLTIConsumerContentGUI
             $this->object->getRefId(),
             $this->object->getId()
         );
+        $returnUrl = !$this->object->isLaunchMethodOwnWin() ? '' : str_replace(
+            '&amp;',
+            '&',
+            ilObjLTIConsumer::getIliasHttpPath() . "/" . $this->dic->ctrl()->getLinkTarget($this, "", "", false)
+        );
 
         $cmixUser = $this->cmixUser;
         return $this->object->buildLaunchParametersLTI13(
@@ -383,7 +401,9 @@ class ilLTIConsumerContentGUI
             $nonce,
             $launchContextType,
             $launchContextId,
-            $launchContextTitle
+            $launchContextTitle,
+            $returnUrl,
+            $additionalArguments
         );
     }
 

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerContentGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerContentGUI.php
@@ -239,16 +239,17 @@ class ilLTIConsumerContentGUI
         $target = $this->object->getLaunchMethod() == "newWin" ? "_blank" : "_self";
         $button = '<input class="btn btn-default ilPre" type="button" onClick="ltilaunch()" value = "' . $this->lng->txt("show_content") . '" />';
         $ltiMessageHint = (string) $this->object->getRefId() . ":" . CLIENT_ID;
+        $html = $this->dic->refinery()->encode()->htmlSpecialCharsAsEntities();
         ilSession::set('lti_message_hint', $ltiMessageHint);
-        $output = '<form id="lti_launch_form" name="lti_launch_form" action="' . $this->object->getProvider()->getInitiateLogin() . '" method="post" target="' . $target . '" encType="application/x-www-form-urlencoded">';
+        $output = '<form id="lti_launch_form" name="lti_launch_form" action="' . $html->transform($this->object->getProvider()->getInitiateLogin()) . '" method="post" target="' . $target . '" encType="application/x-www-form-urlencoded">';
 
-        $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'iss', ilObjLTIConsumer::getIliasHttpPath()) . "\n";
-        $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'target_link_uri', htmlspecialchars($this->getTargetLinkUri(), ENT_QUOTES)) . "\n";
-        $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'login_hint', $user_ident) . "\n";
+        $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'iss', $html->transform(ilObjLTIConsumer::getIliasHttpPath())) . "\n";
+        $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'target_link_uri', $html->transform($this->getTargetLinkUri())) . "\n";
+        $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'login_hint', $html->transform($user_ident)) . "\n";
         $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'lti_message_hint', $ltiMessageHint) . "\n";
-        $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'client_id', $this->object->getProvider()->getClientId()) . "\n";
+        $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'client_id', $html->transform($this->object->getProvider()->getClientId())) . "\n";
         $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'lti_deployment_id', $this->object->getProvider()->getId()) . "\n";
-        $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'launch_presentation_return_url', $returnUrl) . "\n";
+        $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'launch_presentation_return_url', $html->transform($returnUrl)) . "\n";
         $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'lis_result_sourcedid', $token) . "\n";
         $output .= $button;
         $output .= '</form>';
@@ -277,13 +278,14 @@ class ilLTIConsumerContentGUI
         $target = "_self";
         $output = '';
         $ltiMessageHint = (string) $this->object->getRefId() . ":" . CLIENT_ID;
+        $html = $this->dic->refinery()->encode()->htmlSpecialCharsAsEntities();
         ilSession::set('lti_message_hint', $ltiMessageHint);
-        $output = '<form id="lti_launch_form" name="lti_launch_form" action="' . $this->object->getProvider()->getInitiateLogin() . '" method="post" target="' . $target . '" encType="application/x-www-form-urlencoded">';
-        $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'iss', ilObjLTIConsumer::getIliasHttpPath()) . "\n";
-        $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'target_link_uri', htmlspecialchars($this->getTargetLinkUri(), ENT_QUOTES)) . "\n";
-        $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'login_hint', $user_ident) . "\n";
+        $output = '<form id="lti_launch_form" name="lti_launch_form" action="' . $html->transform($this->object->getProvider()->getInitiateLogin()) . '" method="post" target="' . $target . '" encType="application/x-www-form-urlencoded">';
+        $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'iss', $html->transform(ilObjLTIConsumer::getIliasHttpPath())) . "\n";
+        $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'target_link_uri', $html->transform($this->getTargetLinkUri())) . "\n";
+        $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'login_hint', $html->transform($user_ident)) . "\n";
         $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'lti_message_hint', $ltiMessageHint) . "\n";
-        $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'client_id', $this->object->getProvider()->getClientId()) . "\n";
+        $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'client_id', $html->transform($this->object->getProvider()->getClientId())) . "\n";
         $output .= sprintf('<input type="hidden" name="%s" value="%s" />', 'lti_deployment_id', $this->object->getProvider()->getId()) . "\n";
         $output .= '</form>';
 

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeService.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeService.php
@@ -81,12 +81,12 @@ class ilLTIConsumerGradeService extends ilLTIConsumerServiceBase
      */
     public function getPermittedScopes(): array
     {
-        $scopes = array();
-        $scopes[] = self::SCOPE_GRADESERVICE_LINEITEM;
-        $scopes[] = self::SCOPE_GRADESERVICE_LINEITEM_READ;
-        $scopes[] = self::SCOPE_GRADESERVICE_RESULT_READ;
-        $scopes[] = self::SCOPE_GRADESERVICE_SCORE;
-        return $scopes;
+        return [
+            self::SCOPE_GRADESERVICE_LINEITEM,
+            self::SCOPE_GRADESERVICE_LINEITEM_READ,
+            self::SCOPE_GRADESERVICE_RESULT_READ,
+            self::SCOPE_GRADESERVICE_SCORE
+        ];
     }
 
     /**

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeService.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeService.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 
 class ilLTIConsumerGradeService extends ilLTIConsumerServiceBase
 {
+    private ilLTIConsumerLineItemRepository $lineItemRepository;
     /** Read-only access to Gradebook services */
     public const GRADESERVICE_READ = 1;
 
@@ -54,6 +55,8 @@ class ilLTIConsumerGradeService extends ilLTIConsumerServiceBase
     public function __construct()
     {
         parent::__construct();
+        global $DIC;
+        $this->lineItemRepository = new ilLTIConsumerLineItemRepository($DIC->database());
         $this->id = 'gradebookservice';
         $this->name = 'ilLTIConsumerGradeService';
     }
@@ -67,9 +70,9 @@ class ilLTIConsumerGradeService extends ilLTIConsumerServiceBase
         // Lineitems should be after lineitem.
         if (empty($this->resources)) {
             $this->resources = array();
-            $this->resources[] = new ilLTIConsumerGradeServiceLineItem($this);
-            $this->resources[] = new ilLTIConsumerGradeServiceLineItems($this);
-            $this->resources[] = new ilLTIConsumerGradeServiceResults($this);
+            $this->resources[] = new ilLTIConsumerGradeServiceLineItem($this, $this->lineItemRepository);
+            $this->resources[] = new ilLTIConsumerGradeServiceLineItems($this, $this->lineItemRepository);
+            $this->resources[] = new ilLTIConsumerGradeServiceResults($this, $this->lineItemRepository);
             $this->resources[] = new ilLTIConsumerGradeServiceScores($this);
         }
         return $this->resources;

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeService.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeService.php
@@ -73,7 +73,7 @@ class ilLTIConsumerGradeService extends ilLTIConsumerServiceBase
             $this->resources[] = new ilLTIConsumerGradeServiceLineItem($this, $this->lineItemRepository);
             $this->resources[] = new ilLTIConsumerGradeServiceLineItems($this, $this->lineItemRepository);
             $this->resources[] = new ilLTIConsumerGradeServiceResults($this, $this->lineItemRepository);
-            $this->resources[] = new ilLTIConsumerGradeServiceScores($this);
+            $this->resources[] = new ilLTIConsumerGradeServiceScores($this, $this->lineItemRepository);
         }
         return $this->resources;
     }

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItem.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItem.php
@@ -246,7 +246,7 @@ class ilLTIConsumerGradeServiceLineItem extends ilLTIConsumerResourceBase
         global $DIC;
         $tree = $DIC->repositoryTree();
         $node_data = $tree->getNodeData($resource_link_ref_id);
-        if (!$node_data || $node_data['type'] !== 'lti' ||
+        if (!isset($node_data['type']) || $node_data['type'] !== 'lti' ||
             !in_array($context_id, $tree->getPathId($resource_link_ref_id), true)) {
             return false;
         }

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItem.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItem.php
@@ -40,4 +40,282 @@ class ilLTIConsumerGradeServiceLineItem extends ilLTIConsumerResourceBase
         $this->methods[] = self::HTTP_PUT;
         $this->methods[] = self::HTTP_DELETE;
     }
+
+    public function execute(ilLTIConsumerServiceResponse $response): void
+    {
+        $params = $this->parseTemplate();
+        $contextId = (int) ($params['context_id'] ?? 0);
+        $itemId = (int) ($params['item_id'] ?? 0);
+
+        try {
+            $isRealObject = ilObject::_lookupType($itemId) === 'lti';
+
+            if ($response->getRequestMethod() === self::HTTP_GET) {
+                if ($isRealObject) {
+                    $this->handleGetReal($response, $contextId, $itemId);
+                } else {
+                    $this->handleGetStored($response, $contextId, $itemId);
+                }
+            } elseif ($response->getRequestMethod() === self::HTTP_PUT) {
+                $this->handlePut($response, $contextId, $itemId, $isRealObject);
+            } elseif ($response->getRequestMethod() === self::HTTP_DELETE) {
+                $this->handleDelete($response, $contextId, $itemId, $isRealObject);
+            } else {
+                $response->setCode(405);
+            }
+        } catch (Exception $e) {
+            $code = $e->getCode();
+            $response->setCode($code >= 400 && $code < 600 ? $code : 500);
+            $response->setReason($e->getMessage());
+        }
+    }
+
+    protected function handleGetReal(ilLTIConsumerServiceResponse $response, int $contextId, int $itemId): void
+    {
+        $token = $this->checkTool([
+            ilLTIConsumerGradeService::SCOPE_GRADESERVICE_LINEITEM,
+            ilLTIConsumerGradeService::SCOPE_GRADESERVICE_LINEITEM_READ
+        ]);
+        if (!$token) {
+            throw new Exception('invalid request', 401);
+        }
+
+        $object = new ilObjLTIConsumer($itemId, false);
+        $provider = $object->getProvider();
+        if (!$provider || (!$provider->isGradeSynchronization() && !$provider->getHasOutcome())) {
+            throw new Exception('grade synchronization not enabled', 403);
+        }
+        $this->checkProviderMatchesToken($provider, $token);
+
+        $lineItem = self::buildLineItemData($contextId, $itemId, $object);
+        $response->setContentType('application/vnd.ims.lis.v2.lineitem+json');
+        $response->setBody(json_encode($lineItem, JSON_UNESCAPED_SLASHES));
+    }
+
+    protected function handleGetStored(ilLTIConsumerServiceResponse $response, int $contextId, int $itemId): void
+    {
+        $token = $this->checkTool([
+            ilLTIConsumerGradeService::SCOPE_GRADESERVICE_LINEITEM,
+            ilLTIConsumerGradeService::SCOPE_GRADESERVICE_LINEITEM_READ
+        ]);
+        if (!$token) {
+            throw new Exception('invalid request', 401);
+        }
+
+        $row = $this->findStoredLineItem($itemId, $contextId, $this->getClientIdFromToken($token));
+        if (!$row) {
+            throw new Exception('LineItem not found', 404);
+        }
+
+        $lineItem = [
+            'id' => self::buildLineItemUrl($contextId, $itemId),
+            'label' => (string) ($row['label'] ?? ''),
+            'scoreMaximum' => (float) ($row['score_maximum'] ?? 1),
+            'resourceId' => (string) ($row['resource_id'] ?? ''),
+            'resourceLinkId' => (string) ($row['resource_link_id'] ?? ''),
+            'tag' => (string) ($row['tag'] ?? '')
+        ];
+
+        $response->setContentType('application/vnd.ims.lis.v2.lineitem+json');
+        $response->setBody(json_encode($lineItem, JSON_UNESCAPED_SLASHES));
+    }
+
+    protected function handlePut(ilLTIConsumerServiceResponse $response, int $contextId, int $itemId, bool $isRealObject): void
+    {
+        $token = $this->checkTool([
+            ilLTIConsumerGradeService::SCOPE_GRADESERVICE_LINEITEM
+        ]);
+        if (!$token) {
+            throw new Exception('invalid request', 401);
+        }
+        $clientId = $this->getClientIdFromToken($token);
+
+        $body = json_decode($response->getRequestData());
+        if (!is_object($body) || json_last_error() !== JSON_ERROR_NONE) {
+            throw new Exception('Invalid request body', 400);
+        }
+
+        if ($isRealObject) {
+            $object = new ilObjLTIConsumer($itemId, false);
+            $provider = $object->getProvider();
+            if (!$provider || (!$provider->isGradeSynchronization() && !$provider->getHasOutcome())) {
+                throw new Exception('grade synchronization not enabled', 403);
+            }
+            $this->checkProviderMatchesToken($provider, $token);
+
+            if (isset($body->label) && is_string($body->label) && $body->label !== '') {
+                $object->setTitle($body->label);
+            }
+            if (isset($body->scoreMaximum) && is_numeric($body->scoreMaximum) && (float) $body->scoreMaximum > 0) {
+                $object->setScoreMaximum((float) $body->scoreMaximum);
+            }
+            $object->update();
+
+            $lineItem = self::buildLineItemData($contextId, $itemId, $object);
+            $response->setContentType('application/vnd.ims.lis.v2.lineitem+json');
+            $response->setBody(json_encode($lineItem, JSON_UNESCAPED_SLASHES));
+        } else {
+            $row = $this->findStoredLineItem($itemId, $contextId, $clientId);
+            if (!$row) {
+                throw new Exception('LineItem not found', 404);
+            }
+
+            global $DIC;
+            $ilDB = $DIC->database();
+            $storageId = (int) $row['id'];
+
+            $label = isset($body->label) && is_string($body->label) && $body->label !== ''
+                ? (string) $body->label : $row['label'];
+            $scoreMax = isset($body->scoreMaximum) && is_numeric($body->scoreMaximum) && (float) $body->scoreMaximum > 0
+                ? (float) $body->scoreMaximum : (float) ($row['score_maximum'] ?? 1);
+            $resourceId = isset($body->resourceId) ? (string) $body->resourceId : (string) ($row['resource_id'] ?? '');
+            $resourceLinkId = isset($body->resourceLinkId) ? (string) $body->resourceLinkId : (string) ($row['resource_link_id'] ?? '');
+            $tag = isset($body->tag) ? (string) $body->tag : (string) ($row['tag'] ?? '');
+
+            $ilDB->update('lti_consumer_lineitems', [
+                'label' => ['text', $label],
+                'score_maximum' => ['float', $scoreMax],
+                'resource_id' => ['text', $resourceId],
+                'resource_link_id' => ['text', $resourceLinkId],
+                'tag' => ['text', $tag]
+            ], [
+                'id' => ['integer', $storageId]
+            ]);
+
+            $lineItem = [
+                'id' => self::buildLineItemUrl($contextId, $itemId),
+                'label' => $label,
+                'scoreMaximum' => $scoreMax,
+                'resourceId' => $resourceId,
+                'resourceLinkId' => $resourceLinkId,
+                'tag' => $tag
+            ];
+
+            $response->setContentType('application/vnd.ims.lis.v2.lineitem+json');
+            $response->setBody(json_encode($lineItem, JSON_UNESCAPED_SLASHES));
+        }
+    }
+
+    protected function handleDelete(ilLTIConsumerServiceResponse $response, int $contextId, int $itemId, bool $isRealObject): void
+    {
+        $token = $this->checkTool([
+            ilLTIConsumerGradeService::SCOPE_GRADESERVICE_LINEITEM
+        ]);
+        if (!$token) {
+            throw new Exception('invalid request', 401);
+        }
+        $clientId = $this->getClientIdFromToken($token);
+
+        if ($isRealObject) {
+            $object = new ilObjLTIConsumer($itemId, false);
+            $provider = $object->getProvider();
+            if (!$provider || (!$provider->isGradeSynchronization() && !$provider->getHasOutcome())) {
+                throw new Exception('grade synchronization not enabled', 403);
+            }
+            $this->checkProviderMatchesToken($provider, $token);
+            $object->setScoreMaximum(1);
+            if ($object->getTitle() === $provider->getTitle()) {
+                $object->setTitle($object->getTitle());
+            }
+            $object->update();
+        } else {
+            $row = $this->findStoredLineItem($itemId, $contextId, $clientId);
+            if (!$row) {
+                throw new Exception('LineItem not found', 404);
+            }
+
+            global $DIC;
+            $ilDB = $DIC->database();
+            $ilDB->update('lti_consumer_lineitems', [
+                'enabled' => ['integer', 0]
+            ], [
+                'id' => ['integer', (int) $row['id']]
+            ]);
+        }
+
+        $response->setCode(200);
+    }
+
+    protected function findStoredLineItem(int $itemId, int $contextId, string $clientId): ?array
+    {
+        $storedId = -$itemId;
+        if ($storedId <= 0) {
+            return null;
+        }
+
+        global $DIC;
+        $ilDB = $DIC->database();
+        if (!$ilDB->tableExists('lti_consumer_lineitems')) {
+            return null;
+        }
+
+        $query = 'SELECT * FROM lti_consumer_lineitems'
+            . ' WHERE id = ' . $ilDB->quote($storedId, 'integer')
+            . ' AND context_id = ' . $ilDB->quote($contextId, 'integer')
+            . ' AND client_id = ' . $ilDB->quote($clientId, 'text')
+            . ' AND enabled = ' . $ilDB->quote(1, 'integer');
+        $res = $ilDB->query($query);
+        return $ilDB->fetchAssoc($res) ?: null;
+    }
+
+    protected function checkProviderMatchesToken(ilLTIConsumeProvider $provider, object $token): void
+    {
+        if ($provider->getClientId() !== $this->getClientIdFromToken($token)) {
+            throw new Exception('invalid clientId', 403);
+        }
+    }
+
+    protected function getClientIdFromToken(object $token): string
+    {
+        $clientId = $token->sub ?? '';
+        if (!is_string($clientId) || $clientId === '') {
+            throw new Exception('invalid request', 401);
+        }
+        return $clientId;
+    }
+
+    public static function buildLineItemData(int $contextId, int $itemId, ilObjLTIConsumer $object): array
+    {
+        return [
+            'id' => self::buildLineItemUrl($contextId, $itemId),
+            'label' => $object->getTitle(),
+            'scoreMaximum' => $object->getScoreMaximum(),
+            'resourceId' => (string) $itemId,
+            'resourceLinkId' => self::getResourceLinkId($contextId, $itemId)
+        ];
+    }
+
+    protected static function getResourceLinkId(int $contextId, int $itemId): string
+    {
+        global $DIC;
+
+        $refs = ilObject::_getAllReferences($itemId);
+        foreach ($refs as $refId) {
+            $refId = (int) $refId;
+            $path = $DIC->repositoryTree()->getPathId($refId);
+            if (in_array($contextId, $path, true)) {
+                return (string) $refId;
+            }
+        }
+
+        $refId = (int) current($refs);
+        return $refId > 0 ? (string) $refId : '';
+    }
+
+    public static function buildLineItemUrl(int $contextId, int $itemId): string
+    {
+        return self::getServiceRootUrl() . "/ltiservices.php/gradeservice/{$contextId}/lineitems/{$itemId}/lineitem";
+    }
+
+    protected static function getServiceRootUrl(): string
+    {
+        global $DIC;
+
+        $protocol = $DIC['https']->isDetected() ? 'https://' : 'http://';
+        $host = $_SERVER['HTTP_HOST'];
+        $scriptDir = str_replace('\\', '/', dirname($_SERVER['SCRIPT_NAME'] ?? ''));
+        $scriptDir = $scriptDir === '/' ? '' : rtrim($scriptDir, '/');
+
+        return ilContext::modifyHttpPath($protocol . $host . $scriptDir);
+    }
 }

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItem.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItem.php
@@ -32,8 +32,7 @@ class ilLTIConsumerGradeServiceLineItem extends ilLTIConsumerResourceBase
     public function __construct(
         ilLTIConsumerServiceBase $service,
         private readonly ilLTIConsumerLineItemRepository $lineItemRepository
-    )
-    {
+    ) {
         parent::__construct($service);
         $this->id = 'LineItem.item';
         $this->template = '/{context_id}/lineitems/{item_id}/lineitem';

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItem.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItem.php
@@ -29,7 +29,10 @@ declare(strict_types=1);
 
 class ilLTIConsumerGradeServiceLineItem extends ilLTIConsumerResourceBase
 {
-    public function __construct(ilLTIConsumerServiceBase $service)
+    public function __construct(
+        ilLTIConsumerServiceBase $service,
+        private readonly ilLTIConsumerLineItemRepository $lineItemRepository
+    )
     {
         parent::__construct($service);
         $this->id = 'LineItem.item';
@@ -63,9 +66,11 @@ class ilLTIConsumerGradeServiceLineItem extends ilLTIConsumerResourceBase
             } else {
                 $response->setCode(405);
             }
-        } catch (Exception $e) {
-            $code = $e->getCode();
-            $response->setCode($code >= 400 && $code < 600 ? $code : 500);
+        } catch (ilLTIConsumerHttpException $e) {
+            $response->setCode($e->getCode());
+            $response->setReason($e->getMessage());
+        } catch (Throwable $e) {
+            $response->setCode(500);
             $response->setReason($e->getMessage());
         }
     }
@@ -77,13 +82,13 @@ class ilLTIConsumerGradeServiceLineItem extends ilLTIConsumerResourceBase
             ilLTIConsumerGradeService::SCOPE_GRADESERVICE_LINEITEM_READ
         ]);
         if (!$token) {
-            throw new Exception('invalid request', 401);
+            throw ilLTIConsumerHttpException::unauthorized();
         }
 
         $object = new ilObjLTIConsumer($itemId, false);
         $provider = $object->getProvider();
         if (!$provider || (!$provider->isGradeSynchronization() && !$provider->getHasOutcome())) {
-            throw new Exception('grade synchronization not enabled', 403);
+            throw ilLTIConsumerHttpException::forbidden('grade synchronization not enabled');
         }
         $this->checkProviderMatchesToken($provider, $token);
 
@@ -99,25 +104,25 @@ class ilLTIConsumerGradeServiceLineItem extends ilLTIConsumerResourceBase
             ilLTIConsumerGradeService::SCOPE_GRADESERVICE_LINEITEM_READ
         ]);
         if (!$token) {
-            throw new Exception('invalid request', 401);
+            throw ilLTIConsumerHttpException::unauthorized();
         }
 
-        $row = $this->findStoredLineItem($itemId, $contextId, $this->getClientIdFromToken($token));
-        if (!$row) {
-            throw new Exception('LineItem not found', 404);
+        $lineItem = $this->findStoredLineItem($itemId, $contextId, $token->getClientId());
+        if ($lineItem === null) {
+            throw ilLTIConsumerHttpException::notFound('LineItem not found');
         }
 
-        $lineItem = [
+        $lineItemData = [
             'id' => self::buildLineItemUrl($contextId, $itemId),
-            'label' => (string) ($row['label'] ?? ''),
-            'scoreMaximum' => (float) ($row['score_maximum'] ?? 1),
-            'resourceId' => (string) ($row['resource_id'] ?? ''),
-            'resourceLinkId' => (string) ($row['resource_link_id'] ?? ''),
-            'tag' => (string) ($row['tag'] ?? '')
+            'label' => $lineItem->label,
+            'scoreMaximum' => $lineItem->scoreMaximum,
+            'resourceId' => $lineItem->resourceId,
+            'resourceLinkId' => $lineItem->resourceLinkId,
+            'tag' => $lineItem->tag
         ];
 
         $response->setContentType('application/vnd.ims.lis.v2.lineitem+json');
-        $response->setBody(json_encode($lineItem, JSON_UNESCAPED_SLASHES));
+        $response->setBody(json_encode($lineItemData, JSON_UNESCAPED_SLASHES));
     }
 
     protected function handlePut(ilLTIConsumerServiceResponse $response, int $contextId, int $itemId, bool $isRealObject): void
@@ -126,20 +131,20 @@ class ilLTIConsumerGradeServiceLineItem extends ilLTIConsumerResourceBase
             ilLTIConsumerGradeService::SCOPE_GRADESERVICE_LINEITEM
         ]);
         if (!$token) {
-            throw new Exception('invalid request', 401);
+            throw ilLTIConsumerHttpException::unauthorized();
         }
-        $clientId = $this->getClientIdFromToken($token);
+        $clientId = $token->getClientId();
 
         $body = json_decode($response->getRequestData());
         if (!is_object($body) || json_last_error() !== JSON_ERROR_NONE) {
-            throw new Exception('Invalid request body', 400);
+            throw ilLTIConsumerHttpException::badRequest('Invalid request body');
         }
 
         if ($isRealObject) {
             $object = new ilObjLTIConsumer($itemId, false);
             $provider = $object->getProvider();
             if (!$provider || (!$provider->isGradeSynchronization() && !$provider->getHasOutcome())) {
-                throw new Exception('grade synchronization not enabled', 403);
+                throw ilLTIConsumerHttpException::forbidden('grade synchronization not enabled');
             }
             $this->checkProviderMatchesToken($provider, $token);
 
@@ -155,44 +160,32 @@ class ilLTIConsumerGradeServiceLineItem extends ilLTIConsumerResourceBase
             $response->setContentType('application/vnd.ims.lis.v2.lineitem+json');
             $response->setBody(json_encode($lineItem, JSON_UNESCAPED_SLASHES));
         } else {
-            $row = $this->findStoredLineItem($itemId, $contextId, $clientId);
-            if (!$row) {
-                throw new Exception('LineItem not found', 404);
+            $lineItem = $this->findStoredLineItem($itemId, $contextId, $clientId);
+            if ($lineItem === null) {
+                throw ilLTIConsumerHttpException::notFound('LineItem not found');
             }
 
-            global $DIC;
-            $ilDB = $DIC->database();
-            $storageId = (int) $row['id'];
-
             $label = isset($body->label) && is_string($body->label) && $body->label !== ''
-                ? (string) $body->label : $row['label'];
+                ? (string) $body->label : $lineItem->label;
             $scoreMax = isset($body->scoreMaximum) && is_numeric($body->scoreMaximum) && (float) $body->scoreMaximum > 0
-                ? (float) $body->scoreMaximum : (float) ($row['score_maximum'] ?? 1);
-            $resourceId = isset($body->resourceId) ? (string) $body->resourceId : (string) ($row['resource_id'] ?? '');
-            $resourceLinkId = isset($body->resourceLinkId) ? (string) $body->resourceLinkId : (string) ($row['resource_link_id'] ?? '');
-            $tag = isset($body->tag) ? (string) $body->tag : (string) ($row['tag'] ?? '');
+                ? (float) $body->scoreMaximum : $lineItem->scoreMaximum;
+            $resourceId = isset($body->resourceId) ? (string) $body->resourceId : $lineItem->resourceId;
+            $resourceLinkId = isset($body->resourceLinkId) ? (string) $body->resourceLinkId : $lineItem->resourceLinkId;
+            $tag = isset($body->tag) ? (string) $body->tag : $lineItem->tag;
+            $lineItem = $lineItem->withValues($label, $scoreMax, $resourceId, $resourceLinkId, $tag);
+            $this->lineItemRepository->update($lineItem);
 
-            $ilDB->update('lti_consumer_lineitems', [
-                'label' => ['text', $label],
-                'score_maximum' => ['float', $scoreMax],
-                'resource_id' => ['text', $resourceId],
-                'resource_link_id' => ['text', $resourceLinkId],
-                'tag' => ['text', $tag]
-            ], [
-                'id' => ['integer', $storageId]
-            ]);
-
-            $lineItem = [
+            $lineItemData = [
                 'id' => self::buildLineItemUrl($contextId, $itemId),
-                'label' => $label,
-                'scoreMaximum' => $scoreMax,
-                'resourceId' => $resourceId,
-                'resourceLinkId' => $resourceLinkId,
-                'tag' => $tag
+                'label' => $lineItem->label,
+                'scoreMaximum' => $lineItem->scoreMaximum,
+                'resourceId' => $lineItem->resourceId,
+                'resourceLinkId' => $lineItem->resourceLinkId,
+                'tag' => $lineItem->tag
             ];
 
             $response->setContentType('application/vnd.ims.lis.v2.lineitem+json');
-            $response->setBody(json_encode($lineItem, JSON_UNESCAPED_SLASHES));
+            $response->setBody(json_encode($lineItemData, JSON_UNESCAPED_SLASHES));
         }
     }
 
@@ -202,15 +195,15 @@ class ilLTIConsumerGradeServiceLineItem extends ilLTIConsumerResourceBase
             ilLTIConsumerGradeService::SCOPE_GRADESERVICE_LINEITEM
         ]);
         if (!$token) {
-            throw new Exception('invalid request', 401);
+            throw ilLTIConsumerHttpException::unauthorized();
         }
-        $clientId = $this->getClientIdFromToken($token);
+        $clientId = $token->getClientId();
 
         if ($isRealObject) {
             $object = new ilObjLTIConsumer($itemId, false);
             $provider = $object->getProvider();
             if (!$provider || (!$provider->isGradeSynchronization() && !$provider->getHasOutcome())) {
-                throw new Exception('grade synchronization not enabled', 403);
+                throw ilLTIConsumerHttpException::forbidden('grade synchronization not enabled');
             }
             $this->checkProviderMatchesToken($provider, $token);
             $object->setScoreMaximum(1);
@@ -219,61 +212,36 @@ class ilLTIConsumerGradeServiceLineItem extends ilLTIConsumerResourceBase
             }
             $object->update();
         } else {
-            $row = $this->findStoredLineItem($itemId, $contextId, $clientId);
-            if (!$row) {
-                throw new Exception('LineItem not found', 404);
+            $lineItem = $this->findStoredLineItem($itemId, $contextId, $clientId);
+            if ($lineItem === null) {
+                throw ilLTIConsumerHttpException::notFound('LineItem not found');
             }
-
-            global $DIC;
-            $ilDB = $DIC->database();
-            $ilDB->update('lti_consumer_lineitems', [
-                'enabled' => ['integer', 0]
-            ], [
-                'id' => ['integer', (int) $row['id']]
-            ]);
+            $this->lineItemRepository->disable($lineItem);
         }
 
         $response->setCode(200);
     }
 
-    protected function findStoredLineItem(int $itemId, int $contextId, string $clientId): ?array
+    protected function findStoredLineItem(int $itemId, int $contextId, string $clientId): ?ilLTIConsumerLineItem
     {
         $storedId = -$itemId;
         if ($storedId <= 0) {
             return null;
         }
 
-        global $DIC;
-        $ilDB = $DIC->database();
-        if (!$ilDB->tableExists('lti_consumer_lineitems')) {
-            return null;
-        }
-
-        $query = 'SELECT * FROM lti_consumer_lineitems'
-            . ' WHERE id = ' . $ilDB->quote($storedId, 'integer')
-            . ' AND context_id = ' . $ilDB->quote($contextId, 'integer')
-            . ' AND client_id = ' . $ilDB->quote($clientId, 'text')
-            . ' AND enabled = ' . $ilDB->quote(1, 'integer');
-        $res = $ilDB->query($query);
-        return $ilDB->fetchAssoc($res) ?: null;
+        return $this->lineItemRepository->get($storedId, $contextId, $clientId);
     }
 
-    protected function checkProviderMatchesToken(ilLTIConsumeProvider $provider, object $token): void
+    protected function checkProviderMatchesToken(ilLTIConsumeProvider $provider, ilLTIConsumerAccessToken $token): void
     {
-        if ($provider->getClientId() !== $this->getClientIdFromToken($token)) {
-            throw new Exception('invalid clientId', 403);
+        if ($provider->getClientId() !== $token->getClientId()) {
+            throw ilLTIConsumerHttpException::forbidden('invalid clientId');
         }
     }
 
-    protected function getClientIdFromToken(object $token): string
-    {
-        $clientId = $token->sub ?? '';
-        if (!is_string($clientId) || $clientId === '') {
-            throw new Exception('invalid request', 401);
-        }
-        return $clientId;
-    }
-
+    /**
+     * @return array{id: string, label: string, scoreMaximum: float, resourceId: string, resourceLinkId: string}
+     */
     public static function buildLineItemData(int $contextId, int $itemId, ilObjLTIConsumer $object): array
     {
         return [

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItem.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItem.php
@@ -293,25 +293,31 @@ class ilLTIConsumerGradeServiceLineItem extends ilLTIConsumerResourceBase
 
     public static function buildLineItemUrl(int $contextId, int $itemId): string
     {
-        return self::getServiceRootUrl() . "/ltiservices.php/gradeservice/{$contextId}/lineitems/{$itemId}/lineitem";
+        return self::buildLineItemsUrl($contextId) . "/{$itemId}/lineitem";
+    }
+
+    public static function buildLineItemsUrl(int $contextId): string
+    {
+        return self::getServiceRootUrl() . "/ltiservices.php/gradeservice/{$contextId}/lineitems";
     }
 
     /**
-     * ilObjLTIConsumer::getIliasHttpPath() derives its base path from the current
-     * request URI, which breaks here: ltiservices.php uses PATH_INFO routing, so
-     * REQUEST_URI already contains "/gradeservice/{context}/lineitems/...", and
-     * that gets duplicated into every line item URL built from within this script.
-     * SCRIPT_NAME is not affected by PATH_INFO, so it stays safe for this purpose.
+     * AGS 2.0 §3.2.3 asks for a stable line item URL and §3.3.4.3 requires the id a
+     * tool reads back to be identical to the lineitem claim it received at launch.
+     * Both are built from here, so the base must not depend on the current request:
+     * ilObjLTIConsumer::getIliasHttpPath() derives it from REQUEST_URI, which already
+     * contains "/gradeservice/{context}/lineitems/..." under the PATH_INFO routing of
+     * ltiservices.php, and HTTP_HOST does not survive a reverse proxy. The configured
+     * http_path is the same source ILIAS uses for its own absolute links.
      */
     public static function getServiceRootUrl(): string
     {
         global $DIC;
 
-        $protocol = $DIC['https']->isDetected() ? 'https://' : 'http://';
-        $host = $_SERVER['HTTP_HOST'];
-        $scriptDir = str_replace('\\', '/', dirname($_SERVER['SCRIPT_NAME'] ?? ''));
-        $scriptDir = $scriptDir === '/' ? '' : rtrim($scriptDir, '/');
+        $http_path = ilContext::modifyHttpPath(
+            $DIC['ilIliasIniFile']->readVariable('server', 'http_path')
+        );
 
-        return ilContext::modifyHttpPath($protocol . $host . $scriptDir);
+        return (new \ILIAS\Data\Factory())->uri(rtrim($http_path, '/'))->getBaseURI();
     }
 }

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItem.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItem.php
@@ -304,18 +304,6 @@ class ilLTIConsumerGradeServiceLineItem extends ilLTIConsumerResourceBase
 
     public static function buildLineItemUrl(int $contextId, int $itemId): string
     {
-        return self::getServiceRootUrl() . "/ltiservices.php/gradeservice/{$contextId}/lineitems/{$itemId}/lineitem";
-    }
-
-    protected static function getServiceRootUrl(): string
-    {
-        global $DIC;
-
-        $protocol = $DIC['https']->isDetected() ? 'https://' : 'http://';
-        $host = $_SERVER['HTTP_HOST'];
-        $scriptDir = str_replace('\\', '/', dirname($_SERVER['SCRIPT_NAME'] ?? ''));
-        $scriptDir = $scriptDir === '/' ? '' : rtrim($scriptDir, '/');
-
-        return ilContext::modifyHttpPath($protocol . $host . $scriptDir);
+        return ilObjLTIConsumer::getIliasHttpPath() . "/ltiservices.php/gradeservice/{$contextId}/lineitems/{$itemId}/lineitem";
     }
 }

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItem.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItem.php
@@ -214,8 +214,8 @@ class ilLTIConsumerGradeServiceLineItem extends ilLTIConsumerResourceBase
             }
             $this->checkProviderMatchesToken($provider, $token);
             $object->setScoreMaximum(1);
-            if ($object->getTitle() === $provider->getTitle()) {
-                $object->setTitle($object->getTitle());
+            if ($object->getTitle() !== $provider->getTitle()) {
+                $object->setTitle($provider->getTitle());
             }
             $object->update();
         } else {

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItem.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItem.php
@@ -139,6 +139,12 @@ class ilLTIConsumerGradeServiceLineItem extends ilLTIConsumerResourceBase
         if (!is_object($body) || json_last_error() !== JSON_ERROR_NONE) {
             throw ilLTIConsumerHttpException::badRequest('Invalid request body');
         }
+        if (property_exists($body, 'resourceLinkId')) {
+            $resource_link_id = is_scalar($body->resourceLinkId) ? (string) $body->resourceLinkId : '';
+            if (!$this->isClientResourceLink($contextId, $clientId, $resource_link_id)) {
+                throw ilLTIConsumerHttpException::notFound('Resource link not found');
+            }
+        }
 
         if ($isRealObject) {
             $object = new ilObjLTIConsumer($itemId, false);
@@ -200,17 +206,8 @@ class ilLTIConsumerGradeServiceLineItem extends ilLTIConsumerResourceBase
         $clientId = $token->getClientId();
 
         if ($isRealObject) {
-            $object = new ilObjLTIConsumer($itemId, false);
-            $provider = $object->getProvider();
-            if (!$provider || (!$provider->isGradeSynchronization() && !$provider->getHasOutcome())) {
-                throw ilLTIConsumerHttpException::forbidden('grade synchronization not enabled');
-            }
-            $this->checkProviderMatchesToken($provider, $token);
-            $object->setScoreMaximum(1);
-            if ($object->getTitle() !== $provider->getTitle()) {
-                $object->setTitle($provider->getTitle());
-            }
-            $object->update();
+            $response->setCode(405);
+            return;
         } else {
             $lineItem = $this->findStoredLineItem($itemId, $contextId, $clientId);
             if ($lineItem === null) {
@@ -237,6 +234,30 @@ class ilLTIConsumerGradeServiceLineItem extends ilLTIConsumerResourceBase
         if ($provider->getClientId() !== $token->getClientId()) {
             throw ilLTIConsumerHttpException::forbidden('invalid clientId');
         }
+    }
+
+    protected function isClientResourceLink(int $context_id, string $client_id, string $resource_link_id): bool
+    {
+        $resource_link_ref_id = (int) $resource_link_id;
+        if ($resource_link_ref_id <= 0) {
+            return false;
+        }
+
+        global $DIC;
+        $tree = $DIC->repositoryTree();
+        $node_data = $tree->getNodeData($resource_link_ref_id);
+        if (!$node_data || $node_data['type'] !== 'lti' ||
+            !in_array($context_id, $tree->getPathId($resource_link_ref_id), true)) {
+            return false;
+        }
+
+        $object_id = ilObject::_lookupObjId($resource_link_ref_id);
+        if (!$object_id) {
+            return false;
+        }
+
+        $provider = (new ilObjLTIConsumer($object_id, false))->getProvider();
+        return $provider !== null && $provider->getClientId() === $client_id;
     }
 
     /**

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItem.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItem.php
@@ -293,6 +293,25 @@ class ilLTIConsumerGradeServiceLineItem extends ilLTIConsumerResourceBase
 
     public static function buildLineItemUrl(int $contextId, int $itemId): string
     {
-        return ilObjLTIConsumer::getIliasHttpPath() . "/ltiservices.php/gradeservice/{$contextId}/lineitems/{$itemId}/lineitem";
+        return self::getServiceRootUrl() . "/ltiservices.php/gradeservice/{$contextId}/lineitems/{$itemId}/lineitem";
+    }
+
+    /**
+     * ilObjLTIConsumer::getIliasHttpPath() derives its base path from the current
+     * request URI, which breaks here: ltiservices.php uses PATH_INFO routing, so
+     * REQUEST_URI already contains "/gradeservice/{context}/lineitems/...", and
+     * that gets duplicated into every line item URL built from within this script.
+     * SCRIPT_NAME is not affected by PATH_INFO, so it stays safe for this purpose.
+     */
+    public static function getServiceRootUrl(): string
+    {
+        global $DIC;
+
+        $protocol = $DIC['https']->isDetected() ? 'https://' : 'http://';
+        $host = $_SERVER['HTTP_HOST'];
+        $scriptDir = str_replace('\\', '/', dirname($_SERVER['SCRIPT_NAME'] ?? ''));
+        $scriptDir = $scriptDir === '/' ? '' : rtrim($scriptDir, '/');
+
+        return ilContext::modifyHttpPath($protocol . $host . $scriptDir);
     }
 }

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItems.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItems.php
@@ -270,7 +270,7 @@ class ilLTIConsumerGradeServiceLineItems extends ilLTIConsumerResourceBase
             $query['resource_link_id'] = $filters['resourceLinkId'];
         }
 
-        $url = ilLTIConsumerGradeServiceLineItem::getServiceRootUrl() . "/ltiservices.php/gradeservice/{$context_id}/lineitems";
+        $url = ilLTIConsumerGradeServiceLineItem::buildLineItemsUrl($context_id);
         $response->addAdditionalHeader('Link: <' . $url . '?' . http_build_query($query) . '>; rel="next"');
     }
 

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItems.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItems.php
@@ -40,4 +40,236 @@ class ilLTIConsumerGradeServiceLineItems extends ilLTIConsumerResourceBase
         $this->methods[] = self::HTTP_GET;
         $this->methods[] = self::HTTP_POST;
     }
+
+    public function execute(ilLTIConsumerServiceResponse $response): void
+    {
+        $params = $this->parseTemplate();
+        $contextId = (int) ($params['context_id'] ?? 0);
+
+        try {
+            if ($response->getRequestMethod() === self::HTTP_GET) {
+                $this->handleGet($response, $contextId);
+            } elseif ($response->getRequestMethod() === self::HTTP_POST) {
+                $this->handlePost($response, $contextId);
+            } else {
+                $response->setCode(405);
+            }
+        } catch (Exception $e) {
+            $code = $e->getCode();
+            $response->setCode($code >= 400 && $code < 600 ? $code : 500);
+            $response->setReason($e->getMessage());
+        }
+    }
+
+    protected function handleGet(ilLTIConsumerServiceResponse $response, int $contextId): void
+    {
+        $token = $this->checkTool([
+            ilLTIConsumerGradeService::SCOPE_GRADESERVICE_LINEITEM,
+            ilLTIConsumerGradeService::SCOPE_GRADESERVICE_LINEITEM_READ
+        ]);
+        if (!$token) {
+            throw new Exception('invalid request', 401);
+        }
+        $clientId = $this->getClientIdFromToken($token);
+
+        global $DIC;
+        $tree = $DIC->repositoryTree();
+        $nodeData = $tree->getNodeData($contextId);
+        if (!$nodeData) {
+            throw new Exception('Context not found', 404);
+        }
+
+        $lineItems = [];
+        $filters = $this->getFilters();
+
+        $subtree = $tree->getSubTree($nodeData);
+        foreach ($subtree as $node) {
+            if ($node['type'] !== 'lti') {
+                continue;
+            }
+            $objId = ilObject::_lookupObjId((int) $node['child']);
+            if (!$objId) {
+                continue;
+            }
+            $object = new ilObjLTIConsumer($objId, false);
+            $provider = $object->getProvider();
+            if (!$provider || (!$provider->isGradeSynchronization() && !$provider->getHasOutcome())) {
+                continue;
+            }
+            if ($provider->getClientId() !== $clientId) {
+                continue;
+            }
+            $lineItems[] = ilLTIConsumerGradeServiceLineItem::buildLineItemData($contextId, $objId, $object);
+        }
+
+        $storedRows = $this->loadStoredLineItems($contextId, $clientId);
+        foreach ($storedRows as $row) {
+            $lineItems[] = [
+                'id' => ilLTIConsumerGradeServiceLineItem::buildLineItemUrl($contextId, (int) $row['obj_id_or_pseudo']),
+                'label' => (string) ($row['label'] ?? ''),
+                'scoreMaximum' => (float) ($row['score_maximum'] ?? 1),
+                'resourceId' => (string) ($row['resource_id'] ?? ''),
+                'resourceLinkId' => (string) ($row['resource_link_id'] ?? ''),
+                'tag' => (string) ($row['tag'] ?? '')
+            ];
+        }
+
+        $lineItems = $this->filterLineItems($lineItems, $filters);
+
+        $response->setContentType('application/vnd.ims.lis.v2.lineitemcontainer+json');
+        $response->setBody(json_encode($lineItems, JSON_UNESCAPED_SLASHES));
+    }
+
+    protected function handlePost(ilLTIConsumerServiceResponse $response, int $contextId): void
+    {
+        $token = $this->checkTool([
+            ilLTIConsumerGradeService::SCOPE_GRADESERVICE_LINEITEM
+        ]);
+        if (!$token) {
+            throw new Exception('invalid request', 401);
+        }
+        $clientId = $this->getClientIdFromToken($token);
+
+        $body = json_decode($response->getRequestData());
+        if (!is_object($body) || json_last_error() !== JSON_ERROR_NONE) {
+            throw new Exception('Invalid request body', 400);
+        }
+
+        global $DIC;
+        $ilDB = $DIC->database();
+        if (!$this->contextContainsClientTool($contextId, $clientId)) {
+            throw new Exception('Context not available for client', 403);
+        }
+
+        $tableExists = $ilDB->tableExists('lti_consumer_lineitems');
+        if (!$tableExists) {
+            throw new Exception('Line items storage not available', 500);
+        }
+
+        $id = $ilDB->nextId('lti_consumer_lineitems');
+        $objIdOrPseudo = -$id;
+
+        $label = isset($body->label) ? (string) $body->label : 'Line Item ' . $id;
+        $scoreMax = isset($body->scoreMaximum) && is_numeric($body->scoreMaximum) && (float) $body->scoreMaximum > 0
+            ? (float) $body->scoreMaximum : 1;
+        $resourceId = isset($body->resourceId) ? (string) $body->resourceId : '';
+        $resourceLinkId = isset($body->resourceLinkId) ? (string) $body->resourceLinkId : '';
+        $tag = isset($body->tag) ? (string) $body->tag : '';
+
+        $ilDB->insert('lti_consumer_lineitems', [
+            'id' => ['integer', $id],
+            'context_id' => ['integer', $contextId],
+            'obj_id' => ['integer', null],
+            'client_id' => ['text', $clientId],
+            'label' => ['text', $label],
+            'score_maximum' => ['float', $scoreMax],
+            'resource_id' => ['text', $resourceId],
+            'resource_link_id' => ['text', $resourceLinkId],
+            'tag' => ['text', $tag],
+            'enabled' => ['integer', 1]
+        ]);
+
+        $lineItem = [
+            'id' => ilLTIConsumerGradeServiceLineItem::buildLineItemUrl($contextId, $objIdOrPseudo),
+            'label' => $label,
+            'scoreMaximum' => $scoreMax,
+            'resourceId' => $resourceId,
+            'resourceLinkId' => $resourceLinkId,
+            'tag' => $tag
+        ];
+
+        $response->setCode(201);
+        $response->setContentType('application/vnd.ims.lis.v2.lineitem+json');
+        $response->setBody(json_encode($lineItem, JSON_UNESCAPED_SLASHES));
+    }
+
+    protected function loadStoredLineItems(int $contextId, string $clientId): array
+    {
+        global $DIC;
+        $ilDB = $DIC->database();
+        if (!$ilDB->tableExists('lti_consumer_lineitems')) {
+            return [];
+        }
+        $query = 'SELECT * FROM lti_consumer_lineitems'
+            . ' WHERE context_id = ' . $ilDB->quote($contextId, 'integer')
+            . ' AND client_id = ' . $ilDB->quote($clientId, 'text')
+            . ' AND enabled = ' . $ilDB->quote(1, 'integer');
+        $res = $ilDB->query($query);
+        $rows = [];
+        while ($row = $ilDB->fetchAssoc($res)) {
+            $row['obj_id_or_pseudo'] = -((int) $row['id']);
+            $rows[] = $row;
+        }
+        return $rows;
+    }
+
+    protected function getFilters(): array
+    {
+        return [
+            'tag' => isset($_GET['tag']) ? (string) $_GET['tag'] : '',
+            'resourceId' => isset($_GET['resource_id']) ? (string) $_GET['resource_id'] : '',
+            'resourceLinkId' => isset($_GET['resource_link_id']) ? (string) $_GET['resource_link_id'] : '',
+            'limit' => isset($_GET['limit']) && is_numeric($_GET['limit']) ? max(0, (int) $_GET['limit']) : 0
+        ];
+    }
+
+    protected function filterLineItems(array $lineItems, array $filters): array
+    {
+        $filtered = array_values(array_filter($lineItems, static function (array $item) use ($filters): bool {
+            if ($filters['tag'] !== '' && ($item['tag'] ?? '') !== $filters['tag']) {
+                return false;
+            }
+            if ($filters['resourceId'] !== '' && ($item['resourceId'] ?? '') !== $filters['resourceId']) {
+                return false;
+            }
+            if ($filters['resourceLinkId'] !== '' && ($item['resourceLinkId'] ?? '') !== $filters['resourceLinkId']) {
+                return false;
+            }
+            return true;
+        }));
+
+        if ($filters['limit'] > 0) {
+            return array_slice($filtered, 0, $filters['limit']);
+        }
+
+        return $filtered;
+    }
+
+    protected function contextContainsClientTool(int $contextId, string $clientId): bool
+    {
+        global $DIC;
+
+        $tree = $DIC->repositoryTree();
+        $nodeData = $tree->getNodeData($contextId);
+        if (!$nodeData) {
+            return false;
+        }
+
+        foreach ($tree->getSubTree($nodeData) as $node) {
+            if ($node['type'] !== 'lti') {
+                continue;
+            }
+            $objId = ilObject::_lookupObjId((int) $node['child']);
+            if (!$objId) {
+                continue;
+            }
+            $object = new ilObjLTIConsumer($objId, false);
+            $provider = $object->getProvider();
+            if ($provider && ($provider->isGradeSynchronization() || $provider->getHasOutcome()) &&
+                $provider->getClientId() === $clientId) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function getClientIdFromToken(object $token): string
+    {
+        $clientId = $token->sub ?? '';
+        if (!is_string($clientId) || $clientId === '') {
+            throw new Exception('invalid request', 401);
+        }
+        return $clientId;
+    }
 }

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItems.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItems.php
@@ -32,8 +32,7 @@ class ilLTIConsumerGradeServiceLineItems extends ilLTIConsumerResourceBase
     public function __construct(
         ilLTIConsumerServiceBase $service,
         private readonly ilLTIConsumerLineItemRepository $lineItemRepository
-    )
-    {
+    ) {
         parent::__construct($service);
         $this->id = 'LineItem.collection';
         $this->template = '/{context_id}/lineitems';

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItems.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItems.php
@@ -205,11 +205,17 @@ class ilLTIConsumerGradeServiceLineItems extends ilLTIConsumerResourceBase
 
     protected function getFilters(): array
     {
+        global $DIC;
+
+        $query = $DIC->http()->wrapper()->query();
+        $string = $DIC->refinery()->kindlyTo()->string();
+        $limit = $query->has('limit') ? $query->retrieve('limit', $string) : '';
+
         return [
-            'tag' => isset($_GET['tag']) ? (string) $_GET['tag'] : '',
-            'resourceId' => isset($_GET['resource_id']) ? (string) $_GET['resource_id'] : '',
-            'resourceLinkId' => isset($_GET['resource_link_id']) ? (string) $_GET['resource_link_id'] : '',
-            'limit' => isset($_GET['limit']) && is_numeric($_GET['limit']) ? max(0, (int) $_GET['limit']) : 0
+            'tag' => $query->has('tag') ? $query->retrieve('tag', $string) : '',
+            'resourceId' => $query->has('resource_id') ? $query->retrieve('resource_id', $string) : '',
+            'resourceLinkId' => $query->has('resource_link_id') ? $query->retrieve('resource_link_id', $string) : '',
+            'limit' => is_numeric($limit) ? max(0, (int) $limit) : 0
         ];
     }
 

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItems.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItems.php
@@ -119,8 +119,16 @@ class ilLTIConsumerGradeServiceLineItems extends ilLTIConsumerResourceBase
         }
 
         $lineItems = $this->filterLineItems($lineItems, $filters);
+        $offset = ($filters['page'] - 1) * $filters['limit'];
+        $has_next_page = $filters['limit'] > 0 && count($lineItems) > $offset + $filters['limit'];
+        if ($filters['limit'] > 0) {
+            $lineItems = array_slice($lineItems, $offset, $filters['limit']);
+        }
 
         $response->setContentType('application/vnd.ims.lis.v2.lineitemcontainer+json');
+        if ($has_next_page) {
+            $this->addNextPageHeader($response, $contextId, $filters);
+        }
         $response->setBody(json_encode($lineItems, JSON_UNESCAPED_SLASHES));
     }
 
@@ -143,12 +151,24 @@ class ilLTIConsumerGradeServiceLineItems extends ilLTIConsumerResourceBase
             throw ilLTIConsumerHttpException::forbidden('Context not available for client');
         }
 
-        $label = isset($body->label) ? (string) $body->label : null;
-        $scoreMax = isset($body->scoreMaximum) && is_numeric($body->scoreMaximum) && (float) $body->scoreMaximum > 0
-            ? (float) $body->scoreMaximum : 1;
+        if (!property_exists($body, 'label') || !is_string($body->label) || trim($body->label) === '') {
+            throw ilLTIConsumerHttpException::badRequest('LineItem label is required');
+        }
+        if (!property_exists($body, 'scoreMaximum') || !is_numeric($body->scoreMaximum) ||
+            (float) $body->scoreMaximum <= 0) {
+            throw ilLTIConsumerHttpException::badRequest('LineItem scoreMaximum must be greater than zero');
+        }
+
+        $label = $body->label;
+        $scoreMax = (float) $body->scoreMaximum;
         $resourceId = isset($body->resourceId) ? (string) $body->resourceId : '';
-        $resourceLinkId = isset($body->resourceLinkId) ? (string) $body->resourceLinkId : '';
+        $resourceLinkId = isset($body->resourceLinkId) && is_scalar($body->resourceLinkId)
+            ? (string) $body->resourceLinkId : '';
         $tag = isset($body->tag) ? (string) $body->tag : '';
+        if (property_exists($body, 'resourceLinkId') &&
+            (!is_scalar($body->resourceLinkId) || !$this->isClientResourceLink($contextId, $clientId, $resourceLinkId))) {
+            throw ilLTIConsumerHttpException::notFound('Resource link not found');
+        }
 
         $lineItem = $this->lineItemRepository->create(
             $contextId,
@@ -174,7 +194,7 @@ class ilLTIConsumerGradeServiceLineItems extends ilLTIConsumerResourceBase
     }
 
     /**
-     * @return array{tag: string, resourceId: string, resourceLinkId: string, limit: int}
+     * @return array{tag: string, resourceId: string, resourceLinkId: string, limit: int, page: int}
      */
     protected function getFilters(): array
     {
@@ -188,7 +208,9 @@ class ilLTIConsumerGradeServiceLineItems extends ilLTIConsumerResourceBase
             'tag' => $query->has('tag') ? $query->retrieve('tag', $string) : '',
             'resourceId' => $query->has('resource_id') ? $query->retrieve('resource_id', $string) : '',
             'resourceLinkId' => $query->has('resource_link_id') ? $query->retrieve('resource_link_id', $string) : '',
-            'limit' => is_numeric($limit) ? max(0, (int) $limit) : 0
+            'limit' => is_numeric($limit) ? max(0, (int) $limit) : 0,
+            'page' => $query->has('page') && is_numeric($query->retrieve('page', $string))
+                ? max(1, (int) $query->retrieve('page', $string)) : 1
         ];
     }
 
@@ -207,11 +229,49 @@ class ilLTIConsumerGradeServiceLineItems extends ilLTIConsumerResourceBase
             return true;
         }));
 
-        if ($filters['limit'] > 0) {
-            return array_slice($filtered, 0, $filters['limit']);
+        return $filtered;
+    }
+
+    protected function isClientResourceLink(int $context_id, string $client_id, string $resource_link_id): bool
+    {
+        $resource_link_ref_id = (int) $resource_link_id;
+        if ($resource_link_ref_id <= 0) {
+            return false;
         }
 
-        return $filtered;
+        global $DIC;
+        $tree = $DIC->repositoryTree();
+        $node_data = $tree->getNodeData($resource_link_ref_id);
+        if (!$node_data || $node_data['type'] !== 'lti' ||
+            !in_array($context_id, $tree->getPathId($resource_link_ref_id), true)) {
+            return false;
+        }
+
+        $object_id = ilObject::_lookupObjId($resource_link_ref_id);
+        if (!$object_id) {
+            return false;
+        }
+
+        $provider = (new ilObjLTIConsumer($object_id, false))->getProvider();
+        return $provider !== null && $provider->getClientId() === $client_id;
+    }
+
+    /** @param array{tag: string, resourceId: string, resourceLinkId: string, limit: int, page: int} $filters */
+    protected function addNextPageHeader(ilLTIConsumerServiceResponse $response, int $context_id, array $filters): void
+    {
+        $query = ['limit' => $filters['limit'], 'page' => $filters['page'] + 1];
+        if ($filters['tag'] !== '') {
+            $query['tag'] = $filters['tag'];
+        }
+        if ($filters['resourceId'] !== '') {
+            $query['resource_id'] = $filters['resourceId'];
+        }
+        if ($filters['resourceLinkId'] !== '') {
+            $query['resource_link_id'] = $filters['resourceLinkId'];
+        }
+
+        $url = ilObjLTIConsumer::getIliasHttpPath() . "/ltiservices.php/gradeservice/{$context_id}/lineitems";
+        $response->addAdditionalHeader('Link: <' . $url . '?' . http_build_query($query) . '>; rel="next"');
     }
 
     protected function contextContainsClientTool(int $contextId, string $clientId): bool

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItems.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItems.php
@@ -242,7 +242,7 @@ class ilLTIConsumerGradeServiceLineItems extends ilLTIConsumerResourceBase
         global $DIC;
         $tree = $DIC->repositoryTree();
         $node_data = $tree->getNodeData($resource_link_ref_id);
-        if (!$node_data || $node_data['type'] !== 'lti' ||
+        if (!isset($node_data['type']) || $node_data['type'] !== 'lti' ||
             !in_array($context_id, $tree->getPathId($resource_link_ref_id), true)) {
             return false;
         }

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItems.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItems.php
@@ -270,7 +270,7 @@ class ilLTIConsumerGradeServiceLineItems extends ilLTIConsumerResourceBase
             $query['resource_link_id'] = $filters['resourceLinkId'];
         }
 
-        $url = ilObjLTIConsumer::getIliasHttpPath() . "/ltiservices.php/gradeservice/{$context_id}/lineitems";
+        $url = ilLTIConsumerGradeServiceLineItem::getServiceRootUrl() . "/ltiservices.php/gradeservice/{$context_id}/lineitems";
         $response->addAdditionalHeader('Link: <' . $url . '?' . http_build_query($query) . '>; rel="next"');
     }
 

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItems.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceLineItems.php
@@ -29,7 +29,10 @@ declare(strict_types=1);
 
 class ilLTIConsumerGradeServiceLineItems extends ilLTIConsumerResourceBase
 {
-    public function __construct(ilLTIConsumerServiceBase $service)
+    public function __construct(
+        ilLTIConsumerServiceBase $service,
+        private readonly ilLTIConsumerLineItemRepository $lineItemRepository
+    )
     {
         parent::__construct($service);
         $this->id = 'LineItem.collection';
@@ -54,9 +57,11 @@ class ilLTIConsumerGradeServiceLineItems extends ilLTIConsumerResourceBase
             } else {
                 $response->setCode(405);
             }
-        } catch (Exception $e) {
-            $code = $e->getCode();
-            $response->setCode($code >= 400 && $code < 600 ? $code : 500);
+        } catch (ilLTIConsumerHttpException $e) {
+            $response->setCode($e->getCode());
+            $response->setReason($e->getMessage());
+        } catch (Throwable $e) {
+            $response->setCode(500);
             $response->setReason($e->getMessage());
         }
     }
@@ -68,15 +73,15 @@ class ilLTIConsumerGradeServiceLineItems extends ilLTIConsumerResourceBase
             ilLTIConsumerGradeService::SCOPE_GRADESERVICE_LINEITEM_READ
         ]);
         if (!$token) {
-            throw new Exception('invalid request', 401);
+            throw ilLTIConsumerHttpException::unauthorized();
         }
-        $clientId = $this->getClientIdFromToken($token);
+        $clientId = $token->getClientId();
 
         global $DIC;
         $tree = $DIC->repositoryTree();
         $nodeData = $tree->getNodeData($contextId);
         if (!$nodeData) {
-            throw new Exception('Context not found', 404);
+            throw ilLTIConsumerHttpException::notFound('Context not found');
         }
 
         $lineItems = [];
@@ -102,15 +107,14 @@ class ilLTIConsumerGradeServiceLineItems extends ilLTIConsumerResourceBase
             $lineItems[] = ilLTIConsumerGradeServiceLineItem::buildLineItemData($contextId, $objId, $object);
         }
 
-        $storedRows = $this->loadStoredLineItems($contextId, $clientId);
-        foreach ($storedRows as $row) {
+        foreach ($this->lineItemRepository->getForContextAndClient($contextId, $clientId) as $storedLineItem) {
             $lineItems[] = [
-                'id' => ilLTIConsumerGradeServiceLineItem::buildLineItemUrl($contextId, (int) $row['obj_id_or_pseudo']),
-                'label' => (string) ($row['label'] ?? ''),
-                'scoreMaximum' => (float) ($row['score_maximum'] ?? 1),
-                'resourceId' => (string) ($row['resource_id'] ?? ''),
-                'resourceLinkId' => (string) ($row['resource_link_id'] ?? ''),
-                'tag' => (string) ($row['tag'] ?? '')
+                'id' => ilLTIConsumerGradeServiceLineItem::buildLineItemUrl($contextId, -$storedLineItem->id),
+                'label' => $storedLineItem->label,
+                'scoreMaximum' => $storedLineItem->scoreMaximum,
+                'resourceId' => $storedLineItem->resourceId,
+                'resourceLinkId' => $storedLineItem->resourceLinkId,
+                'tag' => $storedLineItem->tag
             ];
         }
 
@@ -126,83 +130,52 @@ class ilLTIConsumerGradeServiceLineItems extends ilLTIConsumerResourceBase
             ilLTIConsumerGradeService::SCOPE_GRADESERVICE_LINEITEM
         ]);
         if (!$token) {
-            throw new Exception('invalid request', 401);
+            throw ilLTIConsumerHttpException::unauthorized();
         }
-        $clientId = $this->getClientIdFromToken($token);
+        $clientId = $token->getClientId();
 
         $body = json_decode($response->getRequestData());
         if (!is_object($body) || json_last_error() !== JSON_ERROR_NONE) {
-            throw new Exception('Invalid request body', 400);
+            throw ilLTIConsumerHttpException::badRequest('Invalid request body');
         }
 
-        global $DIC;
-        $ilDB = $DIC->database();
         if (!$this->contextContainsClientTool($contextId, $clientId)) {
-            throw new Exception('Context not available for client', 403);
+            throw ilLTIConsumerHttpException::forbidden('Context not available for client');
         }
 
-        $tableExists = $ilDB->tableExists('lti_consumer_lineitems');
-        if (!$tableExists) {
-            throw new Exception('Line items storage not available', 500);
-        }
-
-        $id = $ilDB->nextId('lti_consumer_lineitems');
-        $objIdOrPseudo = -$id;
-
-        $label = isset($body->label) ? (string) $body->label : 'Line Item ' . $id;
+        $label = isset($body->label) ? (string) $body->label : null;
         $scoreMax = isset($body->scoreMaximum) && is_numeric($body->scoreMaximum) && (float) $body->scoreMaximum > 0
             ? (float) $body->scoreMaximum : 1;
         $resourceId = isset($body->resourceId) ? (string) $body->resourceId : '';
         $resourceLinkId = isset($body->resourceLinkId) ? (string) $body->resourceLinkId : '';
         $tag = isset($body->tag) ? (string) $body->tag : '';
 
-        $ilDB->insert('lti_consumer_lineitems', [
-            'id' => ['integer', $id],
-            'context_id' => ['integer', $contextId],
-            'obj_id' => ['integer', null],
-            'client_id' => ['text', $clientId],
-            'label' => ['text', $label],
-            'score_maximum' => ['float', $scoreMax],
-            'resource_id' => ['text', $resourceId],
-            'resource_link_id' => ['text', $resourceLinkId],
-            'tag' => ['text', $tag],
-            'enabled' => ['integer', 1]
-        ]);
-
-        $lineItem = [
-            'id' => ilLTIConsumerGradeServiceLineItem::buildLineItemUrl($contextId, $objIdOrPseudo),
-            'label' => $label,
-            'scoreMaximum' => $scoreMax,
-            'resourceId' => $resourceId,
-            'resourceLinkId' => $resourceLinkId,
-            'tag' => $tag
+        $lineItem = $this->lineItemRepository->create(
+            $contextId,
+            $clientId,
+            $label,
+            $scoreMax,
+            $resourceId,
+            $resourceLinkId,
+            $tag
+        );
+        $lineItemData = [
+            'id' => ilLTIConsumerGradeServiceLineItem::buildLineItemUrl($contextId, -$lineItem->id),
+            'label' => $lineItem->label,
+            'scoreMaximum' => $lineItem->scoreMaximum,
+            'resourceId' => $lineItem->resourceId,
+            'resourceLinkId' => $lineItem->resourceLinkId,
+            'tag' => $lineItem->tag
         ];
 
         $response->setCode(201);
         $response->setContentType('application/vnd.ims.lis.v2.lineitem+json');
-        $response->setBody(json_encode($lineItem, JSON_UNESCAPED_SLASHES));
+        $response->setBody(json_encode($lineItemData, JSON_UNESCAPED_SLASHES));
     }
 
-    protected function loadStoredLineItems(int $contextId, string $clientId): array
-    {
-        global $DIC;
-        $ilDB = $DIC->database();
-        if (!$ilDB->tableExists('lti_consumer_lineitems')) {
-            return [];
-        }
-        $query = 'SELECT * FROM lti_consumer_lineitems'
-            . ' WHERE context_id = ' . $ilDB->quote($contextId, 'integer')
-            . ' AND client_id = ' . $ilDB->quote($clientId, 'text')
-            . ' AND enabled = ' . $ilDB->quote(1, 'integer');
-        $res = $ilDB->query($query);
-        $rows = [];
-        while ($row = $ilDB->fetchAssoc($res)) {
-            $row['obj_id_or_pseudo'] = -((int) $row['id']);
-            $rows[] = $row;
-        }
-        return $rows;
-    }
-
+    /**
+     * @return array{tag: string, resourceId: string, resourceLinkId: string, limit: int}
+     */
     protected function getFilters(): array
     {
         global $DIC;
@@ -270,12 +243,4 @@ class ilLTIConsumerGradeServiceLineItems extends ilLTIConsumerResourceBase
         return false;
     }
 
-    protected function getClientIdFromToken(object $token): string
-    {
-        $clientId = $token->sub ?? '';
-        if (!is_string($clientId) || $clientId === '') {
-            throw new Exception('invalid request', 401);
-        }
-        return $clientId;
-    }
 }

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceResults.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceResults.php
@@ -253,7 +253,7 @@ class ilLTIConsumerGradeServiceResults extends ilLTIConsumerResourceBase
         global $DIC;
         $tree = $DIC->repositoryTree();
         $node_data = $tree->getNodeData($resource_link_ref_id);
-        if (!$node_data || $node_data['type'] !== 'lti' ||
+        if (!isset($node_data['type']) || $node_data['type'] !== 'lti' ||
             !in_array($context_id, $tree->getPathId($resource_link_ref_id), true)) {
             throw ilLTIConsumerHttpException::notFound('Resource link not found');
         }

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceResults.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceResults.php
@@ -206,9 +206,15 @@ class ilLTIConsumerGradeServiceResults extends ilLTIConsumerResourceBase
 
     protected function getFilters(): array
     {
+        global $DIC;
+
+        $query = $DIC->http()->wrapper()->query();
+        $string = $DIC->refinery()->kindlyTo()->string();
+        $limit = $query->has('limit') ? $query->retrieve('limit', $string) : '';
+
         return [
-            'userId' => isset($_GET['user_id']) ? (string) $_GET['user_id'] : '',
-            'limit' => isset($_GET['limit']) && is_numeric($_GET['limit']) ? max(0, (int) $_GET['limit']) : 0
+            'userId' => $query->has('user_id') ? $query->retrieve('user_id', $string) : '',
+            'limit' => is_numeric($limit) ? max(0, (int) $limit) : 0
         ];
     }
 

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceResults.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceResults.php
@@ -38,4 +38,128 @@ class ilLTIConsumerGradeServiceResults extends ilLTIConsumerResourceBase
         $this->formats[] = 'application/vnd.ims.lis.v2.resultcontainer+json';
         $this->methods[] = 'GET';
     }
+
+    public function execute(ilLTIConsumerServiceResponse $response): void
+    {
+        $params = $this->parseTemplate();
+        $contextId = (int) ($params['context_id'] ?? 0);
+        $itemId = (int) ($params['item_id'] ?? 0);
+
+        try {
+            $token = $this->checkTool([
+                ilLTIConsumerGradeService::SCOPE_GRADESERVICE_RESULT_READ
+            ]);
+            if (!$token) {
+                throw new Exception('invalid request', 401);
+            }
+            $clientId = $this->getClientIdFromToken($token);
+
+            global $DIC;
+            $ilDB = $DIC->database();
+            $scoreMaximum = 1.0;
+
+            if (ilObject::_lookupType($itemId) === 'lti') {
+                $object = new ilObjLTIConsumer($itemId, false);
+                $provider = $object->getProvider();
+                if (!$provider || (!$provider->isGradeSynchronization() && !$provider->getHasOutcome())) {
+                    throw new Exception('grade synchronization not enabled', 403);
+                }
+                if ($provider->getClientId() !== $clientId) {
+                    throw new Exception('invalid clientId', 403);
+                }
+                $scoreMaximum = $object->getScoreMaximum() > 0 ? $object->getScoreMaximum() : 1.0;
+            } else {
+                $storedId = -$itemId;
+                if ($storedId <= 0 || !$ilDB->tableExists('lti_consumer_lineitems')) {
+                    throw new Exception('LineItem not found', 404);
+                }
+
+                $lineItemQuery = 'SELECT score_maximum FROM lti_consumer_lineitems'
+                    . ' WHERE id = ' . $ilDB->quote($storedId, 'integer')
+                    . ' AND context_id = ' . $ilDB->quote($contextId, 'integer')
+                    . ' AND client_id = ' . $ilDB->quote($clientId, 'text')
+                    . ' AND enabled = ' . $ilDB->quote(1, 'integer');
+                $lineItemRes = $ilDB->query($lineItemQuery);
+                $lineItemRow = $ilDB->fetchAssoc($lineItemRes);
+                if (!$lineItemRow) {
+                    throw new Exception('LineItem not found', 404);
+                }
+                $scoreMaximum = (float) ($lineItemRow['score_maximum'] ?? 1);
+
+                $response->setContentType('application/vnd.ims.lis.v2.resultcontainer+json');
+                $response->setBody(json_encode([], JSON_UNESCAPED_SLASHES));
+                return;
+            }
+
+            $query = 'SELECT * FROM lti_consumer_results'
+                . ' WHERE obj_id = ' . $ilDB->quote($itemId, 'integer');
+            $res = $ilDB->query($query);
+
+            $resultsArr = [];
+            $filters = $this->getFilters();
+            $lineItemUrl = ilLTIConsumerGradeServiceLineItem::buildLineItemUrl($contextId, $itemId);
+            while ($row = $ilDB->fetchAssoc($res)) {
+                $userId = (int) $row['usr_id'];
+
+                $identQuery = 'SELECT usr_ident FROM cmix_users'
+                    . ' WHERE obj_id = ' . $ilDB->quote($itemId, 'integer')
+                    . ' AND usr_id = ' . $ilDB->quote($userId, 'integer');
+                $identRes = $ilDB->query($identQuery);
+                $identRow = $ilDB->fetchAssoc($identRes);
+                $userIdent = $identRow['usr_ident'] ?? (string) $userId;
+                if ($filters['userId'] !== '' && !$this->matchesUserIdentFilter($userIdent, $filters['userId'])) {
+                    continue;
+                }
+
+                $resultValue = $row['result'];
+                if ($resultValue !== null) {
+                    $resultsArr[] = [
+                        'id' => $lineItemUrl . '/results'
+                            . '?user_id=' . rawurlencode($userIdent),
+                        'scoreOf' => $lineItemUrl,
+                        'userId' => $userIdent,
+                        'resultScore' => (float) $resultValue * $scoreMaximum,
+                        'resultMaximum' => $scoreMaximum
+                    ];
+                }
+            }
+
+            if ($filters['limit'] > 0) {
+                $resultsArr = array_slice($resultsArr, 0, $filters['limit']);
+            }
+
+            $response->setContentType('application/vnd.ims.lis.v2.resultcontainer+json');
+            $response->setBody(json_encode($resultsArr, JSON_UNESCAPED_SLASHES));
+        } catch (Exception $e) {
+            $code = $e->getCode();
+            $response->setCode($code >= 400 && $code < 600 ? $code : 500);
+            $response->setReason($e->getMessage());
+        }
+    }
+
+    protected function getFilters(): array
+    {
+        return [
+            'userId' => isset($_GET['user_id']) ? (string) $_GET['user_id'] : '',
+            'limit' => isset($_GET['limit']) && is_numeric($_GET['limit']) ? max(0, (int) $_GET['limit']) : 0
+        ];
+    }
+
+    protected function matchesUserIdentFilter(string $userIdent, string $filter): bool
+    {
+        if ($userIdent === $filter) {
+            return true;
+        }
+
+        return strpos($filter, '@') === false && strpos($userIdent, $filter . '@') === 0;
+    }
+
+    protected function getClientIdFromToken(object $token): string
+    {
+        $clientId = $token->sub ?? '';
+        if (!is_string($clientId) || $clientId === '') {
+            throw new Exception('invalid request', 401);
+        }
+        return $clientId;
+    }
 }

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceResults.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceResults.php
@@ -32,8 +32,7 @@ class ilLTIConsumerGradeServiceResults extends ilLTIConsumerResourceBase
     public function __construct(
         ilLTIConsumerServiceBase $service,
         private readonly ilLTIConsumerLineItemRepository $lineItemRepository
-    )
-    {
+    ) {
         parent::__construct($service);
         $this->id = 'Result.collection';
         $this->template = '/{context_id}/lineitems/{item_id}/lineitem/results';

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceResults.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceResults.php
@@ -95,6 +95,8 @@ class ilLTIConsumerGradeServiceResults extends ilLTIConsumerResourceBase
                 return;
             }
 
+            $privacyIdent = $provider->getPrivacyIdent();
+
             $query = 'SELECT * FROM lti_consumer_results'
                 . ' WHERE obj_id = ' . $ilDB->quote($itemId, 'integer');
             $res = $ilDB->query($query);
@@ -119,13 +121,31 @@ class ilLTIConsumerGradeServiceResults extends ilLTIConsumerResourceBase
 
                 $resultValue = $row['result'];
                 if ($resultValue !== null) {
+                    $ltiUserId = $this->getLtiUserId($privacyIdent, $userId, $userIdent);
+
+                    $latestGradeQuery = 'SELECT score_given, score_maximum FROM lti_consumer_grades'
+                        . ' WHERE obj_id = ' . $ilDB->quote($itemId, 'integer')
+                        . ' AND usr_id = ' . $ilDB->quote($userId, 'integer')
+                        . ' AND score_given IS NOT NULL'
+                        . ' AND score_maximum IS NOT NULL'
+                        . ' ORDER BY lti_timestamp DESC, stored DESC';
+                    $latestGradeRes = $ilDB->query($latestGradeQuery);
+                    $latestGradeRow = $ilDB->fetchAssoc($latestGradeRes);
+
+                    $resultScore = $latestGradeRow !== null
+                        ? (float) $latestGradeRow['score_given']
+                        : (float) $resultValue * $scoreMaximum;
+                    $resultMaximum = $latestGradeRow !== null && (float) $latestGradeRow['score_maximum'] > 0
+                        ? (float) $latestGradeRow['score_maximum']
+                        : $scoreMaximum;
+
                     $resultsArr[] = [
                         'id' => $lineItemUrl . '/results'
-                            . '?user_id=' . rawurlencode($userIdent),
+                            . '?user_id=' . rawurlencode($ltiUserId),
                         'scoreOf' => $lineItemUrl,
-                        'userId' => $userIdent,
-                        'resultScore' => (float) $resultValue * $scoreMaximum,
-                        'resultMaximum' => $scoreMaximum
+                        'userId' => $ltiUserId,
+                        'resultScore' => $resultScore,
+                        'resultMaximum' => $resultMaximum
                     ];
                 }
             }
@@ -158,12 +178,13 @@ class ilLTIConsumerGradeServiceResults extends ilLTIConsumerResourceBase
                         continue;
                     }
 
+                    $ltiUserId = $this->getLtiUserId($privacyIdent, $userId, $userIdent);
                     $resultMaximum = (float) $gradeRow['score_maximum'];
                     $resultsArr[] = [
                         'id' => $lineItemUrl . '/results'
-                            . '?user_id=' . rawurlencode($userIdent),
+                            . '?user_id=' . rawurlencode($ltiUserId),
                         'scoreOf' => $lineItemUrl,
-                        'userId' => $userIdent,
+                        'userId' => $ltiUserId,
                         'resultScore' => (float) $gradeRow['score_given'],
                         'resultMaximum' => $resultMaximum > 0 ? $resultMaximum : $scoreMaximum
                     ];
@@ -198,5 +219,18 @@ class ilLTIConsumerGradeServiceResults extends ilLTIConsumerResourceBase
             throw new Exception('invalid request', 401);
         }
         return $clientId;
+    }
+
+    protected function getLtiUserId(int $privacyIdent, int $userId, string $userIdent): string
+    {
+        $userObj = new ilObjUser($userId);
+        $ltiUserId = ilCmiXapiUser::getIdentAsId($privacyIdent, $userObj);
+        if ($privacyIdent === ilObjCmiXapi::PRIVACY_IDENT_IL_UUID_RANDOM) {
+            $randomPart = strstr($userIdent, '@' . ilCmiXapiUser::getIliasUuid(), true);
+            if ($randomPart !== false && $randomPart !== '') {
+                $ltiUserId = $randomPart;
+            }
+        }
+        return $ltiUserId !== '' ? $ltiUserId : $userIdent;
     }
 }

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceResults.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceResults.php
@@ -164,9 +164,7 @@ class ilLTIConsumerGradeServiceResults extends ilLTIConsumerResourceBase
 
             if (empty($resultsArr)) {
                 $gradeQuery = 'SELECT * FROM lti_consumer_grades'
-                    . ' WHERE obj_id = ' . $ilDB->quote($itemId, 'integer')
-                    . ' AND score_given IS NOT NULL'
-                    . ' AND score_maximum IS NOT NULL';
+                    . ' WHERE obj_id = ' . $ilDB->quote($itemId, 'integer');
                 if ($filterUserId !== null) {
                     $gradeQuery .= ' AND usr_id = ' . $ilDB->quote($filterUserId, 'integer');
                 }
@@ -179,6 +177,12 @@ class ilLTIConsumerGradeServiceResults extends ilLTIConsumerResourceBase
                         continue;
                     }
                     $seenUsers[$userId] = true;
+
+                    // the most recent submission for this user is a cleared score (§3.4.4):
+                    // it must not fall back to an older, non-null grade
+                    if ($gradeRow['score_given'] === null || $gradeRow['score_maximum'] === null) {
+                        continue;
+                    }
 
                     $identQuery = 'SELECT usr_ident FROM cmix_users'
                         . ' WHERE obj_id = ' . $ilDB->quote($itemId, 'integer')
@@ -288,8 +292,6 @@ class ilLTIConsumerGradeServiceResults extends ilLTIConsumerResourceBase
     ): array {
         $query = 'SELECT score_given, score_maximum, usr_id FROM lti_consumer_grades'
             . ' WHERE obj_id = ' . $db->quote($item_id, 'integer')
-            . ' AND score_given IS NOT NULL'
-            . ' AND score_maximum IS NOT NULL'
             . ' ORDER BY lti_timestamp DESC, stored DESC';
         $result = $db->query($query);
         $line_item_url = ilLTIConsumerGradeServiceLineItem::buildLineItemUrl($context_id, $item_id);
@@ -303,6 +305,13 @@ class ilLTIConsumerGradeServiceResults extends ilLTIConsumerResourceBase
             }
 
             $seen_user_ids[$user_id] = true;
+
+            // the most recent submission for this user is a cleared score (§3.4.4):
+            // it must not fall back to an older, non-null grade
+            if ($row['score_given'] === null || $row['score_maximum'] === null) {
+                continue;
+            }
+
             $ident_query = 'SELECT usr_ident FROM cmix_users'
                 . ' WHERE obj_id = ' . $db->quote($lti_object_id, 'integer')
                 . ' AND usr_id = ' . $db->quote($user_id, 'integer');

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceResults.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceResults.php
@@ -107,7 +107,7 @@ class ilLTIConsumerGradeServiceResults extends ilLTIConsumerResourceBase
                 $identRes = $ilDB->query($identQuery);
                 $identRow = $ilDB->fetchAssoc($identRes);
                 $userIdent = $identRow['usr_ident'] ?? (string) $userId;
-                if ($filters['userId'] !== '' && !$this->matchesUserIdentFilter($userIdent, $filters['userId'])) {
+                if ($filters['userId'] !== '' && !$this->matchesLtiUserIdent($itemId, $userId, $userIdent, $filters['userId'])) {
                     continue;
                 }
 
@@ -143,15 +143,6 @@ class ilLTIConsumerGradeServiceResults extends ilLTIConsumerResourceBase
             'userId' => isset($_GET['user_id']) ? (string) $_GET['user_id'] : '',
             'limit' => isset($_GET['limit']) && is_numeric($_GET['limit']) ? max(0, (int) $_GET['limit']) : 0
         ];
-    }
-
-    protected function matchesUserIdentFilter(string $userIdent, string $filter): bool
-    {
-        if ($userIdent === $filter) {
-            return true;
-        }
-
-        return strpos($filter, '@') === false && strpos($userIdent, $filter . '@') === 0;
     }
 
     protected function getClientIdFromToken(object $token): string

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceResults.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceResults.php
@@ -78,7 +78,7 @@ class ilLTIConsumerGradeServiceResults extends ilLTIConsumerResourceBase
                     throw new Exception('LineItem not found', 404);
                 }
 
-                $lineItemQuery = 'SELECT score_maximum FROM lti_consumer_lineitems'
+                $lineItemQuery = 'SELECT id FROM lti_consumer_lineitems'
                     . ' WHERE id = ' . $ilDB->quote($storedId, 'integer')
                     . ' AND context_id = ' . $ilDB->quote($contextId, 'integer')
                     . ' AND client_id = ' . $ilDB->quote($clientId, 'text')
@@ -88,8 +88,6 @@ class ilLTIConsumerGradeServiceResults extends ilLTIConsumerResourceBase
                 if (!$lineItemRow) {
                     throw new Exception('LineItem not found', 404);
                 }
-                $scoreMaximum = (float) ($lineItemRow['score_maximum'] ?? 1);
-
                 $response->setContentType('application/vnd.ims.lis.v2.resultcontainer+json');
                 $response->setBody(json_encode([], JSON_UNESCAPED_SLASHES));
                 return;

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceResults.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceResults.php
@@ -29,7 +29,10 @@ declare(strict_types=1);
 
 class ilLTIConsumerGradeServiceResults extends ilLTIConsumerResourceBase
 {
-    public function __construct(ilLTIConsumerServiceBase $service)
+    public function __construct(
+        ilLTIConsumerServiceBase $service,
+        private readonly ilLTIConsumerLineItemRepository $lineItemRepository
+    )
     {
         parent::__construct($service);
         $this->id = 'Result.collection';
@@ -50,9 +53,9 @@ class ilLTIConsumerGradeServiceResults extends ilLTIConsumerResourceBase
                 ilLTIConsumerGradeService::SCOPE_GRADESERVICE_RESULT_READ
             ]);
             if (!$token) {
-                throw new Exception('invalid request', 401);
+                throw ilLTIConsumerHttpException::unauthorized();
             }
-            $clientId = $this->getClientIdFromToken($token);
+            $clientId = $token->getClientId();
 
             global $DIC;
             $ilDB = $DIC->database();
@@ -66,27 +69,20 @@ class ilLTIConsumerGradeServiceResults extends ilLTIConsumerResourceBase
                 $object = new ilObjLTIConsumer($itemId, false);
                 $provider = $object->getProvider();
                 if (!$provider || (!$provider->isGradeSynchronization() && !$provider->getHasOutcome())) {
-                    throw new Exception('grade synchronization not enabled', 403);
+                    throw ilLTIConsumerHttpException::forbidden('grade synchronization not enabled');
                 }
                 if ($provider->getClientId() !== $clientId) {
-                    throw new Exception('invalid clientId', 403);
+                    throw ilLTIConsumerHttpException::forbidden('invalid clientId');
                 }
                 $scoreMaximum = $object->getScoreMaximum() > 0 ? $object->getScoreMaximum() : 1.0;
             } else {
                 $storedId = -$itemId;
-                if ($storedId <= 0 || !$ilDB->tableExists('lti_consumer_lineitems')) {
-                    throw new Exception('LineItem not found', 404);
+                if ($storedId <= 0) {
+                    throw ilLTIConsumerHttpException::notFound('LineItem not found');
                 }
 
-                $lineItemQuery = 'SELECT id FROM lti_consumer_lineitems'
-                    . ' WHERE id = ' . $ilDB->quote($storedId, 'integer')
-                    . ' AND context_id = ' . $ilDB->quote($contextId, 'integer')
-                    . ' AND client_id = ' . $ilDB->quote($clientId, 'text')
-                    . ' AND enabled = ' . $ilDB->quote(1, 'integer');
-                $lineItemRes = $ilDB->query($lineItemQuery);
-                $lineItemRow = $ilDB->fetchAssoc($lineItemRes);
-                if (!$lineItemRow) {
-                    throw new Exception('LineItem not found', 404);
+                if ($this->lineItemRepository->get($storedId, $contextId, $clientId) === null) {
+                    throw ilLTIConsumerHttpException::notFound('LineItem not found');
                 }
                 $response->setContentType('application/vnd.ims.lis.v2.resultcontainer+json');
                 $response->setBody(json_encode([], JSON_UNESCAPED_SLASHES));
@@ -195,13 +191,18 @@ class ilLTIConsumerGradeServiceResults extends ilLTIConsumerResourceBase
 
             $response->setContentType('application/vnd.ims.lis.v2.resultcontainer+json');
             $response->setBody(json_encode($resultsArr, JSON_UNESCAPED_SLASHES));
-        } catch (Exception $e) {
-            $code = $e->getCode();
-            $response->setCode($code >= 400 && $code < 600 ? $code : 500);
+        } catch (ilLTIConsumerHttpException $e) {
+            $response->setCode($e->getCode());
+            $response->setReason($e->getMessage());
+        } catch (Throwable $e) {
+            $response->setCode(500);
             $response->setReason($e->getMessage());
         }
     }
 
+    /**
+     * @return array{userId: string, limit: int}
+     */
     protected function getFilters(): array
     {
         global $DIC;
@@ -214,15 +215,6 @@ class ilLTIConsumerGradeServiceResults extends ilLTIConsumerResourceBase
             'userId' => $query->has('user_id') ? $query->retrieve('user_id', $string) : '',
             'limit' => is_numeric($limit) ? max(0, (int) $limit) : 0
         ];
-    }
-
-    protected function getClientIdFromToken(object $token): string
-    {
-        $clientId = $token->sub ?? '';
-        if (!is_string($clientId) || $clientId === '') {
-            throw new Exception('invalid request', 401);
-        }
-        return $clientId;
     }
 
     protected function getLtiUserId(int $privacyIdent, int $userId, string $userIdent): string

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceResults.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceResults.php
@@ -57,6 +57,10 @@ class ilLTIConsumerGradeServiceResults extends ilLTIConsumerResourceBase
             global $DIC;
             $ilDB = $DIC->database();
             $scoreMaximum = 1.0;
+            $filters = $this->getFilters();
+            $filterUserId = $filters['userId'] !== ''
+                ? $this->resolveUserIdFromLtiIdent($itemId, $filters['userId'])
+                : null;
 
             if (ilObject::_lookupType($itemId) === 'lti') {
                 $object = new ilObjLTIConsumer($itemId, false);
@@ -96,7 +100,6 @@ class ilLTIConsumerGradeServiceResults extends ilLTIConsumerResourceBase
             $res = $ilDB->query($query);
 
             $resultsArr = [];
-            $filters = $this->getFilters();
             $lineItemUrl = ilLTIConsumerGradeServiceLineItem::buildLineItemUrl($contextId, $itemId);
             while ($row = $ilDB->fetchAssoc($res)) {
                 $userId = (int) $row['usr_id'];
@@ -107,7 +110,10 @@ class ilLTIConsumerGradeServiceResults extends ilLTIConsumerResourceBase
                 $identRes = $ilDB->query($identQuery);
                 $identRow = $ilDB->fetchAssoc($identRes);
                 $userIdent = $identRow['usr_ident'] ?? (string) $userId;
-                if ($filters['userId'] !== '' && !$this->matchesLtiUserIdent($itemId, $userId, $userIdent, $filters['userId'])) {
+                if ($filterUserId !== null && $filterUserId !== $userId) {
+                    continue;
+                }
+                if ($filters['userId'] !== '' && $filterUserId === null && !$this->matchesLtiUserIdent($itemId, $userId, $userIdent, $filters['userId'])) {
                     continue;
                 }
 
@@ -120,6 +126,46 @@ class ilLTIConsumerGradeServiceResults extends ilLTIConsumerResourceBase
                         'userId' => $userIdent,
                         'resultScore' => (float) $resultValue * $scoreMaximum,
                         'resultMaximum' => $scoreMaximum
+                    ];
+                }
+            }
+
+            if (empty($resultsArr)) {
+                $gradeQuery = 'SELECT * FROM lti_consumer_grades'
+                    . ' WHERE obj_id = ' . $ilDB->quote($itemId, 'integer')
+                    . ' AND score_given IS NOT NULL'
+                    . ' AND score_maximum IS NOT NULL';
+                if ($filterUserId !== null) {
+                    $gradeQuery .= ' AND usr_id = ' . $ilDB->quote($filterUserId, 'integer');
+                }
+                $gradeQuery .= ' ORDER BY lti_timestamp DESC, stored DESC';
+                $gradeRes = $ilDB->query($gradeQuery);
+                $seenUsers = [];
+                while ($gradeRow = $ilDB->fetchAssoc($gradeRes)) {
+                    $userId = (int) $gradeRow['usr_id'];
+                    if (isset($seenUsers[$userId])) {
+                        continue;
+                    }
+                    $seenUsers[$userId] = true;
+
+                    $identQuery = 'SELECT usr_ident FROM cmix_users'
+                        . ' WHERE obj_id = ' . $ilDB->quote($itemId, 'integer')
+                        . ' AND usr_id = ' . $ilDB->quote($userId, 'integer');
+                    $identRes = $ilDB->query($identQuery);
+                    $identRow = $ilDB->fetchAssoc($identRes);
+                    $userIdent = $identRow['usr_ident'] ?? (string) $userId;
+                    if ($filterUserId === null && $filters['userId'] !== '' && !$this->matchesLtiUserIdent($itemId, $userId, $userIdent, $filters['userId'])) {
+                        continue;
+                    }
+
+                    $resultMaximum = (float) $gradeRow['score_maximum'];
+                    $resultsArr[] = [
+                        'id' => $lineItemUrl . '/results'
+                            . '?user_id=' . rawurlencode($userIdent),
+                        'scoreOf' => $lineItemUrl,
+                        'userId' => $userIdent,
+                        'resultScore' => (float) $gradeRow['score_given'],
+                        'resultMaximum' => $resultMaximum > 0 ? $resultMaximum : $scoreMaximum
                     ];
                 }
             }

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceResults.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceResults.php
@@ -61,9 +61,7 @@ class ilLTIConsumerGradeServiceResults extends ilLTIConsumerResourceBase
             $ilDB = $DIC->database();
             $scoreMaximum = 1.0;
             $filters = $this->getFilters();
-            $filterUserId = $filters['userId'] !== ''
-                ? $this->resolveUserIdFromLtiIdent($itemId, $filters['userId'])
-                : null;
+            $filterUserId = null;
 
             if (ilObject::_lookupType($itemId) === 'lti') {
                 $object = new ilObjLTIConsumer($itemId, false);
@@ -75,17 +73,37 @@ class ilLTIConsumerGradeServiceResults extends ilLTIConsumerResourceBase
                     throw ilLTIConsumerHttpException::forbidden('invalid clientId');
                 }
                 $scoreMaximum = $object->getScoreMaximum() > 0 ? $object->getScoreMaximum() : 1.0;
+                $filterUserId = $filters['userId'] !== ''
+                    ? $this->resolveUserIdFromLtiIdent($itemId, $filters['userId'])
+                    : null;
             } else {
                 $storedId = -$itemId;
                 if ($storedId <= 0) {
                     throw ilLTIConsumerHttpException::notFound('LineItem not found');
                 }
 
-                if ($this->lineItemRepository->get($storedId, $contextId, $clientId) === null) {
+                $stored_line_item = $this->lineItemRepository->get($storedId, $contextId, $clientId);
+                if ($stored_line_item === null) {
                     throw ilLTIConsumerHttpException::notFound('LineItem not found');
                 }
+
+                $lti_object = $this->getStoredLineItemLtiObject($contextId, $stored_line_item, $clientId);
+                $filterUserId = $filters['userId'] !== ''
+                    ? $this->resolveUserIdFromLtiIdent($lti_object->getId(), $filters['userId'])
+                    : null;
+                $results = $this->getStoredResults(
+                    $ilDB,
+                    $contextId,
+                    $itemId,
+                    $stored_line_item,
+                    $lti_object->getId(),
+                    $lti_object->getProvider()->getPrivacyIdent(),
+                    $filterUserId,
+                    $filters
+                );
                 $response->setContentType('application/vnd.ims.lis.v2.resultcontainer+json');
-                $response->setBody(json_encode([], JSON_UNESCAPED_SLASHES));
+                $this->addNextPageHeader($response, $contextId, $itemId, $filters, $results['has_next_page']);
+                $response->setBody(json_encode($results['items'], JSON_UNESCAPED_SLASHES));
                 return;
             }
 
@@ -185,11 +203,14 @@ class ilLTIConsumerGradeServiceResults extends ilLTIConsumerResourceBase
                 }
             }
 
+            $offset = ($filters['page'] - 1) * $filters['limit'];
+            $has_next_page = $filters['limit'] > 0 && count($resultsArr) > $offset + $filters['limit'];
             if ($filters['limit'] > 0) {
-                $resultsArr = array_slice($resultsArr, 0, $filters['limit']);
+                $resultsArr = array_slice($resultsArr, $offset, $filters['limit']);
             }
 
             $response->setContentType('application/vnd.ims.lis.v2.resultcontainer+json');
+            $this->addNextPageHeader($response, $contextId, $itemId, $filters, $has_next_page);
             $response->setBody(json_encode($resultsArr, JSON_UNESCAPED_SLASHES));
         } catch (ilLTIConsumerHttpException $e) {
             $response->setCode($e->getCode());
@@ -201,7 +222,7 @@ class ilLTIConsumerGradeServiceResults extends ilLTIConsumerResourceBase
     }
 
     /**
-     * @return array{userId: string, limit: int}
+     * @return array{userId: string, limit: int, page: int}
      */
     protected function getFilters(): array
     {
@@ -213,8 +234,124 @@ class ilLTIConsumerGradeServiceResults extends ilLTIConsumerResourceBase
 
         return [
             'userId' => $query->has('user_id') ? $query->retrieve('user_id', $string) : '',
-            'limit' => is_numeric($limit) ? max(0, (int) $limit) : 0
+            'limit' => is_numeric($limit) ? max(0, (int) $limit) : 0,
+            'page' => $query->has('page') && is_numeric($query->retrieve('page', $string))
+                ? max(1, (int) $query->retrieve('page', $string)) : 1
         ];
+    }
+
+    protected function getStoredLineItemLtiObject(
+        int $context_id,
+        ilLTIConsumerLineItem $line_item,
+        string $client_id
+    ): ilObjLTIConsumer {
+        $resource_link_ref_id = (int) $line_item->resourceLinkId;
+        if ($resource_link_ref_id <= 0) {
+            throw ilLTIConsumerHttpException::notFound('Resource link not found');
+        }
+
+        global $DIC;
+        $tree = $DIC->repositoryTree();
+        $node_data = $tree->getNodeData($resource_link_ref_id);
+        if (!$node_data || $node_data['type'] !== 'lti' ||
+            !in_array($context_id, $tree->getPathId($resource_link_ref_id), true)) {
+            throw ilLTIConsumerHttpException::notFound('Resource link not found');
+        }
+
+        $lti_object_id = ilObject::_lookupObjId($resource_link_ref_id);
+        if (!$lti_object_id) {
+            throw ilLTIConsumerHttpException::notFound('Resource link not found');
+        }
+
+        $lti_object = new ilObjLTIConsumer($lti_object_id, false);
+        $provider = $lti_object->getProvider();
+        if (!$provider || $provider->getClientId() !== $client_id) {
+            throw ilLTIConsumerHttpException::forbidden('invalid clientId');
+        }
+
+        return $lti_object;
+    }
+
+    /**
+     * @param array{userId: string, limit: int, page: int} $filters
+     * @return array{items: list<array<string, float|string>>, has_next_page: bool}
+     */
+    protected function getStoredResults(
+        ilDBInterface $db,
+        int $context_id,
+        int $item_id,
+        ilLTIConsumerLineItem $line_item,
+        int $lti_object_id,
+        int $privacy_ident,
+        ?int $filter_user_id,
+        array $filters
+    ): array {
+        $query = 'SELECT score_given, score_maximum, usr_id FROM lti_consumer_grades'
+            . ' WHERE obj_id = ' . $db->quote($item_id, 'integer')
+            . ' AND score_given IS NOT NULL'
+            . ' AND score_maximum IS NOT NULL'
+            . ' ORDER BY lti_timestamp DESC, stored DESC';
+        $result = $db->query($query);
+        $line_item_url = ilLTIConsumerGradeServiceLineItem::buildLineItemUrl($context_id, $item_id);
+        $results = [];
+        $seen_user_ids = [];
+        while ($row = $db->fetchAssoc($result)) {
+            $user_id = (int) $row['usr_id'];
+            if (isset($seen_user_ids[$user_id]) ||
+                ($filter_user_id !== null && $filter_user_id !== $user_id)) {
+                continue;
+            }
+
+            $seen_user_ids[$user_id] = true;
+            $ident_query = 'SELECT usr_ident FROM cmix_users'
+                . ' WHERE obj_id = ' . $db->quote($lti_object_id, 'integer')
+                . ' AND usr_id = ' . $db->quote($user_id, 'integer');
+            $ident_result = $db->query($ident_query);
+            $ident_row = $db->fetchAssoc($ident_result);
+            $user_ident = $ident_row['usr_ident'] ?? (string) $user_id;
+            if ($filter_user_id === null && $filters['userId'] !== '' &&
+                !$this->matchesLtiUserIdent($lti_object_id, $user_id, $user_ident, $filters['userId'])) {
+                continue;
+            }
+
+            $score_maximum = (float) $row['score_maximum'];
+            $lti_user_id = $this->getLtiUserId($privacy_ident, $user_id, $user_ident);
+            $results[] = [
+                'id' => $line_item_url . '/results?user_id=' . rawurlencode($lti_user_id),
+                'scoreOf' => $line_item_url,
+                'userId' => $lti_user_id,
+                'resultScore' => (float) $row['score_given'],
+                'resultMaximum' => $score_maximum > 0 ? $score_maximum : $line_item->scoreMaximum
+            ];
+        }
+
+        $offset = ($filters['page'] - 1) * $filters['limit'];
+        $has_next_page = $filters['limit'] > 0 && count($results) > $offset + $filters['limit'];
+        if ($filters['limit'] > 0) {
+            $results = array_slice($results, $offset, $filters['limit']);
+        }
+
+        return ['items' => $results, 'has_next_page' => $has_next_page];
+    }
+
+    /** @param array{userId: string, limit: int, page: int} $filters */
+    protected function addNextPageHeader(
+        ilLTIConsumerServiceResponse $response,
+        int $context_id,
+        int $item_id,
+        array $filters,
+        bool $has_next_page
+    ): void {
+        if (!$has_next_page) {
+            return;
+        }
+
+        $query = ['limit' => $filters['limit'], 'page' => $filters['page'] + 1];
+        if ($filters['userId'] !== '') {
+            $query['user_id'] = $filters['userId'];
+        }
+        $url = ilLTIConsumerGradeServiceLineItem::buildLineItemUrl($context_id, $item_id) . '/results';
+        $response->addAdditionalHeader('Link: <' . $url . '?' . http_build_query($query) . '>; rel="next"');
     }
 
     protected function getLtiUserId(int $privacyIdent, int $userId, string $userIdent): string

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceScores.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceScores.php
@@ -61,11 +61,8 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
             }
             $this->checkToolMatchesObject((int) $itemId, $token);
 
-            // Bug in Moodle as tool provider, should accept only "204 No Content" but schedules grade sync task will notices a failed status if not exactly 200
-            // see: http://www.imsglobal.org/spec/lti-ags/v2p0#score-service-scope-and-allowed-http-methods
-            //$response->setCode(204); // correct
-            $returnCode = $this->checkScore($response->getRequestData(), (int) $itemId);
-            $response->setCode($returnCode); // not really correct
+            $this->checkScore($response->getRequestData(), (int) $itemId);
+            $response->setCode(204);
         } catch (Exception $e) {
             $code = $e->getCode();
             $response->setCode($code >= 400 && $code < 600 ? $code : 500);
@@ -99,7 +96,7 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
         }
     }
 
-    protected function checkScore(string $requestData, int $objId): int
+    protected function checkScore(string $requestData, int $objId): void
     {
         global $DIC; /* @var \ILIAS\DI\Container $DIC */
 
@@ -234,9 +231,6 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
         ];
         $DIC->database()->insert('lti_consumer_grades', $gradeValues);
 
-
-
-        return 200;
     }
 
     protected static function isValidActivityProgress(string $activityProgress): bool

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceScores.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceScores.php
@@ -159,10 +159,11 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
         $lp_status = ilLPStatus::LP_STATUS_NOT_ATTEMPTED_NUM;
         $updateLpStatus = false;
 
-        if (in_array($score->activityProgress, ['Started', 'InProgress', 'Submitted'], true)) {
+        if (in_array($score->activityProgress, ['Started', 'InProgress'], true) ||
+            ($score->activityProgress === 'Submitted' && $score->gradingProgress !== 'FullyGraded')) {
             $lp_status = ilLPStatus::LP_STATUS_IN_PROGRESS_NUM;
             $updateLpStatus = true;
-        } elseif ($score->activityProgress === 'Completed') {
+        } elseif (in_array($score->activityProgress, ['Submitted', 'Completed'], true)) {
             if ($score->gradingProgress === 'FullyGraded' && $result !== null) {
                 if ($result >= $ltiObjRes->getMasteryScore()) {
                     $lp_status = ilLPStatus::LP_STATUS_COMPLETED_NUM;

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceScores.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceScores.php
@@ -53,29 +53,49 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
         ilObjLTIConsumer::getLogger()->info("objId: " . $itemId);
         ilObjLTIConsumer::getLogger()->info("request data: " . $response->getRequestData());
 
-        // GET is disabled by the moment, but we have the code ready
-        // for a future implementation.
-
-        //$container = empty($contentType) || ($contentType === $this->formats[0]);
-
-        $typeid = 0;
-
         $scope = ilLTIConsumerGradeService::SCOPE_GRADESERVICE_SCORE;
         try {
             $token = $this->checkTool(array($scope));
             if (is_null($token)) {
                 throw new Exception('invalid request', 401);
             }
+            $this->checkToolMatchesObject((int) $itemId, $token);
 
             // Bug in Moodle as tool provider, should accept only "204 No Content" but schedules grade sync task will notices a failed status if not exactly 200
             // see: http://www.imsglobal.org/spec/lti-ags/v2p0#score-service-scope-and-allowed-http-methods
             //$response->setCode(204); // correct
-            $returnCode = 200;
             $returnCode = $this->checkScore($response->getRequestData(), (int) $itemId);
             $response->setCode($returnCode); // not really correct
         } catch (Exception $e) {
-            $response->setCode($e->getCode());
+            $code = $e->getCode();
+            $response->setCode($code >= 400 && $code < 600 ? $code : 500);
             $response->setReason($e->getMessage());
+        }
+    }
+
+    protected function checkToolMatchesObject(int $objId, object $token): void
+    {
+        $clientId = $token->sub ?? '';
+        if (!is_string($clientId) || $clientId === '') {
+            throw new Exception('invalid request', 401);
+        }
+
+        if (ilObject::_lookupType($objId) !== 'lti') {
+            throw new Exception('Tool for Object not available', 404);
+        }
+
+        $ltiObject = new ilObjLTIConsumer($objId, false);
+        $provider = $ltiObject->getProvider();
+        if (!$provider instanceof ilLTIConsumeProvider) {
+            throw new Exception('Tool for Object not available', 404);
+        }
+
+        if ($provider->getClientId() !== $clientId) {
+            throw new Exception('invalid clientId', 403);
+        }
+
+        if (!$provider->isGradeSynchronization() && !$provider->getHasOutcome()) {
+            throw new Exception('grade synchronization not enabled', 403);
         }
     }
 
@@ -87,40 +107,52 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
 
         $logger->info('checkScore');
         $score = json_decode($requestData);
-        //prüfe Userid
-        $userId = ilCmiXapiUser::getUsrIdForObjectAndUsrIdent($objId, $score->userId);
-        if ($userId == null) {
-            ilObjLTIConsumer::getLogger()->info('User not available');
-            throw new Exception('User not available', 404);
-            return 404;
-        }
-
-        ilObjLTIConsumer::getLogger()->dump($score);
-
-        if (empty($score) ||
+        if (!is_object($score) || json_last_error() !== JSON_ERROR_NONE ||
             !isset($score->userId) ||
             !isset($score->gradingProgress) ||
             !isset($score->activityProgress) ||
             !isset($score->timestamp) ||
-            isset($score->timestamp) && !self::validate_iso8601_date($score->timestamp) ||
+            !is_scalar($score->userId) ||
+            !is_string($score->gradingProgress) ||
+            !is_string($score->activityProgress) ||
+            !is_scalar($score->timestamp) ||
+            !self::isValidActivityProgress($score->activityProgress) ||
+            !self::isValidGradingProgress($score->gradingProgress) ||
+            !self::validate_iso8601_date((string) $score->timestamp) ||
             (isset($score->scoreGiven) && !is_numeric($score->scoreGiven)) ||
             (isset($score->scoreGiven) && !isset($score->scoreMaximum)) ||
-            (isset($score->scoreMaximum) && !is_numeric($score->scoreMaximum))
+            (isset($score->scoreMaximum) && (!is_numeric($score->scoreMaximum) || (float) $score->scoreMaximum <= 0)) ||
+            (isset($score->scoreGiven) && isset($score->scoreMaximum) && (
+                (float) $score->scoreGiven < 0 || (float) $score->scoreGiven > (float) $score->scoreMaximum
+            )) ||
+            ($score->gradingProgress === 'FullyGraded' && (!isset($score->scoreGiven) || !isset($score->scoreMaximum)))
         ) {
             ilObjLTIConsumer::getLogger()->info('Incorrect score received');
             ilObjLTIConsumer::getLogger()->dump($score);
             throw new Exception('Incorrect score received', 400);
-            return 400;
         }
 
-        if (!isset($score->scoreMaximum)) {
-            $score->scoreMaximum = 1;
-        }
-        if (!isset($score->scoreGiven)) {
-            $score->scoreGiven = 0;
+        $userId = $this->getUsrIdForScoreUser($objId, (string) $score->userId);
+        if ($userId == null) {
+            ilObjLTIConsumer::getLogger()->info('User not available');
+            throw new Exception('User not available', 404);
         }
 
-        $result = (float) $score->scoreGiven / (float) $score->scoreMaximum;
+        $scoreGiven = isset($score->scoreGiven) ? (float) $score->scoreGiven : null;
+        $scoreMaximum = isset($score->scoreMaximum) ? (float) $score->scoreMaximum : null;
+        $lineItemScoreMaximum = $this->getLineItemScoreMaximum($objId);
+        if ($scoreMaximum !== null && abs($scoreMaximum - $lineItemScoreMaximum) > 0.00001) {
+            throw new Exception('scoreMaximum does not match line item', 400);
+        }
+
+        $result = null;
+        $scoreProgress = null;
+        if ($scoreGiven !== null && $scoreMaximum !== null) {
+            $scoreProgress = $scoreGiven / $scoreMaximum;
+        }
+        if ($score->gradingProgress === 'FullyGraded') {
+            $result = $scoreProgress;
+        }
 
         $ltiObjRes = new ilLTIConsumerResultService();
 
@@ -128,57 +160,68 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
         // check the object status
         if (!$ltiObjRes->isAvailable()) {
             throw new Exception('Tool for Object not available', 404);
-            return 404;
         }
 
         $lp_status = ilLPStatus::LP_STATUS_NOT_ATTEMPTED_NUM;
+        $updateLpStatus = false;
 
-        if ($score->activityProgress === 'InProgress') {
+        if (in_array($score->activityProgress, ['Started', 'InProgress', 'Submitted'], true)) {
             $lp_status = ilLPStatus::LP_STATUS_IN_PROGRESS_NUM;
-        } elseif ($score->activityProgress === 'Completed' && $score->gradingProgress === 'FullyGraded') {
-            if ($result >= $ltiObjRes->getMasteryScore()) {
-                $lp_status = ilLPStatus::LP_STATUS_COMPLETED_NUM;
+            $updateLpStatus = true;
+        } elseif ($score->activityProgress === 'Completed') {
+            if ($score->gradingProgress === 'FullyGraded' && $result !== null) {
+                if ($result >= $ltiObjRes->getMasteryScore()) {
+                    $lp_status = ilLPStatus::LP_STATUS_COMPLETED_NUM;
+                } else {
+                    $lp_status = ilLPStatus::LP_STATUS_IN_PROGRESS_NUM;
+                }
+            } elseif ($score->gradingProgress === 'Failed') {
+                $lp_status = ilLPStatus::LP_STATUS_FAILED_NUM;
             } else {
                 $lp_status = ilLPStatus::LP_STATUS_IN_PROGRESS_NUM;
             }
-        } elseif ($score->activityProgress === 'Completed' && $score->gradingProgress === 'Failed') {
-            $lp_status = ilLPStatus::LP_STATUS_FAILED_NUM;
+            $updateLpStatus = true;
         }
 
-        $lp_percentage = (int) round(100 * $result);
+        $lp_percentage = $scoreProgress === null ? 0 : (int) round(100 * $scoreProgress);
+        $resultForLog = $result === null ? 'null' : (string) $result;
 
-        ilObjLTIConsumer::getLogger()->info("lp_status: $lp_status, lp_percentage: $lp_percentage, result: $result, mastery_score: " . $ltiObjRes->getMasteryScore());
+        ilObjLTIConsumer::getLogger()->info("lp_status: $lp_status, lp_percentage: $lp_percentage, result: $resultForLog, mastery_score: " . $ltiObjRes->getMasteryScore());
 
-        $consRes = ilLTIConsumerResult::getByKeys($objId, $userId, false);
-        if (empty($consRes)) {
-            $DIC->database()->insert(
-                'lti_consumer_results',
-                array(
-                    'id' => array('integer', $DIC->database()->nextId('lti_consumer_results')),
-                    'obj_id' => array('integer', $objId),
-                    'usr_id' => array('integer', $userId),
-                    'result' => array('float', $result)
-                )
-            );
-        } else {
-            $DIC->database()->replace(
-                'lti_consumer_results',
-                array(
-                    'id' => array('integer', $consRes->id)
-                ),
-                array(
-                    'obj_id' => array('integer', $objId),
-                    'usr_id' => array('integer', $userId),
-                    'result' => array('float', $result)
-                )
-            );
+        if ($result !== null) {
+            $consRes = ilLTIConsumerResult::getByKeys($objId, $userId, false);
+            if (empty($consRes)) {
+                $DIC->database()->insert(
+                    'lti_consumer_results',
+                    array(
+                        'id' => array('integer', $DIC->database()->nextId('lti_consumer_results')),
+                        'obj_id' => array('integer', $objId),
+                        'usr_id' => array('integer', $userId),
+                        'result' => array('float', $result)
+                    )
+                );
+            } else {
+                $DIC->database()->replace(
+                    'lti_consumer_results',
+                    array(
+                        'id' => array('integer', $consRes->id)
+                    ),
+                    array(
+                        'obj_id' => array('integer', $objId),
+                        'usr_id' => array('integer', $userId),
+                        'result' => array('float', $result)
+                    )
+                );
+            }
         }
 
-        ilLPStatus::writeStatus($objId, $userId, $lp_status, $lp_percentage, true);
+        if ($updateLpStatus) {
+            ilLPStatus::writeStatus($objId, $userId, $lp_status, $lp_percentage, true);
+        }
 
-        $ltiTimestamp = DateTimeImmutable::createFromFormat(DateTimeInterface::RFC3339_EXTENDED, $score->timestamp);
+        $ltiTimestamp = DateTimeImmutable::createFromFormat(DateTimeInterface::RFC3339_EXTENDED, (string) $score->timestamp);
         if (!$ltiTimestamp) { //moodle 4
-            $ltiTimestamp = DateTimeImmutable::createFromFormat(DateTimeInterface::ISO8601, $score->timestamp);
+            $ltiTimestamp = DateTimeImmutable::createFromFormat(DateTimeInterface::ISO8601, (string) $score->timestamp);
         }
         if (!$ltiTimestamp) { //for example nothing
             $ltiTimestamp = new DateTime('now');
@@ -187,8 +230,8 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
             'id' => array('integer', $DIC->database()->nextId('lti_consumer_grades')),
             'obj_id' => array('integer', $objId),
             'usr_id' => array('integer', $userId),
-            'score_given' => array('float', $score->scoreGiven),
-            'score_maximum' => array('float', $score->scoreMaximum),
+            'score_given' => array('float', $scoreGiven),
+            'score_maximum' => array('float', $scoreMaximum),
             'activity_progress' => array('text', $score->activityProgress),
             'grading_progress' => array('text', $score->gradingProgress),
             'lti_timestamp' => array('timestamp',$ltiTimestamp->format("Y-m-d H:i:s")),
@@ -199,6 +242,51 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
 
 
         return 200;
+    }
+
+    protected function getLineItemScoreMaximum(int $objId): float
+    {
+        $object = new ilObjLTIConsumer($objId, false);
+        $scoreMaximum = $object->getScoreMaximum();
+        return $scoreMaximum > 0 ? $scoreMaximum : 1.0;
+    }
+
+    protected function getUsrIdForScoreUser(int $objId, string $userIdent): ?int
+    {
+        global $DIC;
+        $ilDB = $DIC->database();
+        $query = 'SELECT usr_id FROM cmix_users'
+            . ' WHERE obj_id = ' . $ilDB->quote($objId, 'integer')
+            . ' AND usr_ident = ' . $ilDB->quote($userIdent, 'text');
+        $res = $ilDB->query($query);
+        $row = $ilDB->fetchAssoc($res);
+        if ($row) {
+            return (int) $row['usr_id'];
+        }
+
+        return ilCmiXapiUser::getUsrIdForObjectAndUsrIdent($objId, $userIdent);
+    }
+
+    protected static function isValidActivityProgress(string $activityProgress): bool
+    {
+        return in_array($activityProgress, [
+            'Initialized',
+            'Started',
+            'InProgress',
+            'Submitted',
+            'Completed'
+        ], true);
+    }
+
+    protected static function isValidGradingProgress(string $gradingProgress): bool
+    {
+        return in_array($gradingProgress, [
+            'FullyGraded',
+            'Pending',
+            'PendingManual',
+            'Failed',
+            'NotReady'
+        ], true);
     }
 
     public static function validate_iso8601_date(string $date): bool

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceScores.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceScores.php
@@ -29,7 +29,10 @@ declare(strict_types=1);
 
 class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
 {
-    public function __construct(ilLTIConsumerServiceBase $service)
+    public function __construct(
+        ilLTIConsumerServiceBase $service,
+        private readonly ilLTIConsumerLineItemRepository $line_item_repository
+    )
     {
         parent::__construct($service);
         $this->id = 'Score.collection';
@@ -46,11 +49,11 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
     public function execute(ilLTIConsumerServiceResponse $response): void
     {
         $params = $this->parseTemplate();
-        $contextId = $params['context_id'];
-        $itemId = $params['item_id'];
+        $context_id = (int) ($params['context_id'] ?? 0);
+        $item_id = (int) ($params['item_id'] ?? 0);
 
-        ilObjLTIConsumer::getLogger()->info("contextId: " . $contextId);
-        ilObjLTIConsumer::getLogger()->info("objId: " . $itemId);
+        ilObjLTIConsumer::getLogger()->info("contextId: " . $context_id);
+        ilObjLTIConsumer::getLogger()->info("objId: " . $item_id);
         ilObjLTIConsumer::getLogger()->info("request data: " . $response->getRequestData());
 
         $scope = ilLTIConsumerGradeService::SCOPE_GRADESERVICE_SCORE;
@@ -59,9 +62,12 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
             if (is_null($token)) {
                 throw ilLTIConsumerHttpException::unauthorized();
             }
-            $this->checkToolMatchesObject((int) $itemId, $token);
-
-            $this->checkScore($response->getRequestData(), (int) $itemId);
+            if (ilObject::_lookupType($item_id) === 'lti') {
+                $this->checkToolMatchesObject($item_id, $token);
+                $this->checkScore($response->getRequestData(), $item_id);
+            } else {
+                $this->checkStoredLineItemScore($response->getRequestData(), $context_id, $item_id, $token);
+            }
             $response->setCode(204);
         } catch (ilLTIConsumerHttpException $e) {
             $response->setCode($e->getCode());
@@ -95,7 +101,40 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
         }
     }
 
-    protected function checkScore(string $requestData, int $objId): void
+    protected function checkStoredLineItemScore(
+        string $request_data,
+        int $context_id,
+        int $item_id,
+        ilLTIConsumerAccessToken $token
+    ): void {
+        $stored_line_item = $this->line_item_repository->get(-$item_id, $context_id, $token->getClientId());
+        if ($item_id >= 0 || $stored_line_item === null) {
+            throw ilLTIConsumerHttpException::notFound('LineItem not found');
+        }
+
+        $resource_link_ref_id = (int) $stored_line_item->resourceLinkId;
+        if ($resource_link_ref_id <= 0) {
+            throw ilLTIConsumerHttpException::notFound('Resource link not found');
+        }
+
+        global $DIC;
+        $tree = $DIC->repositoryTree();
+        $node_data = $tree->getNodeData($resource_link_ref_id);
+        if (!$node_data || $node_data['type'] !== 'lti' ||
+            !in_array($context_id, $tree->getPathId($resource_link_ref_id), true)) {
+            throw ilLTIConsumerHttpException::notFound('Resource link not found');
+        }
+
+        $lti_object_id = ilObject::_lookupObjId($resource_link_ref_id);
+        if (!$lti_object_id) {
+            throw ilLTIConsumerHttpException::notFound('Resource link not found');
+        }
+
+        $this->checkToolMatchesObject($lti_object_id, $token);
+        $this->checkScore($request_data, $lti_object_id, $item_id);
+    }
+
+    protected function checkScore(string $requestData, int $objId, ?int $grade_item_id = null): void
     {
         global $DIC; /* @var \ILIAS\DI\Container $DIC */
 
@@ -134,6 +173,24 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
             throw ilLTIConsumerHttpException::notFound('User not available');
         }
 
+        $lti_timestamp = DateTimeImmutable::createFromFormat(DateTimeInterface::RFC3339_EXTENDED, (string) $score->timestamp);
+        if (!$lti_timestamp) { //moodle 4
+            $lti_timestamp = DateTimeImmutable::createFromFormat(DateTimeInterface::ISO8601, (string) $score->timestamp);
+        }
+        if (!$lti_timestamp) { //for example nothing
+            $lti_timestamp = new DateTimeImmutable('now');
+        }
+
+        $grade_item_id_for_query = $grade_item_id ?? $objId;
+        $latest_grade_query = 'SELECT lti_timestamp FROM lti_consumer_grades'
+            . ' WHERE obj_id = ' . $DIC->database()->quote($grade_item_id_for_query, 'integer')
+            . ' AND usr_id = ' . $DIC->database()->quote($userId, 'integer')
+            . ' ORDER BY lti_timestamp DESC, stored DESC';
+        $latest_grade_result = $DIC->database()->query($latest_grade_query);
+        $latest_grade = $DIC->database()->fetchAssoc($latest_grade_result);
+        $is_current_score = $latest_grade === null ||
+            $lti_timestamp >= new DateTimeImmutable($latest_grade['lti_timestamp']);
+
         $scoreGiven = isset($score->scoreGiven) ? (float) $score->scoreGiven : null;
         $scoreMaximum = isset($score->scoreMaximum) ? (float) $score->scoreMaximum : null;
 
@@ -144,6 +201,19 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
         }
         if ($gradingProgress === ilLTIConsumerGradingProgress::FULLY_GRADED) {
             $result = $scoreProgress;
+        }
+
+        if ($grade_item_id !== null) {
+            $this->storeScore(
+                $grade_item_id,
+                $userId,
+                $scoreGiven,
+                $scoreMaximum,
+                $activityProgress,
+                $gradingProgress,
+                $lti_timestamp
+            );
+            return;
         }
 
         $ltiObjRes = new ilLTIConsumerResultService();
@@ -174,14 +244,15 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
             $updateLpStatus = true;
         }
 
-        $lp_percentage = $scoreProgress === null ? 0 : (int) round(100 * $scoreProgress);
+        $lp_percentage = $scoreProgress === null ? 0 : max(0, min(100, (int) round(100 * $scoreProgress)));
         $resultForLog = $result === null ? 'null' : (string) $result;
 
         ilObjLTIConsumer::getLogger()->info("lp_status: $lp_status, lp_percentage: $lp_percentage, result: $resultForLog, mastery_score: " . $ltiObjRes->getMasteryScore());
 
-        if ($result !== null) {
+        $should_update_result = $result !== null || $scoreGiven === null;
+        if ($is_current_score && $should_update_result) {
             $consRes = ilLTIConsumerResult::getByKeys($objId, $userId, false);
-            if (empty($consRes)) {
+            if (empty($consRes) && $result !== null) {
                 $DIC->database()->insert(
                     'lti_consumer_results',
                     array(
@@ -191,7 +262,7 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
                         'result' => array('float', $result)
                     )
                 );
-            } else {
+            } elseif (!empty($consRes)) {
                 $DIC->database()->replace(
                     'lti_consumer_results',
                     array(
@@ -206,30 +277,44 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
             }
         }
 
-        if ($updateLpStatus) {
+        if ($is_current_score && $updateLpStatus) {
             ilLPStatus::writeStatus($objId, $userId, $lp_status, $lp_percentage, true);
         }
 
-        $ltiTimestamp = DateTimeImmutable::createFromFormat(DateTimeInterface::RFC3339_EXTENDED, (string) $score->timestamp);
-        if (!$ltiTimestamp) { //moodle 4
-            $ltiTimestamp = DateTimeImmutable::createFromFormat(DateTimeInterface::ISO8601, (string) $score->timestamp);
-        }
-        if (!$ltiTimestamp) { //for example nothing
-            $ltiTimestamp = new DateTime('now');
-        }
-        $gradeValues = [
+        $this->storeScore(
+            $objId,
+            $userId,
+            $scoreGiven,
+            $scoreMaximum,
+            $activityProgress,
+            $gradingProgress,
+            $lti_timestamp
+        );
+    }
+
+    protected function storeScore(
+        int $item_id,
+        int $user_id,
+        ?float $score_given,
+        ?float $score_maximum,
+        ilLTIConsumerActivityProgress $activity_progress,
+        ilLTIConsumerGradingProgress $grading_progress,
+        DateTimeImmutable $lti_timestamp
+    ): void {
+        global $DIC;
+
+        $grade_values = [
             'id' => array('integer', $DIC->database()->nextId('lti_consumer_grades')),
-            'obj_id' => array('integer', $objId),
-            'usr_id' => array('integer', $userId),
-            'score_given' => array('float', $scoreGiven),
-            'score_maximum' => array('float', $scoreMaximum),
-            'activity_progress' => array('text', $activityProgress->value),
-            'grading_progress' => array('text', $gradingProgress->value),
-            'lti_timestamp' => array('timestamp', $ltiTimestamp->format("Y-m-d H:i:s")),
+            'obj_id' => array('integer', $item_id),
+            'usr_id' => array('integer', $user_id),
+            'score_given' => array('float', $score_given),
+            'score_maximum' => array('float', $score_maximum),
+            'activity_progress' => array('text', $activity_progress->value),
+            'grading_progress' => array('text', $grading_progress->value),
+            'lti_timestamp' => array('timestamp', $lti_timestamp->format('Y-m-d H:i:s')),
             'stored' => array('timestamp', date("Y-m-d H:i:s"))
         ];
-        $DIC->database()->insert('lti_consumer_grades', $gradeValues);
-
+        $DIC->database()->insert('lti_consumer_grades', $grade_values);
     }
 
     public static function validate_iso8601_date(string $date): bool

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceScores.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceScores.php
@@ -122,9 +122,7 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
             (isset($score->scoreGiven) && !is_numeric($score->scoreGiven)) ||
             (isset($score->scoreGiven) && !isset($score->scoreMaximum)) ||
             (isset($score->scoreMaximum) && (!is_numeric($score->scoreMaximum) || (float) $score->scoreMaximum <= 0)) ||
-            (isset($score->scoreGiven) && isset($score->scoreMaximum) && (
-                (float) $score->scoreGiven < 0 || (float) $score->scoreGiven > (float) $score->scoreMaximum
-            )) ||
+            (isset($score->scoreGiven) && (float) $score->scoreGiven < 0) ||
             ($score->gradingProgress === 'FullyGraded' && (!isset($score->scoreGiven) || !isset($score->scoreMaximum)))
         ) {
             ilObjLTIConsumer::getLogger()->info('Incorrect score received');
@@ -140,10 +138,6 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
 
         $scoreGiven = isset($score->scoreGiven) ? (float) $score->scoreGiven : null;
         $scoreMaximum = isset($score->scoreMaximum) ? (float) $score->scoreMaximum : null;
-        $lineItemScoreMaximum = $this->getLineItemScoreMaximum($objId);
-        if ($scoreMaximum !== null && abs($scoreMaximum - $lineItemScoreMaximum) > 0.00001) {
-            throw new Exception('scoreMaximum does not match line item', 400);
-        }
 
         $result = null;
         $scoreProgress = null;
@@ -242,13 +236,6 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
 
 
         return 200;
-    }
-
-    protected function getLineItemScoreMaximum(int $objId): float
-    {
-        $object = new ilObjLTIConsumer($objId, false);
-        $scoreMaximum = $object->getScoreMaximum();
-        return $scoreMaximum > 0 ? $scoreMaximum : 1.0;
     }
 
     protected function getUsrIdForScoreUser(int $objId, string $userIdent): ?int

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceScores.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceScores.php
@@ -32,8 +32,7 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
     public function __construct(
         ilLTIConsumerServiceBase $service,
         private readonly ilLTIConsumerLineItemRepository $line_item_repository
-    )
-    {
+    ) {
         parent::__construct($service);
         $this->id = 'Score.collection';
         $this->template = '/{context_id}/lineitems/{item_id}/lineitem/scores';

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceScores.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceScores.php
@@ -57,42 +57,41 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
         try {
             $token = $this->checkTool(array($scope));
             if (is_null($token)) {
-                throw new Exception('invalid request', 401);
+                throw ilLTIConsumerHttpException::unauthorized();
             }
             $this->checkToolMatchesObject((int) $itemId, $token);
 
             $this->checkScore($response->getRequestData(), (int) $itemId);
             $response->setCode(204);
-        } catch (Exception $e) {
-            $code = $e->getCode();
-            $response->setCode($code >= 400 && $code < 600 ? $code : 500);
+        } catch (ilLTIConsumerHttpException $e) {
+            $response->setCode($e->getCode());
+            $response->setReason($e->getMessage());
+        } catch (Throwable $e) {
+            $response->setCode(500);
             $response->setReason($e->getMessage());
         }
     }
 
-    protected function checkToolMatchesObject(int $objId, object $token): void
+    protected function checkToolMatchesObject(int $objId, ilLTIConsumerAccessToken $token): void
     {
-        $clientId = $token->sub ?? '';
-        if (!is_string($clientId) || $clientId === '') {
-            throw new Exception('invalid request', 401);
-        }
+        $clientId = $token->getClientId();
 
         if (ilObject::_lookupType($objId) !== 'lti') {
-            throw new Exception('Tool for Object not available', 404);
+            throw ilLTIConsumerHttpException::notFound('Tool for Object not available');
         }
 
         $ltiObject = new ilObjLTIConsumer($objId, false);
         $provider = $ltiObject->getProvider();
         if (!$provider instanceof ilLTIConsumeProvider) {
-            throw new Exception('Tool for Object not available', 404);
+            throw ilLTIConsumerHttpException::notFound('Tool for Object not available');
         }
 
         if ($provider->getClientId() !== $clientId) {
-            throw new Exception('invalid clientId', 403);
+            throw ilLTIConsumerHttpException::forbidden('invalid clientId');
         }
 
         if (!$provider->isGradeSynchronization() && !$provider->getHasOutcome()) {
-            throw new Exception('grade synchronization not enabled', 403);
+            throw ilLTIConsumerHttpException::forbidden('grade synchronization not enabled');
         }
     }
 
@@ -104,33 +103,35 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
 
         $logger->info('checkScore');
         $score = json_decode($requestData);
+        $activityProgress = is_object($score) && is_string($score->activityProgress ?? null)
+            ? ilLTIConsumerActivityProgress::tryFrom($score->activityProgress) : null;
+        $gradingProgress = is_object($score) && is_string($score->gradingProgress ?? null)
+            ? ilLTIConsumerGradingProgress::tryFrom($score->gradingProgress) : null;
         if (!is_object($score) || json_last_error() !== JSON_ERROR_NONE ||
             !isset($score->userId) ||
             !isset($score->gradingProgress) ||
             !isset($score->activityProgress) ||
             !isset($score->timestamp) ||
             !is_scalar($score->userId) ||
-            !is_string($score->gradingProgress) ||
-            !is_string($score->activityProgress) ||
             !is_scalar($score->timestamp) ||
-            !self::isValidActivityProgress($score->activityProgress) ||
-            !self::isValidGradingProgress($score->gradingProgress) ||
+            $activityProgress === null ||
+            $gradingProgress === null ||
             !self::validate_iso8601_date((string) $score->timestamp) ||
             (isset($score->scoreGiven) && !is_numeric($score->scoreGiven)) ||
             (isset($score->scoreGiven) && !isset($score->scoreMaximum)) ||
             (isset($score->scoreMaximum) && (!is_numeric($score->scoreMaximum) || (float) $score->scoreMaximum <= 0)) ||
             (isset($score->scoreGiven) && (float) $score->scoreGiven < 0) ||
-            ($score->gradingProgress === 'FullyGraded' && (!isset($score->scoreGiven) || !isset($score->scoreMaximum)))
+            ($gradingProgress === ilLTIConsumerGradingProgress::FULLY_GRADED && (!isset($score->scoreGiven) || !isset($score->scoreMaximum)))
         ) {
             ilObjLTIConsumer::getLogger()->info('Incorrect score received');
             ilObjLTIConsumer::getLogger()->dump($score);
-            throw new Exception('Incorrect score received', 400);
+            throw ilLTIConsumerHttpException::badRequest('Incorrect score received');
         }
 
         $userId = $this->resolveUserIdFromLtiIdent($objId, (string) $score->userId);
         if ($userId == null) {
             ilObjLTIConsumer::getLogger()->info('User not available');
-            throw new Exception('User not available', 404);
+            throw ilLTIConsumerHttpException::notFound('User not available');
         }
 
         $scoreGiven = isset($score->scoreGiven) ? (float) $score->scoreGiven : null;
@@ -141,7 +142,7 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
         if ($scoreGiven !== null && $scoreMaximum !== null) {
             $scoreProgress = $scoreGiven / $scoreMaximum;
         }
-        if ($score->gradingProgress === 'FullyGraded') {
+        if ($gradingProgress === ilLTIConsumerGradingProgress::FULLY_GRADED) {
             $result = $scoreProgress;
         }
 
@@ -150,25 +151,23 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
         $ltiObjRes->readProperties($objId);
         // check the object status
         if (!$ltiObjRes->isAvailable()) {
-            throw new Exception('Tool for Object not available', 404);
+            throw ilLTIConsumerHttpException::notFound('Tool for Object not available');
         }
 
         $lp_status = ilLPStatus::LP_STATUS_NOT_ATTEMPTED_NUM;
         $updateLpStatus = false;
 
-        if (in_array($score->activityProgress, ['Started', 'InProgress'], true) ||
-            ($score->activityProgress === 'Submitted' && $score->gradingProgress !== 'FullyGraded')) {
+        if ($activityProgress->isInProgress() ||
+            ($activityProgress === ilLTIConsumerActivityProgress::SUBMITTED && $gradingProgress->isPending())) {
             $lp_status = ilLPStatus::LP_STATUS_IN_PROGRESS_NUM;
             $updateLpStatus = true;
-        } elseif (in_array($score->activityProgress, ['Submitted', 'Completed'], true)) {
-            if ($score->gradingProgress === 'FullyGraded' && $result !== null) {
+        } elseif ($activityProgress->isSubmittedOrCompleted()) {
+            if ($gradingProgress === ilLTIConsumerGradingProgress::FULLY_GRADED && $result !== null) {
                 if ($result >= $ltiObjRes->getMasteryScore()) {
                     $lp_status = ilLPStatus::LP_STATUS_COMPLETED_NUM;
                 } else {
                     $lp_status = ilLPStatus::LP_STATUS_IN_PROGRESS_NUM;
                 }
-            } elseif ($score->gradingProgress === 'Failed') {
-                $lp_status = ilLPStatus::LP_STATUS_FAILED_NUM;
             } else {
                 $lp_status = ilLPStatus::LP_STATUS_IN_PROGRESS_NUM;
             }
@@ -224,35 +223,13 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
             'usr_id' => array('integer', $userId),
             'score_given' => array('float', $scoreGiven),
             'score_maximum' => array('float', $scoreMaximum),
-            'activity_progress' => array('text', $score->activityProgress),
-            'grading_progress' => array('text', $score->gradingProgress),
+            'activity_progress' => array('text', $activityProgress->value),
+            'grading_progress' => array('text', $gradingProgress->value),
             'lti_timestamp' => array('timestamp', $ltiTimestamp->format("Y-m-d H:i:s")),
             'stored' => array('timestamp', date("Y-m-d H:i:s"))
         ];
         $DIC->database()->insert('lti_consumer_grades', $gradeValues);
 
-    }
-
-    protected static function isValidActivityProgress(string $activityProgress): bool
-    {
-        return in_array($activityProgress, [
-            'Initialized',
-            'Started',
-            'InProgress',
-            'Submitted',
-            'Completed'
-        ], true);
-    }
-
-    protected static function isValidGradingProgress(string $gradingProgress): bool
-    {
-        return in_array($gradingProgress, [
-            'FullyGraded',
-            'Pending',
-            'PendingManual',
-            'Failed',
-            'NotReady'
-        ], true);
     }
 
     public static function validate_iso8601_date(string $date): bool

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceScores.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceScores.php
@@ -130,7 +130,7 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
             throw new Exception('Incorrect score received', 400);
         }
 
-        $userId = $this->getUsrIdForScoreUser($objId, (string) $score->userId);
+        $userId = $this->resolveUserIdFromLtiIdent($objId, (string) $score->userId);
         if ($userId == null) {
             ilObjLTIConsumer::getLogger()->info('User not available');
             throw new Exception('User not available', 404);
@@ -236,37 +236,6 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
 
 
         return 200;
-    }
-
-    protected function getUsrIdForScoreUser(int $objId, string $userIdent): ?int
-    {
-        global $DIC;
-        $ilDB = $DIC->database();
-        $query = 'SELECT usr_id FROM cmix_users'
-            . ' WHERE obj_id = ' . $ilDB->quote($objId, 'integer')
-            . ' AND usr_ident = ' . $ilDB->quote($userIdent, 'text');
-        $res = $ilDB->query($query);
-        $row = $ilDB->fetchAssoc($res);
-        if ($row) {
-            return (int) $row['usr_id'];
-        }
-
-        $userId = ilCmiXapiUser::getUsrIdForObjectAndUsrIdent($objId, $userIdent);
-        if ($userId !== null) {
-            return $userId;
-        }
-
-        $query = 'SELECT usr_id, privacy_ident FROM cmix_users'
-            . ' WHERE obj_id = ' . $ilDB->quote($objId, 'integer');
-        $res = $ilDB->query($query);
-        while ($row = $ilDB->fetchAssoc($res)) {
-            $user = new ilObjUser((int) $row['usr_id']);
-            if (ilCmiXapiUser::getIdentAsId((int) $row['privacy_ident'], $user) === $userIdent) {
-                return (int) $row['usr_id'];
-            }
-        }
-
-        return null;
     }
 
     protected static function isValidActivityProgress(string $activityProgress): bool

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceScores.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceScores.php
@@ -229,7 +229,7 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
             'score_maximum' => array('float', $scoreMaximum),
             'activity_progress' => array('text', $score->activityProgress),
             'grading_progress' => array('text', $score->gradingProgress),
-            'lti_timestamp' => array('timestamp',$ltiTimestamp->format("Y-m-d H:i:s")),
+            'lti_timestamp' => array('timestamp', $ltiTimestamp->format("Y-m-d H:i:s")),
             'stored' => array('timestamp', date("Y-m-d H:i:s"))
         ];
         $DIC->database()->insert('lti_consumer_grades', $gradeValues);

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceScores.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceScores.php
@@ -120,7 +120,7 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
         global $DIC;
         $tree = $DIC->repositoryTree();
         $node_data = $tree->getNodeData($resource_link_ref_id);
-        if (!$node_data || $node_data['type'] !== 'lti' ||
+        if (!isset($node_data['type']) || $node_data['type'] !== 'lti' ||
             !in_array($context_id, $tree->getPathId($resource_link_ref_id), true)) {
             throw ilLTIConsumerHttpException::notFound('Resource link not found');
         }

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceScores.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceScores.php
@@ -264,7 +264,22 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
             return (int) $row['usr_id'];
         }
 
-        return ilCmiXapiUser::getUsrIdForObjectAndUsrIdent($objId, $userIdent);
+        $userId = ilCmiXapiUser::getUsrIdForObjectAndUsrIdent($objId, $userIdent);
+        if ($userId !== null) {
+            return $userId;
+        }
+
+        $query = 'SELECT usr_id, privacy_ident FROM cmix_users'
+            . ' WHERE obj_id = ' . $ilDB->quote($objId, 'integer');
+        $res = $ilDB->query($query);
+        while ($row = $ilDB->fetchAssoc($res)) {
+            $user = new ilObjUser((int) $row['usr_id']);
+            if (ilCmiXapiUser::getIdentAsId((int) $row['privacy_ident'], $user) === $userIdent) {
+                return (int) $row['usr_id'];
+            }
+        }
+
+        return null;
     }
 
     protected static function isValidActivityProgress(string $activityProgress): bool

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeSynchronization.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeSynchronization.php
@@ -85,13 +85,19 @@ class ilLTIConsumerGradeSynchronization
             $query .= ' AND lti_timestamp <= ' . $DIC->database()->quote($endDate->get(IL_CAL_DATETIME), 'timestamp');
         }
 
-        $query .= ' ORDER BY lti_timestamp DESC';
+        $query .= ' ORDER BY lti_timestamp DESC, stored DESC';
 
         $res = $DIC->database()->query($query);
 
         $results = [];
+        $seenUsers = [];
 
         while ($row = $DIC->database()->fetchAssoc($res)) {
+            $userId = (int) $row['usr_id'];
+            if (isset($seenUsers[$userId])) {
+                continue;
+            }
+            $seenUsers[$userId] = true;
             $results[] = $row;
         }
 

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeSynchronizationGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeSynchronizationGUI.php
@@ -62,12 +62,12 @@ class ilLTIConsumerGradeSynchronizationGUI
     {
         global $DIC;
 
-        $isMultiActorReport = $this->access->hasOutcomesAccess();
+        $isMultiActorReport = $this->access->hasOutcomesAccess() || $this->access->hasWriteAccess();
 
         $table = new ilLTIConsumerGradeSynchronizationTableGUI($isMultiActorReport);
 
         $cUser = null;
-        if (!$this->access->hasOutcomesAccess()) {
+        if (!$isMultiActorReport) {
             $cUser = $DIC->user()->getId();
         }
 

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeSynchronizationGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeSynchronizationGUI.php
@@ -62,7 +62,7 @@ class ilLTIConsumerGradeSynchronizationGUI
     {
         global $DIC;
 
-        $isMultiActorReport = $this->access->hasOutcomesAccess() || $this->access->hasWriteAccess();
+        $isMultiActorReport = $this->access->hasOutcomesAccess();
 
         $table = new ilLTIConsumerGradeSynchronizationTableGUI($isMultiActorReport);
 

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeSynchronizationTableGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeSynchronizationTableGUI.php
@@ -69,6 +69,7 @@ class ilLTIConsumerGradeSynchronizationTableGUI implements DataRetrieval
         $records = $this->applyOrdering($this->records, $order, $range);
         foreach ($records as $record) {
             $record['lti_timestamp'] = new DateTimeImmutable($record['lti_timestamp']);
+            $record['actor'] = ilObjUser::_lookupFullname((int) $record['usr_id']);
             $record['score_given'] = $record['score_given'] . ' / ' . $record['score_maximum'];
             $record['activity_progress'] = $this->lng->txt('grade_activity_progress_' . strtolower($record['activity_progress']));
             $record['grading_progress'] = $this->lng->txt('grade_grading_progress_' . strtolower($record['grading_progress']));

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradingProgress.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradingProgress.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+enum ilLTIConsumerGradingProgress: string
+{
+    case FULLY_GRADED = 'FullyGraded';
+    case PENDING = 'Pending';
+    case PENDING_MANUAL = 'PendingManual';
+    case FAILED = 'Failed';
+    case NOT_READY = 'NotReady';
+
+    public function isPending(): bool
+    {
+        return $this !== self::FULLY_GRADED;
+    }
+}

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradingProgress.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradingProgress.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 declare(strict_types=1);
 
 enum ilLTIConsumerGradingProgress: string

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerHttpException.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerHttpException.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 declare(strict_types=1);
 
 final class ilLTIConsumerHttpException extends RuntimeException

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerHttpException.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerHttpException.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+final class ilLTIConsumerHttpException extends RuntimeException
+{
+    public static function badRequest(string $message): self
+    {
+        return new self($message, 400);
+    }
+
+    public static function unauthorized(string $message = 'invalid request'): self
+    {
+        return new self($message, 401);
+    }
+
+    public static function forbidden(string $message): self
+    {
+        return new self($message, 403);
+    }
+
+    public static function notFound(string $message): self
+    {
+        return new self($message, 404);
+    }
+}

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerLineItem.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerLineItem.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+final readonly class ilLTIConsumerLineItem
+{
+    public function __construct(
+        public int $id,
+        public int $contextId,
+        public string $clientId,
+        public string $label,
+        public float $scoreMaximum,
+        public string $resourceId,
+        public string $resourceLinkId,
+        public string $tag
+    ) {
+    }
+
+    public function withValues(
+        string $label,
+        float $scoreMaximum,
+        string $resourceId,
+        string $resourceLinkId,
+        string $tag
+    ): self {
+        return new self(
+            $this->id,
+            $this->contextId,
+            $this->clientId,
+            $label,
+            $scoreMaximum,
+            $resourceId,
+            $resourceLinkId,
+            $tag
+        );
+    }
+}

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerLineItem.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerLineItem.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 declare(strict_types=1);
 
 final readonly class ilLTIConsumerLineItem

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerLineItemRepository.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerLineItemRepository.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+final class ilLTIConsumerLineItemRepository
+{
+    public function __construct(private readonly ilDBInterface $db)
+    {
+    }
+
+    /** @return list<ilLTIConsumerLineItem> */
+    public function getForContextAndClient(int $contextId, string $clientId): array
+    {
+        $result = $this->db->query(
+            'SELECT * FROM lti_consumer_lineitems'
+            . ' WHERE context_id = ' . $this->db->quote($contextId, 'integer')
+            . ' AND client_id = ' . $this->db->quote($clientId, 'text')
+            . ' AND enabled = ' . $this->db->quote(1, 'integer')
+        );
+
+        $lineItems = [];
+        while ($row = $this->db->fetchAssoc($result)) {
+            $lineItems[] = $this->fromRow($row);
+        }
+        return $lineItems;
+    }
+
+    public function get(int $id, int $contextId, string $clientId): ?ilLTIConsumerLineItem
+    {
+        $result = $this->db->query(
+            'SELECT * FROM lti_consumer_lineitems'
+            . ' WHERE id = ' . $this->db->quote($id, 'integer')
+            . ' AND context_id = ' . $this->db->quote($contextId, 'integer')
+            . ' AND client_id = ' . $this->db->quote($clientId, 'text')
+            . ' AND enabled = ' . $this->db->quote(1, 'integer')
+        );
+        $row = $this->db->fetchAssoc($result);
+
+        return $row ? $this->fromRow($row) : null;
+    }
+
+    public function create(
+        int $contextId,
+        string $clientId,
+        ?string $label,
+        float $scoreMaximum,
+        string $resourceId,
+        string $resourceLinkId,
+        string $tag
+    ): ilLTIConsumerLineItem {
+        $id = $this->db->nextId('lti_consumer_lineitems');
+        $lineItem = new ilLTIConsumerLineItem(
+            $id,
+            $contextId,
+            $clientId,
+            $label ?? 'Line Item ' . $id,
+            $scoreMaximum,
+            $resourceId,
+            $resourceLinkId,
+            $tag
+        );
+        $this->db->insert('lti_consumer_lineitems', [
+            'id' => ['integer', $lineItem->id],
+            'context_id' => ['integer', $lineItem->contextId],
+            'obj_id' => ['integer', null],
+            'client_id' => ['text', $lineItem->clientId],
+            'label' => ['text', $lineItem->label],
+            'score_maximum' => ['float', $lineItem->scoreMaximum],
+            'resource_id' => ['text', $lineItem->resourceId],
+            'resource_link_id' => ['text', $lineItem->resourceLinkId],
+            'tag' => ['text', $lineItem->tag],
+            'enabled' => ['integer', 1]
+        ]);
+
+        return $lineItem;
+    }
+
+    public function update(ilLTIConsumerLineItem $lineItem): void
+    {
+        $this->db->update('lti_consumer_lineitems', [
+            'label' => ['text', $lineItem->label],
+            'score_maximum' => ['float', $lineItem->scoreMaximum],
+            'resource_id' => ['text', $lineItem->resourceId],
+            'resource_link_id' => ['text', $lineItem->resourceLinkId],
+            'tag' => ['text', $lineItem->tag]
+        ], [
+            'id' => ['integer', $lineItem->id]
+        ]);
+    }
+
+    public function disable(ilLTIConsumerLineItem $lineItem): void
+    {
+        $this->db->update('lti_consumer_lineitems', [
+            'enabled' => ['integer', 0]
+        ], [
+            'id' => ['integer', $lineItem->id]
+        ]);
+    }
+
+    /** @param array<string, mixed> $row */
+    private function fromRow(array $row): ilLTIConsumerLineItem
+    {
+        return new ilLTIConsumerLineItem(
+            (int) $row['id'],
+            (int) $row['context_id'],
+            (string) ($row['client_id'] ?? ''),
+            (string) ($row['label'] ?? ''),
+            (float) ($row['score_maximum'] ?? 1),
+            (string) ($row['resource_id'] ?? ''),
+            (string) ($row['resource_link_id'] ?? ''),
+            (string) ($row['tag'] ?? '')
+        );
+    }
+}

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerLineItemRepository.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerLineItemRepository.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 declare(strict_types=1);
 
 final class ilLTIConsumerLineItemRepository

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResourceBase.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResourceBase.php
@@ -148,9 +148,24 @@ abstract class ilLTIConsumerResourceBase
     {
         $token = $this->getService()->checkTool();
         $permittedScopes = $this->getService()->getPermittedScopes();
-        if (empty($scopes) || empty(array_intersect($permittedScopes, $scopes))) {
-            $token = null;
+
+        if ($token === null || empty($scopes) || empty(array_intersect($permittedScopes, $scopes))) {
+            return null;
         }
+
+        $tokenScope = $token->{'imsglobal.org.security.scope'} ?? '';
+        if (is_string($tokenScope)) {
+            $tokenScopes = preg_split('/\s+/', trim($tokenScope)) ?: [];
+        } elseif (is_array($tokenScope)) {
+            $tokenScopes = $tokenScope;
+        } else {
+            $tokenScopes = [];
+        }
+
+        if (empty(array_intersect($tokenScopes, $scopes))) {
+            return null;
+        }
+
         return $token;
     }
 }

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResourceBase.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResourceBase.php
@@ -208,7 +208,7 @@ abstract class ilLTIConsumerResourceBase
                 return true;
             }
 
-            if (strpos($filter, '@') === false && strpos($candidate, $filter . '@') === 0) {
+            if (strpos($filter, '@') === false && str_starts_with($candidate, $filter . '@')) {
                 return true;
             }
         }

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResourceBase.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResourceBase.php
@@ -226,8 +226,8 @@ abstract class ilLTIConsumerResourceBase
             . ' WHERE obj_id = ' . $ilDB->quote($objId, 'integer')
             . ' AND usr_id = ' . $ilDB->quote($userId, 'integer');
         $res = $ilDB->query($query);
+        $user = new ilObjUser($userId);
         while ($row = $ilDB->fetchAssoc($res)) {
-            $user = new ilObjUser($userId);
             $idents[] = (string) $row['usr_ident'];
             $idents[] = ilCmiXapiUser::getIdentAsId((int) $row['privacy_ident'], $user);
         }

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResourceBase.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResourceBase.php
@@ -144,7 +144,8 @@ abstract class ilLTIConsumerResourceBase
     /**
      * Check to make sure the request is valid.
      */
-    public function checkTool(array $scopes = array()): ?object
+    /** @param list<string> $scopes */
+    public function checkTool(array $scopes = array()): ?ilLTIConsumerAccessToken
     {
         $token = $this->getService()->checkTool();
         $permittedScopes = $this->getService()->getPermittedScopes();
@@ -153,16 +154,7 @@ abstract class ilLTIConsumerResourceBase
             return null;
         }
 
-        $tokenScope = $token->{'imsglobal.org.security.scope'} ?? '';
-        if (is_string($tokenScope)) {
-            $tokenScopes = preg_split('/\s+/', trim($tokenScope)) ?: [];
-        } elseif (is_array($tokenScope)) {
-            $tokenScopes = $tokenScope;
-        } else {
-            $tokenScopes = [];
-        }
-
-        if (empty(array_intersect($tokenScopes, $scopes))) {
+        if (empty(array_intersect($token->getScopes(), $scopes))) {
             return null;
         }
 

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResourceBase.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResourceBase.php
@@ -168,4 +168,70 @@ abstract class ilLTIConsumerResourceBase
 
         return $token;
     }
+
+    protected function resolveUserIdFromLtiIdent(int $objId, string $userIdent): ?int
+    {
+        global $DIC;
+        $ilDB = $DIC->database();
+
+        $query = 'SELECT usr_id FROM cmix_users'
+            . ' WHERE obj_id = ' . $ilDB->quote($objId, 'integer')
+            . ' AND usr_ident = ' . $ilDB->quote($userIdent, 'text');
+        $res = $ilDB->query($query);
+        $row = $ilDB->fetchAssoc($res);
+        if ($row) {
+            return (int) $row['usr_id'];
+        }
+
+        $userId = ilCmiXapiUser::getUsrIdForObjectAndUsrIdent($objId, $userIdent);
+        if ($userId !== null) {
+            return $userId;
+        }
+
+        $query = 'SELECT usr_id, privacy_ident FROM cmix_users'
+            . ' WHERE obj_id = ' . $ilDB->quote($objId, 'integer');
+        $res = $ilDB->query($query);
+        while ($row = $ilDB->fetchAssoc($res)) {
+            $user = new ilObjUser((int) $row['usr_id']);
+            if (ilCmiXapiUser::getIdentAsId((int) $row['privacy_ident'], $user) === $userIdent) {
+                return (int) $row['usr_id'];
+            }
+        }
+
+        return null;
+    }
+
+    protected function matchesLtiUserIdent(int $objId, int $userId, string $userIdent, string $filter): bool
+    {
+        foreach ($this->getLtiUserIdentCandidates($objId, $userId, $userIdent) as $candidate) {
+            if ($candidate === $filter) {
+                return true;
+            }
+
+            if (strpos($filter, '@') === false && strpos($candidate, $filter . '@') === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function getLtiUserIdentCandidates(int $objId, int $userId, string $userIdent): array
+    {
+        global $DIC;
+        $ilDB = $DIC->database();
+
+        $idents = [$userIdent, (string) $userId];
+        $query = 'SELECT usr_ident, privacy_ident FROM cmix_users'
+            . ' WHERE obj_id = ' . $ilDB->quote($objId, 'integer')
+            . ' AND usr_id = ' . $ilDB->quote($userId, 'integer');
+        $res = $ilDB->query($query);
+        while ($row = $ilDB->fetchAssoc($res)) {
+            $user = new ilObjUser($userId);
+            $idents[] = (string) $row['usr_ident'];
+            $idents[] = ilCmiXapiUser::getIdentAsId((int) $row['privacy_ident'], $user);
+        }
+
+        return array_values(array_unique(array_filter($idents, static fn($ident): bool => $ident !== '')));
+    }
 }

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResult.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResult.php
@@ -168,6 +168,11 @@ class ilLTIConsumerResult
         return $this->result;
     }
 
+    public function setAttended(bool $attended): void
+    {
+        $this->attended = $attended;
+    }
+
     /**
      * @param $objId
      * @return ilLTIConsumerResult[]

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResult.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResult.php
@@ -49,6 +49,11 @@ class ilLTIConsumerResult
     public ?float $result = null;
 
     /**
+     * @var bool
+     */
+    public bool $attended = false;
+
+    /**
      * Get a result by id
      */
     public static function getById(int $a_id): ?ilLTIConsumerResult
@@ -110,6 +115,7 @@ class ilLTIConsumerResult
         $this->obj_id = (int) $data['obj_id'];
         $this->usr_id = (int) $data['usr_id'];
         $this->result = $data['result'] == null ? null : (float) $data['result'];
+        $this->attended = (bool) $data['attended'];
     }
 
     /**
@@ -142,7 +148,8 @@ class ilLTIConsumerResult
             array(
                 'obj_id' => array('integer', $this->obj_id),
                 'usr_id' => array('integer', $this->usr_id),
-                'result' => array('float', $this->result)
+                'result' => array('float', $this->result),
+                'attended' => array('integer', $this->attended)
             )
         );
         return true;

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResultService.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResultService.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 use ceLTIc\LTI\OAuth\OAuthRequest;
 use ceLTIc\LTI\OAuth\OAuthServer;
 use ceLTIc\LTI\OAuth\OAuthSignatureMethod_HMAC_SHA1;
+use ceLTIc\LTI\OAuth\OAuthUtil;
 use ceLTIc\LTI\OAuthDataStore;
 
 /**
@@ -137,10 +138,12 @@ class ilLTIConsumerResultService
 
             // Verify the signature
             $this->readFields($this->result->obj_id);
-            $result = $this->checkSignature($this->fields['KEY'], $this->fields['SECRET']);
-            if ($result instanceof Exception) {
-                $logger->error('LTI Consumer Result Service: Incoming request');
-                $this->respondUnauthorized($result->getMessage());
+            try {
+                $this->checkSignature($this->fields['KEY'], $this->fields['SECRET']);
+            } catch (Exception $e) {
+                $logger->error('LTI Consumer Result Service: Incoming request failed: ' . $e->getMessage());
+                $logger->debug('Incoming request failed: ' . $e->getTraceAsString());
+                $this->respondUnauthorized();
                 return;
             }
 
@@ -206,12 +209,13 @@ class ilLTIConsumerResultService
             $description = "The result is out of range from 0 to 1.";
         } else {
             $this->result->result = (float) $result;
+            $this->result->setAttended(true);
             $this->result->save();
 
             if ($result >= $this->getMasteryScore()) {
                 $lp_status = ilLPStatus::LP_STATUS_COMPLETED_NUM;
             } else {
-                $lp_status = ilLPStatus::LP_STATUS_IN_PROGRESS_NUM;
+                $lp_status = ilLPStatus::LP_STATUS_FAILED_NUM;
             }
             $lp_percentage = (int) round(100 * $result);
 
@@ -241,9 +245,10 @@ class ilLTIConsumerResultService
     protected function deleteResult(\SimpleXMLElement $request): void
     {
         $this->result->result = null;
+        $this->result->setAttended(false);
         $this->result->save();
 
-        $lp_status = ilLPStatus::LP_STATUS_IN_PROGRESS_NUM;
+        $lp_status = ilLPStatus::LP_STATUS_NOT_ATTEMPTED_NUM;
         $lp_percentage = 0;
         ilLPStatus::writeStatus($this->result->obj_id, $this->result->usr_id, $lp_status, $lp_percentage, true);
 
@@ -363,7 +368,7 @@ class ilLTIConsumerResultService
 
         $query = "
 			SELECT lti_ext_provider.provider_key, lti_ext_provider.provider_secret, lti_consumer_settings.launch_key, lti_consumer_settings.launch_secret
-			FROM lti_ext_provider, lti_consumer_settings
+                FROM lti_ext_provider, lti_consumer_settings
 			WHERE lti_ext_provider.id = lti_consumer_settings.provider_id
 			AND lti_consumer_settings.obj_id = %s
 		";
@@ -385,30 +390,34 @@ class ilLTIConsumerResultService
     }
 
     /**
-     * Check the reqest signature
-     * @return bool    Exception or true
+     * Check the request signature
+     * @throws Exception in case of failure
      */
-    private function checkSignature(string $a_key, string $a_secret): bool
+    private function checkSignature(string $a_key, string $a_secret): void
     {
+        global $DIC;
+        $logger = $DIC->logger()->root();
         $platform = new ilLTIPlatform();
 
         $platform->setKey($a_key);
         $platform->setSecret($a_secret);
+        $platform->setRecordId($this->result->obj_id);
 
         $store = new OAuthDataStore($platform);
 
         $server = new OAuthServer($store);
         $method = new OAuthSignatureMethod_HMAC_SHA1();
+
         $server->add_signature_method($method);
+        $logger->info("s_key: " . $a_key . " s_secret: " . $a_secret . " platform key: " . $platform->getKey());
 
-        $request = OAuthRequest::from_request();
-
-        try {
-            $server->verify_request($request);
-        } catch (Exception $e) {
-            return false;
+        $request_headers = OAuthUtil::get_headers();
+        if (isset($request_headers['Authorization']) && str_starts_with($request_headers['Authorization'], 'OAuth ')) {
+            $parameters = OAuthUtil::split_header($request_headers['Authorization']);
         }
-        return true;
+        $request = OAuthRequest::from_request(null, null, $parameters ?? []);
+        $logger->info("Request: " . json_encode($request));
+        $server->verify_request($request);
     }
 
     protected function updateLP(): void

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerServiceBase.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerServiceBase.php
@@ -115,9 +115,10 @@ abstract class ilLTIConsumerServiceBase
     /**
      * Check that the request has been properly signed and is permitted.
      */
-    public function checkTool(): ?object
+    public function checkTool(): ?ilLTIConsumerAccessToken
     {
-        return ilObjLTIConsumer::verifyToken();
+        $token = ilObjLTIConsumer::verifyToken();
+        return $token === null ? null : ilLTIConsumerAccessToken::fromVerifiedToken($token);
     }
 
     /**

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerServiceResponse.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerServiceResponse.php
@@ -195,14 +195,12 @@ class ilLTIConsumerServiceResponse
         $this->body = $body;
     }
 
-    /**
-     * Add an additional header.
-     */
-    /*
-    public function add_additional_header(string $header): void {
+    /** Add an additional header. */
+    public function addAdditionalHeader(string $header): void
+    {
         $this->additionalheaders[] = $header;
     }
-    */
+
     /**
      * Send the response.
      */

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerSettingsFormGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerSettingsFormGUI.php
@@ -143,7 +143,7 @@ class ilLTIConsumerSettingsFormGUI extends ilPropertyFormGUI
         $item->addOption($optEmbedded);
         $this->addItem($item);
 
-        $customParams = new ilTextAreaInputGUI($DIC->language()->txt('launch_custom_params'), 'custom_params');
+        $customParams = new ilTextAreaInputGUI($DIC->language()->txt('lti_con_prov_custom_params'), 'custom_params');
         $customParams->setRows(6);
         $customParams->setValue($this->object->getCustomParams());
         $customParams->setInfo($DIC->language()->txt('lti_con_prov_custom_params_info'));

--- a/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumer.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumer.php
@@ -885,9 +885,11 @@ class ilObjLTIConsumer extends ilObject2
                 break;
         }
 
-        $userIdLTI = ilCmiXapiUser::getIdentAsId($this->getProvider()->getPrivacyIdent(), $DIC->user());
-
         $emailPrimary = $cmixUser->getUsrIdent();
+        $userIdLTI = ilCmiXapiUser::getIdentAsId($this->getProvider()->getPrivacyIdent(), $DIC->user());
+        if ($this->getProvider()->getPrivacyIdent() == ilObjCmiXapi::PRIVACY_IDENT_IL_UUID_RANDOM) {
+            $userIdLTI = strstr($emailPrimary, '@' . ilCmiXapiUser::getIliasUuid(), true);
+        }
 
         ilLTIConsumerResult::getByKeys($this->getId(), $DIC->user()->getId(), true);
 

--- a/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumer.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumer.php
@@ -66,6 +66,8 @@ class ilObjLTIConsumer extends ilObject2
 
     protected string $customParams = '';
 
+    protected float $scoreMaximum = 1.0;
+
     protected ?int $ref_id = 0;
 
     //Highscore
@@ -169,6 +171,16 @@ class ilObjLTIConsumer extends ilObject2
     public function setMasteryScorePercent(float $mastery_score_percent): void
     {
         $this->mastery_score = $mastery_score_percent / 100;
+    }
+
+    public function getScoreMaximum(): float
+    {
+        return $this->scoreMaximum;
+    }
+
+    public function setScoreMaximum(float $scoreMaximum): void
+    {
+        $this->scoreMaximum = $scoreMaximum;
     }
 
     public function getProviderId(): int
@@ -386,6 +398,9 @@ class ilObjLTIConsumer extends ilObject2
             $this->setHighscoreTopNum((int) $row['highscore_top_num']);
 
             $this->setMasteryScore((float) $row['mastery_score']);
+            if (isset($row['score_maximum'])) {
+                $this->setScoreMaximum((float) $row['score_maximum']);
+            }
         }
 
         $this->loadRepositoryActivationSettings();
@@ -419,7 +434,8 @@ class ilObjLTIConsumer extends ilObject2
             'highscore_own_table' => ['integer', (int) $this->getHighscoreOwnTable()],
             'highscore_top_table' => ['integer', (int) $this->getHighscoreTopTable()],
             'highscore_top_num' => ['integer', $this->getHighscoreTopNum()],
-            'mastery_score' => ['float', $this->getMasteryScore()]
+            'mastery_score' => ['float', $this->getMasteryScore()],
+            'score_maximum' => ['float', $this->getScoreMaximum()]
         ]);
 
         $this->saveRepositoryActivationSettings();
@@ -914,15 +930,29 @@ class ilObjLTIConsumer extends ilObject2
 
         if ($this->getProvider()->isGradeSynchronization()) {
             $gradeservice = new ilLTIConsumerGradeService();
-            $launch_vars['custom_lineitem_url'] = self::getIliasHttpPath(
-            ) . "/ltiservices.php/gradeservice/" . $contextId . "/lineitems/" . $this->id . "/lineitem";
+            $lineitemUrl = self::getIliasHttpPath()
+                . "/ltiservices.php/gradeservice/" . $contextId . "/lineitems/" . $this->id . "/lineitem";
+            $lineitemsUrl = self::getIliasHttpPath()
+                . "/ltiservices.php/gradeservice/" . $contextId . "/lineitems";
+
+            $launch_vars['custom_lineitem_url'] = $lineitemUrl;
 
             // ! Moodle as tool provider requires a custom_lineitems_url even though this should be optional in launch request, especially if only posting score scope is permitted by platform
             // http://www.imsglobal.org/spec/lti-ags/v2p0#example-link-has-a-single-line-item-tool-can-only-post-score
-            $launch_vars['custom_lineitems_url'] = self::getIliasHttpPath(
-            ) . "/ltiservices.php/gradeservice/" . $contextId . "/linetitems/";
+            $launch_vars['custom_lineitems_url'] = $lineitemsUrl;
 
             $launch_vars['custom_ags_scopes'] = implode(",", $gradeservice->getPermittedScopes());
+
+            if ($additionalArguments === null) {
+                $additionalArguments = [];
+            }
+            if (!isset($additionalArguments[self::LTI_JWT_CLAIM_PREFIX . '/claim/message_type'])) {
+                $additionalArguments['https://purl.imsglobal.org/spec/lti-ags/claim/endpoint'] = [
+                    'scope' => $gradeservice->getPermittedScopes(),
+                    'lineitems' => $lineitemsUrl,
+                    'lineitem' => $lineitemUrl
+                ];
+            }
         }
 
         if (!empty(self::verifyPrivateKey())) {
@@ -1333,6 +1363,9 @@ class ilObjLTIConsumer extends ilObject2
                 $provider->setContentItemUrl($message['target_link_uri']);
             }
         }
+        if (self::registrationRequestsAgs($data, $toolConfig)) {
+            $provider->setGradeSynchronization(true);
+        }
         /*
         if (isset($data['logo_uri'])) { // needs to be uploaded and then assign filepath
             $provider->setProviderIconFilename($data['logo_uri']);
@@ -1348,6 +1381,42 @@ class ilObjLTIConsumer extends ilObject2
         $reponseData['client_id'] = $tokenObj->aud;
         $reponseData['https://purl.imsglobal.org/spec/lti-tool-configuration']['deployment_id'] = $provider->getId();
         return $reponseData;
+    }
+
+    private static function registrationRequestsAgs(array $data, array $toolConfig): bool
+    {
+        $requestedScopes = [];
+        foreach ([$data['scope'] ?? null, $data['scopes'] ?? null] as $scopeValue) {
+            $requestedScopes = array_merge($requestedScopes, self::normalizeRegistrationScopes($scopeValue));
+        }
+
+        if (isset($toolConfig['services']) && is_array($toolConfig['services'])) {
+            foreach ($toolConfig['services'] as $service) {
+                if (!is_array($service)) {
+                    continue;
+                }
+                $requestedScopes = array_merge(
+                    $requestedScopes,
+                    self::normalizeRegistrationScopes($service['scope'] ?? null),
+                    self::normalizeRegistrationScopes($service['scopes'] ?? null)
+                );
+            }
+        }
+
+        $requestedScopes = array_unique($requestedScopes);
+        $agsScopes = (new ilLTIConsumerGradeService())->getPermittedScopes();
+        return !empty(array_intersect($requestedScopes, $agsScopes));
+    }
+
+    private static function normalizeRegistrationScopes(mixed $scopeValue): array
+    {
+        if (is_string($scopeValue)) {
+            return preg_split('/\s+/', trim($scopeValue)) ?: [];
+        }
+        if (is_array($scopeValue)) {
+            return array_values(array_filter($scopeValue, static fn($scope): bool => is_string($scope) && $scope !== ''));
+        }
+        return [];
     }
 
     public static function getNewClientId(): string

--- a/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumer.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumer.php
@@ -945,10 +945,10 @@ class ilObjLTIConsumer extends ilObject2
 
         if ($this->getProvider()->isGradeSynchronization() || $this->getProvider()->getHasOutcome()) {
             $gradeservice = new ilLTIConsumerGradeService();
-            $lineitemUrl = self::getIliasHttpPath()
-                . "/ltiservices.php/gradeservice/" . $contextId . "/lineitems/" . $this->id . "/lineitem";
-            $lineitemsUrl = self::getIliasHttpPath()
-                . "/ltiservices.php/gradeservice/" . $contextId . "/lineitems";
+            // the launch claim and the id the tool reads back from the service must be
+            // identical (AGS 2.0 §3.3.4.3), so both go through the same builder
+            $lineitemUrl = ilLTIConsumerGradeServiceLineItem::buildLineItemUrl((int) $contextId, (int) $this->id);
+            $lineitemsUrl = ilLTIConsumerGradeServiceLineItem::buildLineItemsUrl((int) $contextId);
 
             $launch_vars['custom_lineitem_url'] = $lineitemUrl;
 

--- a/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumer.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumer.php
@@ -1343,6 +1343,34 @@ class ilObjLTIConsumer extends ilObject2
         return self::getIliasHttpPath() . "/lticerts.php";
     }
 
+    public static function fetchPublicKeyset(string $url): string
+    {
+        $connection = new ilCurlConnection($url);
+
+        try {
+            $connection->init();
+            $connection->setOpt(CURLOPT_RETURNTRANSFER, true);
+            $connection->setOpt(CURLOPT_FOLLOWLOCATION, true);
+            $connection->setOpt(CURLOPT_MAXREDIRS, 3);
+            $connection->setOpt(CURLOPT_CONNECTTIMEOUT, 10);
+            $connection->setOpt(CURLOPT_TIMEOUT, 20);
+            $connection->setOpt(CURLOPT_HTTPHEADER, array(
+                'Accept: application/json, application/jwk-set+json',
+                'User-Agent: ILIAS LTI Consumer'
+            ));
+
+            $keyset = $connection->exec();
+            $status = (int) $connection->getInfo(CURLINFO_RESPONSE_CODE);
+            if ($status < 200 || $status >= 300 || !is_string($keyset)) {
+                throw new ilLtiConsumerException('cannot fetch public keyset');
+            }
+
+            return $keyset;
+        } finally {
+            $connection->close();
+        }
+    }
+
     public static function getRegistrationUrl(): string
     {
         return self::getIliasHttpPath() . "/ltiregistration.php";

--- a/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumer.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumer.php
@@ -108,6 +108,24 @@ class ilObjLTIConsumer extends ilObject2
         parent::__construct($a_id, $a_reference);
     }
 
+    public static function getRefIdOfConsumerByDeploymentId(string $dep_id): int|null
+    {
+        global $ilDB;
+        $refId = null;
+        $refIds = array();
+        $query = /** @lang text */
+            'SELECT ref_id from lti_consumer_settings join object_reference on lti_consumer_settings.obj_id=object_reference.obj_id where provider_id = ' . $dep_id;
+        $res = $ilDB->query($query);
+        while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
+            $refIds[] = $row->ref_id;
+        }
+
+        if (!empty($refIds)) {
+            $refId = $refIds[0];
+        }
+        return $refId;
+    }
+
     protected function initType(): void
     {
         $this->type = "lti";
@@ -765,7 +783,6 @@ class ilObjLTIConsumer extends ilObject2
             "lis_person_name_full" => $nameFull,
             "lis_person_contact_email_primary" => $emailPrimary,
             "context_id" => $contextId,
-            "context_type" => $contextType,
             "context_title" => $contextTitle,
             "context_label" => $contextType . " " . $contextId,
             "launch_presentation_locale" => $this->lng->getLangKey(),
@@ -788,8 +805,7 @@ class ilObjLTIConsumer extends ilObject2
             "tool_consumer_info_version" => ILIAS_VERSION,
             "lis_result_sourcedid" => $token,
             "lis_outcome_service_url" => self::getIliasHttpPath(
-            ) . "/ltiresult.php?client_id=" . CLIENT_ID,
-            "role_scope_mentor" => ""
+            ) . "/ltiresult.php?client_id=" . CLIENT_ID
         ];
 
         $OAuthParams = [
@@ -820,7 +836,8 @@ class ilObjLTIConsumer extends ilObject2
         string $contextType,
         string $contextId,
         string $contextTitle,
-        ?string $returnUrl = ''
+        ?string $returnUrl = '',
+        ?array $additionalArguments = null
     ): ?array {
         global $DIC;
         /* @var \ILIAS\DI\Container $DIC */
@@ -881,7 +898,7 @@ class ilObjLTIConsumer extends ilObject2
         }
         $toolConsumerInstanceGuid .= $parseIliasUrl["host"];
         $launch_vars = [
-            "lti_message_type" => "basic-lti-launch-request",
+            "lti_message_type" => "LtiResourceLinkRequest",
             "lti_version" => "1.3.0",
             "resource_link_id" => (string) $resource_link_id,
             "resource_link_title" => $this->getTitle(),
@@ -914,11 +931,7 @@ class ilObjLTIConsumer extends ilObject2
             "tool_consumer_instance_contact_email" => $DIC->settings()->get("admin_email"),
             "launch_presentation_css_url" => "",
             "tool_consumer_info_product_family_code" => "ilias",
-            "tool_consumer_info_version" => ILIAS_VERSION,
-            "lis_result_sourcedid" => $token,
-            "lis_outcome_service_url" => self::getIliasHttpPath(
-            ) . "/ltiresult.php?client_id=" . CLIENT_ID,
-            "role_scope_mentor" => ""
+            "tool_consumer_info_version" => ILIAS_VERSION
         ];
 
         $provider_custom_params = self::getProviderCustomParamsArray($this->getProvider());
@@ -928,7 +941,7 @@ class ilObjLTIConsumer extends ilObject2
             $launch_vars['custom_' . $key] = $value;
         }
 
-        if ($this->getProvider()->isGradeSynchronization()) {
+        if ($this->getProvider()->isGradeSynchronization() || $this->getProvider()->getHasOutcome()) {
             $gradeservice = new ilLTIConsumerGradeService();
             $lineitemUrl = self::getIliasHttpPath()
                 . "/ltiservices.php/gradeservice/" . $contextId . "/lineitems/" . $this->id . "/lineitem";
@@ -939,6 +952,7 @@ class ilObjLTIConsumer extends ilObject2
 
             // ! Moodle as tool provider requires a custom_lineitems_url even though this should be optional in launch request, especially if only posting score scope is permitted by platform
             // http://www.imsglobal.org/spec/lti-ags/v2p0#example-link-has-a-single-line-item-tool-can-only-post-score
+
             $launch_vars['custom_lineitems_url'] = $lineitemsUrl;
 
             $launch_vars['custom_ags_scopes'] = implode(",", $gradeservice->getPermittedScopes());
@@ -959,7 +973,7 @@ class ilObjLTIConsumer extends ilObject2
             $DIC->ui()->mainTemplate()->setOnScreenMessage('failure', 'ERROR_OPEN_SSL_CONF', true);
             return null;
         }
-        return self::LTISignJWT($launch_vars, $endpoint, $clientId, $deploymentId, $nonce);
+        return self::LTISignJWT($launch_vars, $endpoint, $clientId, $deploymentId, $nonce, $additionalArguments);
     }
 
     /**
@@ -1076,7 +1090,8 @@ class ilObjLTIConsumer extends ilObject2
         string $endpoint,
         string $oAuthConsumerKey,
         $typeId = 0,
-        string $nonce = ''
+        string $nonce = '',
+        ?array $additionalPayload = null,
     ): array {
         if (empty($typeId)) {
             $typeId = 0;
@@ -1119,6 +1134,28 @@ class ilObjLTIConsumer extends ilObject2
             $payLoad[self::LTI_JWT_CLAIM_PREFIX . '/claim/target_link_uri'] = $endpoint;
         }
 
+        if (!empty($parms['custom_lineitem_url']) || !empty($parms['custom_lineitems_url']) || !empty($parms['custom_ags_scopes'])) {
+            $ags_claim = [];
+
+            if (!empty($parms['custom_lineitem_url'])) {
+                $ags_claim['lineitem'] = $parms['custom_lineitem_url'];
+            }
+            if (!empty($parms['custom_lineitems_url'])) {
+                $ags_claim['lineitems'] = $parms['custom_lineitems_url'];
+            }
+            if (!empty($parms['custom_ags_scopes'])) {
+                // scopes are comma-separated in launch_vars
+                $ags_claim['scope'] = array_values(array_filter(array_map('trim', explode(',', $parms['custom_ags_scopes']))));
+            }
+
+            if (!empty($ags_claim)) {
+                $payLoad['https://purl.imsglobal.org/spec/lti-ags/claim/endpoint'] = $ags_claim;
+            }
+
+            // prevent them from also being added to custom/claim/custom later
+            unset($parms['custom_lineitem_url'], $parms['custom_lineitems_url'], $parms['custom_ags_scopes']);
+        }
+
         foreach ($parms as $key => $value) {
             $claim = self::LTI_JWT_CLAIM_PREFIX;
             if (array_key_exists($key, $claimMapping)) {
@@ -1148,11 +1185,13 @@ class ilObjLTIConsumer extends ilObject2
                 $payLoad["{$claim}/claim/ext"][substr($key, 4)] = $value;
             }
         }
-        //self::getLogger()->debug(json_encode($payLoad,JSON_PRETTY_PRINT));
         if (!empty(self::verifyPrivateKey())) {
             throw new DomainException(self::ERROR_OPEN_SSL_CONF);
         }
         $privateKey = self::getPrivateKey();
+        if (isset($additionalPayload)) {
+            $payLoad = array_merge($payLoad, $additionalPayload);
+        }
         $jwt = Firebase\JWT\JWT::encode($payLoad, $privateKey['key'], 'RS256', $privateKey['kid']);
         $newParms = array();
         $newParms['id_token'] = $jwt;
@@ -1235,6 +1274,13 @@ class ilObjLTIConsumer extends ilObject2
         global $DIC;
 
         $logger = $DIC->logger()->root();
+        $f = new \ILIAS\Data\Factory();
+
+        if (!ilContext::usesHTTP() || !isset($_SERVER['HTTP_HOST'], $_SERVER['REQUEST_URI'])) {
+            $iliasHttpPath = ilContext::modifyHttpPath($DIC['ilIliasIniFile']->readVariable('server', 'http_path'));
+            $uri = $f->uri(rtrim($iliasHttpPath, "/"));
+            return $uri->getBaseURI();
+        }
 
         if ($DIC['https']->isDetected()) {
             $protocol = 'https://';
@@ -1261,7 +1307,6 @@ class ilObjLTIConsumer extends ilObject2
         $uri = str_replace("components/ILIAS/LTIConsumer", "", $uri);
         $logger->info("URI --- 2: " . $uri);
         $iliasHttpPath = ilContext::modifyHttpPath(implode('', [$protocol, $host, $uri]));
-        $f = new \ILIAS\Data\Factory();
         $uri = $f->uri(rtrim($iliasHttpPath, "/"));
         return $uri->getBaseURI();
     }
@@ -1351,7 +1396,11 @@ class ilObjLTIConsumer extends ilObject2
         $reponseData = $data;
         $provider = new ilLTIConsumeProvider();
         $toolConfig = $data['https://purl.imsglobal.org/spec/lti-tool-configuration'];
-        $provider->setTitle(strip_tags($data['client_name'], ilObjectGUI::ALLOWED_TAGS_IN_TITLE_AND_DESCRIPTION));
+        $provider->setTitle(
+            $DIC->refinery()->encode()->htmlSpecialCharsAsEntities()->transform(
+                $data['client_name']
+            )
+        );
         $provider->setProviderUrl($toolConfig['target_link_uri']);
         $provider->setInitiateLogin($data['initiate_login_uri']);
         $provider->setRedirectionUris(implode(",", $data['redirect_uris']));
@@ -1472,7 +1521,7 @@ class ilObjLTIConsumer extends ilObject2
         return file_get_contents('php://input');
     }
 
-    public static function getTokenObject(string $token): ?object
+    public static function getTokenObject(string $token): ?stdClass
     {
         try {
             $keys = JWK::parseKeySet(self::getJwks());
@@ -1489,6 +1538,8 @@ class ilObjLTIConsumer extends ilObject2
         if (count($auth) < 1) {
             self::sendResponseError(405, "missing Authorization header");
         }
+        $logger = $DIC->logger()->root();
+        $logger->info("Verifying token: " . json_encode($auth) . " HEADER: " . json_encode($DIC->http()->request()->getHeaders()) . " REQUEST getParsedBody: " . json_encode($DIC->http()->request()->getParsedBody()) . " REQUEST getParsedBody" . json_encode($DIC->http()->request()->getQueryParams()));
         preg_match('/Bearer\s+(.+)$/i', $auth[0], $matches);
         if (count($matches) != 2) {
             self::sendResponseError(405, "missing required Authorization Baerer token");

--- a/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumer.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumer.php
@@ -1089,19 +1089,11 @@ class ilObjLTIConsumer extends ilObject2
 
     public static function getDeepLinkingUserIdentifier(ilLTIConsumeProvider $provider, ilObjUser $user): string
     {
-        if (filter_var($user->getEmail(), FILTER_VALIDATE_EMAIL)) {
-            return $user->getEmail();
-        }
-
         return ilCmiXapiUser::getIdentAsId($provider->getPrivacyIdent(), $user);
     }
 
     public static function getDeepLinkingUserEmail(ilLTIConsumeProvider $provider, ilObjUser $user): string
     {
-        if (filter_var($user->getEmail(), FILTER_VALIDATE_EMAIL)) {
-            return $user->getEmail();
-        }
-
         return ilCmiXapiUser::getIdent($provider->getPrivacyIdent(), $user);
     }
 

--- a/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumer.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumer.php
@@ -1082,7 +1082,7 @@ class ilObjLTIConsumer extends ilObject2
             $DIC->ui()->mainTemplate()->setOnScreenMessage('failure', 'ERROR_OPEN_SSL_CONF', true);
             return null;
         }
-        return self::LTISignJWT($content_select_vars, '', $clientId, $deploymentId, $nonce);
+        return self::LTISignJWT($content_select_vars, $provider->getContentItemUrl(), $clientId, $deploymentId, $nonce);
     }
 
     public static function getDeepLinkingUserIdentifier(ilLTIConsumeProvider $provider, ilObjUser $user): string

--- a/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumer.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumer.php
@@ -1028,8 +1028,8 @@ class ilObjLTIConsumer extends ilObject2
                 break;
         }
 
-        $userIdLTI = ilCmiXapiUser::getIdentAsId($provider->getPrivacyIdent(), $DIC->user());
-        $emailPrimary = ilCmiXapiUser::getIdent($provider->getPrivacyIdent(), $DIC->user());
+        $userIdLTI = self::getDeepLinkingUserIdentifier($provider, $DIC->user());
+        $emailPrimary = self::getDeepLinkingUserEmail($provider, $DIC->user());
         $toolConsumerInstanceGuid = CLIENT_ID . ".";
         $parseIliasUrl = parse_url(self::getIliasHttpPath());
         if (array_key_exists("path", $parseIliasUrl)) {
@@ -1083,6 +1083,24 @@ class ilObjLTIConsumer extends ilObject2
             return null;
         }
         return self::LTISignJWT($content_select_vars, '', $clientId, $deploymentId, $nonce);
+    }
+
+    public static function getDeepLinkingUserIdentifier(ilLTIConsumeProvider $provider, ilObjUser $user): string
+    {
+        if (filter_var($user->getEmail(), FILTER_VALIDATE_EMAIL)) {
+            return $user->getEmail();
+        }
+
+        return ilCmiXapiUser::getIdentAsId($provider->getPrivacyIdent(), $user);
+    }
+
+    public static function getDeepLinkingUserEmail(ilLTIConsumeProvider $provider, ilObjUser $user): string
+    {
+        if (filter_var($user->getEmail(), FILTER_VALIDATE_EMAIL)) {
+            return $user->getEmail();
+        }
+
+        return ilCmiXapiUser::getIdent($provider->getPrivacyIdent(), $user);
     }
 
     public static function LTISignJWT(

--- a/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
@@ -409,7 +409,7 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
         $redirectUrl = $DIC->ctrl()->getLinkTarget($this, 'contentSelectionRequest');
 
         if (!ilSession::has('lti13_login_data')) {
-            $userIdLTI = ilCmiXapiUser::getIdentAsId($provider->getPrivacyIdent(), $DIC->user());
+            $userIdLTI = ilObjLTIConsumer::getDeepLinkingUserIdentifier($provider, $DIC->user());
             //$emailPrimary = ilCmiXapiUser::getIdent($provider->getPrivacyIdent(), $DIC->user());
             $ltiMessageHint = (string) $ref_id . ":" . CLIENT_ID . ":" . base64_encode($redirectUrl);
             $tplLogin = new ilTemplate("tpl.lti_initial_login.html", true, true, "components/ILIAS/LTIConsumer");

--- a/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
@@ -37,6 +37,7 @@ use ILIAS\UI\Component\Input\Container\Form\Standard as StandardForm;
  * @ilCtrl_Calls ilObjLTIConsumerGUI: ilLTIConsumerScoringGUI
  * @ilCtrl_Calls ilObjLTIConsumerGUI: ilLTIConsumerContentGUI
  * @ilCtrl_Calls ilObjLTIConsumerGUI: ilLTIConsumerGradeSynchronizationGUI
+ * @ilCtrl_Calls ilObjLTIConsumerGUI: ilLTIConsumeProviderSettingsGUI
  */
 class ilObjLTIConsumerGUI extends ilObject2GUI
 {
@@ -697,13 +698,21 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
     public function executeCommand(): void
     {
         global $DIC;
+
+        if ($DIC->ctrl()->getCmd() === 'startDeepLinking' && $this->object instanceof ilObjLTIAdministration) {
+            $DIC->ui()->mainTemplate()->setContent(
+                $this->ui_renderer->render($this->ui_factory->messageBox()->info($DIC->language()->txt('lti_deep_linking_not_available_for_admin_objects')))
+            );
+            return;
+        }
+
         /* @var \ILIAS\DI\Container $DIC */
 
         // TODO: general access checks (!)
 
         if (!ilLTIConsumerContentGUI::isEmbeddedLaunchRequest()) {
             $this->prepareOutput();
-            $this->addHeaderAction();
+            //$this->addHeaderAction();
         }
 
         if (!$this->creation_mode) {
@@ -726,6 +735,11 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
         $obj = $this->object;
 
         switch ($DIC->ctrl()->getNextClass()) {
+            case strtolower(ilLTIConsumeProviderSettingsGUI::class):
+                $gui = new ilLTIConsumeProviderSettingsGUI($obj, $this->ltiAccess);
+                $this->ctrl->forwardCommand($gui);
+                break;
+
             case strtolower(ilObjectCopyGUI::class):
 
                 $gui = new ilObjectCopyGUI($this);
@@ -1030,7 +1044,7 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
             $this->object->getId(),
             $DIC->user()->getId()
         );
-
+        // dump("ilObjLTIConsumerGUI", $this->object, $this->object->getId(), $DIC->user()->getId());exit();
         ilLPStatusWrapper::_updateStatus($this->object->getId(), $DIC->user()->getId());
     }
 

--- a/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
@@ -426,7 +426,6 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
                 $DIC->http()->saveResponse($DIC->http()->response()->withStatus(400));
                 $DIC->http()->sendResponse();
                 $DIC->http()->close();
-                exit;
             }
             // ToDo: correct Link!! replace ILIAS_HTTP_PATH
             $data = ilObjLTIConsumer::buildContentSelectionParameters($provider, (int) $ref_id, ilObjLTIConsumer::getIliasHttpPath() . "/" . $DIC->ctrl()->getLinkTarget($this, 'contentSelectionResponse'), $loginData['nonce']);

--- a/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
@@ -726,9 +726,7 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
         }
 
         /* @var \ILIAS\DI\Container $DIC */
-
         // TODO: general access checks (!)
-
         if (!ilLTIConsumerContentGUI::isEmbeddedLaunchRequest()) {
             $this->prepareOutput();
             //$this->addHeaderAction();

--- a/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
@@ -415,7 +415,7 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
             $tplLogin = new ilTemplate("tpl.lti_initial_login.html", true, true, "components/ILIAS/LTIConsumer");
             $tplLogin->setVariable("LTI_INITIAL_LOGIN_ACTION", $provider->getInitiateLogin());
             $tplLogin->setVariable("ISS", ilObjLTIConsumer::getIliasHttpPath());
-            $tplLogin->setVariable("TARGET_LINK_URL", $provider->getProviderUrl());
+            $tplLogin->setVariable("TARGET_LINK_URL", $provider->getContentItemUrl());
             $tplLogin->setVariable("LOGIN_HINT", $userIdLTI);
             $tplLogin->setVariable("LTI_MESSAGE_HINT", $ltiMessageHint);
             $tplLogin->setVariable("CLIENT_ID", $provider->getClientId());
@@ -424,10 +424,18 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
             exit; //TODO: no exit
         } else {
             $loginData = ilSession::get('lti13_login_data');
+            $redirectUri = $loginData['redirect_uri'] ?? '';
+            $allowedRedirectUris = array_map('trim', explode(',', $provider->getRedirectionUris()));
+            if (!in_array($redirectUri, $allowedRedirectUris, true)) {
+                $DIC->http()->saveResponse($DIC->http()->response()->withStatus(400));
+                $DIC->http()->sendResponse();
+                $DIC->http()->close();
+                exit;
+            }
             // ToDo: correct Link!! replace ILIAS_HTTP_PATH
             $data = ilObjLTIConsumer::buildContentSelectionParameters($provider, (int) $ref_id, ilObjLTIConsumer::getIliasHttpPath() . "/" . $DIC->ctrl()->getLinkTarget($this, 'contentSelectionResponse'), $loginData['nonce']);
             $tplContentSelection = new ilTemplate("tpl.lti_jwt_autosubmit.html", true, true, "components/ILIAS/LTIConsumer");
-            $tplContentSelection->setVariable("LTI_JWT_FORM_ACTION", $provider->getContentItemUrl());
+            $tplContentSelection->setVariable("LTI_JWT_FORM_ACTION", $redirectUri);
             $tplContentSelection->setVariable("LTI_JWT_ID_TOKEN", $data['id_token']);
             $tplContentSelection->setVariable("LTI_JWT_STATE", $loginData['state']);
             ilSession::clear('lti13_login_data');

--- a/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
@@ -405,6 +405,14 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
         $redirectUrl = $DIC->ctrl()->getLinkTarget($this, 'contentSelectionRequest');
 
         if (!ilSession::has('lti13_login_data')) {
+            $state = bin2hex(random_bytes(32));
+            ilSession::set('lti13_deep_linking_state', [
+                'state' => $state,
+                'provider_id' => $provider->getId(),
+                'ref_id' => (int) $ref_id,
+                'flow' => 'content_selection',
+                'created_at' => time()
+            ]);
             $userIdLTI = ilObjLTIConsumer::getDeepLinkingUserIdentifier($provider, $DIC->user());
             //$emailPrimary = ilCmiXapiUser::getIdent($provider->getPrivacyIdent(), $DIC->user());
             $ltiMessageHint = (string) $ref_id . ":" . CLIENT_ID . ":" . base64_encode($redirectUrl);
@@ -416,6 +424,7 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
             $tplLogin->setVariable("LTI_MESSAGE_HINT", $ltiMessageHint);
             $tplLogin->setVariable("CLIENT_ID", $provider->getClientId());
             $tplLogin->setVariable("LTI_DEPLOYMENT_ID", (string) $provider->getId());
+            $tplLogin->setVariable("STATE", $state);
             echo $tplLogin->get();
             exit; //TODO: no exit
         } else {

--- a/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
@@ -516,8 +516,13 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
             $newObj->setProvider($provider);
             // custom params
             $customParams = [];
-            foreach ($item->{'custom'} as $key => $value) {
-                $customParams[] = $key . "=" . $value;
+            if (isset($item->url)) {
+                $customParams[] = 'target_link_uri=' . (string) $item->url;
+            }
+            if (isset($item->custom) && is_object($item->custom)) {
+                foreach ($item->custom as $key => $value) {
+                    $customParams[] = $key . "=" . $value;
+                }
             }
             if (count($customParams) > 0) {
                 $newObj->setCustomParams(implode(";", $customParams));

--- a/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
@@ -380,9 +380,7 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
     public function contentSelection(string $providerId, string $newType, string $refId, ilLTIConsumeProvider $provider): void
     {
         global $DIC;
-        if (!ilLTIConsumerAccess::hasCustomProviderCreationAccess()) {
-            throw new ilLtiConsumerException('permission denied!');
-        }
+        $this->checkContentSelectionAccess($refId);
         $DIC->ctrl()->setParameter($this, "new_type", $newType);
         $DIC->ctrl()->setParameter($this, "provider_id", $providerId);
         $DIC->ctrl()->setParameter($this, "ref_id", $refId);
@@ -395,15 +393,13 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
     public function contentSelectionRequest(): void
     {
         global $DIC;
-        if (!ilLTIConsumerAccess::hasCustomProviderCreationAccess()) {
-            throw new ilLtiConsumerException('permission denied!');
-        }
         $new_type = $this->getRequestValue("new_type");
         $DIC->ctrl()->setParameter($this, "new_type", $new_type);
         $provider_id = $this->getRequestValue("provider_id");
         $DIC->ctrl()->setParameter($this, "provider_id", $provider_id);
         $ref_id = $this->getRequestValue("ref_id");
         $DIC->ctrl()->setParameter($this, "ref_id", $ref_id);
+        $this->checkContentSelectionAccess($ref_id);
         $DIC->language()->loadLanguageModule($new_type);
         $provider = new ilLTIConsumeProvider((int) $provider_id);
         $redirectUrl = $DIC->ctrl()->getLinkTarget($this, 'contentSelectionRequest');
@@ -447,15 +443,13 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
     public function contentSelectionResponse(): void
     {
         global $DIC;
-        if (!ilLTIConsumerAccess::hasCustomProviderCreationAccess()) {
-            throw new ilLtiConsumerException('permission denied!');
-        }
         $new_type = $this->getRequestValue("new_type");
         $DIC->ctrl()->setParameter($this, "new_type", $new_type);
         $provider_id = $this->getRequestValue("provider_id");
         $DIC->ctrl()->setParameter($this, "provider_id", $provider_id);
         $ref_id = $this->getRequestValue("ref_id");
         $DIC->ctrl()->setParameter($this, "ref_id", $ref_id);
+        $this->checkContentSelectionAccess($ref_id);
         $DIC->language()->loadLanguageModule($new_type);
         $token = '';
         if ($DIC->http()->wrapper()->post()->has('JWT')) {
@@ -477,12 +471,17 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
     public function cancelContentSelection(): void
     {
         global $DIC;
-        if (!ilLTIConsumerAccess::hasCustomProviderCreationAccess()) {
-            throw new ilLtiConsumerException('permission denied!');
-        }
+        $this->checkContentSelectionAccess($this->getRequestValue("ref_id"));
         $new_type = $this->getRequestValue("new_type");
         $DIC->ctrl()->setParameterByClass(ilRepositoryGUI::class, 'new_type', $new_type);
         $DIC->ctrl()->redirectByClass(ilRepositoryGUI::class, 'create');
+    }
+
+    protected function checkContentSelectionAccess(?string $refId): void
+    {
+        if ($refId === null || !$this->checkPermissionBool('create', '', 'lti', (int) $refId)) {
+            throw new ilLtiConsumerException('permission denied!');
+        }
     }
 
     public function saveContentSelection(ilLTIConsumeProvider $provider, string $token): void

--- a/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
@@ -172,7 +172,7 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
         /* @var \ILIAS\DI\Container $DIC */
         $provider = new ilLTIConsumeProvider();
         $form = new ilLTIConsumeProviderFormGUI($provider);
-        $form->initDynRegForm($this->ctrl->getFormAction($this, "cancelDynReg"));
+        $form->initDynRegForm($this->ctrl->getFormAction($this, "addDynReg"));
         $form->setTitle($DIC->language()->txt($a_new_type . '_dynamic_registration'));
         return $form;
     }
@@ -854,6 +854,10 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
                         $DIC->ctrl()->redirectToURL($this->ctrl->getLinkTargetByClass(ilInfoScreenGUI::class));
                     }
                     $command = $DIC->ctrl()->getCmd(self::DEFAULT_CMD);
+                    if (!$this->object instanceof ilObjLTIConsumer && $command === self::DEFAULT_CMD) {
+                        $DIC->ctrl()->setParameterByClass(ilRepositoryGUI::class, 'new_type', $this->getType());
+                        $DIC->ctrl()->redirectByClass(ilRepositoryGUI::class, 'create');
+                    }
                     $this->{$command}();
                 }
         }

--- a/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
@@ -498,8 +498,7 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
             $key = $provider->getPublicKey();
             $keys = new Firebase\JWT\Key($key, "RS256");
         } else {
-            $jwks = file_get_contents($provider->getPublicKeyset());
-            //ToDo: Errorhandling
+            $jwks = ilObjLTIConsumer::fetchPublicKeyset($provider->getPublicKeyset());
             $keyset = json_decode($jwks, true);
             $keys = Firebase\JWT\JWK::parseKeySet($keyset);
         }

--- a/components/ILIAS/LTIConsumer/resources/ltiauth.php
+++ b/components/ILIAS/LTIConsumer/resources/ltiauth.php
@@ -104,7 +104,7 @@ if (empty($ltiMessageHint)) {
 ilSession::set('lti13_login_data', $data);
 
 if ($isDlMode) {
-    if ($deploymentId === null || $refId <= 0) {
+    if ($refId <= 0) {
         $DIC->http()->saveResponse(
             $DIC->http()->response()->withStatus(400)
         );

--- a/components/ILIAS/LTIConsumer/resources/ltiauth.php
+++ b/components/ILIAS/LTIConsumer/resources/ltiauth.php
@@ -99,7 +99,6 @@ if (empty($ltiMessageHint)) {
     );
     $DIC->http()->sendResponse();
     $DIC->http()->close();
-    exit;
 }
 
 ilSession::set('lti13_login_data', $data);
@@ -111,7 +110,6 @@ if ($isDlMode) {
         );
         $DIC->http()->sendResponse();
         $DIC->http()->close();
-        exit;
     }
 
     $DIC->ctrl()->setParameterByClass(ilObjLTIConsumerGUI::class, 'new_type', 'lti');
@@ -137,7 +135,6 @@ if ($isDlMode) {
         $DIC->http()->close();
     }
 
-    exit;
 }
 
 $parts = explode(":", $ltiMessageHint, 3);
@@ -156,7 +153,6 @@ if (count($parts) === 2) {
     );
     $DIC->http()->sendResponse();
     $DIC->http()->close();
-    exit;
 }
 
 if ($isContentSelection) {

--- a/components/ILIAS/LTIConsumer/resources/ltiauth.php
+++ b/components/ILIAS/LTIConsumer/resources/ltiauth.php
@@ -158,10 +158,6 @@ if ($isDlMode) {
 
 }
 
-if (!$isDlMode) {
-    ilSession::set('lti13_login_data', $data);
-}
-
 $parts = explode(":", $ltiMessageHint, 3);
 $isContentSelection = false;
 $ref_id = '';
@@ -196,6 +192,10 @@ if ($isContentSelection) {
 } else {
     $url = "../../../goto.php?target=lti_" . $ref_id . "&client_id=" . $il_client_id;
 }
+
+// only persist the login data once the request has fully passed validation,
+// so a rejected request never leaves unvalidated data behind in the session
+ilSession::set('lti13_login_data', $data);
 
 function buildSameSiteNoneSessionCookieHeader(): ?string
 {

--- a/components/ILIAS/LTIConsumer/resources/ltiauth.php
+++ b/components/ILIAS/LTIConsumer/resources/ltiauth.php
@@ -18,14 +18,22 @@
 
 declare(strict_types=1);
 
-/** @noRector */
-require_once("../vendor/composer/vendor/autoload.php");
-
 
 /**
  * There is no way to process a $_GET Request with
  * a valid third-party client_id param in regular initILIAS
  */
+
+function sanitizeJson(string $string)
+{
+    $string = preg_replace('/(\w+):(\w+)/', '"$1":"$2"', $string);
+    $string = str_replace("'", '"', $string);
+    $string = str_replace('{', '{', $string);
+    $string = str_replace('}', '}', $string);
+    return json_decode($string, true);
+}
+
+
 if (strtoupper($_SERVER['REQUEST_METHOD']) == 'POST') {
     $orig = new ArrayObject($_POST);
     $data = $orig->getArrayCopy();
@@ -43,41 +51,118 @@ if (strtoupper($_SERVER['REQUEST_METHOD']) == 'POST') {
     exit;
 }
 
-ilInitialisation::initILIAS();
+require_once '../vendor/composer/vendor/autoload.php';
+require_once __DIR__ . '/../artifacts/bootstrap_default.php';
+entry_point('ILIAS Legacy Initialisation Adapter');
 
 global $DIC;
+$scope = $data['scope'] ?? '';
+$responseType = $data['response_type'] ?? '';
+$redirectUri = $data['redirect_uri'] ?? '';
+$clientId = $data['client_id'] ?? $data['id'] ?? '';
+$state = $data['state'] ?? '';
+$nonce = $data['nonce'] ?? '';
+$ltiMessageHint = $data['lti_message_hint'] ?? '';
+$loginHint = $data['login_hint'] ?? '';
 
-$ltiMessageHint = $data['lti_message_hint'];
+$isDlMode = false;
+$hint = null;
+$deploymentId = null;
+$provider_id = 0;
+$childRefId = 0;
+$refId = 0;
+
+if (
+    $scope === 'openid' &&
+    $responseType === 'id_token' &&
+    $redirectUri !== '' &&
+    $clientId !== ''
+) {
+    $provider_id = ilLTIConsumeProvider::getProviderIdFromClientId($clientId);
+    $provider = ilLTIConsumeProvider::getInstance($provider_id);
+
+    $hint = sanitizeJson($ltiMessageHint);
+    if ($provider->getContentItemUrl() == $redirectUri && isset($hint['deployment_id'])) {
+
+        $isDlMode = true;
+        $deploymentId = (int) $hint['deployment_id'];
+        $childRefId = ilObjLTIConsumer::getRefIdOfConsumerByDeploymentId((string) $deploymentId);
+        $refId = $DIC->repositoryTree()->getParentId($childRefId);
+    }
+
+}
+
 
 if (empty($ltiMessageHint)) {
     $DIC->http()->saveResponse(
-        $DIC->http()->response()
-        ->withStatus(400)
+        $DIC->http()->response()->withStatus(400)
     );
+    $DIC->http()->sendResponse();
+    $DIC->http()->close();
+    exit;
+}
+
+ilSession::set('lti13_login_data', $data);
+
+if ($isDlMode) {
+    if ($deploymentId === null || $refId <= 0) {
+        $DIC->http()->saveResponse(
+            $DIC->http()->response()->withStatus(400)
+        );
+        $DIC->http()->sendResponse();
+        $DIC->http()->close();
+        exit;
+    }
+
+    $DIC->ctrl()->setParameterByClass(ilObjLTIConsumerGUI::class, 'new_type', 'lti');
+    $DIC->ctrl()->setParameterByClass(ilObjLTIConsumerGUI::class, 'provider_id', (string) $deploymentId);
+    $DIC->ctrl()->setParameterByClass(ilObjLTIConsumerGUI::class, 'ref_id', (string) $refId);
+    $url = $DIC->ctrl()->getLinkTargetByClass([ilRepositoryGUI::class, ilObjLTIConsumerGUI::class], 'contentSelectionRequest');
+
+    $response = $DIC->http()->response()
+        ->withStatus(302)
+        ->withAddedHeader('Location', $url);
+
+    $sessionCookieHeader = buildSameSiteNoneSessionCookieHeader();
+    if ($sessionCookieHeader !== null) {
+        $response = $response->withAddedHeader('Set-Cookie', $sessionCookieHeader);
+    }
+
+    $DIC->http()->saveResponse($response);
+
     try {
         $DIC->http()->sendResponse();
         $DIC->http()->close();
     } catch (\ILIAS\HTTP\Response\Sender\ResponseSendingException $e) {
         $DIC->http()->close();
     }
-}
-$mh = explode(":", $ltiMessageHint);
-$isContentSelection = false;
-$ref_id = '';
-$client_id = '';
-$redirect_uri = '';
-if (count($mh) == 2) { // launch message auth
-    list($ref_id, $client_id) = explode(":", $ltiMessageHint);
-} else { // contentSelection message auth
-    $isContentSelection = true;
-    list($ref_id, $client_id, $redirect_uri) = explode(":", $ltiMessageHint);
+
+    exit;
 }
 
-ilSession::set('lti13_login_data', $data);
+$parts = explode(":", $ltiMessageHint, 3);
+$isContentSelection = false;
+$ref_id = '';
+$il_client_id = '';
+$redirect_uri = '';
+if (count($parts) === 2) {
+    [$ref_id, $il_client_id] = $parts;
+} elseif (count($parts) === 3) {
+    $isContentSelection = true;
+    [$ref_id, $il_client_id, $redirect_uri] = $parts;
+} else {
+    $DIC->http()->saveResponse(
+        $DIC->http()->response()->withStatus(400)
+    );
+    $DIC->http()->sendResponse();
+    $DIC->http()->close();
+    exit;
+}
+
 if ($isContentSelection) {
     $url = "../../../" . base64_decode($redirect_uri);
 } else {
-    $url = "../../../goto.php?target=lti_" . $ref_id . "&client_id=" . $client_id;
+    $url = "../../../goto.php?target=lti_" . $ref_id . "&client_id=" . $il_client_id;
 }
 
 function buildSameSiteNoneSessionCookieHeader(): ?string
@@ -127,6 +212,7 @@ if ($sessionCookieHeader !== null) {
 $DIC->http()->saveResponse(
     $response
 );
+
 try {
     $DIC->http()->sendResponse();
     $DIC->http()->close();

--- a/components/ILIAS/LTIConsumer/resources/ltiauth.php
+++ b/components/ILIAS/LTIConsumer/resources/ltiauth.php
@@ -181,7 +181,18 @@ if (count($parts) === 2) {
 }
 
 if ($isContentSelection) {
-    $url = "../../../" . base64_decode($redirect_uri);
+    $redirect_target = base64_decode($redirect_uri, true);
+    if ($redirect_target === false || $redirect_target === '' ||
+        str_starts_with($redirect_target, '/') || str_contains($redirect_target, '..') ||
+        parse_url($redirect_target, PHP_URL_SCHEME) !== null ||
+        parse_url($redirect_target, PHP_URL_HOST) !== null) {
+        $DIC->http()->saveResponse(
+            $DIC->http()->response()->withStatus(400)
+        );
+        $DIC->http()->sendResponse();
+        $DIC->http()->close();
+    }
+    $url = "../../../" . $redirect_target;
 } else {
     $url = "../../../goto.php?target=lti_" . $ref_id . "&client_id=" . $il_client_id;
 }

--- a/components/ILIAS/LTIConsumer/resources/ltiauth.php
+++ b/components/ILIAS/LTIConsumer/resources/ltiauth.php
@@ -82,26 +82,45 @@ if (
     $provider = ilLTIConsumeProvider::getInstance($provider_id);
 
     $hint = sanitizeJson($ltiMessageHint);
-    if (isset($hint['deployment_id'])) {
+    $expectedState = ilSession::get('lti13_deep_linking_state');
+    $allowedRedirectUris = array_map('trim', explode(',', $provider->getRedirectionUris()));
+    if (
+        is_array($hint) &&
+        isset($hint['deployment_id']) &&
+        is_array($expectedState) &&
+        ($expectedState['flow'] ?? '') === 'content_selection' &&
+        is_string($expectedState['state'] ?? null) &&
+        is_int($expectedState['created_at'] ?? null) &&
+        $expectedState['created_at'] >= time() - 300 &&
+        $expectedState['created_at'] <= time() &&
+        is_string($state) &&
+        hash_equals($expectedState['state'], $state) &&
+        ($expectedState['provider_id'] ?? 0) === $provider->getId() &&
+        (int) $hint['deployment_id'] === $provider->getId() &&
+        in_array($redirectUri, $allowedRedirectUris, true)
+    ) {
 
-        $isDlMode = true;
         $deploymentId = (int) $hint['deployment_id'];
         $childRefId = ilObjLTIConsumer::getRefIdOfConsumerByDeploymentId((string) $deploymentId);
-        $refId = $DIC->repositoryTree()->getParentId($childRefId);
+        if ($childRefId !== null) {
+            $refId = $DIC->repositoryTree()->getParentId($childRefId);
+        }
+        if ($refId > 0 && ($expectedState['ref_id'] ?? 0) === $refId) {
+            $isDlMode = true;
+            ilSession::clear('lti13_deep_linking_state');
+        }
     }
 
 }
 
 
-if (empty($ltiMessageHint)) {
+if (empty($ltiMessageHint) || (is_array($hint) && !$isDlMode)) {
     $DIC->http()->saveResponse(
         $DIC->http()->response()->withStatus(400)
     );
     $DIC->http()->sendResponse();
     $DIC->http()->close();
 }
-
-ilSession::set('lti13_login_data', $data);
 
 if ($isDlMode) {
     if ($refId <= 0) {
@@ -111,6 +130,8 @@ if ($isDlMode) {
         $DIC->http()->sendResponse();
         $DIC->http()->close();
     }
+
+    ilSession::set('lti13_login_data', $data);
 
     $DIC->ctrl()->setParameterByClass(ilObjLTIConsumerGUI::class, 'new_type', 'lti');
     $DIC->ctrl()->setParameterByClass(ilObjLTIConsumerGUI::class, 'provider_id', (string) $deploymentId);
@@ -135,6 +156,10 @@ if ($isDlMode) {
         $DIC->http()->close();
     }
 
+}
+
+if (!$isDlMode) {
+    ilSession::set('lti13_login_data', $data);
 }
 
 $parts = explode(":", $ltiMessageHint, 3);

--- a/components/ILIAS/LTIConsumer/resources/ltiauth.php
+++ b/components/ILIAS/LTIConsumer/resources/ltiauth.php
@@ -82,7 +82,7 @@ if (
     $provider = ilLTIConsumeProvider::getInstance($provider_id);
 
     $hint = sanitizeJson($ltiMessageHint);
-    if ($provider->getContentItemUrl() == $redirectUri && isset($hint['deployment_id'])) {
+    if (isset($hint['deployment_id'])) {
 
         $isDlMode = true;
         $deploymentId = (int) $hint['deployment_id'];

--- a/components/ILIAS/LTIConsumer/resources/lticerts.php
+++ b/components/ILIAS/LTIConsumer/resources/lticerts.php
@@ -19,10 +19,11 @@
 declare(strict_types=1);
 
 /** @noRector */
-require_once("../vendor/composer/vendor/autoload.php");
+require_once '../vendor/composer/vendor/autoload.php';
+require_once __DIR__ . '/../artifacts/bootstrap_default.php';
+entry_point('ILIAS Legacy Initialisation Adapter');
 
 ilContext::init(ilContext::CONTEXT_SCORM);
-ilInitialisation::initILIAS();
 
 if (!empty(ilObjLTIConsumer::verifyPrivateKey())) {
     echo "ERROR_OPEN_SSL_CONF";

--- a/components/ILIAS/LTIConsumer/resources/lticonfig.php
+++ b/components/ILIAS/LTIConsumer/resources/lticonfig.php
@@ -19,9 +19,11 @@
 declare(strict_types=1);
 
 /** @noRector */
-require_once("../vendor/composer/vendor/autoload.php");
+require_once '../vendor/composer/vendor/autoload.php';
+require_once __DIR__ . '/../artifacts/bootstrap_default.php';
+entry_point('ILIAS Legacy Initialisation Adapter');
 
 ilContext::init(ilContext::CONTEXT_SCORM);
-ilInitialisation::initILIAS();
+
 header('Content-Type: application/json; charset=utf-8');
 echo json_encode(ilObjLTIConsumer::getOpenidConfig(), JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);

--- a/components/ILIAS/LTIConsumer/resources/ltiregend.php
+++ b/components/ILIAS/LTIConsumer/resources/ltiregend.php
@@ -19,10 +19,10 @@
 declare(strict_types=1);
 
 /** @noRector */
-require_once("../vendor/composer/vendor/autoload.php");
+require_once '../vendor/composer/vendor/autoload.php';
+require_once __DIR__ . '/../artifacts/bootstrap_default.php';
+entry_point('ILIAS Legacy Initialisation Adapter');
 
-
-ilInitialisation::initILIAS();
 $clientId = (ilSession::has('lti_dynamic_registration_client_id')) ? (string) ilSession::get('lti_dynamic_registration_client_id') : '';
 $response = [];
 if (empty($clientId)) {

--- a/components/ILIAS/LTIConsumer/resources/ltiregistration.php
+++ b/components/ILIAS/LTIConsumer/resources/ltiregistration.php
@@ -19,10 +19,11 @@
 declare(strict_types=1);
 
 /** @noRector */
-require_once("../vendor/composer/vendor/autoload.php");
+require_once '../vendor/composer/vendor/autoload.php';
+require_once __DIR__ . '/../artifacts/bootstrap_default.php';
+entry_point('ILIAS Legacy Initialisation Adapter');
 
 ilContext::init(ilContext::CONTEXT_SCORM);
-ilInitialisation::initILIAS();
 
 try {
     $token = ilObjLTIConsumer::verifyToken();

--- a/components/ILIAS/LTIConsumer/resources/ltiregstart.php
+++ b/components/ILIAS/LTIConsumer/resources/ltiregstart.php
@@ -19,9 +19,10 @@
 declare(strict_types=1);
 
 /** @noRector */
-require_once("../vendor/composer/vendor/autoload.php");
+require_once '../vendor/composer/vendor/autoload.php';
+require_once __DIR__ . '/../artifacts/bootstrap_default.php';
+entry_point('ILIAS Legacy Initialisation Adapter');
 
-ilInitialisation::initILIAS();
 global $DIC;
 
 if (!$DIC->user()->getId() || !ilLTIConsumerAccess::hasCustomProviderCreationAccess()) {

--- a/components/ILIAS/LTIConsumer/resources/ltiregstart.php
+++ b/components/ILIAS/LTIConsumer/resources/ltiregstart.php
@@ -70,7 +70,10 @@ try {
         ilSession::set('lti_dynamic_registration_custom_params', $customParams);
     }
     ilSession::set('lti_dynamic_registration_client_id', $clientId);
-    header("Location: " . $url . "&openid_configuration=" . urlencode(ilObjLTIConsumer::getOpenidConfigUrl()) . "&registration_token=" . $regToken);
+    // a tool registration URL usually carries no query string of its own, so the
+    // parameters must start with "?" in that case or they end up in the path
+    $separator = str_contains($url, '?') ? '&' : '?';
+    header("Location: " . $url . $separator . "openid_configuration=" . urlencode(ilObjLTIConsumer::getOpenidConfigUrl()) . "&registration_token=" . $regToken);
 } catch (Exception $exception) {
     ilObjLTIConsumer::sendResponseError(500, "error in ltiregstart.php: " . $exception->getMessage());
 }

--- a/components/ILIAS/LTIConsumer/resources/ltiresult.php
+++ b/components/ILIAS/LTIConsumer/resources/ltiresult.php
@@ -18,7 +18,9 @@
 
 declare(strict_types=1);
 
-require_once("../vendor/composer/vendor/autoload.php");
+require_once '../vendor/composer/vendor/autoload.php';
+require_once __DIR__ . '/../artifacts/bootstrap_default.php';
+entry_point('ILIAS Legacy Initialisation Adapter');
 
 if (!isset($_GET['client_id']) || !strlen($_GET['client_id'])) {
     $log = ilLoggerFactory::getLogger('lti');
@@ -28,7 +30,6 @@ if (!isset($_GET['client_id']) || !strlen($_GET['client_id'])) {
 }
 
 \ilContext::init(\ilContext::CONTEXT_SCORM);
-\ilInitialisation::initILIAS();
 
 $dic = $GLOBALS['DIC'];
 $log = ilLoggerFactory::getLogger('lti');

--- a/components/ILIAS/LTIConsumer/resources/ltiservices.php
+++ b/components/ILIAS/LTIConsumer/resources/ltiservices.php
@@ -20,10 +20,11 @@ declare(strict_types=1);
 
 /** @noRector */
 
-require_once("../vendor/composer/vendor/autoload.php");
+require_once '../vendor/composer/vendor/autoload.php';
+require_once __DIR__ . '/../artifacts/bootstrap_default.php';
+entry_point('ILIAS Legacy Initialisation Adapter');
 
 ilContext::init(ilContext::CONTEXT_SCORM);
-ilInitialisation::initILIAS();
 
 global $DIC;
 

--- a/components/ILIAS/LTIConsumer/resources/ltitoken.php
+++ b/components/ILIAS/LTIConsumer/resources/ltitoken.php
@@ -24,10 +24,11 @@ use Firebase\JWT\JWT;
 use Firebase\JWT\JWK;
 use Firebase\JWT\Key;
 
-require_once("../vendor/composer/vendor/autoload.php");
+require_once '../vendor/composer/vendor/autoload.php';
+require_once __DIR__ . '/../artifacts/bootstrap_default.php';
+entry_point('ILIAS Legacy Initialisation Adapter');
 
 ilContext::init(ilContext::CONTEXT_SCORM);
-ilInitialisation::initILIAS();
 
 global $DIC;
 

--- a/components/ILIAS/LTIConsumer/resources/ltitoken.php
+++ b/components/ILIAS/LTIConsumer/resources/ltitoken.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 use ILIAS\Filesystem\Exception\IOException;
 use Firebase\JWT\JWT;
 use Firebase\JWT\JWK;
+use Firebase\JWT\Key;
 
 require_once("../vendor/composer/vendor/autoload.php");
 
@@ -71,7 +72,7 @@ if ($claims == null) {
     invalidRequest("bad request: no claims");
 }
 
-$clientId = $claims['sub'];
+$clientId = $claims['sub'] ?? '';
 if (empty($clientId)) {
     invalidRequest("bad request: no claims");
 }
@@ -82,13 +83,17 @@ $provider = null;
 try {
     $providerId = ilLTIConsumeProvider::getProviderIdFromClientId($clientId);
 } catch (IOException $e) {
-    invalidRequest(var_export($e, true));
+    invalidClient(var_export($e, true));
+}
+
+if ($providerId <= 0) {
+    invalidClient("unknown client_id: " . $clientId);
 }
 
 try {
     $provider = new ilLTIConsumeProvider($providerId);
 } catch (IOException $e) {
-    serverError(var_export($e, true));
+    invalidClient(var_export($e, true));
 }
 
 validateServiceToken($clientAssertion, $provider);
@@ -110,16 +115,34 @@ function validateServiceToken(string $token, ilLTIConsumeProvider $provider): vo
     try {
         ilObjLTIConsumer::getLogger()->debug("validateServiceToken");
         // ToDo: caching
-        $jwks = file_get_contents($provider->getPublicKeyset());
-        $keyset = json_decode($jwks, true);
-        $keys = JWK::parseKeySet($keyset);
+        if ($provider->getKeyType() === 'RSA_KEY') {
+            $publicKey = trim($provider->getPublicKey());
+            if ($publicKey === '') {
+                invalidClient('missing public key');
+            }
+            $keys = new Key($publicKey, 'RS256');
+        } else {
+            $publicKeyset = trim($provider->getPublicKeyset());
+            if ($publicKeyset === '') {
+                invalidClient('missing public keyset');
+            }
+            $jwks = @file_get_contents($publicKeyset);
+            if ($jwks === false) {
+                invalidClient('cannot fetch public keyset');
+            }
+            $keyset = json_decode($jwks, true);
+            if (!is_array($keyset)) {
+                invalidClient('invalid public keyset');
+            }
+            $keys = JWK::parseKeySet($keyset);
+        }
         $data = JWT::decode($token, $keys);
         //ilObjLTIConsumer::getLogger()->debug(var_export($data, TRUE));
         if ($provider->getClientId() != $data->iss || $provider->getClientId() != $data->sub) {
-            invalidRequest("invalid clientId");
+            invalidClient("invalid clientId");
         }
     } catch (Exception $e) {
-        serverError(var_export($e, true));
+        invalidClient(var_export($e, true));
     }
 }
 
@@ -154,6 +177,7 @@ function serverError(string $log = ""): void
         ilObjLTIConsumer::getLogger()->error($log);
     }
     ilObjLTIConsumer::sendResponseError(500, json_encode(array('error' => "ERROR_OPEN_SSL_CONF")));
+    exit;
 }
 
 function invalidRequest(string $log = ""): void
@@ -162,4 +186,14 @@ function invalidRequest(string $log = ""): void
         ilObjLTIConsumer::getLogger()->error($log);
     }
     ilObjLTIConsumer::sendResponseError(400, json_encode(array('error' => 'invalid_request')));
+    exit;
+}
+
+function invalidClient(string $log = ""): void
+{
+    if (!empty($log)) {
+        ilObjLTIConsumer::getLogger()->error($log);
+    }
+    ilObjLTIConsumer::sendResponseError(401, json_encode(array('error' => 'invalid_client')));
+    exit;
 }

--- a/components/ILIAS/LTIConsumer/resources/ltitoken.php
+++ b/components/ILIAS/LTIConsumer/resources/ltitoken.php
@@ -126,8 +126,9 @@ function validateServiceToken(string $token, ilLTIConsumeProvider $provider): vo
             if ($publicKeyset === '') {
                 invalidClient('missing public keyset');
             }
-            $jwks = @file_get_contents($publicKeyset);
-            if ($jwks === false) {
+            try {
+                $jwks = ilObjLTIConsumer::fetchPublicKeyset($publicKeyset);
+            } catch (ilLtiConsumerException $exception) {
                 invalidClient('cannot fetch public keyset');
             }
             $keyset = json_decode($jwks, true);

--- a/components/ILIAS/LTIConsumer/templates/default/tpl.lti_content_selection_finished.html
+++ b/components/ILIAS/LTIConsumer/templates/default/tpl.lti_content_selection_finished.html
@@ -1,3 +1,17 @@
 <script>
-  window.parent.location.href= "{CONTENT_SELECTION_REDIRECT}";
+  (function () {
+    var redirectUrl = "{CONTENT_SELECTION_REDIRECT}";
+
+    if (window.parent && typeof window.parent.onLtiDeepLinkDone === 'function') {
+      window.parent.onLtiDeepLinkDone(redirectUrl);
+      return;
+    }
+
+    if (window.top) {
+      window.top.location.href = redirectUrl;
+      return;
+    }
+
+    window.location.href = redirectUrl;
+  })();
 </script>

--- a/components/ILIAS/LTIConsumer/templates/default/tpl.lti_initial_login.html
+++ b/components/ILIAS/LTIConsumer/templates/default/tpl.lti_initial_login.html
@@ -5,6 +5,7 @@
     <input type="hidden" name="lti_message_hint" value="{LTI_MESSAGE_HINT}" /><!--$ltiMessageHint-->
     <input type="hidden" name="client_id" value="{CLIENT_ID}" /><!--$this->object->getProvider()->getClientId())-->
     <input type="hidden" name="lti_deployment_id" value="{LTI_DEPLOYMENT_ID}" /><!--$this->object->getProvider()->getId()-->
+    <input type="hidden" name="state" value="{STATE}" />
 </form>
 <script>
   document.ltiInitialLoginForm.submit();

--- a/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilAuthProviderLTI.php
+++ b/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilAuthProviderLTI.php
@@ -82,13 +82,17 @@ class ilAuthProviderLTI extends \ilAuthProvider implements \ilAuthProviderInterf
     {
         global $ilDB;
 
-        // move to connector
-        $query = 'SELECT consumer_pk from lti2_consumer where enabled = ' . $ilDB->quote(1, 'integer');
+        // Users store the external LTI consumer id in usr_data.auth_mode (lti_<id>).
+        $query = /** @lang text */
+            'SELECT DISTINCT ec.id FROM lti_ext_consumer ec ' .
+            'JOIN lti2_consumer c ON c.ext_consumer_id = ec.id ' .
+            'WHERE ec.active = ' . $ilDB->quote(1, 'integer') . ' ' .
+            'AND c.enabled = ' . $ilDB->quote(1, 'integer');
         $res = $ilDB->query($query);
 
         $sids = array();
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            $sids[] = $row->consumer_pk;
+            $sids[] = $row->id;
         }
         return $sids;
     }
@@ -100,13 +104,15 @@ class ilAuthProviderLTI extends \ilAuthProvider implements \ilAuthProviderInterf
     {
         global $ilDB;
 
-        // move to connector
-        $query = 'SELECT distinct(consumer_pk) consumer_pk from lti2_consumer';
+        // Users store the external LTI consumer id in usr_data.auth_mode (lti_<id>).
+        $query = /** @lang text */
+            'SELECT DISTINCT ec.id FROM lti_ext_consumer ec ' .
+            'JOIN lti2_consumer c ON c.ext_consumer_id = ec.id';
         $res = $ilDB->query($query);
 
         $sids = array();
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            $sids[] = $row->consumer_pk;
+            $sids[] = $row->id;
         }
         return $sids;
     }
@@ -119,11 +125,9 @@ class ilAuthProviderLTI extends \ilAuthProvider implements \ilAuthProviderInterf
     public static function lookupConsumer(int $a_sid): string
     {
         $connector = new ilLTIDataConnector();
-        $consumer = ilLTIPlatform::fromRecordId($a_sid, $connector);
+        $consumer = ilLTIPlatform::fromExternalConsumerId($a_sid, $connector);
 
-        $object_ref = $consumer->getRefId();
-        $object_title = ilObject2::_lookupTitle(ilObject2::_lookupObjectId($object_ref));
-        return $consumer->getTitle() . " / " . $object_title;
+        return $consumer->getTitle() . ' (ID ' . $a_sid . ')';
     }
 
     /**
@@ -164,10 +168,11 @@ class ilAuthProviderLTI extends \ilAuthProvider implements \ilAuthProviderInterf
     {
         global $ilDB;
 
-        $query = 'SELECT consumer_pk from lti2_consumer where consumer_key = ' . $ilDB->quote(
-            $a_oauth_consumer_key,
-            'text'
-        );
+        $query = /** @lang text */
+            'SELECT consumer_pk from lti2_consumer where consumer_key = ' . $ilDB->quote(
+                $a_oauth_consumer_key,
+                'text'
+            );
         // $query = 'SELECT id from lti_ext_consumer where consumer_key = '.$ilDB->quote($a_oauth_consumer_key,'text');
         $this->getLogger()->debug($query);
         $res = $ilDB->query($query);
@@ -190,7 +195,8 @@ class ilAuthProviderLTI extends \ilAuthProvider implements \ilAuthProviderInterf
     {
         global $ilDB;
 
-        $query = 'SELECT prefix from lti_ext_consumer where id = ' . $ilDB->quote($a_lti_id, 'integer');
+        $query = /** @lang text */
+            'SELECT prefix from lti_ext_consumer where id = ' . $ilDB->quote($a_lti_id, 'integer');
         $this->getLogger()->debug($query);
         $res = $ilDB->query($query);
 
@@ -212,7 +218,8 @@ class ilAuthProviderLTI extends \ilAuthProvider implements \ilAuthProviderInterf
     {
         global $ilDB;
 
-        $query = 'SELECT role from lti_ext_consumer where id = ' . $ilDB->quote($a_lti_id, 'integer');
+        $query = /** @lang text */
+            'SELECT role from lti_ext_consumer where id = ' . $ilDB->quote($a_lti_id, 'integer');
         $this->getLogger()->debug($query);
         $res = $ilDB->query($query);
 
@@ -243,6 +250,11 @@ class ilAuthProviderLTI extends \ilAuthProvider implements \ilAuthProviderInterf
             setcookie("launch_presentation_return_url", $this->launchReturnUrl, time() + 86400, "/", "", true, true);
             $this->logger->info("Setting launch_presentation_return_url in cookie storage " . $this->launchReturnUrl);
         }
+        $pk = ilObjLTIConsumer::getPrivateKey();
+
+        $lti_provider->rsaKey = $pk['key'];
+        $lti_provider->kid = $pk['kid'];
+        $lti_provider->signatureMethod = 'RS256';
         $lti_provider->handleRequest();
         $this->provider = $lti_provider;
         $this->messageParameters = $this->provider->getMessageParameters();
@@ -406,8 +418,8 @@ class ilAuthProviderLTI extends \ilAuthProvider implements \ilAuthProviderInterf
             $user_obj->setTimeLimitFrom(time() - 60);
             $user_obj->setTimeLimitUntil(time() + (int) $ilClientIniFile->readVariable("session", "expire"));
         }
-        $user_obj->refreshLogin();
         $user_obj->update();
+        $user_obj->refreshLogin();
 
         $GLOBALS['DIC']->rbac()->admin()->assignUser($consumer->getRole(), $user_obj->getId());
         $this->getLogger()->debug('Assigned user to: ' . $consumer->getRole());
@@ -434,76 +446,31 @@ class ilAuthProviderLTI extends \ilAuthProvider implements \ilAuthProviderInterf
         //        }
         $userObj = new ilObjUser();
         $local_user = ilAuthUtils::_generateLogin($consumer->getPrefix() . '_' . $this->getCredentials()->getUsername());
-
-        $newUser["login"] = $local_user;
+        $userObj->setLogin($local_user);
         if (isset($this->messageParameters['lis_person_name_given'])) {
-            $newUser["firstname"] = $this->messageParameters['lis_person_name_given'];
+            $userObj->setFirstname($this->messageParameters['lis_person_name_given']);
         } else {
-            $newUser["firstname"] = '-';
+            $userObj->setFirstname('-');
         }
         if (isset($this->messageParameters['lis_person_name_family'])) {
-            $newUser["lastname"] = $this->messageParameters['lis_person_name_family'];
+            $userObj->setLastname($this->messageParameters['lis_person_name_family']);
         } else {
-            $newUser["lastname"] = '-';
+            $userObj->setLastname('-');
         }
-        $newUser['email'] = $this->messageParameters['lis_person_contact_email_primary'];
+        $userObj->setEmail($this->messageParameters['lis_person_contact_email_primary']);
 
         // set "plain md5" password (= no valid password)
         //        $newUser["passwd"] = "";
-        $newUser["passwd_type"] = ilObjUser::PASSWD_CRYPTED;
+        $userObj->setPasswd(ilObjUser::PASSWD_CRYPTED);
 
-        $newUser["auth_mode"] = 'lti_' . $consumer->getExtConsumerId();
-        $newUser['ext_account'] = $this->getCredentials()->getUsername();
-        $newUser["profile_incomplete"] = 0;
+        $userObj->setAuthMode('lti_' . $consumer->getExtConsumerId());
+        $userObj->setExternalAccount($this->getCredentials()->getUsername());
+        $userObj->setProfileIncomplete(false);
 
         // ILIAS 8
         //check
-        $newUser["gender"] = 'n';
-        $newUser["title"] = null;
-        $newUser["birthday"] = null;
-        $newUser["institution"] = null;
-        $newUser["department"] = null;
-        $newUser["street"] = null;
-        $newUser["city"] = null;
-        $newUser["zipcode"] = null;
-        $newUser["country"] = null;
-        $newUser["sel_country"] = null;
-        $newUser["phone_office"] = null;
-        $newUser["phone_home"] = null;
-        $newUser["phone_mobile"] = null;
-        $newUser["fax"] = null;
-        $newUser["matriculation"] = null;
-        $newUser["second_email"] = null;
-        $newUser["hobby"] = null;
-        $newUser["client_ip"] = null;
-        $newUser["passwd_salt"] = null;//$newUser->getPasswordSalt();
-        $newUser["latitude"] = null;
-        $newUser["longitude"] = null;
-        $newUser["loc_zoom"] = null;
-        $newUser["last_login"] = null;
-        $newUser["first_login"] = null;
-        $newUser["last_profile_prompt"] = null;
-        $newUser["last_update"] = ilUtil::now();
-        $newUser["create_date"] = ilUtil::now();
-        $newUser["referral_comment"] = null;
-        $newUser["approve_date"] = null;
-        $newUser["agree_date"] = null;
-        $newUser["inactivation_date"] = null;
-        $newUser["time_limit_from"] = null;
-        $newUser["time_limit_until"] = null;
-        $newUser["is_self_registered"] = null;
-        //end to check
+        $userObj->setGender('n');
 
-        $newUser["passwd_enc_type"] = "";
-        $newUser["active"] = true;
-        $newUser["time_limit_owner"] = 7;
-        $newUser["time_limit_unlimited"] = 0;
-        $newUser["time_limit_message"] = 0;
-        $newUser["passwd"] = " ";
-        //        $newUser["last_update"]
-
-        // system data
-        $userObj->assignData($newUser);
         $userObj->setTitle($userObj->getFullname());
         $userObj->setDescription($userObj->getEmail());
 
@@ -514,11 +481,12 @@ class ilAuthProviderLTI extends \ilAuthProvider implements \ilAuthProviderInterf
         $userObj->setTimeLimitOwner(7);
         $userObj->setTimeLimitUnlimited(false);
         $userObj->setTimeLimitFrom(time() - 5);
-        //        todo ?
         $userObj->setTimeLimitUntil(time() + (int) $ilClientIniFile->readVariable("session", "expire"));
 
         // Create user in DB
         $userObj->setOwner(6);
+        $tmp_date = new ilDateTime(time(), IL_CAL_UNIX);
+        $userObj->setAgreeDate($tmp_date->get(IL_CAL_DATETIME));
         $userObj->create();
         $userObj->setActive(true);
         //        $userObj->updateOwner();

--- a/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilLTIProviderObjectSettingGUI.php
+++ b/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilLTIProviderObjectSettingGUI.php
@@ -158,7 +158,6 @@ class ilLTIProviderObjectSettingGUI
         $this->tpl->setContent($form->getHTML());
     }
 
-
     /**
      * Init object settings form
      */
@@ -231,8 +230,12 @@ class ilLTIProviderObjectSettingGUI
             $sh->setValue($this->lng->txt("lti_13_step1_info"));
             $op1->addSubItem($sh);
             $url = new ilNonEditableValueGUI($this->lng->txt('lti_launch_url'), 'url');
-            $url->setValue(ILIAS_HTTP_PATH . '/lti.php?client_id=' . CLIENT_ID);
+            $url->setValue(ILIAS_HTTP_PATH . '/lti.php');
             $op1->addSubItem($url);
+
+            $urlJwks = new ilNonEditableValueGUI($this->lng->txt('lti_con_key_type_jwk'), $this->lng->txt('lti_con_key_type_jwk'));
+            $urlJwks->setValue(ILIAS_HTTP_PATH . '/lticerts.php');
+            $op1->addSubItem($urlJwks);
             //                    $url = new ilNonEditableValueGUI($this->lng->txt('lti_13_initiate_url'), 'url');
             //                    $url->setValue(ILIAS_HTTP_PATH . '/lti.php?client_id=' . CLIENT_ID);
             //                    $version->addSubItem($url);

--- a/components/ILIAS/LTIProvider/classes/Screen/LtiViewLayoutProvider.php
+++ b/components/ILIAS/LTIProvider/classes/Screen/LtiViewLayoutProvider.php
@@ -59,6 +59,7 @@ class LtiViewLayoutProvider extends AbstractModificationProvider implements Modi
     public function getPageBuilderDecorator(CalledContexts $screen_context_stack): ?PageBuilderModification
     {
         $this->globalScreen()->layout()->meta()->addCss('./components/ILIAS/LTIProvider/templates/default/lti.css');
+        $this->disableTopFrameTargets();
         $is_exit_mode = $this->isLTIExitMode($screen_context_stack);
         $external_css = ($is_exit_mode) ? '' : $this->dic["lti"]->getExternalCss();
         if ($external_css !== '') {
@@ -79,6 +80,32 @@ class LtiViewLayoutProvider extends AbstractModificationProvider implements Modi
                                  }
                              )
                              ->withHighPriority();
+    }
+
+    private function disableTopFrameTargets(): void
+    {
+        $this->dic->ui()->mainTemplate()->addOnLoadCode(<<<'JS'
+(function () {
+    if (window.self === window.top) {
+        return;
+    }
+    var update = function (root) {
+        root.querySelectorAll('a[target="_top"], form[target="_top"]').forEach(function (element) {
+            element.setAttribute('target', '_self');
+        });
+    };
+    update(document);
+    new MutationObserver(function (mutations) {
+        mutations.forEach(function (mutation) {
+            mutation.addedNodes.forEach(function (node) {
+                if (node.nodeType === Node.ELEMENT_NODE) {
+                    update(node);
+                }
+            });
+        });
+    }).observe(document.body, {childList: true, subtree: true});
+}());
+JS);
     }
 
     protected function isLTIExitMode(CalledContexts $screen_context_stack): bool

--- a/components/ILIAS/LTIProvider/classes/class.ilLTIAppEventListener.php
+++ b/components/ILIAS/LTIProvider/classes/class.ilLTIAppEventListener.php
@@ -21,18 +21,19 @@ declare(strict_types=1);
 use ceLTIc\LTI\Enum\ServiceAction;
 use ceLTIc\LTI\Outcome;
 use ceLTIc\LTI\ResourceLink;
+use ceLTIc\LTI\Tool;
 use ceLTIc\LTI\UserResult;
 
 /**
  * Class ilLTIAppEventListener
  */
-class ilLTIAppEventListener implements \ilAppEventListener
+class ilLTIAppEventListener
 {
-    private static ?\ilLTIAppEventListener $instance = null;
+    private static ?ilLTIAppEventListener $instance = null;
 
-    private ?\ilLogger $logger = null;
+    private ?ilLogger $logger = null;
 
-    private ?\ilLTIDataConnector $connector = null;
+    private ?ilLTIDataConnector $connector = null;
 
 
     /**
@@ -41,14 +42,13 @@ class ilLTIAppEventListener implements \ilAppEventListener
     protected function __construct()
     {
         global $DIC;
-
-        $this->logger = ilLoggerFactory::getLogger('ltis');
+        $this->logger = $DIC->logger()->root();
         $this->connector = new ilLTIDataConnector();
     }
 
-    protected static function getInstance(): \ilLTIAppEventListener
+    protected static function getInstance(): ilLTIAppEventListener
     {
-        if (!self::$instance instanceof \ilLTIAppEventListener) {
+        if (!self::$instance instanceof ilLTIAppEventListener) {
             self::$instance = new self();
         }
         return self::$instance;
@@ -80,7 +80,7 @@ class ilLTIAppEventListener implements \ilAppEventListener
             );
 
             $this->logger->debug('Resources for update:');
-            $this->logger->dump($resources, ilLogLevel::DEBUG);
+            $this->logger->debug("resources: " . json_encode($resources));
 
             foreach ($resources as $resource) {
                 $this->tryOutcomeService((int) $resource, $ext_account, $a_status, $a_percentage);
@@ -164,22 +164,7 @@ class ilLTIAppEventListener implements \ilAppEventListener
         $this->logger->info('Trying outcome service with status ' . $a_status . ' and percentage ' . $a_percentage);
         $user = UserResult::fromResourceLink($resource_link, $ext_account);
 
-        if (!$a_percentage && $a_status != ilLPStatus::LP_STATUS_NOT_ATTEMPTED_NUM) {
-            $score = 0;
-        } else {
-            if ($a_status == ilLPStatus::LP_STATUS_COMPLETED_NUM || $a_status == ilLPStatus::LP_STATUS_FAILED_NUM) {
-                $score = $a_percentage / 100;
-            } elseif (
-                $a_status == ilLPStatus::LP_STATUS_NOT_ATTEMPTED_NUM
-            ) {
-                $score = null;
-            } else {
-                $score = 0;
-            }
-        }
-
-        $this->logger->info('Sending score: ' . (string) $score);
-
+        $score = $a_status == ilLPStatus::LP_STATUS_NOT_ATTEMPTED_NUM ? null : $a_percentage / 100;
         $platform = $resource_link->getPlatform();
 
         $platform->accessTokenUrl = $platform->accessTokenUrl
@@ -232,13 +217,16 @@ class ilLTIAppEventListener implements \ilAppEventListener
 
 
     /**
-     * @inheritdoc
+     * Handle an event in a listener.
+     * @param	string $a_component component, e.g. "components/ILIAS/Forum" or "components/ILIAS/User"
+     * @param	string $a_event     event e.g. "createUser", "updateUser", "deleteUser", ...
+     * @param	array<string, mixed> $a_parameter parameter array (assoc), array("name" => ..., "phone_office" => ...)
      */
     public static function handleEvent(string $a_component, string $a_event, array $a_parameter): void
     {
-        $logger = ilLoggerFactory::getLogger('ltis');
+        global $DIC;
+        $logger = $DIC->logger()->root();
         $logger->info('Handling event: ' . $a_event . ' from ' . $a_component);
-
         if ($a_component == 'components/ILIAS/Tracking') {
             if ($a_event == 'updateStatus') {
                 $listener = self::getInstance();

--- a/components/ILIAS/LTIProvider/classes/class.ilLTIAppEventListener.php
+++ b/components/ILIAS/LTIProvider/classes/class.ilLTIAppEventListener.php
@@ -157,7 +157,7 @@ class ilLTIAppEventListener implements \ilAppEventListener
     protected function tryOutcomeService(int $resource, string $ext_account, int $a_status, int $a_percentage): void
     {
         $resource_link = ResourceLink::fromRecordId($resource, $this->connector);
-        if (!$resource_link->hasOutcomesService()) {
+        if (!$resource_link->hasOutcomesService() && !$resource_link->hasScoreService()) {
             $this->logger->info('No outcome service available for resource id: ' . $resource);
             return;
         }
@@ -179,6 +179,25 @@ class ilLTIAppEventListener implements \ilAppEventListener
         }
 
         $this->logger->info('Sending score: ' . (string) $score);
+
+        $platform = $resource_link->getPlatform();
+
+        $platform->accessTokenUrl = $platform->accessTokenUrl
+            ?: $platform->getSetting('custom_oauth2_access_token_url');
+
+        $priv = \ilObjLTIConsumer::getPrivateKey();
+
+        $tool = new Tool();
+        $tool->rsaKey = $priv['key'];
+        $tool->kid = $priv['kid'];
+        $tool->jku = \ilObjLTIConsumer::getPublicKeysetUrl();
+        $tool->requiredScopes = [
+            "https://purl.imsglobal.org/spec/lti-ags/scope/score",
+        ];
+        $tool->signatureMethod = $platform->signatureMethod;
+
+        Tool::$defaultTool = $tool;
+        $tool->platform = $platform;
 
         $pointsPossible = 1;
 

--- a/components/ILIAS/LTIProvider/classes/class.ilLTIDataConnector.php
+++ b/components/ILIAS/LTIProvider/classes/class.ilLTIDataConnector.php
@@ -522,6 +522,7 @@ class ilLTIDataConnector extends DataConnector
     {
         $ilDB = $this->database;
 
+        $signatureMethod = \ceLTIc\LTI\Enum\LtiVersion::V1P3 === $platform->ltiVersion ? "RS256" : "HMAC-SHA1";
         $id = $platform->getRecordId();
         $key = $platform->getKey();
         $protected = ($platform->protected) ? 1 : 0;
@@ -556,57 +557,59 @@ class ilLTIDataConnector extends DataConnector
             // $query = "INSERT INTO {$this->dbTableNamePrefix}" . $this->CONSUMER_TABLE_NAME . ' (consumer_key256, consumer_key, name, ' .
             $query = 'INSERT INTO lti2_consumer (consumer_key, name, ' .
                 'secret, lti_version, consumer_name, consumer_version, consumer_guid, profile, tool_proxy, settings, protected, enabled, ' .
-                'enable_from, enable_until, last_access, created, updated, consumer_pk, ext_consumer_id, ref_id, platform_id, client_id, deployment_id, public_key) ' .
-                'VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)';
+                'enable_from, enable_until, last_access, created, updated, consumer_pk, ext_consumer_id, ref_id, platform_id, client_id, deployment_id, public_key, signature_method) ' .
+                'VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)';
             $types = array("text",
-                           "text",
-                           "text",
-                           "text",
-                           "text",
-                           "text",
-                           "text",
-                           "text",
-                           "text",
-                           "text",
-                           "integer",
-                           "integer",
-                           "timestamp",
-                           "timestamp",
-                           "timestamp",
-                           "timestamp",
-                           "timestamp",
-                           "integer",
-                           'integer',
-                           'integer',
-                           "text",
-                           "text",
-                           "text",
-                           "text"
+                "text",
+                "text",
+                "text",
+                "text",
+                "text",
+                "text",
+                "text",
+                "text",
+                "text",
+                "integer",
+                "integer",
+                "timestamp",
+                "timestamp",
+                "timestamp",
+                "timestamp",
+                "timestamp",
+                "integer",
+                'integer',
+                'integer',
+                "text",
+                "text",
+                "text",
+                "text",
+                "text"
             );
             $values = array($key,
-                            $platform->name,
-                            $platform->secret,
-                            $platform->ltiVersion->value,
-                            $platform->consumerName,
-                            $platform->consumerVersion,
-                            $platform->consumerGuid,
-                            $profile,
-                            $platform->toolProxy,
-                            $settingsValue,
-                            $protected,
-                            $enabled,
-                            $from,
-                            $until,
-                            $last,
-                            $now,
-                            $now,
-                            $id,
-                            $platform->getExtConsumerId(),
-                            $platform->getRefId(),
-                            (string) $platform->platformId,
-                            $platform->clientId,
-                            $platform->deploymentId,
-                            $platform->rsaKey
+                $platform->name,
+                $platform->secret,
+                $platform->ltiVersion->value,
+                $platform->consumerName,
+                $platform->consumerVersion,
+                $platform->consumerGuid,
+                $profile,
+                $platform->toolProxy,
+                $settingsValue,
+                $protected,
+                $enabled,
+                $from,
+                $until,
+                $last,
+                $now,
+                $now,
+                $id,
+                $platform->getExtConsumerId(),
+                $platform->getRefId(),
+                (string) $platform->platformId,
+                $platform->clientId,
+                $platform->deploymentId,
+                $platform->rsaKey,
+                $signatureMethod
             );
             $ilDB->manipulateF($query, $types, $values);
         } else {
@@ -617,51 +620,55 @@ class ilLTIDataConnector extends DataConnector
                 'secret= %s, lti_version = %s, consumer_name = %s, consumer_version = %s, consumer_guid = %s, ' .
                 'profile = %s, tool_proxy = %s, settings = %s, protected = %s, enabled = %s, ' .
                 'enable_from = %s, enable_until = %s, last_access = %s, updated = %s, ' .
-                'platform_id = %s, client_id = %s, deployment_id = %s, public_key = %s ' .
+                'platform_id = %s, client_id = %s, deployment_id = %s, public_key = %s, signature_method = %s ' .
                 'WHERE consumer_pk = %s';
             $types = array("text",
-                           "text",
-                           "text",
-                           "text",
-                           "text",
-                           "text",
-                           "text",
-                           "text",
-                           "text",
-                           "text",
-                           "integer",
-                           "integer",
-                           "timestamp",
-                           "timestamp",
-                           "timestamp",
-                           "timestamp",
-                           "text",
-                           "text",
-                           "text",
-                           "text",
-                           "integer"
+                "text",
+                "text",
+                "text",
+                "text",
+                "text",
+                "text",
+                "text",
+                "text",
+                "text",
+                "integer",
+                "integer",
+                "timestamp",
+                "timestamp",
+                "timestamp",
+                "timestamp",
+                "text",
+                "text",
+                "text",
+                "text",
+                "text",
+                "integer"
+
             );
             $values = array($key,
-                            $platform->name,
-                            $platform->secret,
-                            $platform->ltiVersion->value,
-                            $platform->consumerName,
-                            $platform->consumerVersion,
-                            $platform->consumerGuid,
-                            $profile,
-                            $platform->toolProxy,
-                            $settingsValue,
-                            $protected,
-                            $enabled,
-                            $from,
-                            $until,
-                            $last,
-                            $now,
-                            $platform->platformId,
-                            $platform->clientId,
-                            $platform->deploymentId,
-                            $platform->rsaKey,
-                            $id
+                $platform->name,
+                $platform->secret,
+                $platform->ltiVersion->value,
+                $platform->consumerName,
+                $platform->consumerVersion,
+                $platform->consumerGuid,
+                $profile,
+                $platform->toolProxy,
+                $settingsValue,
+                $protected,
+                $enabled,
+                $from,
+                $until,
+                $last,
+                $now,
+                $platform->platformId,
+                $platform->clientId,
+                $platform->deploymentId,
+                $platform->rsaKey,
+                $signatureMethod,
+                $id
+
             );
             $ilDB->manipulateF($query, $types, $values);
         }
@@ -1219,24 +1226,24 @@ class ilLTIDataConnector extends DataConnector
                 'lti_resource_link_id, settings, primary_resource_link_pk, share_approved, created, updated) ' .
                 'VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)';
             $types = array("integer",
-                           "integer",
-                           "integer",
-                           "text",
-                           "text",
-                           "integer",
-                           "integer",
-                           "timestamp",
-                           "timestamp"
+                "integer",
+                "integer",
+                "text",
+                "text",
+                "integer",
+                "integer",
+                "timestamp",
+                "timestamp"
             );
             $values = array($id,
-                            $platformId,
-                            $contextId,
-                            $resourceLink->getId(),
-                            $settingsValue,
-                            $primaryResourceLinkId,
-                            $approved,
-                            $now,
-                            $now
+                $platformId,
+                $contextId,
+                $resourceLink->getId(),
+                $settingsValue,
+                $primaryResourceLinkId,
+                $approved,
+                $now,
+                $now
             );
         } elseif (!is_null($contextId)) {
             $query = "UPDATE {$this->dbTableNamePrefix}" . DataConnector::RESOURCE_LINK_TABLE_NAME . ' SET ' .
@@ -1245,13 +1252,13 @@ class ilLTIDataConnector extends DataConnector
                 'WHERE (context_pk = %s) AND (resource_link_pk = %s)';
             $types = array("integer", "text", "text", "integer", "integer", "timestamp", "integer", "integer");
             $values = array($platformId,
-                            $resourceLink->getId(),
-                            $settingsValue,
-                            $primaryResourceLinkId,
-                            $approved,
-                            $now,
-                            $contextId,
-                            $id
+                $resourceLink->getId(),
+                $settingsValue,
+                $primaryResourceLinkId,
+                $approved,
+                $now,
+                $contextId,
+                $id
             );
         } else {
             $query = "UPDATE {$this->dbTableNamePrefix}" . DataConnector::RESOURCE_LINK_TABLE_NAME . ' SET ' .
@@ -1260,13 +1267,13 @@ class ilLTIDataConnector extends DataConnector
                 'WHERE (consumer_pk = %s) AND (resource_link_pk = %s)';
             $types = array("integer", "text", "text", "integer", "integer", "timestamp", "integer", "integer");
             $values = array($contextId,
-                            $resourceLink->getId(),
-                            $settingsValue,
-                            $primaryResourceLinkId,
-                            $approved,
-                            $now,
-                            $platformId,
-                            $id
+                $resourceLink->getId(),
+                $settingsValue,
+                $primaryResourceLinkId,
+                $approved,
+                $now,
+                $platformId,
+                $id
             );
         }
         $ok = (bool) $ilDB->manipulateF($query, $types, $values);

--- a/components/ILIAS/LTIProvider/classes/class.ilLTIDataConnector.php
+++ b/components/ILIAS/LTIProvider/classes/class.ilLTIDataConnector.php
@@ -72,7 +72,12 @@ class ilLTIDataConnector extends DataConnector
             $types = array('integer');
             $values = array($id);
         } elseif (!empty($platform->platformId)) {
-            if (empty($platform->clientId)) {
+            if (empty($platform->clientId) && !empty($platform->deploymentId)) {
+                $allowMultiple = true;
+                $query .= '(platform_id = %s) AND (deployment_id = %s)';
+                $types = array('text', 'text');
+                $values = array($platform->platformId, $platform->deploymentId);
+            } elseif (empty($platform->clientId)) {
                 $allowMultiple = true;
                 $query .= '(platform_id = %s)';
                 $types = array('text');

--- a/components/ILIAS/LTIProvider/classes/class.ilLTIViewGUI.php
+++ b/components/ILIAS/LTIProvider/classes/class.ilLTIViewGUI.php
@@ -175,7 +175,7 @@ class ilLTIViewGUI
         // context_id = ref_id in request
         if (ilSession::has('lti_' . $ref_id . '_post_data')) {
             $this->log->debug("lti context session exists for " . $ref_id);
-            //            return $ref_id;
+            return $ref_id;
         }
         // sub item request
         $this->log->debug("ref_id not exists as context_id, walking tree backwards to find a valid context_id");

--- a/components/ILIAS/LTIProvider/resources/lti.php
+++ b/components/ILIAS/LTIProvider/resources/lti.php
@@ -18,15 +18,15 @@
 
 declare(strict_types=1);
 
-require_once("../vendor/composer/vendor/autoload.php");
 
-ilContext::init(ilContext::CONTEXT_LTI_PROVIDER);
-
-// This is done to replace the deprecated method $DIC->ctrl()->setCmd
 $_GET['cmd'] = 'post';
 $_POST['cmd'] = 'doLTIAuthentication';
 
-ilInitialisation::initILIAS();
+require_once '../vendor/composer/vendor/autoload.php';
+require_once __DIR__ . '/../artifacts/bootstrap_default.php';
+entry_point('ILIAS Legacy Initialisation Adapter');
+
+ilContext::init(ilContext::CONTEXT_LTI_PROVIDER);
 
 global $DIC;
 

--- a/components/ILIAS/Tracking/classes/status/class.ilLPStatusLtiOutcome.php
+++ b/components/ILIAS/Tracking/classes/status/class.ilLPStatusLtiOutcome.php
@@ -87,7 +87,8 @@ class ilLPStatusLtiOutcome extends ilLPStatus
                 return self::LP_STATUS_FAILED_NUM;
             }
 
-            if (in_array($activityProgress, ['Started', 'InProgress', 'Submitted'], true) ||
+            if (in_array($activityProgress, ['Started', 'InProgress'], true) ||
+                ($activityProgress === 'Submitted' && $gradingProgress !== 'FullyGraded') ||
                 in_array($gradingProgress, ['Pending', 'PendingManual', 'NotReady'], true)) {
                 return self::LP_STATUS_IN_PROGRESS_NUM;
             }

--- a/components/ILIAS/Tracking/classes/status/class.ilLPStatusLtiOutcome.php
+++ b/components/ILIAS/Tracking/classes/status/class.ilLPStatusLtiOutcome.php
@@ -75,6 +75,9 @@ class ilLPStatusLtiOutcome extends ilLPStatus
         int $a_usr_id,
         ?object $a_obj = null
     ): int {
+        global $DIC;
+        $logger = $DIC->logger()->root();
+
         $latestGrade = $this->getLatestAgsGrade($a_obj_id, $a_usr_id);
         if ($latestGrade !== null) {
             $activityProgress = (string) ($latestGrade['activity_progress'] ?? '');

--- a/components/ILIAS/Tracking/classes/status/class.ilLPStatusLtiOutcome.php
+++ b/components/ILIAS/Tracking/classes/status/class.ilLPStatusLtiOutcome.php
@@ -51,11 +51,45 @@ class ilLPStatusLtiOutcome extends ilLPStatus
         return $object;
     }
 
+    private function getLatestAgsGrade(int $objId, int $usrId): ?array
+    {
+        global $DIC;
+
+        $db = $DIC->database();
+        if (!$db->tableExists('lti_consumer_grades')) {
+            return null;
+        }
+
+        $query = 'SELECT * FROM lti_consumer_grades'
+            . ' WHERE obj_id = ' . $db->quote($objId, 'integer')
+            . ' AND usr_id = ' . $db->quote($usrId, 'integer')
+            . ' ORDER BY lti_timestamp DESC, stored DESC, id DESC';
+        $res = $db->query($query);
+        $row = $db->fetchAssoc($res);
+
+        return $row ?: null;
+    }
+
     public function determineStatus(
         int $a_obj_id,
         int $a_usr_id,
         ?object $a_obj = null
     ): int {
+        $latestGrade = $this->getLatestAgsGrade($a_obj_id, $a_usr_id);
+        if ($latestGrade !== null) {
+            $activityProgress = (string) ($latestGrade['activity_progress'] ?? '');
+            $gradingProgress = (string) ($latestGrade['grading_progress'] ?? '');
+
+            if ($gradingProgress === 'Failed') {
+                return self::LP_STATUS_FAILED_NUM;
+            }
+
+            if (in_array($activityProgress, ['Started', 'InProgress', 'Submitted'], true) ||
+                in_array($gradingProgress, ['Pending', 'PendingManual', 'NotReady'], true)) {
+                return self::LP_STATUS_IN_PROGRESS_NUM;
+            }
+        }
+
         $ltiResult = $this->getLtiUserResult($a_obj_id, $a_usr_id);
 
         if ($ltiResult instanceof ilLTIConsumerResult) {
@@ -77,6 +111,14 @@ class ilLPStatusLtiOutcome extends ilLPStatus
         int $a_usr_id,
         ?object $a_obj = null
     ): int {
+        $latestGrade = $this->getLatestAgsGrade($a_obj_id, $a_usr_id);
+        if ($latestGrade !== null &&
+            is_numeric($latestGrade['score_given'] ?? null) &&
+            is_numeric($latestGrade['score_maximum'] ?? null) &&
+            (float) $latestGrade['score_maximum'] > 0) {
+            return (int) round(((float) $latestGrade['score_given'] / (float) $latestGrade['score_maximum']) * 100);
+        }
+
         $ltiResult = $this->getLtiUserResult($a_obj_id, $a_usr_id);
 
         if ($ltiResult instanceof ilLTIConsumerResult) {

--- a/components/ILIAS/Tracking/classes/status/class.ilLPStatusLtiOutcome.php
+++ b/components/ILIAS/Tracking/classes/status/class.ilLPStatusLtiOutcome.php
@@ -80,16 +80,12 @@ class ilLPStatusLtiOutcome extends ilLPStatus
 
         $latestGrade = $this->getLatestAgsGrade($a_obj_id, $a_usr_id);
         if ($latestGrade !== null) {
-            $activityProgress = (string) ($latestGrade['activity_progress'] ?? '');
-            $gradingProgress = (string) ($latestGrade['grading_progress'] ?? '');
+            $activityProgress = ilLTIConsumerActivityProgress::tryFrom((string) ($latestGrade['activity_progress'] ?? ''));
+            $gradingProgress = ilLTIConsumerGradingProgress::tryFrom((string) ($latestGrade['grading_progress'] ?? ''));
 
-            if ($gradingProgress === 'Failed') {
-                return self::LP_STATUS_FAILED_NUM;
-            }
-
-            if (in_array($activityProgress, ['Started', 'InProgress'], true) ||
-                ($activityProgress === 'Submitted' && $gradingProgress !== 'FullyGraded') ||
-                in_array($gradingProgress, ['Pending', 'PendingManual', 'NotReady'], true)) {
+            if (($activityProgress?->isInProgress() ?? false) ||
+                ($activityProgress === ilLTIConsumerActivityProgress::SUBMITTED && $gradingProgress?->isPending()) ||
+                ($gradingProgress?->isPending() ?? false)) {
                 return self::LP_STATUS_IN_PROGRESS_NUM;
             }
         }

--- a/components/ILIAS/Tracking/classes/status/class.ilLPStatusLtiOutcome.php
+++ b/components/ILIAS/Tracking/classes/status/class.ilLPStatusLtiOutcome.php
@@ -116,7 +116,9 @@ class ilLPStatusLtiOutcome extends ilLPStatus
             is_numeric($latestGrade['score_given'] ?? null) &&
             is_numeric($latestGrade['score_maximum'] ?? null) &&
             (float) $latestGrade['score_maximum'] > 0) {
-            return (int) round(((float) $latestGrade['score_given'] / (float) $latestGrade['score_maximum']) * 100);
+            return max(0, min(100, (int) round(
+                ((float) $latestGrade['score_given'] / (float) $latestGrade['score_maximum']) * 100
+            )));
         }
 
         $ltiResult = $this->getLtiUserResult($a_obj_id, $a_usr_id);

--- a/lang/ilias_ar.lang
+++ b/lang/ilias_ar.lang
@@ -11189,6 +11189,10 @@ lti#:#conf_privacy_ident_il_uuid_ext_account#:#External User ID combined with a 
 lti#:#conf_privacy_ident_il_uuid_ext_account_info#:#This is identical to each call, but may allow a direct conclusion about the user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login#:#ILIAS Login combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login_info#:#Sends the login name. This is identical to each call, but may allow a direct conclusion about the ILIAS user.###26 08 2024 new variable
+lti#:#conf_privacy_ident_il_uuid_random#:#Random ID combined with a unique ILIAS platform ID formatted as an E-Mail address###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_random_info#:#For each ILIAS object and ILIAS user a random ID is generated which remains identical for each call. Conclusions about a user are very limited because it is practically impossible to create user profiles across objects.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url#:#Hash combined with the ILIAS Domain formatted as an E-Mail address.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url_info#:#This is identical to each call, with with a maximum of 80 characters significantly shorter than the variant with the ILIAS platform ID and allows only very limited conclusions about the ILIAS user.###04 12 2025 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id#:#ILIAS user id combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id_info#:#Sends the internal numeric user id. This is identical to each call, but may allow conclusions about the ILIAS user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_info#:#Standard is frequently the email address. The unique ILIAS platform id is:###26 08 2024 new variable
@@ -11274,13 +11278,16 @@ lti#:#launched#:#Resource was already launched.###07 02 2020 new variable
 lti#:#learning_progress_options#:#Options for Learning Progress###07 02 2020 new variable
 lti#:#lm_only_one_download_per_type#:#Please note that you can only make one file per type (XML, HTML, SCORM) public accessible.###31 08 2017 new variable
 lti#:#lti13_hints#:#If the tool was created without dynamic registration, the following data must be entered for the tool to run.###26 08 2024 new variable
+lti#:#lti_13_authentication_url#:#Authentication Request URL###04 12 2025 new variable
 lti#:#lti_13_client_id#:#Client-ID###26 08 2024 new variable
 lti#:#lti_13_deployment_id#:#Deployment-ID###26 08 2024 new variable
+lti#:#lti_13_keyset_url#:#Public Keyset URL###04 12 2025 new variable
 lti#:#lti_13_platform_id#:#Platform-ID###26 08 2024 new variable
 lti#:#lti_13_step1#:#Step 1###26 08 2024 new variable
 lti#:#lti_13_step1_info#:#For the initiating platform (consumer), enter the following address for Launch URL, Initiate Login URL, Redirection URI, and Registration URL:###26 08 2024 new variable
 lti#:#lti_13_step2#:#Step 2###26 08 2024 new variable
 lti#:#lti_13_step2_info#:#You will receive information from the initiating platform (Consumer), which you must enter in the following fields. After saving, the LTI 1.3 functionalities are available.###26 08 2024 new variable
+lti#:#lti_13_token_url#:#Access Token URL###04 12 2025 new variable
 lti#:#lti_action_accept_provider_as_global#:#Accept Provider as Global Provider for all Users###07 02 2020 new variable
 lti#:#lti_action_accept_providers_as_global#:#Accept Providers as Global###07 02 2020 new variable
 lti#:#lti_action_delete_providers#:#Delete Providers###07 02 2020 new variable
@@ -11294,6 +11301,8 @@ lti#:#lti_at_least_one_prov_has_usages#:#At least one provider could not be dele
 lti#:#lti_auth_failed_invalid_key#:#Authentication failed, no valid consumer key given.###31 08 2017 new variable
 lti#:#lti_con_content_item#:#Support for Deep Linking###26 08 2024 new variable
 lti#:#lti_con_content_item_url#:#Content URL###26 08 2024 new variable
+lti#:#lti_con_grade_synchronization#:#Assignment and Grade Services###04 12 2025 new variable
+lti#:#lti_con_grade_synchronization_info#:#The LTI tool must offer 'Assignment and Grade Services'.###04 12 2025 new variable
 lti#:#lti_con_initiate_login_url#:#Initiate Login URL###26 08 2024 new variable
 lti#:#lti_con_key_type#:#Public Key Type###26 08 2024 new variable
 lti#:#lti_con_key_type_jwk#:#URL (Json Web Token)###26 08 2024 new variable
@@ -11313,6 +11322,10 @@ lti#:#lti_con_prov_category_info#:#Category to filter entries when LTI Consumer 
 lti#:#lti_con_prov_custom_params#:#Custom Parameters for this specific Provider###07 02 2020 new variable
 lti#:#lti_con_prov_custom_params_info#:#Please enter them in the form param1=value1; param2=value2###07 02 2020 new variable
 lti#:#lti_con_prov_description#:#Description###07 02 2020 new variable
+lti#:#lti_con_prov_dyn_reg_params#:#Optional Parameters###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_params_info#:#Here, for example, references to target objects in the tool can be specified.###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url#:#Registration URL of the Tool###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url_info#:#Note: Not every tool supports dynamic registration.###04 12 2025 new variable
 lti#:#lti_con_prov_external_provider#:#External Provider###07 02 2020 new variable
 lti#:#lti_con_prov_external_provider_info#:#A hint will be shown to users when dealing with an external Provider. An external Provider is characterized by insufficient influence on the Provider by the operator of the ILIAS-installation. This is the case when there are no rights to delete.###07 02 2020 new variable
 lti#:#lti_con_prov_group_options#:#Options to group and filter Providers###07 02 2020 new variable
@@ -11382,12 +11395,13 @@ lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Ad
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable
+lti#:#lti_dynamic_registration#:#Create Own Settings for Tool with Dynamic Registration (LTI 1.3)###04 12 2025
 lti#:#lti_edit_consumer#:#Edit LTI Consumer###31 08 2017 new variable
 lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
-lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_content_selection#:#اختيار المحتوى
+lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable
@@ -11438,6 +11452,7 @@ lti#:#subtab_certificate#:#Certificate###07 02 2020 new variable
 lti#:#subtab_object_settings#:#Object Settings###07 02 2020 new variable
 lti#:#subtab_provider_settings#:#LTI Provider Settings###07 02 2020 new variable
 lti#:#tab_content#:#Content###07 02 2020 new variable
+lti#:#tab_grade_synchronization#:#Gradebook
 lti#:#tab_info#:#Info###07 02 2020 new variable
 lti#:#tab_scoring#:#Ranking###07 02 2020 new variable
 lti#:#tab_settings#:#Settings###07 02 2020 new variable

--- a/lang/ilias_ar.lang
+++ b/lang/ilias_ar.lang
@@ -11378,6 +11378,7 @@ lti#:#lti_create_lti_user_role#:#Create recommended global role for LTI users###
 lti#:#lti_cron_title#:#LTI Outcome Service###07 02 2020 new variable
 lti#:#lti_cron_title_desc#:#Synchronizes the learning progress of LTI users with the LTI consumer, if it supports the outcome service. This cron job is only required to transfer status updates after Learning progress settings updates.###07 02 2020 new variable
 lti#:#lti_custom_new#:#Create Own Provider Settings###07 02 2020 new variable
+lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Administration do not allow content selection
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable

--- a/lang/ilias_ar.lang
+++ b/lang/ilias_ar.lang
@@ -11387,6 +11387,7 @@ lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
 lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
+lti#:#lti_form_provider_content_selection#:#اختيار المحتوى
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable

--- a/lang/ilias_bg.lang
+++ b/lang/ilias_bg.lang
@@ -11387,6 +11387,7 @@ lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
 lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
+lti#:#lti_form_provider_content_selection#:#Избор на съдържание
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable

--- a/lang/ilias_bg.lang
+++ b/lang/ilias_bg.lang
@@ -11189,6 +11189,10 @@ lti#:#conf_privacy_ident_il_uuid_ext_account#:#External User ID combined with a 
 lti#:#conf_privacy_ident_il_uuid_ext_account_info#:#This is identical to each call, but may allow a direct conclusion about the user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login#:#ILIAS Login combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login_info#:#Sends the login name. This is identical to each call, but may allow a direct conclusion about the ILIAS user.###26 08 2024 new variable
+lti#:#conf_privacy_ident_il_uuid_random#:#Random ID combined with a unique ILIAS platform ID formatted as an E-Mail address###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_random_info#:#For each ILIAS object and ILIAS user a random ID is generated which remains identical for each call. Conclusions about a user are very limited because it is practically impossible to create user profiles across objects.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url#:#Hash combined with the ILIAS Domain formatted as an E-Mail address.###21 05 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url_info#:#This is identical to each call, with with a maximum of 80 characters significantly shorter than the variant with the ILIAS platform ID and allows only very limited conclusions about the ILIAS user.###04 12 2025 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id#:#ILIAS user id combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id_info#:#Sends the internal numeric user id. This is identical to each call, but may allow conclusions about the ILIAS user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_info#:#Standard is frequently the email address. The unique ILIAS platform id is:###26 08 2024 new variable
@@ -11274,13 +11278,16 @@ lti#:#launched#:#Resource was already launched.###07 02 2020 new variable
 lti#:#learning_progress_options#:#Options for Learning Progress###07 02 2020 new variable
 lti#:#lm_only_one_download_per_type#:#Please note that you can only make one file per type (XML, HTML, SCORM) public accessible.###31 08 2017 new variable
 lti#:#lti13_hints#:#If the tool was created without dynamic registration, the following data must be entered for the tool to run.###26 08 2024 new variable
+lti#:#lti_13_authentication_url#:#Authentication Request URL###04 12 2025 new variable
 lti#:#lti_13_client_id#:#Client-ID###26 08 2024 new variable
 lti#:#lti_13_deployment_id#:#Deployment-ID###26 08 2024 new variable
+lti#:#lti_13_keyset_url#:#Public Keyset URL###04 12 2025 new variable
 lti#:#lti_13_platform_id#:#Platform-ID###26 08 2024 new variable
 lti#:#lti_13_step1#:#Step 1###26 08 2024 new variable
 lti#:#lti_13_step1_info#:#For the initiating platform (consumer), enter the following address for Launch URL, Initiate Login URL, Redirection URI, and Registration URL:###26 08 2024 new variable
 lti#:#lti_13_step2#:#Step 2###26 08 2024 new variable
 lti#:#lti_13_step2_info#:#You will receive information from the initiating platform (Consumer), which you must enter in the following fields. After saving, the LTI 1.3 functionalities are available.###26 08 2024 new variable
+lti#:#lti_13_token_url#:#Access Token URL###04 12 2025 new variable
 lti#:#lti_action_accept_provider_as_global#:#Accept Provider as Global Provider for all Users###07 02 2020 new variable
 lti#:#lti_action_accept_providers_as_global#:#Accept Providers as Global###07 02 2020 new variable
 lti#:#lti_action_delete_providers#:#Delete Providers###07 02 2020 new variable
@@ -11294,6 +11301,8 @@ lti#:#lti_at_least_one_prov_has_usages#:#At least one provider could not be dele
 lti#:#lti_auth_failed_invalid_key#:#Authentication failed, no valid consumer key given.###31 08 2017 new variable
 lti#:#lti_con_content_item#:#Support for Deep Linking###26 08 2024 new variable
 lti#:#lti_con_content_item_url#:#Content URL###26 08 2024 new variable
+lti#:#lti_con_grade_synchronization#:#Assignment and Grade Services###04 12 2025 new variable
+lti#:#lti_con_grade_synchronization_info#:#The LTI tool must offer 'Assignment and Grade Services'.###04 12 2025 new variable
 lti#:#lti_con_initiate_login_url#:#Initiate Login URL###26 08 2024 new variable
 lti#:#lti_con_key_type#:#Public Key Type###26 08 2024 new variable
 lti#:#lti_con_key_type_jwk#:#URL (Json Web Token)###26 08 2024 new variable
@@ -11313,6 +11322,10 @@ lti#:#lti_con_prov_category_info#:#Category to filter entries when LTI Consumer 
 lti#:#lti_con_prov_custom_params#:#Custom Parameters for this specific Provider###07 02 2020 new variable
 lti#:#lti_con_prov_custom_params_info#:#Please enter them in the form param1=value1; param2=value2###07 02 2020 new variable
 lti#:#lti_con_prov_description#:#Description###07 02 2020 new variable
+lti#:#lti_con_prov_dyn_reg_params#:#Optional Parameters###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_params_info#:#Here, for example, references to target objects in the tool can be specified.###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url#:#Registration URL of the Tool###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url_info#:#Note: Not every tool supports dynamic registration.###04 12 2025 new variable
 lti#:#lti_con_prov_external_provider#:#External Provider###07 02 2020 new variable
 lti#:#lti_con_prov_external_provider_info#:#A hint will be shown to users when dealing with an external Provider. An external Provider is characterized by insufficient influence on the Provider by the operator of the ILIAS-installation. This is the case when there are no rights to delete.###07 02 2020 new variable
 lti#:#lti_con_prov_group_options#:#Options to group and filter Providers###07 02 2020 new variable
@@ -11382,12 +11395,13 @@ lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Ad
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable
+lti#:#lti_dynamic_registration#:#Create Own Settings for Tool with Dynamic Registration (LTI 1.3)###04 12 2025
 lti#:#lti_edit_consumer#:#Edit LTI Consumer###31 08 2017 new variable
 lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
-lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_content_selection#:#Избор на съдържание
+lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable
@@ -11438,6 +11452,7 @@ lti#:#subtab_certificate#:#Certificate###07 02 2020 new variable
 lti#:#subtab_object_settings#:#Object Settings###07 02 2020 new variable
 lti#:#subtab_provider_settings#:#LTI Provider Settings###07 02 2020 new variable
 lti#:#tab_content#:#Content###07 02 2020 new variable
+lti#:#tab_grade_synchronization#:#Gradebook
 lti#:#tab_info#:#Info###07 02 2020 new variable
 lti#:#tab_scoring#:#Ranking###07 02 2020 new variable
 lti#:#tab_settings#:#Settings###07 02 2020 new variable

--- a/lang/ilias_bg.lang
+++ b/lang/ilias_bg.lang
@@ -11378,6 +11378,7 @@ lti#:#lti_create_lti_user_role#:#Create recommended global role for LTI users###
 lti#:#lti_cron_title#:#LTI Outcome Service###07 02 2020 new variable
 lti#:#lti_cron_title_desc#:#Synchronizes the learning progress of LTI users with the LTI consumer, if it supports the outcome service. This cron job is only required to transfer status updates after Learning progress settings updates.###07 02 2020 new variable
 lti#:#lti_custom_new#:#Create Own Provider Settings###07 02 2020 new variable
+lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Administration do not allow content selection
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable

--- a/lang/ilias_cs.lang
+++ b/lang/ilias_cs.lang
@@ -11378,6 +11378,7 @@ lti#:#lti_create_lti_user_role#:#Create recommended global role for LTI users###
 lti#:#lti_cron_title#:#Služba LTI Outcome Service
 lti#:#lti_cron_title_desc#:#Synchronizuje průběh učení uživatelů LTI se spotřebitelem LTI, pokud podporuje službu výstupu. Tato úloha cron je vyžadována pouze pro přenos aktualizací statusu po aktualizacích nastavení postupu výuky.
 lti#:#lti_custom_new#:#Create Own Provider Settings###07 02 2020 new variable
+lti#:#lti_deep_linking_not_available_for_admin_objects#:#Spotřebitelé vytvoření ve správě neumožňují výběr obsahu
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable

--- a/lang/ilias_cs.lang
+++ b/lang/ilias_cs.lang
@@ -11189,6 +11189,10 @@ lti#:#conf_privacy_ident_il_uuid_ext_account#:#External User ID combined with a 
 lti#:#conf_privacy_ident_il_uuid_ext_account_info#:#This is identical to each call, but may allow a direct conclusion about the user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login#:#ILIAS Login combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login_info#:#Sends the login name. This is identical to each call, but may allow a direct conclusion about the ILIAS user.###26 08 2024 new variable
+lti#:#conf_privacy_ident_il_uuid_random#:#Random ID combined with a unique ILIAS platform ID formatted as an E-Mail address###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_random_info#:#For each ILIAS object and ILIAS user a random ID is generated which remains identical for each call. Conclusions about a user are very limited because it is practically impossible to create user profiles across objects.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url#:#Hash combined with the ILIAS Domain formatted as an E-Mail address.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url_info#:#This is identical to each call, with with a maximum of 80 characters significantly shorter than the variant with the ILIAS platform ID and allows only very limited conclusions about the ILIAS user.###04 12 2025 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id#:#ILIAS user id combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id_info#:#Sends the internal numeric user id. This is identical to each call, but may allow conclusions about the ILIAS user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_info#:#Standard is frequently the email address. The unique ILIAS platform id is:###26 08 2024 new variable
@@ -11274,13 +11278,16 @@ lti#:#launched#:#Resource was already launched.###07 02 2020 new variable
 lti#:#learning_progress_options#:#Options for Learning Progress###07 02 2020 new variable
 lti#:#lm_only_one_download_per_type#:#Vezměte prosím na vědomí, že můžete zpřístupnit pouze jeden soubor na jeden typ (XML, HTML, SCORM).
 lti#:#lti13_hints#:#If the tool was created without dynamic registration, the following data must be entered for the tool to run.###26 08 2024 new variable
+lti#:#lti_13_authentication_url#:#Authentication Request URL###04 12 2025 new variable
 lti#:#lti_13_client_id#:#Client-ID###26 08 2024 new variable
 lti#:#lti_13_deployment_id#:#Deployment-ID###26 08 2024 new variable
+lti#:#lti_13_keyset_url#:#Public Keyset URL###04 12 2025 new variable
 lti#:#lti_13_platform_id#:#Platform-ID###26 08 2024 new variable
 lti#:#lti_13_step1#:#Step 1###26 08 2024 new variable
 lti#:#lti_13_step1_info#:#For the initiating platform (consumer), enter the following address for Launch URL, Initiate Login URL, Redirection URI, and Registration URL:###26 08 2024 new variable
 lti#:#lti_13_step2#:#Step 2###26 08 2024 new variable
 lti#:#lti_13_step2_info#:#You will receive information from the initiating platform (Consumer), which you must enter in the following fields. After saving, the LTI 1.3 functionalities are available.###26 08 2024 new variable
+lti#:#lti_13_token_url#:#Access Token URL###04 12 2025 new variable
 lti#:#lti_action_accept_provider_as_global#:#Accept Provider as Global Provider for all Users###07 02 2020 new variable
 lti#:#lti_action_accept_providers_as_global#:#Accept Providers as Global###07 02 2020 new variable
 lti#:#lti_action_delete_providers#:#Delete Providers###07 02 2020 new variable
@@ -11294,6 +11301,8 @@ lti#:#lti_at_least_one_prov_has_usages#:#At least one provider could not be dele
 lti#:#lti_auth_failed_invalid_key#:#Ověřování se nezdařilo, nebyl zadán žádný platný spotřebitelský klíč.
 lti#:#lti_con_content_item#:#Support for Deep Linking###26 08 2024 new variable
 lti#:#lti_con_content_item_url#:#Content URL###26 08 2024 new variable
+lti#:#lti_con_grade_synchronization#:#Assignment and Grade Services###04 12 2025 new variable
+lti#:#lti_con_grade_synchronization_info#:#The LTI tool must offer 'Assignment and Grade Services'.###04 12 2025 new variable
 lti#:#lti_con_initiate_login_url#:#Initiate Login URL###26 08 2024 new variable
 lti#:#lti_con_key_type#:#Public Key Type###26 08 2024 new variable
 lti#:#lti_con_key_type_jwk#:#URL (Json Web Token)###26 08 2024 new variable
@@ -11313,6 +11322,10 @@ lti#:#lti_con_prov_category_info#:#Category to filter entries when LTI Consumer 
 lti#:#lti_con_prov_custom_params#:#Custom Parameters for this specific Provider###07 02 2020 new variable
 lti#:#lti_con_prov_custom_params_info#:#Please enter them in the form param1=value1; param2=value2###07 02 2020 new variable
 lti#:#lti_con_prov_description#:#Description###07 02 2020 new variable
+lti#:#lti_con_prov_dyn_reg_params#:#Optional Parameters###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_params_info#:#Here, for example, references to target objects in the tool can be specified.###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url#:#Registration URL of the Tool###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url_info#:#Note: Not every tool supports dynamic registration.###04 12 2025 new variable
 lti#:#lti_con_prov_external_provider#:#External Provider###07 02 2020 new variable
 lti#:#lti_con_prov_external_provider_info#:#A hint will be shown to users when dealing with an external Provider. An external Provider is characterized by insufficient influence on the Provider by the operator of the ILIAS-installation. This is the case when there are no rights to delete.###07 02 2020 new variable
 lti#:#lti_con_prov_group_options#:#Options to group and filter Providers###07 02 2020 new variable
@@ -11382,12 +11395,13 @@ lti#:#lti_deep_linking_not_available_for_admin_objects#:#Spotřebitelé vytvoře
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable
+lti#:#lti_dynamic_registration#:#Create Own Settings for Tool with Dynamic Registration (LTI 1.3)###04 12 2025
 lti#:#lti_edit_consumer#:#Upravit spotřebitele LTI
 lti#:#lti_exit#:#Ukončit relaci LTI
 lti#:#lti_exited#:#Relace LTI byla ukončena
 lti#:#lti_exited_info#:#Relace LTI byla úspěšně ukončena
-lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_content_selection#:#Výběr obsahu
+lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable
@@ -11438,6 +11452,7 @@ lti#:#subtab_certificate#:#Certificate###07 02 2020 new variable
 lti#:#subtab_object_settings#:#Object Settings###07 02 2020 new variable
 lti#:#subtab_provider_settings#:#LTI Provider Settings###07 02 2020 new variable
 lti#:#tab_content#:#Content###07 02 2020 new variable
+lti#:#tab_grade_synchronization#:#Gradebook
 lti#:#tab_info#:#Info###07 02 2020 new variable
 lti#:#tab_scoring#:#Ranking###07 02 2020 new variable
 lti#:#tab_settings#:#Settings###07 02 2020 new variable

--- a/lang/ilias_cs.lang
+++ b/lang/ilias_cs.lang
@@ -11387,6 +11387,7 @@ lti#:#lti_exit#:#Ukončit relaci LTI
 lti#:#lti_exited#:#Relace LTI byla ukončena
 lti#:#lti_exited_info#:#Relace LTI byla úspěšně ukončena
 lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
+lti#:#lti_form_provider_content_selection#:#Výběr obsahu
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable

--- a/lang/ilias_da.lang
+++ b/lang/ilias_da.lang
@@ -11387,6 +11387,7 @@ lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
 lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
+lti#:#lti_form_provider_content_selection#:#Valg af indhold
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable

--- a/lang/ilias_da.lang
+++ b/lang/ilias_da.lang
@@ -11378,6 +11378,7 @@ lti#:#lti_create_lti_user_role#:#Create recommended global role for LTI users###
 lti#:#lti_cron_title#:#LTI Outcome Service###07 02 2020 new variable
 lti#:#lti_cron_title_desc#:#Synchronizes the learning progress of LTI users with the LTI consumer, if it supports the outcome service. This cron job is only required to transfer status updates after Learning progress settings updates.###07 02 2020 new variable
 lti#:#lti_custom_new#:#Create Own Provider Settings###07 02 2020 new variable
+lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Administration do not allow content selection
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable

--- a/lang/ilias_da.lang
+++ b/lang/ilias_da.lang
@@ -11189,6 +11189,10 @@ lti#:#conf_privacy_ident_il_uuid_ext_account#:#External User ID combined with a 
 lti#:#conf_privacy_ident_il_uuid_ext_account_info#:#This is identical to each call, but may allow a direct conclusion about the user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login#:#ILIAS Login combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login_info#:#Sends the login name. This is identical to each call, but may allow a direct conclusion about the ILIAS user.###26 08 2024 new variable
+lti#:#conf_privacy_ident_il_uuid_random#:#Random ID combined with a unique ILIAS platform ID formatted as an E-Mail address###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_random_info#:#For each ILIAS object and ILIAS user a random ID is generated which remains identical for each call. Conclusions about a user are very limited because it is practically impossible to create user profiles across objects.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url#:#Hash combined with the ILIAS Domain formatted as an E-Mail address.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url_info#:#This is identical to each call, with with a maximum of 80 characters significantly shorter than the variant with the ILIAS platform ID and allows only very limited conclusions about the ILIAS user.###04 12 2025 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id#:#ILIAS user id combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id_info#:#Sends the internal numeric user id. This is identical to each call, but may allow conclusions about the ILIAS user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_info#:#Standard is frequently the email address. The unique ILIAS platform id is:###26 08 2024 new variable
@@ -11274,13 +11278,16 @@ lti#:#launched#:#Resource was already launched.###07 02 2020 new variable
 lti#:#learning_progress_options#:#Options for Learning Progress###07 02 2020 new variable
 lti#:#lm_only_one_download_per_type#:#Please note that you can only make one file per type (XML, HTML, SCORM) public accessible.###31 08 2017 new variable
 lti#:#lti13_hints#:#If the tool was created without dynamic registration, the following data must be entered for the tool to run.###26 08 2024 new variable
+lti#:#lti_13_authentication_url#:#Authentication Request URL###04 12 2025 new variable
 lti#:#lti_13_client_id#:#Client-ID###26 08 2024 new variable
 lti#:#lti_13_deployment_id#:#Deployment-ID###26 08 2024 new variable
+lti#:#lti_13_keyset_url#:#Public Keyset URL###04 12 2025 new variable
 lti#:#lti_13_platform_id#:#Platform-ID###26 08 2024 new variable
 lti#:#lti_13_step1#:#Step 1###26 08 2024 new variable
 lti#:#lti_13_step1_info#:#For the initiating platform (consumer), enter the following address for Launch URL, Initiate Login URL, Redirection URI, and Registration URL:###26 08 2024 new variable
 lti#:#lti_13_step2#:#Step 2###26 08 2024 new variable
 lti#:#lti_13_step2_info#:#You will receive information from the initiating platform (Consumer), which you must enter in the following fields. After saving, the LTI 1.3 functionalities are available.###26 08 2024 new variable
+lti#:#lti_13_token_url#:#Access Token URL###04 12 2025 new variable
 lti#:#lti_action_accept_provider_as_global#:#Accept Provider as Global Provider for all Users###07 02 2020 new variable
 lti#:#lti_action_accept_providers_as_global#:#Accept Providers as Global###07 02 2020 new variable
 lti#:#lti_action_delete_providers#:#Delete Providers###07 02 2020 new variable
@@ -11294,6 +11301,8 @@ lti#:#lti_at_least_one_prov_has_usages#:#At least one provider could not be dele
 lti#:#lti_auth_failed_invalid_key#:#Authentication failed, no valid consumer key given.###31 08 2017 new variable
 lti#:#lti_con_content_item#:#Support for Deep Linking###26 08 2024 new variable
 lti#:#lti_con_content_item_url#:#Content URL###26 08 2024 new variable
+lti#:#lti_con_grade_synchronization#:#Assignment and Grade Services###04 12 2025 new variable
+lti#:#lti_con_grade_synchronization_info#:#The LTI tool must offer 'Assignment and Grade Services'.###04 12 2025 new variable
 lti#:#lti_con_initiate_login_url#:#Initiate Login URL###26 08 2024 new variable
 lti#:#lti_con_key_type#:#Public Key Type###26 08 2024 new variable
 lti#:#lti_con_key_type_jwk#:#URL (Json Web Token)###26 08 2024 new variable
@@ -11313,6 +11322,10 @@ lti#:#lti_con_prov_category_info#:#Category to filter entries when LTI Consumer 
 lti#:#lti_con_prov_custom_params#:#Custom Parameters for this specific Provider###07 02 2020 new variable
 lti#:#lti_con_prov_custom_params_info#:#Please enter them in the form param1=value1; param2=value2###07 02 2020 new variable
 lti#:#lti_con_prov_description#:#Description###07 02 2020 new variable
+lti#:#lti_con_prov_dyn_reg_params#:#Optional Parameters###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_params_info#:#Here, for example, references to target objects in the tool can be specified.###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url#:#Registration URL of the Tool###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url_info#:#Note: Not every tool supports dynamic registration.###04 12 2025 new variable
 lti#:#lti_con_prov_external_provider#:#External Provider###07 02 2020 new variable
 lti#:#lti_con_prov_external_provider_info#:#A hint will be shown to users when dealing with an external Provider. An external Provider is characterized by insufficient influence on the Provider by the operator of the ILIAS-installation. This is the case when there are no rights to delete.###07 02 2020 new variable
 lti#:#lti_con_prov_group_options#:#Options to group and filter Providers###07 02 2020 new variable
@@ -11382,12 +11395,13 @@ lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Ad
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable
+lti#:#lti_dynamic_registration#:#Create Own Settings for Tool with Dynamic Registration (LTI 1.3)###04 12 2025
 lti#:#lti_edit_consumer#:#Edit LTI Consumer###31 08 2017 new variable
 lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
-lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_content_selection#:#Valg af indhold
+lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable
@@ -11438,6 +11452,7 @@ lti#:#subtab_certificate#:#Certificate###07 02 2020 new variable
 lti#:#subtab_object_settings#:#Object Settings###07 02 2020 new variable
 lti#:#subtab_provider_settings#:#LTI Provider Settings###07 02 2020 new variable
 lti#:#tab_content#:#Content###07 02 2020 new variable
+lti#:#tab_grade_synchronization#:#Gradebook
 lti#:#tab_info#:#Info###07 02 2020 new variable
 lti#:#tab_scoring#:#Ranking###07 02 2020 new variable
 lti#:#tab_settings#:#Settings###07 02 2020 new variable

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -11487,6 +11487,7 @@ lti#:#lti_create_lti_user_role#:#Empfohlene globale Rolle für LTI-User anlegen
 lti#:#lti_cron_title#:#LTI Outcome Service
 lti#:#lti_cron_title_desc#:#Überträgt den Lernfortschritt von LTI-Benutzern an die aufrufende Plattform. Dieser Cron-Job wird nur in den Fällen benötigt, wenn der Lernfortschritt aufgrund von Einstellungsänderungen neu berechnet werden muss.
 lti#:#lti_custom_new#:#Eigene Provider-Einstellungen anlegen
+lti#:#lti_deep_linking_not_available_for_admin_objects#:#In der Administration angelegte Konsumenten erlauben keine Inhaltsauswahl
 lti#:#lti_delete_consume_provider#:#Provider löschen
 lti#:#lti_delete_consume_providers#:#Provider löschen
 lti#:#lti_delete_provider#:#Provider löschen

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -11496,6 +11496,7 @@ lti#:#lti_exit#:#LTI-Sitzung beenden
 lti#:#lti_exited#:#LTI-Sitzung beendet
 lti#:#lti_exited_info#:#Die LTI-Sitzung wurde erfolgreich beendet.
 lti#:#lti_form_provider_create#:#Provider-Einstellungen anlegen
+lti#:#lti_form_provider_content_selection#:#Inhaltsauswahl
 lti#:#lti_form_provider_edit#:#Provider-Einstellungen bearbeiten
 lti#:#lti_form_section_appearance#:#Optionen für den Start
 lti#:#lti_global_settings_form#:#Globale Einstellungen

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -11298,6 +11298,10 @@ lti#:#conf_privacy_ident_il_uuid_ext_account#:#Die externe Konten-ID wird kombin
 lti#:#conf_privacy_ident_il_uuid_ext_account_info#:#Die Identifikation ist identisch bei jedem Aufruf und lässt direkte Rückschlüsse auf das ILIAS-Konto und die zugehörige Person zu.
 lti#:#conf_privacy_ident_il_uuid_login#:#ILIAS-Anmeldename kombiniert mit einer eindeutigen ILIAS-Plattform-ID, die als E-Mail-Adresse formatiert ist.
 lti#:#conf_privacy_ident_il_uuid_login_info#:#Sendet den Anmeldenamen. Dies ist identisch mit jedem Aufruf, kann aber direkte Rückschlüsse auf den ILIAS-Benutzer zulassen.
+lti#:#conf_privacy_ident_il_uuid_random#:#Zufalls-ID@ILIAS-Plattform-ID.ilias###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_random_info#:#Pro ILIAS-Objekt und ILIAS-Konto wird eine Zufalls-ID erzeugt, die bei jedem Aufruf identisch bleibt. Die E-Mail-Adresse setzt sich zusammen aus der Zufalls-ID und einer eigens###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url#:#Hash@ILIAS-Domain###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url_info#:#Die E-Mail-Adresse setzt sich zusammen aus einem Hash-Wert und einer ILIAS-Domain. Diese Option ist mit maximal 80 Zeichen deutlich kürzer als die mit ILIAS-Plattform-ID. Ohne Zugriff auf die ILIAS-Datenbank ermöglicht diese Option sind nur sehr eingeschränkte Rückschlüsse auf ein ILIAS-Konto.###04 12 2025 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id#:#ID des ILIAS-Kontos kombiniert mit einer eindeutigen ILIAS-Plattform-ID, die als E-Mail-Adresse formatiert ist
 lti#:#conf_privacy_ident_il_uuid_user_id_info#:#Die interne numerische ID ist bei jedem Aufruf identisch und ermöglicht Rückschlüsse auf das ILIAS-Konto.
 lti#:#conf_privacy_ident_info#:#Standard ist häufig die E-Mail-Adresse. Die eindeutige ILIAS-Plattform-ID lautet:
@@ -11383,13 +11387,16 @@ lti#:#launched#:#Die Ressource wurde bereits gestartet.
 lti#:#learning_progress_options#:#Optionen für den Lernfortschritt
 lti#:#lm_only_one_download_per_type#:#Es kann nur eine Datei je Typ (XML, HTML, SCORM) zum Download bereitgestellt werden.
 lti#:#lti13_hints#:#Hinweise
+lti#:#lti_13_authentication_url#:#URL für die Authentifizierungsanfrage###04 12 2025 new variable
 lti#:#lti_13_client_id#:#Client-ID
 lti#:#lti_13_deployment_id#:#Deployment-ID
+lti#:#lti_13_keyset_url#:#URL für den öffentlichen Schlüsselsatz###04 12 2025 new variable
 lti#:#lti_13_platform_id#:#Plattform-ID
 lti#:#lti_13_step1#:#Schritt 1
 lti#:#lti_13_step1_info#:#Tragen Sie bei der initiierenden Plattform (Consumer) die folgende Adresse für Launch URL, Initiate Login URL, Redirection URI und Registration URL ein:
 lti#:#lti_13_step2#:#Schritt 2
 lti#:#lti_13_step2_info#:#Von der initiierenden Plattform (Consumer) erhalten Sie Angaben, die Sie in den folgenden Feldern eintragen müssen. Nach dem Speichern stehen die LTI 1.3-Funktionalitäten zur Verfügung.
+lti#:#lti_13_token_url#:#URL für den Zugriffstoken###04 12 2025 new variable
 lti#:#lti_action_accept_provider_as_global#:#Den Provider als globalen Provider für alle Benutzer übernehmen.
 lti#:#lti_action_accept_providers_as_global#:#Provider als globalen Provider übernehmen
 lti#:#lti_action_delete_providers#:#Provider löschen
@@ -11403,6 +11410,8 @@ lti#:#lti_at_least_one_prov_has_usages#:#Mindestens ein Provider konnte nicht ge
 lti#:#lti_auth_failed_invalid_key#:#Authentifizierung nicht möglich. Es wurde kein gültiger Consumer-Key übermittelt.
 lti#:#lti_con_content_item#:#Unterstützung für Deep Linking
 lti#:#lti_con_content_item_url#:#Inhalts-URL
+lti#:#lti_con_grade_synchronization#:#Assignment and Grade Services###04 12 2025 new variable
+lti#:#lti_con_grade_synchronization_info#:#Das LTI-Tool muss 'Assignment and Grade Services' anbieten.###04 12 2025 new variable
 lti#:#lti_con_initiate_login_url#:#Initiate Login URL
 lti#:#lti_con_key_type#:#Typ des öffentlichen Schlüssels
 lti#:#lti_con_key_type_jwk#:#URL (Json Web Token)
@@ -11422,6 +11431,10 @@ lti#:#lti_con_prov_category_info#:#Kategorie, um Einträge zu filtern, wenn ein 
 lti#:#lti_con_prov_custom_params#:#Definition der Parameter für diesen spezifischen Provider
 lti#:#lti_con_prov_custom_params_info#:#Bitte geben Sie diese in der Form ein: param1=value1; param2=value2
 lti#:#lti_con_prov_description#:#Beschreibung
+lti#:#lti_con_prov_dyn_reg_params#:#Optionale Parameter###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_params_info#:#Hier können z.B. Verweise auf Zielobjekte im Tool angegeben werden.###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url#:#Registrierungs-URL des Tools###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url_info#:#Hinweis: Nicht jedes Tool unterstützt die dynamische Registrierung.###04 12 2025 new variable
 lti#:#lti_con_prov_external_provider#:#Externer Provider
 lti#:#lti_con_prov_external_provider_info#:#Bei der Zusammenarbeit mit einem externen Provider bzw. Tool wird ein Hinweis angezeigt. Die Rechte zum Löschen persönlicher Daten durch die ILIAS-Administration sind bei externen Providern in der Regel nicht gegeben.
 lti#:#lti_con_prov_group_options#:#Optionen zum Gruppieren und Filtern von Providern
@@ -11491,12 +11504,13 @@ lti#:#lti_deep_linking_not_available_for_admin_objects#:#In der Administration a
 lti#:#lti_delete_consume_provider#:#Provider löschen
 lti#:#lti_delete_consume_providers#:#Provider löschen
 lti#:#lti_delete_provider#:#Provider löschen
+lti#:#lti_dynamic_registration#:#Eigene Tool-Einstellungen mit dynamischer Registrierung anlegen (LTI 1.3)###04 12 2025 new variable
 lti#:#lti_edit_consumer#:#LTI-Konsument bearbeiten
 lti#:#lti_exit#:#LTI-Sitzung beenden
 lti#:#lti_exited#:#LTI-Sitzung beendet
 lti#:#lti_exited_info#:#Die LTI-Sitzung wurde erfolgreich beendet.
-lti#:#lti_form_provider_create#:#Provider-Einstellungen anlegen
 lti#:#lti_form_provider_content_selection#:#Inhaltsauswahl
+lti#:#lti_form_provider_create#:#Provider-Einstellungen anlegen
 lti#:#lti_form_provider_edit#:#Provider-Einstellungen bearbeiten
 lti#:#lti_form_section_appearance#:#Optionen für den Start
 lti#:#lti_global_settings_form#:#Globale Einstellungen
@@ -11547,6 +11561,7 @@ lti#:#subtab_certificate#:#Zertifikat
 lti#:#subtab_object_settings#:#Objekteinstellungen
 lti#:#subtab_provider_settings#:#LTI-Provider-Einstellungen
 lti#:#tab_content#:#Inhalt
+lti#:#tab_grade_synchronization#:#Gradebook
 lti#:#tab_info#:#Info
 lti#:#tab_scoring#:#Platzierungen
 lti#:#tab_settings#:#Einstellungen

--- a/lang/ilias_el.lang
+++ b/lang/ilias_el.lang
@@ -11379,6 +11379,7 @@ lti#:#lti_create_lti_user_role#:#Create recommended global role for LTI users###
 lti#:#lti_cron_title#:#LTI Outcome Service###07 02 2020 new variable
 lti#:#lti_cron_title_desc#:#Synchronizes the learning progress of LTI users with the LTI consumer, if it supports the outcome service. This cron job is only required to transfer status updates after Learning progress settings updates.###07 02 2020 new variable
 lti#:#lti_custom_new#:#Create Own Provider Settings###07 02 2020 new variable
+lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Administration do not allow content selection
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable

--- a/lang/ilias_el.lang
+++ b/lang/ilias_el.lang
@@ -11190,6 +11190,10 @@ lti#:#conf_privacy_ident_il_uuid_ext_account#:#External User ID combined with a 
 lti#:#conf_privacy_ident_il_uuid_ext_account_info#:#This is identical to each call, but may allow a direct conclusion about the user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login#:#ILIAS Login combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login_info#:#Sends the login name. This is identical to each call, but may allow a direct conclusion about the ILIAS user.###26 08 2024 new variable
+lti#:#conf_privacy_ident_il_uuid_random#:#Random ID combined with a unique ILIAS platform ID formatted as an E-Mail address###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_random_info#:#For each ILIAS object and ILIAS user a random ID is generated which remains identical for each call. Conclusions about a user are very limited because it is practically impossible to create user profiles across objects.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url#:#Hash combined with the ILIAS Domain formatted as an E-Mail address.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url_info#:#This is identical to each call, with with a maximum of 80 characters significantly shorter than the variant with the ILIAS platform ID and allows only very limited conclusions about the ILIAS user.###04 12 2025 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id#:#ILIAS user id combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id_info#:#Sends the internal numeric user id. This is identical to each call, but may allow conclusions about the ILIAS user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_info#:#Standard is frequently the email address. The unique ILIAS platform id is:###26 08 2024 new variable
@@ -11275,13 +11279,16 @@ lti#:#launched#:#Resource was already launched.###07 02 2020 new variable
 lti#:#learning_progress_options#:#Options for Learning Progress###07 02 2020 new variable
 lti#:#lm_only_one_download_per_type#:#Please note that you can only make one file per type (XML, HTML, SCORM) public accessible.###31 08 2017 new variable
 lti#:#lti13_hints#:#If the tool was created without dynamic registration, the following data must be entered for the tool to run.###26 08 2024 new variable
+lti#:#lti_13_authentication_url#:#Authentication Request URL###04 12 2025 new variable
 lti#:#lti_13_client_id#:#Client-ID###26 08 2024 new variable
 lti#:#lti_13_deployment_id#:#Deployment-ID###26 08 2024 new variable
+lti#:#lti_13_keyset_url#:#Public Keyset URL###04 12 2025 new variable
 lti#:#lti_13_platform_id#:#Platform-ID###26 08 2024 new variable
 lti#:#lti_13_step1#:#Step 1###26 08 2024 new variable
 lti#:#lti_13_step1_info#:#For the initiating platform (consumer), enter the following address for Launch URL, Initiate Login URL, Redirection URI, and Registration URL:###26 08 2024 new variable
 lti#:#lti_13_step2#:#Step 2###26 08 2024 new variable
 lti#:#lti_13_step2_info#:#You will receive information from the initiating platform (Consumer), which you must enter in the following fields. After saving, the LTI 1.3 functionalities are available.###26 08 2024 new variable
+lti#:#lti_13_token_url#:#Access Token URL###04 12 2025 new variable
 lti#:#lti_action_accept_provider_as_global#:#Accept Provider as Global Provider for all Users###07 02 2020 new variable
 lti#:#lti_action_accept_providers_as_global#:#Accept Providers as Global###07 02 2020 new variable
 lti#:#lti_action_delete_providers#:#Delete Providers###07 02 2020 new variable
@@ -11295,6 +11302,8 @@ lti#:#lti_at_least_one_prov_has_usages#:#At least one provider could not be dele
 lti#:#lti_auth_failed_invalid_key#:#Authentication failed, no valid consumer key given.###31 08 2017 new variable
 lti#:#lti_con_content_item#:#Support for Deep Linking###26 08 2024 new variable
 lti#:#lti_con_content_item_url#:#Content URL###26 08 2024 new variable
+lti#:#lti_con_grade_synchronization#:#Assignment and Grade Services###04 12 2025 new variable
+lti#:#lti_con_grade_synchronization_info#:#The LTI tool must offer 'Assignment and Grade Services'.###04 12 2025 new variable
 lti#:#lti_con_initiate_login_url#:#Initiate Login URL###26 08 2024 new variable
 lti#:#lti_con_key_type#:#Public Key Type###26 08 2024 new variable
 lti#:#lti_con_key_type_jwk#:#URL (Json Web Token)###26 08 2024 new variable
@@ -11314,6 +11323,10 @@ lti#:#lti_con_prov_category_info#:#Category to filter entries when LTI Consumer 
 lti#:#lti_con_prov_custom_params#:#Custom Parameters for this specific Provider###07 02 2020 new variable
 lti#:#lti_con_prov_custom_params_info#:#Please enter them in the form param1=value1; param2=value2###07 02 2020 new variable
 lti#:#lti_con_prov_description#:#Description###07 02 2020 new variable
+lti#:#lti_con_prov_dyn_reg_params#:#Optional Parameters###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_params_info#:#Here, for example, references to target objects in the tool can be specified.###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url#:#Registration URL of the Tool###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url_info#:#Note: Not every tool supports dynamic registration.###04 12 2025 new variable
 lti#:#lti_con_prov_external_provider#:#External Provider###07 02 2020 new variable
 lti#:#lti_con_prov_external_provider_info#:#A hint will be shown to users when dealing with an external Provider. An external Provider is characterized by insufficient influence on the Provider by the operator of the ILIAS-installation. This is the case when there are no rights to delete.###07 02 2020 new variable
 lti#:#lti_con_prov_group_options#:#Options to group and filter Providers###07 02 2020 new variable
@@ -11383,12 +11396,13 @@ lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Ad
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable
+lti#:#lti_dynamic_registration#:#Create Own Settings for Tool with Dynamic Registration (LTI 1.3)###04 12 2025
 lti#:#lti_edit_consumer#:#Edit LTI Consumer###31 08 2017 new variable
 lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
-lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_content_selection#:#Επιλογή περιεχομένου
+lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable
@@ -11439,6 +11453,7 @@ lti#:#subtab_certificate#:#Certificate###07 02 2020 new variable
 lti#:#subtab_object_settings#:#Object Settings###07 02 2020 new variable
 lti#:#subtab_provider_settings#:#LTI Provider Settings###07 02 2020 new variable
 lti#:#tab_content#:#Content###07 02 2020 new variable
+lti#:#tab_grade_synchronization#:#Gradebook
 lti#:#tab_info#:#Info###07 02 2020 new variable
 lti#:#tab_scoring#:#Ranking###07 02 2020 new variable
 lti#:#tab_settings#:#Settings###07 02 2020 new variable

--- a/lang/ilias_el.lang
+++ b/lang/ilias_el.lang
@@ -11388,6 +11388,7 @@ lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
 lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
+lti#:#lti_form_provider_content_selection#:#Επιλογή περιεχομένου
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -11468,6 +11468,7 @@ lti#:#lti_exit#:#Close LTI Session
 lti#:#lti_exited#:#LTI Session closed
 lti#:#lti_exited_info#:#LTI Session successfully closed
 lti#:#lti_form_provider_create#:#Create Provider Settings
+lti#:#lti_form_provider_content_selection#:#Content Selection
 lti#:#lti_form_provider_edit#:#Edit Provider Settings
 lti#:#lti_form_section_appearance#:#Options for launch
 lti#:#lti_global_settings_form#:#Global Settings

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -11459,6 +11459,7 @@ lti#:#lti_create_lti_user_role#:#Create recommended global role for LTI users
 lti#:#lti_cron_title#:#LTI Outcome Service
 lti#:#lti_cron_title_desc#:#Synchronizes the learning progress of LTI users with the LTI consumer, if it supports the outcome service. This cron job is only required to transfer status updates after Learning progress settings updates.
 lti#:#lti_custom_new#:#Create Own Provider Settings
+lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Administration do not allow content selection
 lti#:#lti_delete_consume_provider#:#Delete Provider
 lti#:#lti_delete_consume_providers#:#Delete Providers
 lti#:#lti_delete_provider#:#Delete Provider

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -11270,6 +11270,10 @@ lti#:#conf_privacy_ident_il_uuid_ext_account#:#External User ID combined with a 
 lti#:#conf_privacy_ident_il_uuid_ext_account_info#:#This is identical to each call, but may allow a direct conclusion about the user.
 lti#:#conf_privacy_ident_il_uuid_login#:#ILIAS Login combined with a unique ILIAS platform id formatted as an E-Mail address
 lti#:#conf_privacy_ident_il_uuid_login_info#:#Sends the login name. This is identical to each call, but may allow a direct conclusion about the ILIAS user.
+lti#:#conf_privacy_ident_il_uuid_random#:#Random ID combined with a unique ILIAS platform ID formatted as an E-Mail address###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_random_info#:#For each ILIAS object and ILIAS user a random ID is generated which remains identical for each call. Conclusions about a user are very limited because it is practically impossible to create user profiles across objects.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url#:#Hash combined with the ILIAS Domain formatted as an E-Mail address.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url_info#:#This is identical to each call, with with a maximum of 80 characters significantly shorter than the variant with the ILIAS platform ID and allows only very limited conclusions about the ILIAS user.###04 12 2025 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id#:#ILIAS user id combined with a unique ILIAS platform id formatted as an E-Mail address
 lti#:#conf_privacy_ident_il_uuid_user_id_info#:#Sends the internal numeric user id. This is identical to each call, but may allow conclusions about the ILIAS user.
 lti#:#conf_privacy_ident_info#:#Standard is frequently the email address. The unique ILIAS platform id is:
@@ -11355,13 +11359,16 @@ lti#:#launched#:#Resource was already launched.
 lti#:#learning_progress_options#:#Options for Learning Progress
 lti#:#lm_only_one_download_per_type#:#Only one file per type (XML, HTML, SCORM) can be released publicly.
 lti#:#lti13_hints#:#If the tool was created without dynamic registration, the following data must be entered for the tool to run.
+lti#:#lti_13_authentication_url#:#Authentication Request URL###04 12 2025 new variable
 lti#:#lti_13_client_id#:#Client-ID
 lti#:#lti_13_deployment_id#:#Deployment-ID
+lti#:#lti_13_keyset_url#:#Public Keyset URL###04 12 2025 new variable
 lti#:#lti_13_platform_id#:#Platform-ID
 lti#:#lti_13_step1#:#Step 1
 lti#:#lti_13_step1_info#:#For the initiating platform (consumer), enter the following address for Launch URL, Initiate Login URL, Redirection URI, and Registration URL:
 lti#:#lti_13_step2#:#Step 2
 lti#:#lti_13_step2_info#:#You will receive information from the initiating platform (Consumer), which you must enter in the following fields. After saving, the LTI 1.3 functionalities are available.
+lti#:#lti_13_token_url#:#Access Token URL###04 12 2025 new variable
 lti#:#lti_action_accept_provider_as_global#:#Accept Provider as Global Provider for all Users
 lti#:#lti_action_accept_providers_as_global#:#Accept Providers as Global
 lti#:#lti_action_delete_providers#:#Delete Providers
@@ -11375,6 +11382,8 @@ lti#:#lti_at_least_one_prov_has_usages#:#At least one provider could not be dele
 lti#:#lti_auth_failed_invalid_key#:#Authentication failed, no valid consumer key given.
 lti#:#lti_con_content_item#:#Support for Deep Linking
 lti#:#lti_con_content_item_url#:#Content URL
+lti#:#lti_con_grade_synchronization#:#Assignment and Grade Services###04 12 2025 new variable
+lti#:#lti_con_grade_synchronization_info#:#The LTI tool must offer 'Assignment and Grade Services'.###04 12 2025 new variable
 lti#:#lti_con_initiate_login_url#:#Initiate Login URL
 lti#:#lti_con_key_type#:#Public Key Type
 lti#:#lti_con_key_type_jwk#:#URL (Json Web Token)
@@ -11394,6 +11403,10 @@ lti#:#lti_con_prov_category_info#:#Category to filter entries when LTI Consumer 
 lti#:#lti_con_prov_custom_params#:#Custom Parameters for this specific Provider
 lti#:#lti_con_prov_custom_params_info#:#Please enter them in the form param1=value1; param2=value2
 lti#:#lti_con_prov_description#:#Description
+lti#:#lti_con_prov_dyn_reg_params#:#Optional Parameters###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_params_info#:#Here, for example, references to target objects in the tool can be specified.###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url#:#Registration URL of the Tool###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url_info#:#Note: Not every tool supports dynamic registration.###04 12 2025 new variable
 lti#:#lti_con_prov_external_provider#:#External Provider
 lti#:#lti_con_prov_external_provider_info#:#A hint will be shown to users when dealing with an external Provider. An external Provider is characterized by insufficient influence on the Provider by the operator of the ILIAS-installation. This is the case when there are no rights to delete.
 lti#:#lti_con_prov_group_options#:#Options to group and filter Providers
@@ -11463,12 +11476,13 @@ lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Ad
 lti#:#lti_delete_consume_provider#:#Delete Provider
 lti#:#lti_delete_consume_providers#:#Delete Providers
 lti#:#lti_delete_provider#:#Delete Provider
+lti#:#lti_dynamic_registration#:#Create Own Settings for Tool with Dynamic Registration (LTI 1.3)###04 12 2025
 lti#:#lti_edit_consumer#:#Edit LTI Consumer
 lti#:#lti_exit#:#Close LTI Session
 lti#:#lti_exited#:#LTI Session closed
 lti#:#lti_exited_info#:#LTI Session successfully closed
-lti#:#lti_form_provider_create#:#Create Provider Settings
 lti#:#lti_form_provider_content_selection#:#Content Selection
+lti#:#lti_form_provider_create#:#Create Provider Settings
 lti#:#lti_form_provider_edit#:#Edit Provider Settings
 lti#:#lti_form_section_appearance#:#Options for launch
 lti#:#lti_global_settings_form#:#Global Settings
@@ -11519,6 +11533,7 @@ lti#:#subtab_certificate#:#Certificate
 lti#:#subtab_object_settings#:#Object Settings
 lti#:#subtab_provider_settings#:#LTI Provider Settings
 lti#:#tab_content#:#Content
+lti#:#tab_grade_synchronization#:#Gradebook
 lti#:#tab_info#:#Info
 lti#:#tab_scoring#:#Ranking
 lti#:#tab_settings#:#Settings

--- a/lang/ilias_es.lang
+++ b/lang/ilias_es.lang
@@ -11248,6 +11248,10 @@ lti#:#conf_privacy_ident_il_uuid_ext_account#:#ID de usuario externo combinado c
 lti#:#conf_privacy_ident_il_uuid_ext_account_info#:#Esto es idéntico para cada llamada, pero puede permitir una conclusión directa sobre el usuario.
 lti#:#conf_privacy_ident_il_uuid_login#:#Nombre de usuario de ILIAS combinado con un ID de plataforma ILIAS único con formato de dirección de correo electrónico
 lti#:#conf_privacy_ident_il_uuid_login_info#:#Envía el nombre de usuario. Esto es idéntico para cada llamada, pero puede permitir una conclusión directa sobre el usuario de ILIAS.
+lti#:#conf_privacy_ident_il_uuid_random#:#ID aleatorio combinado con un ID de plataforma ILIAS único con formato de dirección de correo electrónico
+lti#:#conf_privacy_ident_il_uuid_random_info#:#Para cada objeto ILIAS y usuario de ILIAS se genera un ID aleatorio que permanece idéntico para cada llamada. Las conclusiones sobre un usuario son muy limitadas porque es prácticamente imposible crear perfiles de usuario a través de los objetos.
+lti#:#conf_privacy_ident_il_uuid_sha256url#:#Hash combinado con el dominio de ILIAS con formato de dirección de correo electrónico.
+lti#:#conf_privacy_ident_il_uuid_sha256url_info#:#Esto es idéntico para cada llamada, con un máximo de 80 caracteres, significativamente más corto que la variante con el ID de la plataforma ILIAS y permite solo conclusiones muy limitadas sobre el usuario de ILIAS.
 lti#:#conf_privacy_ident_il_uuid_user_id#:#ID de usuario de ILIAS combinado con un ID de plataforma ILIAS único con formato de dirección de correo electrónico
 lti#:#conf_privacy_ident_il_uuid_user_id_info#:#Envía el ID de usuario numérico interno. Esto es idéntico para cada llamada, pero puede permitir conclusiones sobre el usuario de ILIAS.
 lti#:#conf_privacy_ident_info#:#El estándar es frecuentemente la dirección de correo electrónico. El ID único de la plataforma ILIAS es:
@@ -11333,13 +11337,16 @@ lti#:#launched#:#El recurso ya fue lanzado.
 lti#:#learning_progress_options#:#Opciones para el Progreso de Aprendizaje
 lti#:#lm_only_one_download_per_type#:#Solo se puede publicar un archivo por tipo (XML, HTML, SCORM).
 lti#:#lti13_hints#:#Si la herramienta se creó sin registro dinámico, se deben introducir los siguientes datos para que la herramienta funcione.
+lti#:#lti_13_authentication_url#:#URL de solicitud de autenticación
 lti#:#lti_13_client_id#:#ID de cliente (Client-ID)
 lti#:#lti_13_deployment_id#:#ID de despliegue (Deployment-ID)
+lti#:#lti_13_keyset_url#:#URL de conjunto de claves públicas
 lti#:#lti_13_platform_id#:#ID de plataforma (Platform-ID)
 lti#:#lti_13_step1#:#Paso 1
 lti#:#lti_13_step1_info#:#Para la plataforma iniciadora (consumidor), introduzca la siguiente dirección para la URL de lanzamiento, URL de inicio de sesión, URI de redirección y URL de registro:
 lti#:#lti_13_step2#:#Paso 2
 lti#:#lti_13_step2_info#:#Recibirá información de la plataforma iniciadora (Consumidor), que deberá introducir en los siguientes campos. Después de guardar, las funcionalidades de LTI 1.3 estarán disponibles.
+lti#:#lti_13_token_url#:#URL de token de acceso
 lti#:#lti_action_accept_provider_as_global#:#Aceptar proveedor como proveedor global para todos los usuarios
 lti#:#lti_action_accept_providers_as_global#:#Aceptar proveedores como globales
 lti#:#lti_action_delete_providers#:#Eliminar proveedores
@@ -11353,6 +11360,8 @@ lti#:#lti_at_least_one_prov_has_usages#:#Al menos un proveedor no pudo ser elimi
 lti#:#lti_auth_failed_invalid_key#:#Error de autenticación, no se proporcionó una clave de consumidor válida.
 lti#:#lti_con_content_item#:#Soporte para Deep Linking
 lti#:#lti_con_content_item_url#:#URL de Contenido
+lti#:#lti_con_grade_synchronization#:#Assignment and Grade Services
+lti#:#lti_con_grade_synchronization_info#:#La herramienta LTI debe ofrecer 'Assignment and Grade Services'.
 lti#:#lti_con_initiate_login_url#:#URL de Inicio de Sesión
 lti#:#lti_con_key_type#:#Tipo de Clave Pública
 lti#:#lti_con_key_type_jwk#:#URL (Json Web Token)
@@ -11372,6 +11381,10 @@ lti#:#lti_con_prov_category_info#:#Categoría para filtrar entradas al crear el 
 lti#:#lti_con_prov_custom_params#:#Parámetros Personalizados para este Proveedor específico
 lti#:#lti_con_prov_custom_params_info#:#Por favor, introdúzcalos en el formato param1=valor1; param2=valor2
 lti#:#lti_con_prov_description#:#Descripción
+lti#:#lti_con_prov_dyn_reg_params#:#Parámetros Opcionales
+lti#:#lti_con_prov_dyn_reg_params_info#:#Aquí se pueden especificar, por ejemplo, referencias a objetos de destino en la herramienta.
+lti#:#lti_con_prov_dyn_reg_url#:#URL de Registro de la Herramienta
+lti#:#lti_con_prov_dyn_reg_url_info#:#Nota: No todas las herramientas admiten el registro dinámico.
 lti#:#lti_con_prov_external_provider#:#Proveedor externo
 lti#:#lti_con_prov_external_provider_info#:#Se mostrará un aviso a los usuarios cuando se trate de un proveedor externo. Un proveedor externo se caracteriza por la insuficiente influencia sobre el proveedor por parte del operador de la instalación de ILIAS. Este es el caso cuando no existen derechos de eliminación.
 lti#:#lti_con_prov_group_options#:#Opciones para agrupar y filtrar proveedores
@@ -11441,12 +11454,13 @@ lti#:#lti_deep_linking_not_available_for_admin_objects#:#Los Consumidores creado
 lti#:#lti_delete_consume_provider#:#Eliminar Proveedor
 lti#:#lti_delete_consume_providers#:#Eliminar Proveedores
 lti#:#lti_delete_provider#:#Eliminar Proveedor
+lti#:#lti_dynamic_registration#:#Crear ajustes propios para herramienta con registro dinámico (LTI 1.3)
 lti#:#lti_edit_consumer#:#Editar Consumidor LTI
 lti#:#lti_exit#:#Cerrar sesión LTI
 lti#:#lti_exited#:#Sesión LTI cerrada
 lti#:#lti_exited_info#:#Sesión LTI cerrada con éxito
-lti#:#lti_form_provider_create#:#Crear configuración de proveedor
 lti#:#lti_form_provider_content_selection#:#Selección de contenido
+lti#:#lti_form_provider_create#:#Crear configuración de proveedor
 lti#:#lti_form_provider_edit#:#Editar configuración de proveedor
 lti#:#lti_form_section_appearance#:#Opciones de lanzamiento
 lti#:#lti_global_settings_form#:#Ajustes globales
@@ -11497,6 +11511,7 @@ lti#:#subtab_certificate#:#Certificado
 lti#:#subtab_object_settings#:#Configuración del objeto
 lti#:#subtab_provider_settings#:#Configuración del proveedor LTI
 lti#:#tab_content#:#Contenido
+lti#:#tab_grade_synchronization#:#Gradebook
 lti#:#tab_info#:#Información
 lti#:#tab_scoring#:#Ranking
 lti#:#tab_settings#:#Configuración

--- a/lang/ilias_es.lang
+++ b/lang/ilias_es.lang
@@ -11446,6 +11446,7 @@ lti#:#lti_exit#:#Cerrar sesión LTI
 lti#:#lti_exited#:#Sesión LTI cerrada
 lti#:#lti_exited_info#:#Sesión LTI cerrada con éxito
 lti#:#lti_form_provider_create#:#Crear configuración de proveedor
+lti#:#lti_form_provider_content_selection#:#Selección de contenido
 lti#:#lti_form_provider_edit#:#Editar configuración de proveedor
 lti#:#lti_form_section_appearance#:#Opciones de lanzamiento
 lti#:#lti_global_settings_form#:#Ajustes globales

--- a/lang/ilias_es.lang
+++ b/lang/ilias_es.lang
@@ -11437,6 +11437,7 @@ lti#:#lti_create_lti_user_role#:#Crear el rol global recomendado para usuarios L
 lti#:#lti_cron_title#:#Servicio de Resultados LTI (Outcome Service)
 lti#:#lti_cron_title_desc#:#Sincroniza el progreso de aprendizaje de los usuarios de LTI con el consumidor de LTI, si este es compatible con el servicio de resultados. Esta tarea programada (cron job) sólo es necesaria para transferir actualizaciones de estado tras la actualización de la configuración del progreso de aprendizaje.
 lti#:#lti_custom_new#:#Crear ajustes de proveedor propios
+lti#:#lti_deep_linking_not_available_for_admin_objects#:#Los Consumidores creados desde Administración no permiten la selección de contenido
 lti#:#lti_delete_consume_provider#:#Eliminar Proveedor
 lti#:#lti_delete_consume_providers#:#Eliminar Proveedores
 lti#:#lti_delete_provider#:#Eliminar Proveedor

--- a/lang/ilias_et.lang
+++ b/lang/ilias_et.lang
@@ -11189,6 +11189,10 @@ lti#:#conf_privacy_ident_il_uuid_ext_account#:#External User ID combined with a 
 lti#:#conf_privacy_ident_il_uuid_ext_account_info#:#This is identical to each call, but may allow a direct conclusion about the user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login#:#ILIAS Login combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login_info#:#Sends the login name. This is identical to each call, but may allow a direct conclusion about the ILIAS user.###26 08 2024 new variable
+lti#:#conf_privacy_ident_il_uuid_random#:#Random ID combined with a unique ILIAS platform ID formatted as an E-Mail address###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_random_info#:#For each ILIAS object and ILIAS user a random ID is generated which remains identical for each call. Conclusions about a user are very limited because it is practically impossible to create user profiles across objects.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url#:#Hash combined with the ILIAS Domain formatted as an E-Mail address.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url_info#:#This is identical to each call, with with a maximum of 80 characters significantly shorter than the variant with the ILIAS platform ID and allows only very limited conclusions about the ILIAS user.###04 12 2025 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id#:#ILIAS user id combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id_info#:#Sends the internal numeric user id. This is identical to each call, but may allow conclusions about the ILIAS user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_info#:#Standard is frequently the email address. The unique ILIAS platform id is:###26 08 2024 new variable
@@ -11274,13 +11278,16 @@ lti#:#launched#:#Resource was already launched.###07 02 2020 new variable
 lti#:#learning_progress_options#:#Options for Learning Progress###07 02 2020 new variable
 lti#:#lm_only_one_download_per_type#:#Please note that you can only make one file per type (XML, HTML, SCORM) public accessible.###31 08 2017 new variable
 lti#:#lti13_hints#:#If the tool was created without dynamic registration, the following data must be entered for the tool to run.###26 08 2024 new variable
+lti#:#lti_13_authentication_url#:#Authentication Request URL###04 12 2025 new variable
 lti#:#lti_13_client_id#:#Client-ID###26 08 2024 new variable
 lti#:#lti_13_deployment_id#:#Deployment-ID###26 08 2024 new variable
+lti#:#lti_13_keyset_url#:#Public Keyset URL###04 12 2025 new variable
 lti#:#lti_13_platform_id#:#Platform-ID###26 08 2024 new variable
 lti#:#lti_13_step1#:#Step 1###26 08 2024 new variable
 lti#:#lti_13_step1_info#:#For the initiating platform (consumer), enter the following address for Launch URL, Initiate Login URL, Redirection URI, and Registration URL:###26 08 2024 new variable
 lti#:#lti_13_step2#:#Step 2###26 08 2024 new variable
 lti#:#lti_13_step2_info#:#You will receive information from the initiating platform (Consumer), which you must enter in the following fields. After saving, the LTI 1.3 functionalities are available.###26 08 2024 new variable
+lti#:#lti_13_token_url#:#Access Token URL###04 12 2025 new variable
 lti#:#lti_action_accept_provider_as_global#:#Accept Provider as Global Provider for all Users###07 02 2020 new variable
 lti#:#lti_action_accept_providers_as_global#:#Accept Providers as Global###07 02 2020 new variable
 lti#:#lti_action_delete_providers#:#Delete Providers###07 02 2020 new variable
@@ -11294,6 +11301,8 @@ lti#:#lti_at_least_one_prov_has_usages#:#At least one provider could not be dele
 lti#:#lti_auth_failed_invalid_key#:#Authentication failed, no valid consumer key given.###31 08 2017 new variable
 lti#:#lti_con_content_item#:#Support for Deep Linking###26 08 2024 new variable
 lti#:#lti_con_content_item_url#:#Content URL###26 08 2024 new variable
+lti#:#lti_con_grade_synchronization#:#Assignment and Grade Services###04 12 2025 new variable
+lti#:#lti_con_grade_synchronization_info#:#The LTI tool must offer 'Assignment and Grade Services'.###04 12 2025 new variable
 lti#:#lti_con_initiate_login_url#:#Initiate Login URL###26 08 2024 new variable
 lti#:#lti_con_key_type#:#Public Key Type###26 08 2024 new variable
 lti#:#lti_con_key_type_jwk#:#URL (Json Web Token)###26 08 2024 new variable
@@ -11313,6 +11322,10 @@ lti#:#lti_con_prov_category_info#:#Category to filter entries when LTI Consumer 
 lti#:#lti_con_prov_custom_params#:#Custom Parameters for this specific Provider###07 02 2020 new variable
 lti#:#lti_con_prov_custom_params_info#:#Please enter them in the form param1=value1; param2=value2###07 02 2020 new variable
 lti#:#lti_con_prov_description#:#Description###07 02 2020 new variable
+lti#:#lti_con_prov_dyn_reg_params#:#Optional Parameters###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_params_info#:#Here, for example, references to target objects in the tool can be specified.###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url#:#Registration URL of the Tool###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url_info#:#Note: Not every tool supports dynamic registration.###04 12 2025 new variable
 lti#:#lti_con_prov_external_provider#:#External Provider###07 02 2020 new variable
 lti#:#lti_con_prov_external_provider_info#:#A hint will be shown to users when dealing with an external Provider. An external Provider is characterized by insufficient influence on the Provider by the operator of the ILIAS-installation. This is the case when there are no rights to delete.###07 02 2020 new variable
 lti#:#lti_con_prov_group_options#:#Options to group and filter Providers###07 02 2020 new variable
@@ -11382,12 +11395,13 @@ lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Ad
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable
+lti#:#lti_dynamic_registration#:#Create Own Settings for Tool with Dynamic Registration (LTI 1.3)###04 12 2025
 lti#:#lti_edit_consumer#:#Edit LTI Consumer###31 08 2017 new variable
 lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
-lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_content_selection#:#Sisu valik
+lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable
@@ -11438,6 +11452,7 @@ lti#:#subtab_certificate#:#Certificate###07 02 2020 new variable
 lti#:#subtab_object_settings#:#Object Settings###07 02 2020 new variable
 lti#:#subtab_provider_settings#:#LTI Provider Settings###07 02 2020 new variable
 lti#:#tab_content#:#Content###07 02 2020 new variable
+lti#:#tab_grade_synchronization#:#Gradebook
 lti#:#tab_info#:#Info###07 02 2020 new variable
 lti#:#tab_scoring#:#Ranking###07 02 2020 new variable
 lti#:#tab_settings#:#Settings###07 02 2020 new variable

--- a/lang/ilias_et.lang
+++ b/lang/ilias_et.lang
@@ -11378,6 +11378,7 @@ lti#:#lti_create_lti_user_role#:#Create recommended global role for LTI users###
 lti#:#lti_cron_title#:#LTI Outcome Service###07 02 2020 new variable
 lti#:#lti_cron_title_desc#:#Synchronizes the learning progress of LTI users with the LTI consumer, if it supports the outcome service. This cron job is only required to transfer status updates after Learning progress settings updates.###07 02 2020 new variable
 lti#:#lti_custom_new#:#Create Own Provider Settings###07 02 2020 new variable
+lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Administration do not allow content selection
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable

--- a/lang/ilias_et.lang
+++ b/lang/ilias_et.lang
@@ -11387,6 +11387,7 @@ lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
 lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
+lti#:#lti_form_provider_content_selection#:#Sisu valik
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable

--- a/lang/ilias_fa.lang
+++ b/lang/ilias_fa.lang
@@ -11189,6 +11189,10 @@ lti#:#conf_privacy_ident_il_uuid_ext_account#:#External User ID combined with a 
 lti#:#conf_privacy_ident_il_uuid_ext_account_info#:#This is identical to each call, but may allow a direct conclusion about the user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login#:#ILIAS Login combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login_info#:#Sends the login name. This is identical to each call, but may allow a direct conclusion about the ILIAS user.###26 08 2024 new variable
+lti#:#conf_privacy_ident_il_uuid_random#:#Random ID combined with a unique ILIAS platform ID formatted as an E-Mail address###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_random_info#:#For each ILIAS object and ILIAS user a random ID is generated which remains identical for each call. Conclusions about a user are very limited because it is practically impossible to create user profiles across objects.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url#:#Hash combined with the ILIAS Domain formatted as an E-Mail address.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url_info#:#This is identical to each call, with with a maximum of 80 characters significantly shorter than the variant with the ILIAS platform ID and allows only very limited conclusions about the ILIAS user.###04 12 2025 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id#:#ILIAS user id combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id_info#:#Sends the internal numeric user id. This is identical to each call, but may allow conclusions about the ILIAS user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_info#:#Standard is frequently the email address. The unique ILIAS platform id is:###26 08 2024 new variable
@@ -11274,13 +11278,16 @@ lti#:#launched#:#Resource was already launched.###07 02 2020 new variable
 lti#:#learning_progress_options#:#Options for Learning Progress###07 02 2020 new variable
 lti#:#lm_only_one_download_per_type#:#Please note that you can only make one file per type (XML, HTML, SCORM) public accessible.###31 08 2017 new variable
 lti#:#lti13_hints#:#If the tool was created without dynamic registration, the following data must be entered for the tool to run.###26 08 2024 new variable
+lti#:#lti_13_authentication_url#:#Authentication Request URL###04 12 2025 new variable
 lti#:#lti_13_client_id#:#Client-ID###26 08 2024 new variable
 lti#:#lti_13_deployment_id#:#Deployment-ID###26 08 2024 new variable
+lti#:#lti_13_keyset_url#:#Public Keyset URL###04 12 2025 new variable
 lti#:#lti_13_platform_id#:#Platform-ID###26 08 2024 new variable
 lti#:#lti_13_step1#:#Step 1###26 08 2024 new variable
 lti#:#lti_13_step1_info#:#For the initiating platform (consumer), enter the following address for Launch URL, Initiate Login URL, Redirection URI, and Registration URL:###26 08 2024 new variable
 lti#:#lti_13_step2#:#Step 2###26 08 2024 new variable
 lti#:#lti_13_step2_info#:#You will receive information from the initiating platform (Consumer), which you must enter in the following fields. After saving, the LTI 1.3 functionalities are available.###26 08 2024 new variable
+lti#:#lti_13_token_url#:#Access Token URL###04 12 2025 new variable
 lti#:#lti_action_accept_provider_as_global#:#Accept Provider as Global Provider for all Users###07 02 2020 new variable
 lti#:#lti_action_accept_providers_as_global#:#Accept Providers as Global###07 02 2020 new variable
 lti#:#lti_action_delete_providers#:#Delete Providers###07 02 2020 new variable
@@ -11294,6 +11301,8 @@ lti#:#lti_at_least_one_prov_has_usages#:#At least one provider could not be dele
 lti#:#lti_auth_failed_invalid_key#:#Authentication failed, no valid consumer key given.###31 08 2017 new variable
 lti#:#lti_con_content_item#:#Support for Deep Linking###26 08 2024 new variable
 lti#:#lti_con_content_item_url#:#Content URL###26 08 2024 new variable
+lti#:#lti_con_grade_synchronization#:#Assignment and Grade Services###04 12 2025 new variable
+lti#:#lti_con_grade_synchronization_info#:#The LTI tool must offer 'Assignment and Grade Services'.###04 12 2025 new variable
 lti#:#lti_con_initiate_login_url#:#Initiate Login URL###26 08 2024 new variable
 lti#:#lti_con_key_type#:#Public Key Type###26 08 2024 new variable
 lti#:#lti_con_key_type_jwk#:#URL (Json Web Token)###26 08 2024 new variable
@@ -11313,6 +11322,10 @@ lti#:#lti_con_prov_category_info#:#Category to filter entries when LTI Consumer 
 lti#:#lti_con_prov_custom_params#:#Custom Parameters for this specific Provider###07 02 2020 new variable
 lti#:#lti_con_prov_custom_params_info#:#Please enter them in the form param1=value1; param2=value2###07 02 2020 new variable
 lti#:#lti_con_prov_description#:#Description###07 02 2020 new variable
+lti#:#lti_con_prov_dyn_reg_params#:#Optional Parameters###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_params_info#:#Here, for example, references to target objects in the tool can be specified.###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url#:#Registration URL of the Tool###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url_info#:#Note: Not every tool supports dynamic registration.###04 12 2025 new variable
 lti#:#lti_con_prov_external_provider#:#External Provider###07 02 2020 new variable
 lti#:#lti_con_prov_external_provider_info#:#A hint will be shown to users when dealing with an external Provider. An external Provider is characterized by insufficient influence on the Provider by the operator of the ILIAS-installation. This is the case when there are no rights to delete.###07 02 2020 new variable
 lti#:#lti_con_prov_group_options#:#Options to group and filter Providers###07 02 2020 new variable
@@ -11382,12 +11395,13 @@ lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Ad
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable
+lti#:#lti_dynamic_registration#:#Create Own Settings for Tool with Dynamic Registration (LTI 1.3)###04 12 2025
 lti#:#lti_edit_consumer#:#Edit LTI Consumer###31 08 2017 new variable
 lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
-lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_content_selection#:#انتخاب محتوا
+lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable
@@ -11438,6 +11452,7 @@ lti#:#subtab_certificate#:#Certificate###07 02 2020 new variable
 lti#:#subtab_object_settings#:#Object Settings###07 02 2020 new variable
 lti#:#subtab_provider_settings#:#LTI Provider Settings###07 02 2020 new variable
 lti#:#tab_content#:#Content###07 02 2020 new variable
+lti#:#tab_grade_synchronization#:#Gradebook
 lti#:#tab_info#:#Info###07 02 2020 new variable
 lti#:#tab_scoring#:#Ranking###07 02 2020 new variable
 lti#:#tab_settings#:#Settings###07 02 2020 new variable

--- a/lang/ilias_fa.lang
+++ b/lang/ilias_fa.lang
@@ -11378,6 +11378,7 @@ lti#:#lti_create_lti_user_role#:#Create recommended global role for LTI users###
 lti#:#lti_cron_title#:#LTI Outcome Service###07 02 2020 new variable
 lti#:#lti_cron_title_desc#:#Synchronizes the learning progress of LTI users with the LTI consumer, if it supports the outcome service. This cron job is only required to transfer status updates after Learning progress settings updates.###07 02 2020 new variable
 lti#:#lti_custom_new#:#Create Own Provider Settings###07 02 2020 new variable
+lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Administration do not allow content selection
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable

--- a/lang/ilias_fa.lang
+++ b/lang/ilias_fa.lang
@@ -11387,6 +11387,7 @@ lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
 lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
+lti#:#lti_form_provider_content_selection#:#انتخاب محتوا
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable

--- a/lang/ilias_fr.lang
+++ b/lang/ilias_fr.lang
@@ -11363,6 +11363,7 @@ lti#:#lti_create_lti_user_role#:#Create recommended global role for LTI users
 lti#:#lti_cron_title#:#LTI Outcome Service
 lti#:#lti_cron_title_desc#:#Synchronizes the learning progress of LTI users with the LTI consumer, if it supports the outcome service. This cron job is only required to transfer status updates after Learning progress settings updates.
 lti#:#lti_custom_new#:#Create Own Provider Settings
+lti#:#lti_deep_linking_not_available_for_admin_objects#:#Les consommateurs créés dans l'administration ne permettent pas la sélection de contenu
 lti#:#lti_delete_consume_provider#:#Delete Provider
 lti#:#lti_delete_consume_providers#:#Delete Providers
 lti#:#lti_delete_provider#:#Delete Provider

--- a/lang/ilias_fr.lang
+++ b/lang/ilias_fr.lang
@@ -11372,6 +11372,7 @@ lti#:#lti_exit#:#Fermer session LTI
 lti#:#lti_exited#:#Session LTI fermée
 lti#:#lti_exited_info#:#Session LTI fermée avec succès
 lti#:#lti_form_provider_create#:#Create Provider Settings
+lti#:#lti_form_provider_content_selection#:#Sélection de contenu
 lti#:#lti_form_provider_edit#:#Edit Provider Settings
 lti#:#lti_form_section_appearance#:#Options for launch
 lti#:#lti_global_settings_form#:#Global Settings

--- a/lang/ilias_fr.lang
+++ b/lang/ilias_fr.lang
@@ -11174,6 +11174,10 @@ lti#:#conf_privacy_ident_il_uuid_ext_account#:#External User Id combined with a 
 lti#:#conf_privacy_ident_il_uuid_ext_account_info#:#This is identical to each call, but may allow a direct conclusion about the user.
 lti#:#conf_privacy_ident_il_uuid_login#:#ILIAS Login combined with a unique ILIAS platform id formated as an email adress.
 lti#:#conf_privacy_ident_il_uuid_login_info#:#This is identical to each call, but may allow a direct conclusion about the ILIAS user.
+lti#:#conf_privacy_ident_il_uuid_random#:#Random ID combined with a unique ILIAS platform ID formatted as an E-Mail address###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_random_info#:#For each ILIAS object and ILIAS user a random ID is generated which remains identical for each call. Conclusions about a user are very limited because it is practically impossible to create user profiles across objects.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url#:#Hash combined with the ILIAS Domain formatted as an E-Mail address.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url_info#:#This is identical to each call, with with a maximum of 80 characters significantly shorter than the variant with the ILIAS platform ID and allows only very limited conclusions about the ILIAS user.###04 12 2025 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id#:#ILIAS user id combined with a unique ILIAS platform id formated as an email adress.
 lti#:#conf_privacy_ident_il_uuid_user_id_info#:#This is identical to each call, but doesn't allow a direct conclusion about the ILIAS user.
 lti#:#conf_privacy_ident_info#:#Standard is frequently the email address. The unique ILIAS platform id is:
@@ -11259,13 +11263,16 @@ lti#:#launched#:#Resource was already launched.
 lti#:#learning_progress_options#:#Options for Learning Progress
 lti#:#lm_only_one_download_per_type#:#Veuillez noter que vous ne pouvez rendre accessible au public qu’un seul fichier par type (XML, HTML, SCORM).
 lti#:#lti13_hints#:#If the tool was created without dynamic registration, the following data must be entered for the tool to run.###31 10 2023 new variable
+lti#:#lti_13_authentication_url#:#Authentication Request URL###04 12 2025 new variable
 lti#:#lti_13_client_id#:#Client-ID###31 10 2023 new variable
 lti#:#lti_13_deployment_id#:#Deployment-ID###31 10 2023 new variable
+lti#:#lti_13_keyset_url#:#Public Keyset URL###04 12 2025 new variable
 lti#:#lti_13_platform_id#:#Platform-ID###31 10 2023 new variable
 lti#:#lti_13_step1#:#Step 1###31 10 2023 new variable
 lti#:#lti_13_step1_info#:#For the initiating platform (consumer), enter the following address for Launch URL, Initiate Login URL, Redirection URI, and Registration URL:###31 10 2023 new variable
 lti#:#lti_13_step2#:#Step 2###31 10 2023 new variable
 lti#:#lti_13_step2_info#:#You will receive information from the initiating platform (Consumer), which you must enter in the following fields. After saving, the LTI 1.3 functionalities are available.###31 10 2023 new variable
+lti#:#lti_13_token_url#:#Access Token URL###04 12 2025 new variable
 lti#:#lti_action_accept_provider_as_global#:#Accept Provider as Global Provider for all Users
 lti#:#lti_action_accept_providers_as_global#:#Accept Providers as Global
 lti#:#lti_action_delete_providers#:#Delete Providers
@@ -11279,6 +11286,8 @@ lti#:#lti_at_least_one_prov_has_usages#:#At least one provider could not be dele
 lti#:#lti_auth_failed_invalid_key#:#Authentification échouée, aucune clé consommateur valide donnée.
 lti#:#lti_con_content_item#:#Support for Deep Linking###31 10 2023 new variable
 lti#:#lti_con_content_item_url#:#Content URL###31 10 2023 new variable
+lti#:#lti_con_grade_synchronization#:#Assignment and Grade Services###04 12 2025 new variable
+lti#:#lti_con_grade_synchronization_info#:#L'outil LTI doit proposer 'Assignment and Grade Services'.###04 12 2025 new variable
 lti#:#lti_con_initiate_login_url#:#Initiate Login URL###31 10 2023 new variable
 lti#:#lti_con_key_type#:#Public Key Type###31 10 2023 new variable
 lti#:#lti_con_key_type_jwk#:#URL (Json Web Token)###31 10 2023 new variable
@@ -11298,6 +11307,10 @@ lti#:#lti_con_prov_category_info#:#Category to filter entries when LTI Consumer 
 lti#:#lti_con_prov_custom_params#:#Custom Parameters for this specific Provider
 lti#:#lti_con_prov_custom_params_info#:#Please enter them in the form param1=value1; param2=value2
 lti#:#lti_con_prov_description#:#Description
+lti#:#lti_con_prov_dyn_reg_params#:#Optional Parameters###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_params_info#:#Here, for example, references to target objects in the tool can be specified.###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url#:#Registration URL of the Tool###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url_info#:#Note: Not every tool supports dynamic registration.###04 12 2025 new variable
 lti#:#lti_con_prov_external_provider#:#External Provider
 lti#:#lti_con_prov_external_provider_info#:#A hint will be shown to users when dealing with an external Provider. An external Provider is characterized by insufficient influence on the Provider by the operator of the ILIAS-installation. This is the case when there are no rights to delete.
 lti#:#lti_con_prov_group_options#:#Options to group and filter Providers
@@ -11367,12 +11380,13 @@ lti#:#lti_deep_linking_not_available_for_admin_objects#:#Les consommateurs cré�
 lti#:#lti_delete_consume_provider#:#Delete Provider
 lti#:#lti_delete_consume_providers#:#Delete Providers
 lti#:#lti_delete_provider#:#Delete Provider
+lti#:#lti_dynamic_registration#:#Create Own Settings for Tool with Dynamic Registration (LTI 1.3)###04 12 2025
 lti#:#lti_edit_consumer#:#Éditer consommateur LTI
 lti#:#lti_exit#:#Fermer session LTI
 lti#:#lti_exited#:#Session LTI fermée
 lti#:#lti_exited_info#:#Session LTI fermée avec succès
-lti#:#lti_form_provider_create#:#Create Provider Settings
 lti#:#lti_form_provider_content_selection#:#Sélection de contenu
+lti#:#lti_form_provider_create#:#Create Provider Settings
 lti#:#lti_form_provider_edit#:#Edit Provider Settings
 lti#:#lti_form_section_appearance#:#Options for launch
 lti#:#lti_global_settings_form#:#Global Settings
@@ -11423,6 +11437,7 @@ lti#:#subtab_certificate#:#Certificate
 lti#:#subtab_object_settings#:#Object Settings
 lti#:#subtab_provider_settings#:#LTI Provider Settings
 lti#:#tab_content#:#Content
+lti#:#tab_grade_synchronization#:#Gradebook
 lti#:#tab_info#:#Info
 lti#:#tab_scoring#:#Ranking
 lti#:#tab_settings#:#Settings

--- a/lang/ilias_hr.lang
+++ b/lang/ilias_hr.lang
@@ -11378,6 +11378,7 @@ lti#:#lti_create_lti_user_role#:#Create recommended global role for LTI users###
 lti#:#lti_cron_title#:#LTI izlazna usluga
 lti#:#lti_cron_title_desc#:#Sinkronizira napredak učenja LTI korisnika s LTI potrošačem, ako podržava izlaznu uslugu. Ovaj cron job potreban je samo za prijenos ažuriranja statusa nakon ažuriranja postavki napretka učenja.
 lti#:#lti_custom_new#:#Create Own Provider Settings###04 06 2021 new variable
+lti#:#lti_deep_linking_not_available_for_admin_objects#:#Potrošači stvoreni u Administraciji ne dopuštaju odabir sadržaja
 lti#:#lti_delete_consume_provider#:#Delete Provider###04 06 2021 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###04 06 2021 new variable
 lti#:#lti_delete_provider#:#Delete Provider###04 06 2021 new variable

--- a/lang/ilias_hr.lang
+++ b/lang/ilias_hr.lang
@@ -11387,6 +11387,7 @@ lti#:#lti_exit#:#Zatvori LTI sesiju
 lti#:#lti_exited#:#LTI sesija zatvorena
 lti#:#lti_exited_info#:#LTI sesija je uspješno zatvorena
 lti#:#lti_form_provider_create#:#Create Provider Settings###04 06 2021 new variable
+lti#:#lti_form_provider_content_selection#:#Odabir sadržaja
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###04 06 2021 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###04 06 2021 new variable
 lti#:#lti_global_settings_form#:#Global Settings###04 06 2021 new variable

--- a/lang/ilias_hr.lang
+++ b/lang/ilias_hr.lang
@@ -11189,6 +11189,10 @@ lti#:#conf_privacy_ident_il_uuid_ext_account#:#External User ID combined with a 
 lti#:#conf_privacy_ident_il_uuid_ext_account_info#:#This is identical to each call, but may allow a direct conclusion about the user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login#:#ILIAS Login combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login_info#:#Sends the login name. This is identical to each call, but may allow a direct conclusion about the ILIAS user.###26 08 2024 new variable
+lti#:#conf_privacy_ident_il_uuid_random#:#Random ID combined with a unique ILIAS platform ID formatted as an E-Mail address###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_random_info#:#For each ILIAS object and ILIAS user a random ID is generated which remains identical for each call. Conclusions about a user are very limited because it is practically impossible to create user profiles across objects.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url#:#Hash combined with the ILIAS Domain formatted as an E-Mail address.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url_info#:#This is identical to each call, with with a maximum of 80 characters significantly shorter than the variant with the ILIAS platform ID and allows only very limited conclusions about the ILIAS user.###04 12 2025 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id#:#ILIAS user id combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id_info#:#Sends the internal numeric user id. This is identical to each call, but may allow conclusions about the ILIAS user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_info#:#Standard is frequently the email address. The unique ILIAS platform id is:###26 08 2024 new variable
@@ -11274,13 +11278,16 @@ lti#:#launched#:#Resource was already launched.###04 06 2021 new variable
 lti#:#learning_progress_options#:#Options for Learning Progress###04 06 2021 new variable
 lti#:#lm_only_one_download_per_type#:#Napominjemo da možete učiniti javno dostupnom samo jednu datoteku po tipu (XML, HTML, SCORM).
 lti#:#lti13_hints#:#If the tool was created without dynamic registration, the following data must be entered for the tool to run.###26 08 2024 new variable
+lti#:#lti_13_authentication_url#:#Authentication Request URL###04 12 2025 new variable
 lti#:#lti_13_client_id#:#Client-ID###26 08 2024 new variable
 lti#:#lti_13_deployment_id#:#Deployment-ID###26 08 2024 new variable
+lti#:#lti_13_keyset_url#:#Public Keyset URL###04 12 2025 new variable
 lti#:#lti_13_platform_id#:#Platform-ID###26 08 2024 new variable
 lti#:#lti_13_step1#:#Step 1###26 08 2024 new variable
 lti#:#lti_13_step1_info#:#For the initiating platform (consumer), enter the following address for Launch URL, Initiate Login URL, Redirection URI, and Registration URL:###26 08 2024 new variable
 lti#:#lti_13_step2#:#Step 2###26 08 2024 new variable
 lti#:#lti_13_step2_info#:#You will receive information from the initiating platform (Consumer), which you must enter in the following fields. After saving, the LTI 1.3 functionalities are available.###26 08 2024 new variable
+lti#:#lti_13_token_url#:#Access Token URL###04 12 2025 new variable
 lti#:#lti_action_accept_provider_as_global#:#Accept Provider as Global Provider for all Users###04 06 2021 new variable
 lti#:#lti_action_accept_providers_as_global#:#Accept Providers as Global###04 06 2021 new variable
 lti#:#lti_action_delete_providers#:#Delete Providers###04 06 2021 new variable
@@ -11294,6 +11301,8 @@ lti#:#lti_at_least_one_prov_has_usages#:#At least one provider could not be dele
 lti#:#lti_auth_failed_invalid_key#:#Autentifikacija nije uspjela, nije dan valjani potrošački ključ.
 lti#:#lti_con_content_item#:#Support for Deep Linking###26 08 2024 new variable
 lti#:#lti_con_content_item_url#:#Content URL###26 08 2024 new variable
+lti#:#lti_con_grade_synchronization#:#Assignment and Grade Services###04 12 2025 new variable
+lti#:#lti_con_grade_synchronization_info#:#The LTI tool must offer 'Assignment and Grade Services'.###04 12 2025 new variable
 lti#:#lti_con_initiate_login_url#:#Initiate Login URL###26 08 2024 new variable
 lti#:#lti_con_key_type#:#Public Key Type###26 08 2024 new variable
 lti#:#lti_con_key_type_jwk#:#URL (Json Web Token)###26 08 2024 new variable
@@ -11313,6 +11322,10 @@ lti#:#lti_con_prov_category_info#:#Category to filter entries when LTI Consumer 
 lti#:#lti_con_prov_custom_params#:#Custom Parameters for this specific Provider###04 06 2021 new variable
 lti#:#lti_con_prov_custom_params_info#:#Please enter them in the form param1=value1; param2=value2###04 06 2021 new variable
 lti#:#lti_con_prov_description#:#Description###04 06 2021 new variable
+lti#:#lti_con_prov_dyn_reg_params#:#Optional Parameters###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_params_info#:#Here, for example, references to target objects in the tool can be specified.###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url#:#Registration URL of the Tool###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url_info#:#Note: Not every tool supports dynamic registration.###04 12 2025 new variable
 lti#:#lti_con_prov_external_provider#:#External Provider###04 06 2021 new variable
 lti#:#lti_con_prov_external_provider_info#:#A hint will be shown to users when dealing with an external Provider. An external Provider is characterized by insufficient influence on the Provider by the operator of the ILIAS-installation. This is the case when there are no rights to delete.###04 06 2021 new variable
 lti#:#lti_con_prov_group_options#:#Options to group and filter Providers###04 06 2021 new variable
@@ -11382,12 +11395,13 @@ lti#:#lti_deep_linking_not_available_for_admin_objects#:#Potrošači stvoreni u 
 lti#:#lti_delete_consume_provider#:#Delete Provider###04 06 2021 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###04 06 2021 new variable
 lti#:#lti_delete_provider#:#Delete Provider###04 06 2021 new variable
+lti#:#lti_dynamic_registration#:#Create Own Settings for Tool with Dynamic Registration (LTI 1.3)###04 12 2025
 lti#:#lti_edit_consumer#:#Uredi LTI potrošača
 lti#:#lti_exit#:#Zatvori LTI sesiju
 lti#:#lti_exited#:#LTI sesija zatvorena
 lti#:#lti_exited_info#:#LTI sesija je uspješno zatvorena
-lti#:#lti_form_provider_create#:#Create Provider Settings###04 06 2021 new variable
 lti#:#lti_form_provider_content_selection#:#Odabir sadržaja
+lti#:#lti_form_provider_create#:#Create Provider Settings###04 06 2021 new variable
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###04 06 2021 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###04 06 2021 new variable
 lti#:#lti_global_settings_form#:#Global Settings###04 06 2021 new variable
@@ -11438,6 +11452,7 @@ lti#:#subtab_certificate#:#Certificate###04 06 2021 new variable
 lti#:#subtab_object_settings#:#Object Settings###04 06 2021 new variable
 lti#:#subtab_provider_settings#:#LTI Provider Settings###04 06 2021 new variable
 lti#:#tab_content#:#Content###04 06 2021 new variable
+lti#:#tab_grade_synchronization#:#Gradebook
 lti#:#tab_info#:#Info###04 06 2021 new variable
 lti#:#tab_scoring#:#Ranking###04 06 2021 new variable
 lti#:#tab_settings#:#Settings###04 06 2021 new variable

--- a/lang/ilias_hu.lang
+++ b/lang/ilias_hu.lang
@@ -1249,7 +1249,7 @@ assessment#:#saved_adjustment#:#Változások mentése sikerült.
 assessment#:#score_anon#:#Pontozás névtelenül
 assessment#:#score_partsol_enabled#:#Részmegoldások pontozásának bekapcsolása
 assessment#:#score_partsol_enabled_info#:#A felhasználóknak általában az összes kérdést hibátlanul meg kell válaszolniuk a beállított pont eléréséhez. Evvel a lehetőséggel a beállított pont felét megszerezhetik legalább három hibátlan döntés esetén.
-assessment#:#scored_by#:#Pontozta: 
+assessment#:#scored_by#:#Pontozta:
 assessment#:#scored_pass#:#Sikeres kitöltés
 assessment#:#scoring#:#Pontozás és eredmények
 assessment#:#scoringadjust#:#Utólagos módosítás

--- a/lang/ilias_hu.lang
+++ b/lang/ilias_hu.lang
@@ -11468,6 +11468,7 @@ lti#:#lti_create_lti_user_role#:#LTI-felhasználónak ajánlott globális szerep
 lti#:#lti_cron_title#:#LTI-kimeneti Szolgáltatás
 lti#:#lti_cron_title_desc#:#Az LTI-felhasználók tanulási haladási állapotát szinkronizálja egy LTI-eszközfogyasztóval, amennyiben az támogatja a kimeneti szolgáltatást. Erre az ütemezett feladatra csak a tanulási haladás beállításainak módosítása után van szükség.
 lti#:#lti_custom_new#:#Create Own Settings for Provider resp. Tool
+lti#:#lti_deep_linking_not_available_for_admin_objects#:#Az Adminisztrációban létrehozott fogyasztók nem teszik lehetővé a tartalom kiválasztását
 lti#:#lti_delete_consume_provider#:#Kiszolgáló törlése
 lti#:#lti_delete_consume_providers#:# Kiszolgálók törlése
 lti#:#lti_delete_provider#:#Kiszolgáló törlése
@@ -11476,6 +11477,7 @@ lti#:#lti_edit_consumer#:#LTI-fogyasztó módosítása
 lti#:#lti_exit#:#LTI-munkamenet lezárása
 lti#:#lti_exited#:#LTI-munkamenet lezárva
 lti#:#lti_exited_info#:#LTI-munkamenet sikeresen lezárult
+lti#:#lti_form_provider_content_selection#:#Tartalom kiválasztása
 lti#:#lti_form_provider_create#:#Kiszolgáló beállításainak létrehozása
 lti#:#lti_form_provider_edit#:#Kiszolgáló beállításainak módosítása
 lti#:#lti_form_section_appearance#:#Indítás beállításai
@@ -11527,6 +11529,7 @@ lti#:#subtab_certificate#:#Tanúsítványok
 lti#:#subtab_object_settings#:#Objektum beállításai
 lti#:#subtab_provider_settings#:#Kiszolgáló resp. Eszköz beállításai
 lti#:#tab_content#:#Tartalom
+lti#:#tab_grade_synchronization#:#Gradebook
 lti#:#tab_info#:#Info
 lti#:#tab_scoring#:#Helyezés
 lti#:#tab_settings#:#Beállítások

--- a/lang/ilias_it.lang
+++ b/lang/ilias_it.lang
@@ -11192,6 +11192,10 @@ lti#:#conf_privacy_ident_il_uuid_ext_account#:#External User ID combined with a 
 lti#:#conf_privacy_ident_il_uuid_ext_account_info#:#This is identical to each call, but may allow a direct conclusion about the user.###28 11 2025 new variable
 lti#:#conf_privacy_ident_il_uuid_login#:#ILIAS Login combined with a unique ILIAS platform id formatted as an E-Mail address###28 11 2025 new variable
 lti#:#conf_privacy_ident_il_uuid_login_info#:#Sends the login name. This is identical to each call, but may allow a direct conclusion about the ILIAS user.###28 11 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_random#:#Random ID combined with a unique ILIAS platform ID formatted as an E-Mail address###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_random_info#:#For each ILIAS object and ILIAS user a random ID is generated which remains identical for each call. Conclusions about a user are very limited because it is practically impossible to create user profiles across objects.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url#:#Hash combined with the ILIAS Domain formatted as an E-Mail address.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url_info#:#This is identical to each call, with with a maximum of 80 characters significantly shorter than the variant with the ILIAS platform ID and allows only very limited conclusions about the ILIAS user.###04 12 2025 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id#:#ILIAS user id combined with a unique ILIAS platform id formatted as an E-Mail address###28 11 2025 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id_info#:#Sends the internal numeric user id. This is identical to each call, but may allow conclusions about the ILIAS user.###28 11 2025 new variable
 lti#:#conf_privacy_ident_info#:#Standard is frequently the email address. The unique ILIAS platform id is:###28 11 2025 new variable
@@ -11277,13 +11281,16 @@ lti#:#launched#:#La risorsa è stata già avviata.
 lti#:#learning_progress_options#:#Opzioni per i progressi didattici
 lti#:#lm_only_one_download_per_type#:#Si prega di notare che è possibile creare un solo file per tipo (XLM, HTML, SCORM) accessibile al pubblico.
 lti#:#lti13_hints#:#Hints###31 03 2023 new variable
+lti#:#lti_13_authentication_url#:#Authentication Request URL###04 12 2025 new variable
 lti#:#lti_13_client_id#:#Client-ID###31 03 2023 new variable
 lti#:#lti_13_deployment_id#:#Deployment-ID###31 03 2023 new variable
+lti#:#lti_13_keyset_url#:#Public Keyset URL###04 12 2025 new variable
 lti#:#lti_13_platform_id#:#Platform-ID###31 03 2023 new variable
 lti#:#lti_13_step1#:#Step 1###31 03 2023 new variable
 lti#:#lti_13_step1_info#:#For the initiating platform (consumer), enter the following address for Launch URL, Initiate Login URL, Redirection URI, and Registration URL:###31 03 2023 new variable
 lti#:#lti_13_step2#:#Step 2###31 03 2023 new variable
 lti#:#lti_13_step2_info#:#You will receive information from the initiating platform (Consumer), which you must enter in the following fields. After saving, the LTI 1.3 functionalities are available.###31 03 2023 new variable
+lti#:#lti_13_token_url#:#Access Token URL###04 12 2025 new variable
 lti#:#lti_action_accept_provider_as_global#:#Accetta fornitori come globali per tutti gli utenti
 lti#:#lti_action_accept_providers_as_global#:#Accetta fornitori come globali
 lti#:#lti_action_delete_providers#:#Cancella fornitore
@@ -11297,6 +11304,8 @@ lti#:#lti_at_least_one_prov_has_usages#:#Almeno uno dei provider non può essere
 lti#:#lti_auth_failed_invalid_key#:#Autenticazione fallita, nessuna chiave del consumatore valida fornita.
 lti#:#lti_con_content_item#:#Support for Deep Linking###31 03 2023 new variable
 lti#:#lti_con_content_item_url#:#Content URL###31 03 2023 new variable
+lti#:#lti_con_grade_synchronization#:#Assignment and Grade Services###04 12 2025 new variable
+lti#:#lti_con_grade_synchronization_info#:#Lo strumento LTI deve offrire 'Assignment and Grade Services'.###04 12 2025 new variable
 lti#:#lti_con_initiate_login_url#:#Initiate Login URL###31 03 2023 new variable
 lti#:#lti_con_key_type#:#Public Key Type###31 03 2023 new variable
 lti#:#lti_con_key_type_jwk#:#URL (Json Web Token)###31 03 2023 new variable
@@ -11316,6 +11325,10 @@ lti#:#lti_con_prov_category_info#:#Categoria da cui filtrare quando l'oggetto vi
 lti#:#lti_con_prov_custom_params#:#Parametri personalizzati per questo fornitore
 lti#:#lti_con_prov_custom_params_info#:#Per favore inseriscili con il formato: param1=value1; param2=value2
 lti#:#lti_con_prov_description#:#Descrizione
+lti#:#lti_con_prov_dyn_reg_params#:#Optional Parameters###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_params_info#:#Here, for example, references to target objects in the tool can be specified.###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url#:#Registration URL of the Tool###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url_info#:#Note: Not every tool supports dynamic registration.###04 12 2025 new variable
 lti#:#lti_con_prov_external_provider#:#Fornitore esterno
 lti#:#lti_con_prov_external_provider_info#:#Un suggerimento che verrà mostrato a tutti gli utenti che stanno lavorando con un fornitore esterno. Un fornitore esterno è caratterizzato da una insufficiente gestione del fornitore da parte del gestore della piattaforma ILIAS.<br />Questo è il caso in cui non ci sono diritti da rimuovere.
 lti#:#lti_con_prov_group_options#:#Opzione per raggruppare e filtrare i fornitori
@@ -11385,12 +11398,13 @@ lti#:#lti_deep_linking_not_available_for_admin_objects#:#I consumer creati in Am
 lti#:#lti_delete_consume_provider#:#Elimina fornitore
 lti#:#lti_delete_consume_providers#:#Elimina fornitori
 lti#:#lti_delete_provider#:#Elimina fornitore
+lti#:#lti_dynamic_registration#:#Create Own Settings for Tool with Dynamic Registration (LTI 1.3)###04 12 2025
 lti#:#lti_edit_consumer#:#Modifica consumatore LTI
 lti#:#lti_exit#:#Chiudi sessione LTI
 lti#:#lti_exited#:#Sessione LTI chiusa
 lti#:#lti_exited_info#:#Sessione LTI chiusa con successo
-lti#:#lti_form_provider_create#:#Impostazioni di creazione fornitore
 lti#:#lti_form_provider_content_selection#:#Selezione contenuto
+lti#:#lti_form_provider_create#:#Impostazioni di creazione fornitore
 lti#:#lti_form_provider_edit#:#Modifica impostazioni del fornitore
 lti#:#lti_form_section_appearance#:#Opzioni di avvio
 lti#:#lti_global_settings_form#:#Impostazioni globali
@@ -11441,6 +11455,7 @@ lti#:#subtab_certificate#:#Certificato
 lti#:#subtab_object_settings#:#Impostazioni oggetto
 lti#:#subtab_provider_settings#:#Impostazioni fornitore LTI
 lti#:#tab_content#:#Contenuto
+lti#:#tab_grade_synchronization#:#Gradebook
 lti#:#tab_info#:#Info
 lti#:#tab_scoring#:#Classifica
 lti#:#tab_settings#:#Impostazioni

--- a/lang/ilias_it.lang
+++ b/lang/ilias_it.lang
@@ -11390,6 +11390,7 @@ lti#:#lti_exit#:#Chiudi sessione LTI
 lti#:#lti_exited#:#Sessione LTI chiusa
 lti#:#lti_exited_info#:#Sessione LTI chiusa con successo
 lti#:#lti_form_provider_create#:#Impostazioni di creazione fornitore
+lti#:#lti_form_provider_content_selection#:#Selezione contenuto
 lti#:#lti_form_provider_edit#:#Modifica impostazioni del fornitore
 lti#:#lti_form_section_appearance#:#Opzioni di avvio
 lti#:#lti_global_settings_form#:#Impostazioni globali

--- a/lang/ilias_it.lang
+++ b/lang/ilias_it.lang
@@ -11381,6 +11381,7 @@ lti#:#lti_create_lti_user_role#:#Crea un ruolo globale raccomandato per gli uten
 lti#:#lti_cron_title#:#Servizio esiti LTI
 lti#:#lti_cron_title_desc#:#Sincronizza i progressi didattici degli utenti LTI con i consumatori LTI, se supporta il servizio degli esiti. Questo cron job è richiesto solo per trasferire aggiornamenti di stato dopo l'aggiornamento dei settaggi dei progressi didattici.
 lti#:#lti_custom_new#:#Impostazioni di creazione fornitore personale
+lti#:#lti_deep_linking_not_available_for_admin_objects#:#I consumer creati in Amministrazione non consentono la selezione del contenuto
 lti#:#lti_delete_consume_provider#:#Elimina fornitore
 lti#:#lti_delete_consume_providers#:#Elimina fornitori
 lti#:#lti_delete_provider#:#Elimina fornitore

--- a/lang/ilias_ja.lang
+++ b/lang/ilias_ja.lang
@@ -11218,6 +11218,10 @@ lti#:#conf_privacy_ident_il_uuid_ext_account#:#Eメールアドレス用にユ�
 lti#:#conf_privacy_ident_il_uuid_ext_account_info#:#これはコール毎に同じですが、ユーザに関してはダイレクトに終結する事があります。
 lti#:#conf_privacy_ident_il_uuid_login#:#EメールアドレスでユニークなILIASプラットフォームでフォーマットされて組み合されたILIASログイン
 lti#:#conf_privacy_ident_il_uuid_login_info#:#ログイン名を送信。これはコール毎に同じですが、ILIASユーザに関してはダイレクトに終結することがあります。
+lti#:#conf_privacy_ident_il_uuid_random#:#EメールアドレスでユニークなILIASプラットフォームでフォーマットされて組み合されたランダムID
+lti#:#conf_privacy_ident_il_uuid_random_info#:#それぞれILIASオブジェクトとILIASユーザランダムIDは、コール毎に同一のままのランダムIDを生成します。オブジェクトを超えたユーザプロファイル生成がほぼ不可能でる事によりユーザに関する結論は、極めて限定的です。
+lti#:#conf_privacy_ident_il_uuid_sha256url#:#EメールアドレスのILIASドメインでフォーマットされたハッシュ
+lti#:#conf_privacy_ident_il_uuid_sha256url_info#:#これはコール毎に同じILIASプラットホームIDで可変の最高80文字よりかなり短く、ILIASユーザーに関して非常に限定された結果のみを許容。
 lti#:#conf_privacy_ident_il_uuid_user_id#:#EメールアドレスでユニークなILIASプラットフォームでフォーマットされて組み合されたILIASユーザ
 lti#:#conf_privacy_ident_il_uuid_user_id_info#:#内部数字ユーザIDを送信。これはコール毎に同じですが、ILIASユーザに関してはダイレクトに終結することがあります。
 lti#:#conf_privacy_ident_info#:#標準は通常emailアドレスです。ユニークなILIASプラットフォームIDは:
@@ -11303,13 +11307,16 @@ lti#:#launched#:#リソースは既に起動しています。
 lti#:#learning_progress_options#:#学習進捗オプション
 lti#:#lm_only_one_download_per_type#:#パブリックアクセス可能なタイプ(XML, HTML, SCORM)当たり1ファイルしか作成できない事に注意願います。
 lti#:#lti13_hints#:#ヒント
+lti#:#lti_13_authentication_url#:#認証要求URL
 lti#:#lti_13_client_id#:#Client-ID
 lti#:#lti_13_deployment_id#:#Deployment-ID
+lti#:#lti_13_keyset_url#:#Public Keyset URL
 lti#:#lti_13_platform_id#:#Platform-ID
 lti#:#lti_13_step1#:#Step 1
 lti#:#lti_13_step1_info#:#プラットフォーム(comsumer)起動には、次の開始URL、リダイレクトURI、登録URLを入力:
 lti#:#lti_13_step2#:#Step 2
 lti#:#lti_13_step2_info#:#次のフィールドへ入力する事により起動プラットフォーム(Concumer)から情報を受け取ります。保存するとLTI 1.3機能が利用可能になります。
+lti#:#lti_13_token_url#:#アクセストークンURL
 lti#:#lti_action_accept_provider_as_global#:#全ユーザ用のグローバルプロバイダーとしてプロバイダを承認
 lti#:#lti_action_accept_providers_as_global#:#グローバルとしてプロバイダーを承認
 lti#:#lti_action_delete_providers#:#プロバイダーを削除
@@ -11323,6 +11330,8 @@ lti#:#lti_at_least_one_prov_has_usages#:# 一つ以上にこのプロバイダ�
 lti#:#lti_auth_failed_invalid_key#:#有効なconsumer keyがないので認証を失敗しました。
 lti#:#lti_con_content_item#:#ディープリンクのサポート
 lti#:#lti_con_content_item_url#:#Content URL
+lti#:#lti_con_grade_synchronization#:#Assignment and Grade Services
+lti#:#lti_con_grade_synchronization_info#:#LTIツールは'Assignment and Grade Services'を提供する必要があります。
 lti#:#lti_con_initiate_login_url#:#Login URLを起動
 lti#:#lti_con_key_type#:#Public Key Type
 lti#:#lti_con_key_type_jwk#:#URL (Json Web Token)
@@ -11342,6 +11351,10 @@ lti#:#lti_con_prov_category_info#:#LTI Consumerオブジェクトが作成され
 lti#:#lti_con_prov_custom_params#:#この特定のプロバイダー用のカスタムパラメータ
 lti#:#lti_con_prov_custom_params_info#:#フォームへ入力してください。 param1=value1; param2=value2
 lti#:#lti_con_prov_description#:#説明
+lti#:#lti_con_prov_dyn_reg_params#:#オプションのパラメーター
+lti#:#lti_con_prov_dyn_reg_params_info#:#例として、ツール内のターゲットオブジェクトにレファレンスはここで定義できます。
+lti#:#lti_con_prov_dyn_reg_url#:#ツールの登録URL
+lti#:#lti_con_prov_dyn_reg_url_info#:#注意: どのツールもダイナミック登録をサポートしているわけではありません。
 lti#:#lti_con_prov_external_provider#:#External Provider
 lti#:#lti_con_prov_external_provider_info#:#External Providerと通信中ユーザへヒントが表示されます。External ProviderはILIASシステムのオペレータによりプロバイダに対しては不十分な影響として特徴づけられます。これは削除する権利がない時の場合です。
 lti#:#lti_con_prov_group_options#:#グループオプションとプロバイダフィルター
@@ -11411,12 +11424,13 @@ lti#:#lti_deep_linking_not_available_for_admin_objects#:#管理画面で作成�
 lti#:#lti_delete_consume_provider#:#プロバイダーを削除
 lti#:#lti_delete_consume_providers#:#プロバイダーを削除
 lti#:#lti_delete_provider#:#プロバイダーを削除
+lti#:#lti_dynamic_registration#:#ダイナミック登録(LTI 1.3)ありのツール用の自身の設定を作成。
 lti#:#lti_edit_consumer#:#LTI Consumerを編集
 lti#:#lti_exit#:#LTI Sessionをクローズ
 lti#:#lti_exited#:#LTI セッションをクローズしました
 lti#:#lti_exited_info#:#LTIセッションは正しくクローズしました
-lti#:#lti_form_provider_create#:#プロバイダー設定を作成
 lti#:#lti_form_provider_content_selection#:#コンテンツ選択
+lti#:#lti_form_provider_create#:#プロバイダー設定を作成
 lti#:#lti_form_provider_edit#:#プロバイダー設定を編集
 lti#:#lti_form_section_appearance#:#起動のオプション
 lti#:#lti_global_settings_form#:#グローバル設定
@@ -11467,6 +11481,7 @@ lti#:#subtab_certificate#:#履修状況
 lti#:#subtab_object_settings#:#オブジェクト設定
 lti#:#subtab_provider_settings#:#LTI Provider設定
 lti#:#tab_content#:#コンテンツ
+lti#:#tab_grade_synchronization#:#Gradebook
 lti#:#tab_info#:#Info
 lti#:#tab_scoring#:#ランキング
 lti#:#tab_settings#:#設定

--- a/lang/ilias_ja.lang
+++ b/lang/ilias_ja.lang
@@ -11407,6 +11407,7 @@ lti#:#lti_create_lti_user_role#:#LTI ユーザ用の推奨グローバル役割�
 lti#:#lti_cron_title#:#LTI Outcome Service
 lti#:#lti_cron_title_desc#:#結果サービスをサポートしてる場合、LTI consumerでLTIユーザの学習進捗を同期します。このcron jobは学習進捗設定更新の後でステータス更新を送信する事が必須となります。
 lti#:#lti_custom_new#:#自身のプロバイダー設定を作成
+lti#:#lti_deep_linking_not_available_for_admin_objects#:#管理画面で作成されたコンシューマーではコンテンツを選択できません
 lti#:#lti_delete_consume_provider#:#プロバイダーを削除
 lti#:#lti_delete_consume_providers#:#プロバイダーを削除
 lti#:#lti_delete_provider#:#プロバイダーを削除

--- a/lang/ilias_ja.lang
+++ b/lang/ilias_ja.lang
@@ -11416,6 +11416,7 @@ lti#:#lti_exit#:#LTI Sessionをクローズ
 lti#:#lti_exited#:#LTI セッションをクローズしました
 lti#:#lti_exited_info#:#LTIセッションは正しくクローズしました
 lti#:#lti_form_provider_create#:#プロバイダー設定を作成
+lti#:#lti_form_provider_content_selection#:#コンテンツ選択
 lti#:#lti_form_provider_edit#:#プロバイダー設定を編集
 lti#:#lti_form_section_appearance#:#起動のオプション
 lti#:#lti_global_settings_form#:#グローバル設定

--- a/lang/ilias_ka.lang
+++ b/lang/ilias_ka.lang
@@ -11387,6 +11387,7 @@ lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
 lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
+lti#:#lti_form_provider_content_selection#:#შინაარსის არჩევა
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable

--- a/lang/ilias_ka.lang
+++ b/lang/ilias_ka.lang
@@ -11378,6 +11378,7 @@ lti#:#lti_create_lti_user_role#:#Create recommended global role for LTI users###
 lti#:#lti_cron_title#:#LTI Outcome Service###07 02 2020 new variable
 lti#:#lti_cron_title_desc#:#Synchronizes the learning progress of LTI users with the LTI consumer, if it supports the outcome service. This cron job is only required to transfer status updates after Learning progress settings updates.###07 02 2020 new variable
 lti#:#lti_custom_new#:#Create Own Provider Settings###07 02 2020 new variable
+lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Administration do not allow content selection
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable

--- a/lang/ilias_ka.lang
+++ b/lang/ilias_ka.lang
@@ -11189,6 +11189,10 @@ lti#:#conf_privacy_ident_il_uuid_ext_account#:#External User ID combined with a 
 lti#:#conf_privacy_ident_il_uuid_ext_account_info#:#This is identical to each call, but may allow a direct conclusion about the user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login#:#ILIAS Login combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login_info#:#Sends the login name. This is identical to each call, but may allow a direct conclusion about the ILIAS user.###26 08 2024 new variable
+lti#:#conf_privacy_ident_il_uuid_random#:#Random ID combined with a unique ILIAS platform ID formatted as an E-Mail address###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_random_info#:#For each ILIAS object and ILIAS user a random ID is generated which remains identical for each call. Conclusions about a user are very limited because it is practically impossible to create user profiles across objects.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url#:#Hash combined with the ILIAS Domain formatted as an E-Mail address.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url_info#:#This is identical to each call, with with a maximum of 80 characters significantly shorter than the variant with the ILIAS platform ID and allows only very limited conclusions about the ILIAS user.###04 12 2025 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id#:#ILIAS user id combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id_info#:#Sends the internal numeric user id. This is identical to each call, but may allow conclusions about the ILIAS user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_info#:#Standard is frequently the email address. The unique ILIAS platform id is:###26 08 2024 new variable
@@ -11274,13 +11278,16 @@ lti#:#launched#:#Resource was already launched.###07 02 2020 new variable
 lti#:#learning_progress_options#:#Options for Learning Progress###07 02 2020 new variable
 lti#:#lm_only_one_download_per_type#:#Please note that you can only make one file per type (XML, HTML, SCORM) public accessible.###31 08 2017 new variable
 lti#:#lti13_hints#:#If the tool was created without dynamic registration, the following data must be entered for the tool to run.###26 08 2024 new variable
+lti#:#lti_13_authentication_url#:#Authentication Request URL###04 12 2025 new variable
 lti#:#lti_13_client_id#:#Client-ID###26 08 2024 new variable
 lti#:#lti_13_deployment_id#:#Deployment-ID###26 08 2024 new variable
+lti#:#lti_13_keyset_url#:#Public Keyset URL###04 12 2025 new variable
 lti#:#lti_13_platform_id#:#Platform-ID###26 08 2024 new variable
 lti#:#lti_13_step1#:#Step 1###26 08 2024 new variable
 lti#:#lti_13_step1_info#:#For the initiating platform (consumer), enter the following address for Launch URL, Initiate Login URL, Redirection URI, and Registration URL:###26 08 2024 new variable
 lti#:#lti_13_step2#:#Step 2###26 08 2024 new variable
 lti#:#lti_13_step2_info#:#You will receive information from the initiating platform (Consumer), which you must enter in the following fields. After saving, the LTI 1.3 functionalities are available.###26 08 2024 new variable
+lti#:#lti_13_token_url#:#Access Token URL###04 12 2025 new variable
 lti#:#lti_action_accept_provider_as_global#:#Accept Provider as Global Provider for all Users###07 02 2020 new variable
 lti#:#lti_action_accept_providers_as_global#:#Accept Providers as Global###07 02 2020 new variable
 lti#:#lti_action_delete_providers#:#Delete Providers###07 02 2020 new variable
@@ -11294,6 +11301,8 @@ lti#:#lti_at_least_one_prov_has_usages#:#At least one provider could not be dele
 lti#:#lti_auth_failed_invalid_key#:#Authentication failed, no valid consumer key given.###31 08 2017 new variable
 lti#:#lti_con_content_item#:#Support for Deep Linking###26 08 2024 new variable
 lti#:#lti_con_content_item_url#:#Content URL###26 08 2024 new variable
+lti#:#lti_con_grade_synchronization#:#Assignment and Grade Services###04 12 2025 new variable
+lti#:#lti_con_grade_synchronization_info#:#The LTI tool must offer 'Assignment and Grade Services'.###04 12 2025 new variable
 lti#:#lti_con_initiate_login_url#:#Initiate Login URL###26 08 2024 new variable
 lti#:#lti_con_key_type#:#Public Key Type###26 08 2024 new variable
 lti#:#lti_con_key_type_jwk#:#URL (Json Web Token)###26 08 2024 new variable
@@ -11313,6 +11322,10 @@ lti#:#lti_con_prov_category_info#:#Category to filter entries when LTI Consumer 
 lti#:#lti_con_prov_custom_params#:#Custom Parameters for this specific Provider###07 02 2020 new variable
 lti#:#lti_con_prov_custom_params_info#:#Please enter them in the form param1=value1; param2=value2###07 02 2020 new variable
 lti#:#lti_con_prov_description#:#Description###07 02 2020 new variable
+lti#:#lti_con_prov_dyn_reg_params#:#Optional Parameters###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_params_info#:#Here, for example, references to target objects in the tool can be specified.###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url#:#Registration URL of the Tool###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url_info#:#Note: Not every tool supports dynamic registration.###04 12 2025 new variable
 lti#:#lti_con_prov_external_provider#:#External Provider###07 02 2020 new variable
 lti#:#lti_con_prov_external_provider_info#:#A hint will be shown to users when dealing with an external Provider. An external Provider is characterized by insufficient influence on the Provider by the operator of the ILIAS-installation. This is the case when there are no rights to delete.###07 02 2020 new variable
 lti#:#lti_con_prov_group_options#:#Options to group and filter Providers###07 02 2020 new variable
@@ -11382,12 +11395,13 @@ lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Ad
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable
+lti#:#lti_dynamic_registration#:#Create Own Settings for Tool with Dynamic Registration (LTI 1.3)###04 12 2025
 lti#:#lti_edit_consumer#:#Edit LTI Consumer###31 08 2017 new variable
 lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
-lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_content_selection#:#შინაარსის არჩევა
+lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable
@@ -11438,6 +11452,7 @@ lti#:#subtab_certificate#:#Certificate###07 02 2020 new variable
 lti#:#subtab_object_settings#:#Object Settings###07 02 2020 new variable
 lti#:#subtab_provider_settings#:#LTI Provider Settings###07 02 2020 new variable
 lti#:#tab_content#:#Content###07 02 2020 new variable
+lti#:#tab_grade_synchronization#:#Gradebook
 lti#:#tab_info#:#Info###07 02 2020 new variable
 lti#:#tab_scoring#:#Ranking###07 02 2020 new variable
 lti#:#tab_settings#:#Settings###07 02 2020 new variable

--- a/lang/ilias_lt.lang
+++ b/lang/ilias_lt.lang
@@ -11387,6 +11387,7 @@ lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
 lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
+lti#:#lti_form_provider_content_selection#:#Turinio pasirinkimas
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable

--- a/lang/ilias_lt.lang
+++ b/lang/ilias_lt.lang
@@ -11378,6 +11378,7 @@ lti#:#lti_create_lti_user_role#:#Create recommended global role for LTI users###
 lti#:#lti_cron_title#:#LTI Outcome Service###07 02 2020 new variable
 lti#:#lti_cron_title_desc#:#Synchronizes the learning progress of LTI users with the LTI consumer, if it supports the outcome service. This cron job is only required to transfer status updates after Learning progress settings updates.###07 02 2020 new variable
 lti#:#lti_custom_new#:#Create Own Provider Settings###07 02 2020 new variable
+lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Administration do not allow content selection
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable

--- a/lang/ilias_lt.lang
+++ b/lang/ilias_lt.lang
@@ -11189,6 +11189,10 @@ lti#:#conf_privacy_ident_il_uuid_ext_account#:#External User ID combined with a 
 lti#:#conf_privacy_ident_il_uuid_ext_account_info#:#This is identical to each call, but may allow a direct conclusion about the user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login#:#ILIAS Login combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login_info#:#Sends the login name. This is identical to each call, but may allow a direct conclusion about the ILIAS user.###26 08 2024 new variable
+lti#:#conf_privacy_ident_il_uuid_random#:#Random ID combined with a unique ILIAS platform ID formatted as an E-Mail address###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_random_info#:#For each ILIAS object and ILIAS user a random ID is generated which remains identical for each call. Conclusions about a user are very limited because it is practically impossible to create user profiles across objects.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url#:#Hash combined with the ILIAS Domain formatted as an E-Mail address.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url_info#:#This is identical to each call, with with a maximum of 80 characters significantly shorter than the variant with the ILIAS platform ID and allows only very limited conclusions about the ILIAS user.###04 12 2025 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id#:#ILIAS user id combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id_info#:#Sends the internal numeric user id. This is identical to each call, but may allow conclusions about the ILIAS user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_info#:#Standard is frequently the email address. The unique ILIAS platform id is:###26 08 2024 new variable
@@ -11274,13 +11278,16 @@ lti#:#launched#:#Resource was already launched.###07 02 2020 new variable
 lti#:#learning_progress_options#:#Options for Learning Progress###07 02 2020 new variable
 lti#:#lm_only_one_download_per_type#:#Please note that you can only make one file per type (XML, HTML, SCORM) public accessible.###31 08 2017 new variable
 lti#:#lti13_hints#:#If the tool was created without dynamic registration, the following data must be entered for the tool to run.###26 08 2024 new variable
+lti#:#lti_13_authentication_url#:#Authentication Request URL###04 12 2025 new variable
 lti#:#lti_13_client_id#:#Client-ID###26 08 2024 new variable
 lti#:#lti_13_deployment_id#:#Deployment-ID###26 08 2024 new variable
+lti#:#lti_13_keyset_url#:#Public Keyset URL###04 12 2025 new variable
 lti#:#lti_13_platform_id#:#Platform-ID###26 08 2024 new variable
 lti#:#lti_13_step1#:#Step 1###26 08 2024 new variable
 lti#:#lti_13_step1_info#:#For the initiating platform (consumer), enter the following address for Launch URL, Initiate Login URL, Redirection URI, and Registration URL:###26 08 2024 new variable
 lti#:#lti_13_step2#:#Step 2###26 08 2024 new variable
 lti#:#lti_13_step2_info#:#You will receive information from the initiating platform (Consumer), which you must enter in the following fields. After saving, the LTI 1.3 functionalities are available.###26 08 2024 new variable
+lti#:#lti_13_token_url#:#Access Token URL###04 12 2025 new variable
 lti#:#lti_action_accept_provider_as_global#:#Accept Provider as Global Provider for all Users###07 02 2020 new variable
 lti#:#lti_action_accept_providers_as_global#:#Accept Providers as Global###07 02 2020 new variable
 lti#:#lti_action_delete_providers#:#Delete Providers###07 02 2020 new variable
@@ -11294,6 +11301,8 @@ lti#:#lti_at_least_one_prov_has_usages#:#At least one provider could not be dele
 lti#:#lti_auth_failed_invalid_key#:#Authentication failed, no valid consumer key given.###31 08 2017 new variable
 lti#:#lti_con_content_item#:#Support for Deep Linking###26 08 2024 new variable
 lti#:#lti_con_content_item_url#:#Content URL###26 08 2024 new variable
+lti#:#lti_con_grade_synchronization#:#Assignment and Grade Services###04 12 2025 new variable
+lti#:#lti_con_grade_synchronization_info#:#The LTI tool must offer 'Assignment and Grade Services'.###04 12 2025 new variable
 lti#:#lti_con_initiate_login_url#:#Initiate Login URL###26 08 2024 new variable
 lti#:#lti_con_key_type#:#Public Key Type###26 08 2024 new variable
 lti#:#lti_con_key_type_jwk#:#URL (Json Web Token)###26 08 2024 new variable
@@ -11313,6 +11322,10 @@ lti#:#lti_con_prov_category_info#:#Category to filter entries when LTI Consumer 
 lti#:#lti_con_prov_custom_params#:#Custom Parameters for this specific Provider###07 02 2020 new variable
 lti#:#lti_con_prov_custom_params_info#:#Please enter them in the form param1=value1; param2=value2###07 02 2020 new variable
 lti#:#lti_con_prov_description#:#Description###07 02 2020 new variable
+lti#:#lti_con_prov_dyn_reg_params#:#Optional Parameters###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_params_info#:#Here, for example, references to target objects in the tool can be specified.###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url#:#Registration URL of the Tool###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url_info#:#Note: Not every tool supports dynamic registration.###04 12 2025 new variable
 lti#:#lti_con_prov_external_provider#:#External Provider###07 02 2020 new variable
 lti#:#lti_con_prov_external_provider_info#:#A hint will be shown to users when dealing with an external Provider. An external Provider is characterized by insufficient influence on the Provider by the operator of the ILIAS-installation. This is the case when there are no rights to delete.###07 02 2020 new variable
 lti#:#lti_con_prov_group_options#:#Options to group and filter Providers###07 02 2020 new variable
@@ -11382,12 +11395,13 @@ lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Ad
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable
+lti#:#lti_dynamic_registration#:#Create Own Settings for Tool with Dynamic Registration (LTI 1.3)###04 12 2025
 lti#:#lti_edit_consumer#:#Edit LTI Consumer###31 08 2017 new variable
 lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
-lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_content_selection#:#Turinio pasirinkimas
+lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable
@@ -11438,6 +11452,7 @@ lti#:#subtab_certificate#:#Certificate###07 02 2020 new variable
 lti#:#subtab_object_settings#:#Object Settings###07 02 2020 new variable
 lti#:#subtab_provider_settings#:#LTI Provider Settings###07 02 2020 new variable
 lti#:#tab_content#:#Content###07 02 2020 new variable
+lti#:#tab_grade_synchronization#:#Gradebook
 lti#:#tab_info#:#Info###07 02 2020 new variable
 lti#:#tab_scoring#:#Ranking###07 02 2020 new variable
 lti#:#tab_settings#:#Settings###07 02 2020 new variable

--- a/lang/ilias_nl.lang
+++ b/lang/ilias_nl.lang
@@ -11387,6 +11387,7 @@ lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
 lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
+lti#:#lti_form_provider_content_selection#:#Inhoud selecteren
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable

--- a/lang/ilias_nl.lang
+++ b/lang/ilias_nl.lang
@@ -11189,6 +11189,10 @@ lti#:#conf_privacy_ident_il_uuid_ext_account#:#External User ID combined with a 
 lti#:#conf_privacy_ident_il_uuid_ext_account_info#:#This is identical to each call, but may allow a direct conclusion about the user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login#:#ILIAS Login combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login_info#:#Sends the login name. This is identical to each call, but may allow a direct conclusion about the ILIAS user.###26 08 2024 new variable
+lti#:#conf_privacy_ident_il_uuid_random#:#Random ID combined with a unique ILIAS platform ID formatted as an E-Mail address###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_random_info#:#For each ILIAS object and ILIAS user a random ID is generated which remains identical for each call. Conclusions about a user are very limited because it is practically impossible to create user profiles across objects.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url#:#Hash combined with the ILIAS Domain formatted as an E-Mail address.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url_info#:#This is identical to each call, with with a maximum of 80 characters significantly shorter than the variant with the ILIAS platform ID and allows only very limited conclusions about the ILIAS user.###04 12 2025 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id#:#ILIAS user id combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id_info#:#Sends the internal numeric user id. This is identical to each call, but may allow conclusions about the ILIAS user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_info#:#Standard is frequently the email address. The unique ILIAS platform id is:###26 08 2024 new variable
@@ -11274,13 +11278,16 @@ lti#:#launched#:#Resource was already launched.###07 02 2020 new variable
 lti#:#learning_progress_options#:#Options for Learning Progress###07 02 2020 new variable
 lti#:#lm_only_one_download_per_type#:#Please note that you can only make one file per type (XML, HTML, SCORM) public accessible.###31 08 2017 new variable
 lti#:#lti13_hints#:#If the tool was created without dynamic registration, the following data must be entered for the tool to run.###26 08 2024 new variable
+lti#:#lti_13_authentication_url#:#Authentication Request URL###04 12 2025 new variable
 lti#:#lti_13_client_id#:#Client-ID###26 08 2024 new variable
 lti#:#lti_13_deployment_id#:#Deployment-ID###26 08 2024 new variable
+lti#:#lti_13_keyset_url#:#Public Keyset URL###04 12 2025 new variable
 lti#:#lti_13_platform_id#:#Platform-ID###26 08 2024 new variable
 lti#:#lti_13_step1#:#Step 1###26 08 2024 new variable
 lti#:#lti_13_step1_info#:#For the initiating platform (consumer), enter the following address for Launch URL, Initiate Login URL, Redirection URI, and Registration URL:###26 08 2024 new variable
 lti#:#lti_13_step2#:#Step 2###26 08 2024 new variable
 lti#:#lti_13_step2_info#:#You will receive information from the initiating platform (Consumer), which you must enter in the following fields. After saving, the LTI 1.3 functionalities are available.###26 08 2024 new variable
+lti#:#lti_13_token_url#:#Access Token URL###04 12 2025 new variable
 lti#:#lti_action_accept_provider_as_global#:#Accept Provider as Global Provider for all Users###07 02 2020 new variable
 lti#:#lti_action_accept_providers_as_global#:#Accept Providers as Global###07 02 2020 new variable
 lti#:#lti_action_delete_providers#:#Delete Providers###07 02 2020 new variable
@@ -11294,6 +11301,8 @@ lti#:#lti_at_least_one_prov_has_usages#:#At least one provider could not be dele
 lti#:#lti_auth_failed_invalid_key#:#Authentication failed, no valid consumer key given.###31 08 2017 new variable
 lti#:#lti_con_content_item#:#Support for Deep Linking###26 08 2024 new variable
 lti#:#lti_con_content_item_url#:#Content URL###26 08 2024 new variable
+lti#:#lti_con_grade_synchronization#:#Assignment and Grade Services###04 12 2025 new variable
+lti#:#lti_con_grade_synchronization_info#:#The LTI tool must offer 'Assignment and Grade Services'.###04 12 2025 new variable
 lti#:#lti_con_initiate_login_url#:#Initiate Login URL###26 08 2024 new variable
 lti#:#lti_con_key_type#:#Public Key Type###26 08 2024 new variable
 lti#:#lti_con_key_type_jwk#:#URL (Json Web Token)###26 08 2024 new variable
@@ -11313,6 +11322,10 @@ lti#:#lti_con_prov_category_info#:#Category to filter entries when LTI Consumer 
 lti#:#lti_con_prov_custom_params#:#Custom Parameters for this specific Provider###07 02 2020 new variable
 lti#:#lti_con_prov_custom_params_info#:#Please enter them in the form param1=value1; param2=value2###07 02 2020 new variable
 lti#:#lti_con_prov_description#:#Description###07 02 2020 new variable
+lti#:#lti_con_prov_dyn_reg_params#:#Optional Parameters###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_params_info#:#Here, for example, references to target objects in the tool can be specified.###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url#:#Registration URL of the Tool###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url_info#:#Note: Not every tool supports dynamic registration.###04 12 2025 new variable
 lti#:#lti_con_prov_external_provider#:#External Provider###07 02 2020 new variable
 lti#:#lti_con_prov_external_provider_info#:#A hint will be shown to users when dealing with an external Provider. An external Provider is characterized by insufficient influence on the Provider by the operator of the ILIAS-installation. This is the case when there are no rights to delete.###07 02 2020 new variable
 lti#:#lti_con_prov_group_options#:#Options to group and filter Providers###07 02 2020 new variable
@@ -11382,12 +11395,13 @@ lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Ad
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable
+lti#:#lti_dynamic_registration#:#Create Own Settings for Tool with Dynamic Registration (LTI 1.3)###04 12 2025
 lti#:#lti_edit_consumer#:#Edit LTI Consumer###31 08 2017 new variable
 lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
-lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_content_selection#:#Inhoud selecteren
+lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable
@@ -11438,6 +11452,7 @@ lti#:#subtab_certificate#:#Certificate###07 02 2020 new variable
 lti#:#subtab_object_settings#:#Object Settings###07 02 2020 new variable
 lti#:#subtab_provider_settings#:#LTI Provider Settings###07 02 2020 new variable
 lti#:#tab_content#:#Content###07 02 2020 new variable
+lti#:#tab_grade_synchronization#:#Gradebook
 lti#:#tab_info#:#Info###07 02 2020 new variable
 lti#:#tab_scoring#:#Ranking###07 02 2020 new variable
 lti#:#tab_settings#:#Settings###07 02 2020 new variable

--- a/lang/ilias_nl.lang
+++ b/lang/ilias_nl.lang
@@ -11378,6 +11378,7 @@ lti#:#lti_create_lti_user_role#:#Create recommended global role for LTI users###
 lti#:#lti_cron_title#:#LTI Outcome Service###07 02 2020 new variable
 lti#:#lti_cron_title_desc#:#Synchronizes the learning progress of LTI users with the LTI consumer, if it supports the outcome service. This cron job is only required to transfer status updates after Learning progress settings updates.###07 02 2020 new variable
 lti#:#lti_custom_new#:#Create Own Provider Settings###07 02 2020 new variable
+lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Administration do not allow content selection
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable

--- a/lang/ilias_pl.lang
+++ b/lang/ilias_pl.lang
@@ -11189,6 +11189,10 @@ lti#:#conf_privacy_ident_il_uuid_ext_account#:#External User ID combined with a 
 lti#:#conf_privacy_ident_il_uuid_ext_account_info#:#This is identical to each call, but may allow a direct conclusion about the user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login#:#ILIAS Login combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login_info#:#Sends the login name. This is identical to each call, but may allow a direct conclusion about the ILIAS user.###26 08 2024 new variable
+lti#:#conf_privacy_ident_il_uuid_random#:#Random ID combined with a unique ILIAS platform ID formatted as an E-Mail address###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_random_info#:#For each ILIAS object and ILIAS user a random ID is generated which remains identical for each call. Conclusions about a user are very limited because it is practically impossible to create user profiles across objects.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url#:#Hash combined with the ILIAS Domain formatted as an E-Mail address.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url_info#:#This is identical to each call, with with a maximum of 80 characters significantly shorter than the variant with the ILIAS platform ID and allows only very limited conclusions about the ILIAS user.###04 12 2025 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id#:#ILIAS user id combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id_info#:#Sends the internal numeric user id. This is identical to each call, but may allow conclusions about the ILIAS user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_info#:#Standard is frequently the email address. The unique ILIAS platform id is:###26 08 2024 new variable
@@ -11274,13 +11278,16 @@ lti#:#launched#:#Resource was already launched.###07 02 2020 new variable
 lti#:#learning_progress_options#:#Options for Learning Progress###07 02 2020 new variable
 lti#:#lm_only_one_download_per_type#:#Dla każdego typu (XML, HTML, SCORM) można udostępnić tylko jeden plik do pobrania.
 lti#:#lti13_hints#:#If the tool was created without dynamic registration, the following data must be entered for the tool to run.###26 08 2024 new variable
+lti#:#lti_13_authentication_url#:#Authentication Request URL###04 12 2025 new variable
 lti#:#lti_13_client_id#:#Client-ID###26 08 2024 new variable
 lti#:#lti_13_deployment_id#:#Deployment-ID###26 08 2024 new variable
+lti#:#lti_13_keyset_url#:#Public Keyset URL###04 12 2025 new variable
 lti#:#lti_13_platform_id#:#Platform-ID###26 08 2024 new variable
 lti#:#lti_13_step1#:#Step 1###26 08 2024 new variable
 lti#:#lti_13_step1_info#:#For the initiating platform (consumer), enter the following address for Launch URL, Initiate Login URL, Redirection URI, and Registration URL:###26 08 2024 new variable
 lti#:#lti_13_step2#:#Step 2###26 08 2024 new variable
 lti#:#lti_13_step2_info#:#You will receive information from the initiating platform (Consumer), which you must enter in the following fields. After saving, the LTI 1.3 functionalities are available.###26 08 2024 new variable
+lti#:#lti_13_token_url#:#Access Token URL###04 12 2025 new variable
 lti#:#lti_action_accept_provider_as_global#:#Accept Provider as Global Provider for all Users###07 02 2020 new variable
 lti#:#lti_action_accept_providers_as_global#:#Accept Providers as Global###07 02 2020 new variable
 lti#:#lti_action_delete_providers#:#Delete Providers###07 02 2020 new variable
@@ -11294,6 +11301,8 @@ lti#:#lti_at_least_one_prov_has_usages#:#At least one provider could not be dele
 lti#:#lti_auth_failed_invalid_key#:#Identyfikacja nie jest możliwa. Nie przekazano ważnego klucza odbiorcy.
 lti#:#lti_con_content_item#:#Support for Deep Linking###26 08 2024 new variable
 lti#:#lti_con_content_item_url#:#Content URL###26 08 2024 new variable
+lti#:#lti_con_grade_synchronization#:#Assignment and Grade Services###04 12 2025 new variable
+lti#:#lti_con_grade_synchronization_info#:#The LTI tool must offer 'Assignment and Grade Services'.###04 12 2025 new variable
 lti#:#lti_con_initiate_login_url#:#Initiate Login URL###26 08 2024 new variable
 lti#:#lti_con_key_type#:#Public Key Type###26 08 2024 new variable
 lti#:#lti_con_key_type_jwk#:#URL (Json Web Token)###26 08 2024 new variable
@@ -11313,6 +11322,10 @@ lti#:#lti_con_prov_category_info#:#Category to filter entries when LTI Consumer 
 lti#:#lti_con_prov_custom_params#:#Custom Parameters for this specific Provider###07 02 2020 new variable
 lti#:#lti_con_prov_custom_params_info#:#Please enter them in the form param1=value1; param2=value2###07 02 2020 new variable
 lti#:#lti_con_prov_description#:#Description###07 02 2020 new variable
+lti#:#lti_con_prov_dyn_reg_params#:#Optional Parameters###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_params_info#:#Here, for example, references to target objects in the tool can be specified.###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url#:#Registration URL of the Tool###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url_info#:#Note: Not every tool supports dynamic registration.###04 12 2025 new variable
 lti#:#lti_con_prov_external_provider#:#External Provider###07 02 2020 new variable
 lti#:#lti_con_prov_external_provider_info#:#A hint will be shown to users when dealing with an external Provider. An external Provider is characterized by insufficient influence on the Provider by the operator of the ILIAS-installation. This is the case when there are no rights to delete.###07 02 2020 new variable
 lti#:#lti_con_prov_group_options#:#Options to group and filter Providers###07 02 2020 new variable
@@ -11382,12 +11395,13 @@ lti#:#lti_deep_linking_not_available_for_admin_objects#:#Konsumenci utworzeni w 
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable
+lti#:#lti_dynamic_registration#:#Create Own Settings for Tool with Dynamic Registration (LTI 1.3)###04 12 2025
 lti#:#lti_edit_consumer#:#Edytuj odbiorcę LTI
 lti#:#lti_exit#:#Zakończ sesję LTI
 lti#:#lti_exited#:#Sesja LTI zakończona
 lti#:#lti_exited_info#:#Udało się zakończyć sesję LTI
-lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_content_selection#:#Wybór treści
+lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable
@@ -11438,6 +11452,7 @@ lti#:#subtab_certificate#:#Certificate###07 02 2020 new variable
 lti#:#subtab_object_settings#:#Object Settings###07 02 2020 new variable
 lti#:#subtab_provider_settings#:#LTI Provider Settings###07 02 2020 new variable
 lti#:#tab_content#:#Content###07 02 2020 new variable
+lti#:#tab_grade_synchronization#:#Gradebook
 lti#:#tab_info#:#Info###07 02 2020 new variable
 lti#:#tab_scoring#:#Ranking###07 02 2020 new variable
 lti#:#tab_settings#:#Settings###07 02 2020 new variable

--- a/lang/ilias_pl.lang
+++ b/lang/ilias_pl.lang
@@ -11387,6 +11387,7 @@ lti#:#lti_exit#:#Zakończ sesję LTI
 lti#:#lti_exited#:#Sesja LTI zakończona
 lti#:#lti_exited_info#:#Udało się zakończyć sesję LTI
 lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
+lti#:#lti_form_provider_content_selection#:#Wybór treści
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable

--- a/lang/ilias_pl.lang
+++ b/lang/ilias_pl.lang
@@ -11378,6 +11378,7 @@ lti#:#lti_create_lti_user_role#:#Create recommended global role for LTI users###
 lti#:#lti_cron_title#:#LTI Outcome Service###07 02 2020 new variable
 lti#:#lti_cron_title_desc#:#Synchronizes the learning progress of LTI users with the LTI consumer, if it supports the outcome service. This cron job is only required to transfer status updates after Learning progress settings updates.###07 02 2020 new variable
 lti#:#lti_custom_new#:#Create Own Provider Settings###07 02 2020 new variable
+lti#:#lti_deep_linking_not_available_for_admin_objects#:#Konsumenci utworzeni w Administracji nie pozwalają na wybór treści
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable

--- a/lang/ilias_pt.lang
+++ b/lang/ilias_pt.lang
@@ -11387,6 +11387,7 @@ lti#:#lti_exit#:#Fechar sessão LTI
 lti#:#lti_exited#:#Sessão LTI fechada
 lti#:#lti_exited_info#:#Sessão LTI fechada com sucesso
 lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
+lti#:#lti_form_provider_content_selection#:#Seleção de conteúdo
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable

--- a/lang/ilias_pt.lang
+++ b/lang/ilias_pt.lang
@@ -11189,6 +11189,10 @@ lti#:#conf_privacy_ident_il_uuid_ext_account#:#External User ID combined with a 
 lti#:#conf_privacy_ident_il_uuid_ext_account_info#:#This is identical to each call, but may allow a direct conclusion about the user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login#:#ILIAS Login combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login_info#:#Sends the login name. This is identical to each call, but may allow a direct conclusion about the ILIAS user.###26 08 2024 new variable
+lti#:#conf_privacy_ident_il_uuid_random#:#Random ID combined with a unique ILIAS platform ID formatted as an E-Mail address###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_random_info#:#For each ILIAS object and ILIAS user a random ID is generated which remains identical for each call. Conclusions about a user are very limited because it is practically impossible to create user profiles across objects.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url#:#Hash combined with the ILIAS Domain formatted as an E-Mail address.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url_info#:#This is identical to each call, with with a maximum of 80 characters significantly shorter than the variant with the ILIAS platform ID and allows only very limited conclusions about the ILIAS user.###04 12 2025 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id#:#ILIAS user id combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id_info#:#Sends the internal numeric user id. This is identical to each call, but may allow conclusions about the ILIAS user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_info#:#Standard is frequently the email address. The unique ILIAS platform id is:###26 08 2024 new variable
@@ -11274,13 +11278,16 @@ lti#:#launched#:#Resource was already launched.###07 02 2020 new variable
 lti#:#learning_progress_options#:#Options for Learning Progress###07 02 2020 new variable
 lti#:#lm_only_one_download_per_type#:#Note que pode apenas dar acesso público a um ficheiro por tipo (XML, HTML, SCORM).
 lti#:#lti13_hints#:#If the tool was created without dynamic registration, the following data must be entered for the tool to run.###26 08 2024 new variable
+lti#:#lti_13_authentication_url#:#Authentication Request URL###04 12 2025 new variable
 lti#:#lti_13_client_id#:#Client-ID###26 08 2024 new variable
 lti#:#lti_13_deployment_id#:#Deployment-ID###26 08 2024 new variable
+lti#:#lti_13_keyset_url#:#Public Keyset URL###04 12 2025 new variable
 lti#:#lti_13_platform_id#:#Platform-ID###26 08 2024 new variable
 lti#:#lti_13_step1#:#Step 1###26 08 2024 new variable
 lti#:#lti_13_step1_info#:#For the initiating platform (consumer), enter the following address for Launch URL, Initiate Login URL, Redirection URI, and Registration URL:###26 08 2024 new variable
 lti#:#lti_13_step2#:#Step 2###26 08 2024 new variable
 lti#:#lti_13_step2_info#:#You will receive information from the initiating platform (Consumer), which you must enter in the following fields. After saving, the LTI 1.3 functionalities are available.###26 08 2024 new variable
+lti#:#lti_13_token_url#:#Access Token URL###04 12 2025 new variable
 lti#:#lti_action_accept_provider_as_global#:#Accept Provider as Global Provider for all Users###07 02 2020 new variable
 lti#:#lti_action_accept_providers_as_global#:#Accept Providers as Global###07 02 2020 new variable
 lti#:#lti_action_delete_providers#:#Delete Providers###07 02 2020 new variable
@@ -11294,6 +11301,8 @@ lti#:#lti_at_least_one_prov_has_usages#:#At least one provider could not be dele
 lti#:#lti_auth_failed_invalid_key#:#Autenticação falhou, nenhuma chave de consumidor fornecida.
 lti#:#lti_con_content_item#:#Support for Deep Linking###26 08 2024 new variable
 lti#:#lti_con_content_item_url#:#Content URL###26 08 2024 new variable
+lti#:#lti_con_grade_synchronization#:#Assignment and Grade Services###04 12 2025 new variable
+lti#:#lti_con_grade_synchronization_info#:#The LTI tool must offer 'Assignment and Grade Services'.###04 12 2025 new variable
 lti#:#lti_con_initiate_login_url#:#Initiate Login URL###26 08 2024 new variable
 lti#:#lti_con_key_type#:#Public Key Type###26 08 2024 new variable
 lti#:#lti_con_key_type_jwk#:#URL (Json Web Token)###26 08 2024 new variable
@@ -11313,6 +11322,10 @@ lti#:#lti_con_prov_category_info#:#Category to filter entries when LTI Consumer 
 lti#:#lti_con_prov_custom_params#:#Custom Parameters for this specific Provider###07 02 2020 new variable
 lti#:#lti_con_prov_custom_params_info#:#Please enter them in the form param1=value1; param2=value2###07 02 2020 new variable
 lti#:#lti_con_prov_description#:#Description###07 02 2020 new variable
+lti#:#lti_con_prov_dyn_reg_params#:#Optional Parameters###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_params_info#:#Here, for example, references to target objects in the tool can be specified.###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url#:#Registration URL of the Tool###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url_info#:#Note: Not every tool supports dynamic registration.###04 12 2025 new variable
 lti#:#lti_con_prov_external_provider#:#External Provider###07 02 2020 new variable
 lti#:#lti_con_prov_external_provider_info#:#A hint will be shown to users when dealing with an external Provider. An external Provider is characterized by insufficient influence on the Provider by the operator of the ILIAS-installation. This is the case when there are no rights to delete.###07 02 2020 new variable
 lti#:#lti_con_prov_group_options#:#Options to group and filter Providers###07 02 2020 new variable
@@ -11382,12 +11395,13 @@ lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumidores criados na
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable
+lti#:#lti_dynamic_registration#:#Create Own Settings for Tool with Dynamic Registration (LTI 1.3)###04 12 2025
 lti#:#lti_edit_consumer#:#Editar consumidor LIT
 lti#:#lti_exit#:#Fechar sessão LTI
 lti#:#lti_exited#:#Sessão LTI fechada
 lti#:#lti_exited_info#:#Sessão LTI fechada com sucesso
-lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_content_selection#:#Seleção de conteúdo
+lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable
@@ -11438,6 +11452,7 @@ lti#:#subtab_certificate#:#Certificate###07 02 2020 new variable
 lti#:#subtab_object_settings#:#Object Settings###07 02 2020 new variable
 lti#:#subtab_provider_settings#:#LTI Provider Settings###07 02 2020 new variable
 lti#:#tab_content#:#Content###07 02 2020 new variable
+lti#:#tab_grade_synchronization#:#Gradebook
 lti#:#tab_info#:#Info###07 02 2020 new variable
 lti#:#tab_scoring#:#Ranking###07 02 2020 new variable
 lti#:#tab_settings#:#Settings###07 02 2020 new variable

--- a/lang/ilias_pt.lang
+++ b/lang/ilias_pt.lang
@@ -11378,6 +11378,7 @@ lti#:#lti_create_lti_user_role#:#Create recommended global role for LTI users###
 lti#:#lti_cron_title#:#Autoavaliação
 lti#:#lti_cron_title_desc#:#Densidade semântica
 lti#:#lti_custom_new#:#Create Own Provider Settings###07 02 2020 new variable
+lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumidores criados na Administração não permitem a seleção de conteúdo
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable

--- a/lang/ilias_ro.lang
+++ b/lang/ilias_ro.lang
@@ -11378,6 +11378,7 @@ lti#:#lti_create_lti_user_role#:#Create recommended global role for LTI users###
 lti#:#lti_cron_title#:#LTI Outcome Service###07 02 2020 new variable
 lti#:#lti_cron_title_desc#:#Synchronizes the learning progress of LTI users with the LTI consumer, if it supports the outcome service. This cron job is only required to transfer status updates after Learning progress settings updates.###07 02 2020 new variable
 lti#:#lti_custom_new#:#Create Own Provider Settings###07 02 2020 new variable
+lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Administration do not allow content selection
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable

--- a/lang/ilias_ro.lang
+++ b/lang/ilias_ro.lang
@@ -11387,6 +11387,7 @@ lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
 lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
+lti#:#lti_form_provider_content_selection#:#Selectarea conținutului
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable

--- a/lang/ilias_ro.lang
+++ b/lang/ilias_ro.lang
@@ -11189,6 +11189,10 @@ lti#:#conf_privacy_ident_il_uuid_ext_account#:#External User ID combined with a 
 lti#:#conf_privacy_ident_il_uuid_ext_account_info#:#This is identical to each call, but may allow a direct conclusion about the user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login#:#ILIAS Login combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login_info#:#Sends the login name. This is identical to each call, but may allow a direct conclusion about the ILIAS user.###26 08 2024 new variable
+lti#:#conf_privacy_ident_il_uuid_random#:#Random ID combined with a unique ILIAS platform ID formatted as an E-Mail address###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_random_info#:#For each ILIAS object and ILIAS user a random ID is generated which remains identical for each call. Conclusions about a user are very limited because it is practically impossible to create user profiles across objects.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url#:#Hash combined with the ILIAS Domain formatted as an E-Mail address.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url_info#:#This is identical to each call, with with a maximum of 80 characters significantly shorter than the variant with the ILIAS platform ID and allows only very limited conclusions about the ILIAS user.###04 12 2025 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id#:#ILIAS user id combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id_info#:#Sends the internal numeric user id. This is identical to each call, but may allow conclusions about the ILIAS user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_info#:#Standard is frequently the email address. The unique ILIAS platform id is:###26 08 2024 new variable
@@ -11274,13 +11278,16 @@ lti#:#launched#:#Resource was already launched.###07 02 2020 new variable
 lti#:#learning_progress_options#:#Options for Learning Progress###07 02 2020 new variable
 lti#:#lm_only_one_download_per_type#:#Please note that you can only make one file per type (XML, HTML, SCORM) public accessible.###31 08 2017 new variable
 lti#:#lti13_hints#:#If the tool was created without dynamic registration, the following data must be entered for the tool to run.###26 08 2024 new variable
+lti#:#lti_13_authentication_url#:#Authentication Request URL###04 12 2025 new variable
 lti#:#lti_13_client_id#:#Client-ID###26 08 2024 new variable
 lti#:#lti_13_deployment_id#:#Deployment-ID###26 08 2024 new variable
+lti#:#lti_13_keyset_url#:#Public Keyset URL###04 12 2025 new variable
 lti#:#lti_13_platform_id#:#Platform-ID###26 08 2024 new variable
 lti#:#lti_13_step1#:#Step 1###26 08 2024 new variable
 lti#:#lti_13_step1_info#:#For the initiating platform (consumer), enter the following address for Launch URL, Initiate Login URL, Redirection URI, and Registration URL:###26 08 2024 new variable
 lti#:#lti_13_step2#:#Step 2###26 08 2024 new variable
 lti#:#lti_13_step2_info#:#You will receive information from the initiating platform (Consumer), which you must enter in the following fields. After saving, the LTI 1.3 functionalities are available.###26 08 2024 new variable
+lti#:#lti_13_token_url#:#Access Token URL###04 12 2025 new variable
 lti#:#lti_action_accept_provider_as_global#:#Accept Provider as Global Provider for all Users###07 02 2020 new variable
 lti#:#lti_action_accept_providers_as_global#:#Accept Providers as Global###07 02 2020 new variable
 lti#:#lti_action_delete_providers#:#Delete Providers###07 02 2020 new variable
@@ -11294,6 +11301,8 @@ lti#:#lti_at_least_one_prov_has_usages#:#At least one provider could not be dele
 lti#:#lti_auth_failed_invalid_key#:#Authentication failed, no valid consumer key given.###31 08 2017 new variable
 lti#:#lti_con_content_item#:#Support for Deep Linking###26 08 2024 new variable
 lti#:#lti_con_content_item_url#:#Content URL###26 08 2024 new variable
+lti#:#lti_con_grade_synchronization#:#Assignment and Grade Services###04 12 2025 new variable
+lti#:#lti_con_grade_synchronization_info#:#The LTI tool must offer 'Assignment and Grade Services'.###04 12 2025 new variable
 lti#:#lti_con_initiate_login_url#:#Initiate Login URL###26 08 2024 new variable
 lti#:#lti_con_key_type#:#Public Key Type###26 08 2024 new variable
 lti#:#lti_con_key_type_jwk#:#URL (Json Web Token)###26 08 2024 new variable
@@ -11313,6 +11322,10 @@ lti#:#lti_con_prov_category_info#:#Category to filter entries when LTI Consumer 
 lti#:#lti_con_prov_custom_params#:#Custom Parameters for this specific Provider###07 02 2020 new variable
 lti#:#lti_con_prov_custom_params_info#:#Please enter them in the form param1=value1; param2=value2###07 02 2020 new variable
 lti#:#lti_con_prov_description#:#Description###07 02 2020 new variable
+lti#:#lti_con_prov_dyn_reg_params#:#Optional Parameters###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_params_info#:#Here, for example, references to target objects in the tool can be specified.###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url#:#Registration URL of the Tool###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url_info#:#Note: Not every tool supports dynamic registration.###04 12 2025 new variable
 lti#:#lti_con_prov_external_provider#:#External Provider###07 02 2020 new variable
 lti#:#lti_con_prov_external_provider_info#:#A hint will be shown to users when dealing with an external Provider. An external Provider is characterized by insufficient influence on the Provider by the operator of the ILIAS-installation. This is the case when there are no rights to delete.###07 02 2020 new variable
 lti#:#lti_con_prov_group_options#:#Options to group and filter Providers###07 02 2020 new variable
@@ -11382,12 +11395,13 @@ lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Ad
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable
+lti#:#lti_dynamic_registration#:#Create Own Settings for Tool with Dynamic Registration (LTI 1.3)###04 12 2025
 lti#:#lti_edit_consumer#:#Edit LTI Consumer###31 08 2017 new variable
 lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
-lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_content_selection#:#Selectarea conținutului
+lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable
@@ -11438,6 +11452,7 @@ lti#:#subtab_certificate#:#Certificate###07 02 2020 new variable
 lti#:#subtab_object_settings#:#Object Settings###07 02 2020 new variable
 lti#:#subtab_provider_settings#:#LTI Provider Settings###07 02 2020 new variable
 lti#:#tab_content#:#Content###07 02 2020 new variable
+lti#:#tab_grade_synchronization#:#Gradebook
 lti#:#tab_info#:#Info###07 02 2020 new variable
 lti#:#tab_scoring#:#Ranking###07 02 2020 new variable
 lti#:#tab_settings#:#Settings###07 02 2020 new variable

--- a/lang/ilias_ru.lang
+++ b/lang/ilias_ru.lang
@@ -11189,6 +11189,10 @@ lti#:#conf_privacy_ident_il_uuid_ext_account#:#External User ID combined with a 
 lti#:#conf_privacy_ident_il_uuid_ext_account_info#:#This is identical to each call, but may allow a direct conclusion about the user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login#:#ILIAS Login combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login_info#:#Sends the login name. This is identical to each call, but may allow a direct conclusion about the ILIAS user.###26 08 2024 new variable
+lti#:#conf_privacy_ident_il_uuid_random#:#Random ID combined with a unique ILIAS platform ID formatted as an E-Mail address###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_random_info#:#For each ILIAS object and ILIAS user a random ID is generated which remains identical for each call. Conclusions about a user are very limited because it is practically impossible to create user profiles across objects.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url#:#Hash combined with the ILIAS Domain formatted as an E-Mail address.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url_info#:#This is identical to each call, with with a maximum of 80 characters significantly shorter than the variant with the ILIAS platform ID and allows only very limited conclusions about the ILIAS user.###04 12 2025 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id#:#ILIAS user id combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id_info#:#Sends the internal numeric user id. This is identical to each call, but may allow conclusions about the ILIAS user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_info#:#Standard is frequently the email address. The unique ILIAS platform id is:###26 08 2024 new variable
@@ -11274,13 +11278,16 @@ lti#:#launched#:#Resource was already launched.###07 02 2020 new variable
 lti#:#learning_progress_options#:#Options for Learning Progress###07 02 2020 new variable
 lti#:#lm_only_one_download_per_type#:#Please note that you can only make one file per type (XML, HTML, SCORM) public accessible.###31 08 2017 new variable
 lti#:#lti13_hints#:#If the tool was created without dynamic registration, the following data must be entered for the tool to run.###26 08 2024 new variable
+lti#:#lti_13_authentication_url#:#Authentication Request URL###04 12 2025 new variable
 lti#:#lti_13_client_id#:#Client-ID###26 08 2024 new variable
 lti#:#lti_13_deployment_id#:#Deployment-ID###26 08 2024 new variable
+lti#:#lti_13_keyset_url#:#Public Keyset URL###04 12 2025 new variable
 lti#:#lti_13_platform_id#:#Platform-ID###26 08 2024 new variable
 lti#:#lti_13_step1#:#Step 1###26 08 2024 new variable
 lti#:#lti_13_step1_info#:#For the initiating platform (consumer), enter the following address for Launch URL, Initiate Login URL, Redirection URI, and Registration URL:###26 08 2024 new variable
 lti#:#lti_13_step2#:#Step 2###26 08 2024 new variable
 lti#:#lti_13_step2_info#:#You will receive information from the initiating platform (Consumer), which you must enter in the following fields. After saving, the LTI 1.3 functionalities are available.###26 08 2024 new variable
+lti#:#lti_13_token_url#:#Access Token URL###04 12 2025 new variable
 lti#:#lti_action_accept_provider_as_global#:#Accept Provider as Global Provider for all Users###07 02 2020 new variable
 lti#:#lti_action_accept_providers_as_global#:#Accept Providers as Global###07 02 2020 new variable
 lti#:#lti_action_delete_providers#:#Delete Providers###07 02 2020 new variable
@@ -11294,6 +11301,8 @@ lti#:#lti_at_least_one_prov_has_usages#:#At least one provider could not be dele
 lti#:#lti_auth_failed_invalid_key#:#Authentication failed, no valid consumer key given.###31 08 2017 new variable
 lti#:#lti_con_content_item#:#Support for Deep Linking###26 08 2024 new variable
 lti#:#lti_con_content_item_url#:#Content URL###26 08 2024 new variable
+lti#:#lti_con_grade_synchronization#:#Assignment and Grade Services###04 12 2025 new variable
+lti#:#lti_con_grade_synchronization_info#:#The LTI tool must offer 'Assignment and Grade Services'.###04 12 2025 new variable
 lti#:#lti_con_initiate_login_url#:#Initiate Login URL###26 08 2024 new variable
 lti#:#lti_con_key_type#:#Public Key Type###26 08 2024 new variable
 lti#:#lti_con_key_type_jwk#:#URL (Json Web Token)###26 08 2024 new variable
@@ -11313,6 +11322,10 @@ lti#:#lti_con_prov_category_info#:#Category to filter entries when LTI Consumer 
 lti#:#lti_con_prov_custom_params#:#Custom Parameters for this specific Provider###07 02 2020 new variable
 lti#:#lti_con_prov_custom_params_info#:#Please enter them in the form param1=value1; param2=value2###07 02 2020 new variable
 lti#:#lti_con_prov_description#:#Description###07 02 2020 new variable
+lti#:#lti_con_prov_dyn_reg_params#:#Optional Parameters###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_params_info#:#Here, for example, references to target objects in the tool can be specified.###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url#:#Registration URL of the Tool###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url_info#:#Note: Not every tool supports dynamic registration.###04 12 2025 new variable
 lti#:#lti_con_prov_external_provider#:#External Provider###07 02 2020 new variable
 lti#:#lti_con_prov_external_provider_info#:#A hint will be shown to users when dealing with an external Provider. An external Provider is characterized by insufficient influence on the Provider by the operator of the ILIAS-installation. This is the case when there are no rights to delete.###07 02 2020 new variable
 lti#:#lti_con_prov_group_options#:#Options to group and filter Providers###07 02 2020 new variable
@@ -11382,12 +11395,13 @@ lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Ad
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable
+lti#:#lti_dynamic_registration#:#Create Own Settings for Tool with Dynamic Registration (LTI 1.3)###04 12 2025
 lti#:#lti_edit_consumer#:#Edit LTI Consumer###31 08 2017 new variable
 lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
-lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_content_selection#:#Выбор содержимого
+lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable
@@ -11438,6 +11452,7 @@ lti#:#subtab_certificate#:#Certificate###07 02 2020 new variable
 lti#:#subtab_object_settings#:#Object Settings###07 02 2020 new variable
 lti#:#subtab_provider_settings#:#LTI Provider Settings###07 02 2020 new variable
 lti#:#tab_content#:#Content###07 02 2020 new variable
+lti#:#tab_grade_synchronization#:#Gradebook
 lti#:#tab_info#:#Info###07 02 2020 new variable
 lti#:#tab_scoring#:#Ranking###07 02 2020 new variable
 lti#:#tab_settings#:#Settings###07 02 2020 new variable

--- a/lang/ilias_ru.lang
+++ b/lang/ilias_ru.lang
@@ -11378,6 +11378,7 @@ lti#:#lti_create_lti_user_role#:#Create recommended global role for LTI users###
 lti#:#lti_cron_title#:#LTI Outcome Service###07 02 2020 new variable
 lti#:#lti_cron_title_desc#:#Synchronizes the learning progress of LTI users with the LTI consumer, if it supports the outcome service. This cron job is only required to transfer status updates after Learning progress settings updates.###07 02 2020 new variable
 lti#:#lti_custom_new#:#Create Own Provider Settings###07 02 2020 new variable
+lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Administration do not allow content selection
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable

--- a/lang/ilias_ru.lang
+++ b/lang/ilias_ru.lang
@@ -11387,6 +11387,7 @@ lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
 lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
+lti#:#lti_form_provider_content_selection#:#Выбор содержимого
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable

--- a/lang/ilias_sk.lang
+++ b/lang/ilias_sk.lang
@@ -11189,6 +11189,10 @@ lti#:#conf_privacy_ident_il_uuid_ext_account#:#External User ID combined with a 
 lti#:#conf_privacy_ident_il_uuid_ext_account_info#:#This is identical to each call, but may allow a direct conclusion about the user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login#:#ILIAS Login combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login_info#:#Sends the login name. This is identical to each call, but may allow a direct conclusion about the ILIAS user.###26 08 2024 new variable
+lti#:#conf_privacy_ident_il_uuid_random#:#Random ID combined with a unique ILIAS platform ID formatted as an E-Mail address###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_random_info#:#For each ILIAS object and ILIAS user a random ID is generated which remains identical for each call. Conclusions about a user are very limited because it is practically impossible to create user profiles across objects.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url#:#Hash combined with the ILIAS Domain formatted as an E-Mail address.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url_info#:#This is identical to each call, with with a maximum of 80 characters significantly shorter than the variant with the ILIAS platform ID and allows only very limited conclusions about the ILIAS user.###04 12 2025 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id#:#ILIAS user id combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id_info#:#Sends the internal numeric user id. This is identical to each call, but may allow conclusions about the ILIAS user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_info#:#Standard is frequently the email address. The unique ILIAS platform id is:###26 08 2024 new variable
@@ -11274,13 +11278,16 @@ lti#:#launched#:#Resource was already launched.###07 02 2020 new variable
 lti#:#learning_progress_options#:#Options for Learning Progress###07 02 2020 new variable
 lti#:#lm_only_one_download_per_type#:#Please note that you can only make one file per type (XML, HTML, SCORM) public accessible.###31 08 2017 new variable
 lti#:#lti13_hints#:#If the tool was created without dynamic registration, the following data must be entered for the tool to run.###26 08 2024 new variable
+lti#:#lti_13_authentication_url#:#Authentication Request URL###04 12 2025 new variable
 lti#:#lti_13_client_id#:#Client-ID###26 08 2024 new variable
 lti#:#lti_13_deployment_id#:#Deployment-ID###26 08 2024 new variable
+lti#:#lti_13_keyset_url#:#Public Keyset URL###04 12 2025 new variable
 lti#:#lti_13_platform_id#:#Platform-ID###26 08 2024 new variable
 lti#:#lti_13_step1#:#Step 1###26 08 2024 new variable
 lti#:#lti_13_step1_info#:#For the initiating platform (consumer), enter the following address for Launch URL, Initiate Login URL, Redirection URI, and Registration URL:###26 08 2024 new variable
 lti#:#lti_13_step2#:#Step 2###26 08 2024 new variable
 lti#:#lti_13_step2_info#:#You will receive information from the initiating platform (Consumer), which you must enter in the following fields. After saving, the LTI 1.3 functionalities are available.###26 08 2024 new variable
+lti#:#lti_13_token_url#:#Access Token URL###04 12 2025 new variable
 lti#:#lti_action_accept_provider_as_global#:#Accept Provider as Global Provider for all Users###07 02 2020 new variable
 lti#:#lti_action_accept_providers_as_global#:#Accept Providers as Global###07 02 2020 new variable
 lti#:#lti_action_delete_providers#:#Delete Providers###07 02 2020 new variable
@@ -11294,6 +11301,8 @@ lti#:#lti_at_least_one_prov_has_usages#:#At least one provider could not be dele
 lti#:#lti_auth_failed_invalid_key#:#Authentication failed, no valid consumer key given.###31 08 2017 new variable
 lti#:#lti_con_content_item#:#Support for Deep Linking###26 08 2024 new variable
 lti#:#lti_con_content_item_url#:#Content URL###26 08 2024 new variable
+lti#:#lti_con_grade_synchronization#:#Assignment and Grade Services###04 12 2025 new variable
+lti#:#lti_con_grade_synchronization_info#:#The LTI tool must offer 'Assignment and Grade Services'.###04 12 2025 new variable
 lti#:#lti_con_initiate_login_url#:#Initiate Login URL###26 08 2024 new variable
 lti#:#lti_con_key_type#:#Public Key Type###26 08 2024 new variable
 lti#:#lti_con_key_type_jwk#:#URL (Json Web Token)###26 08 2024 new variable
@@ -11313,6 +11322,10 @@ lti#:#lti_con_prov_category_info#:#Category to filter entries when LTI Consumer 
 lti#:#lti_con_prov_custom_params#:#Custom Parameters for this specific Provider###07 02 2020 new variable
 lti#:#lti_con_prov_custom_params_info#:#Please enter them in the form param1=value1; param2=value2###07 02 2020 new variable
 lti#:#lti_con_prov_description#:#Description###07 02 2020 new variable
+lti#:#lti_con_prov_dyn_reg_params#:#Optional Parameters###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_params_info#:#Here, for example, references to target objects in the tool can be specified.###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url#:#Registration URL of the Tool###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url_info#:#Note: Not every tool supports dynamic registration.###04 12 2025 new variable
 lti#:#lti_con_prov_external_provider#:#External Provider###07 02 2020 new variable
 lti#:#lti_con_prov_external_provider_info#:#A hint will be shown to users when dealing with an external Provider. An external Provider is characterized by insufficient influence on the Provider by the operator of the ILIAS-installation. This is the case when there are no rights to delete.###07 02 2020 new variable
 lti#:#lti_con_prov_group_options#:#Options to group and filter Providers###07 02 2020 new variable
@@ -11382,12 +11395,13 @@ lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Ad
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable
+lti#:#lti_dynamic_registration#:#Create Own Settings for Tool with Dynamic Registration (LTI 1.3)###04 12 2025
 lti#:#lti_edit_consumer#:#Edit LTI Consumer###31 08 2017 new variable
 lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
-lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_content_selection#:#Výber obsahu
+lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable
@@ -11438,6 +11452,7 @@ lti#:#subtab_certificate#:#Certificate###07 02 2020 new variable
 lti#:#subtab_object_settings#:#Object Settings###07 02 2020 new variable
 lti#:#subtab_provider_settings#:#LTI Provider Settings###07 02 2020 new variable
 lti#:#tab_content#:#Content###07 02 2020 new variable
+lti#:#tab_grade_synchronization#:#Gradebook
 lti#:#tab_info#:#Info###07 02 2020 new variable
 lti#:#tab_scoring#:#Ranking###07 02 2020 new variable
 lti#:#tab_settings#:#Settings###07 02 2020 new variable

--- a/lang/ilias_sk.lang
+++ b/lang/ilias_sk.lang
@@ -11387,6 +11387,7 @@ lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
 lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
+lti#:#lti_form_provider_content_selection#:#Výber obsahu
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable

--- a/lang/ilias_sk.lang
+++ b/lang/ilias_sk.lang
@@ -11378,6 +11378,7 @@ lti#:#lti_create_lti_user_role#:#Create recommended global role for LTI users###
 lti#:#lti_cron_title#:#LTI Outcome Service###07 02 2020 new variable
 lti#:#lti_cron_title_desc#:#Synchronizes the learning progress of LTI users with the LTI consumer, if it supports the outcome service. This cron job is only required to transfer status updates after Learning progress settings updates.###07 02 2020 new variable
 lti#:#lti_custom_new#:#Create Own Provider Settings###07 02 2020 new variable
+lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Administration do not allow content selection
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable

--- a/lang/ilias_sl.lang
+++ b/lang/ilias_sl.lang
@@ -11378,6 +11378,7 @@ lti#:#lti_create_lti_user_role#:#Create recommended global role for LTI users
 lti#:#lti_cron_title#:#LTI Outcome Service
 lti#:#lti_cron_title_desc#:#Prenese učni napredek od uporabnikov LTI na platformo za priklic. Ta cron job je potreben samo v primerih, ko je treba učni napredek na novo izračunati zaradi sprememb nastavitev.
 lti#:#lti_custom_new#:#Create Own Provider Settings
+lti#:#lti_deep_linking_not_available_for_admin_objects#:#Potrošniki, ustvarjeni v Administraciji, ne omogočajo izbire vsebine
 lti#:#lti_delete_consume_provider#:#Delete Provider
 lti#:#lti_delete_consume_providers#:#Delete Providers
 lti#:#lti_delete_provider#:#Delete Provider

--- a/lang/ilias_sl.lang
+++ b/lang/ilias_sl.lang
@@ -11387,6 +11387,7 @@ lti#:#lti_exit#:#Zaključi sejo LTI
 lti#:#lti_exited#:#Seja LTI je zaključena
 lti#:#lti_exited_info#:#Seja LTI je bila uspešno zaključena
 lti#:#lti_form_provider_create#:#Create Provider Settings
+lti#:#lti_form_provider_content_selection#:#Izbira vsebine
 lti#:#lti_form_provider_edit#:#Edit Provider Settings
 lti#:#lti_form_section_appearance#:#Options for launch
 lti#:#lti_global_settings_form#:#Global Settings

--- a/lang/ilias_sl.lang
+++ b/lang/ilias_sl.lang
@@ -11189,6 +11189,10 @@ lti#:#conf_privacy_ident_il_uuid_ext_account#:#External User Id combined with a 
 lti#:#conf_privacy_ident_il_uuid_ext_account_info#:#This is identical to each call, but may allow a direct conclusion about the user.
 lti#:#conf_privacy_ident_il_uuid_login#:#ILIAS Login combined with a unique ILIAS platform id formated as an email adress.
 lti#:#conf_privacy_ident_il_uuid_login_info#:#This is identical to each call, but may allow a direct conclusion about the ILIAS user.
+lti#:#conf_privacy_ident_il_uuid_random#:#Random ID combined with a unique ILIAS platform ID formatted as an E-Mail address###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_random_info#:#For each ILIAS object and ILIAS user a random ID is generated which remains identical for each call. Conclusions about a user are very limited because it is practically impossible to create user profiles across objects.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url#:#Hash combined with the ILIAS Domain formatted as an E-Mail address.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url_info#:#This is identical to each call, with with a maximum of 80 characters significantly shorter than the variant with the ILIAS platform ID and allows only very limited conclusions about the ILIAS user.###04 12 2025 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id#:#ILIAS user id combined with a unique ILIAS platform id formated as an email adress.
 lti#:#conf_privacy_ident_il_uuid_user_id_info#:#This is identical to each call, but doesn't allow a direct conclusion about the ILIAS user.
 lti#:#conf_privacy_ident_info#:#Standard is frequently the email address. The unique ILIAS platform id is
@@ -11274,13 +11278,16 @@ lti#:#launched#:#Resource was already launched.
 lti#:#learning_progress_options#:#Options for Learning Progress
 lti#:#lm_only_one_download_per_type#:#Za vsak tip (XML, HTML, SCORM) lahko daste na razpolago samo eno datoteko za prenos.
 lti#:#lti13_hints#:#Hints###19 08 2022 new variable
+lti#:#lti_13_authentication_url#:#Authentication Request URL###04 12 2025 new variable
 lti#:#lti_13_client_id#:#Client-ID###19 08 2022 new variable
 lti#:#lti_13_deployment_id#:#Deployment-ID###19 08 2022 new variable
+lti#:#lti_13_keyset_url#:#Public Keyset URL###04 12 2025 new variable
 lti#:#lti_13_platform_id#:#Platform-ID###19 08 2022 new variable
 lti#:#lti_13_step1#:#Step 1###19 08 2022 new variable
 lti#:#lti_13_step1_info#:#For the initiating platform (consumer), enter the following address for Launch URL, Initiate Login URL, Redirection URI, and Registration URL:###19 08 2022 new variable
 lti#:#lti_13_step2#:#Step 2###19 08 2022 new variable
 lti#:#lti_13_step2_info#:#You will receive information from the initiating platform (Consumer), which you must enter in the following fields. After saving, the LTI 1.3 functionalities are available.###19 08 2022 new variable
+lti#:#lti_13_token_url#:#Access Token URL###04 12 2025 new variable
 lti#:#lti_action_accept_provider_as_global#:#Accept Provider as Global Provider for all Users
 lti#:#lti_action_accept_providers_as_global#:#Accept Providers as Global
 lti#:#lti_action_delete_providers#:#Delete Providers
@@ -11294,6 +11301,8 @@ lti#:#lti_at_least_one_prov_has_usages#:#At least one provider could not be dele
 lti#:#lti_auth_failed_invalid_key#:#Avtentikacija ni mogoča. Noben veljaven consumer key ni bil prenesen.
 lti#:#lti_con_content_item#:#Support for Deep Linking###19 08 2022 new variable
 lti#:#lti_con_content_item_url#:#Content URL###19 08 2022 new variable
+lti#:#lti_con_grade_synchronization#:#Assignment and Grade Services###04 12 2025 new variable
+lti#:#lti_con_grade_synchronization_info#:#The LTI tool must offer 'Assignment and Grade Services'.###04 12 2025 new variable
 lti#:#lti_con_initiate_login_url#:#Initiate Login URL###19 08 2022 new variable
 lti#:#lti_con_key_type#:#Public Key Type###19 08 2022 new variable
 lti#:#lti_con_key_type_jwk#:#URL (Json Web Token)###19 08 2022 new variable
@@ -11313,6 +11322,10 @@ lti#:#lti_con_prov_category_info#:#Category to filter entries when LTI Consumer 
 lti#:#lti_con_prov_custom_params#:#Custom Parameters for this specific Provider
 lti#:#lti_con_prov_custom_params_info#:#Please enter them in the form param1=value1; param2=value2
 lti#:#lti_con_prov_description#:#Description
+lti#:#lti_con_prov_dyn_reg_params#:#Optional Parameters###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_params_info#:#Here, for example, references to target objects in the tool can be specified.###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url#:#Registration URL of the Tool###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url_info#:#Note: Not every tool supports dynamic registration.###04 12 2025 new variable
 lti#:#lti_con_prov_external_provider#:#External Provider
 lti#:#lti_con_prov_external_provider_info#:#A hint will be shown to users when dealing with an external Provider. An external Provider is characterized by insufficient influence on the Provider by the operator of the ILIAS-installation. This is the case when there are no rights to delete.
 lti#:#lti_con_prov_group_options#:#Options to group and filter Providers
@@ -11382,12 +11395,13 @@ lti#:#lti_deep_linking_not_available_for_admin_objects#:#Potrošniki, ustvarjeni
 lti#:#lti_delete_consume_provider#:#Delete Provider
 lti#:#lti_delete_consume_providers#:#Delete Providers
 lti#:#lti_delete_provider#:#Delete Provider
+lti#:#lti_dynamic_registration#:#Create Own Settings for Tool with Dynamic Registration (LTI 1.3)###04 12 2025
 lti#:#lti_edit_consumer#:#Uredi potrošnika LTI
 lti#:#lti_exit#:#Zaključi sejo LTI
 lti#:#lti_exited#:#Seja LTI je zaključena
 lti#:#lti_exited_info#:#Seja LTI je bila uspešno zaključena
-lti#:#lti_form_provider_create#:#Create Provider Settings
 lti#:#lti_form_provider_content_selection#:#Izbira vsebine
+lti#:#lti_form_provider_create#:#Create Provider Settings
 lti#:#lti_form_provider_edit#:#Edit Provider Settings
 lti#:#lti_form_section_appearance#:#Options for launch
 lti#:#lti_global_settings_form#:#Global Settings
@@ -11438,6 +11452,7 @@ lti#:#subtab_certificate#:#Certificate
 lti#:#subtab_object_settings#:#Object Settings
 lti#:#subtab_provider_settings#:#LTI Provider Settings
 lti#:#tab_content#:#Content
+lti#:#tab_grade_synchronization#:#Gradebook
 lti#:#tab_info#:#Info
 lti#:#tab_scoring#:#Ranking
 lti#:#tab_settings#:#Settings

--- a/lang/ilias_sq.lang
+++ b/lang/ilias_sq.lang
@@ -11189,6 +11189,10 @@ lti#:#conf_privacy_ident_il_uuid_ext_account#:#External User ID combined with a 
 lti#:#conf_privacy_ident_il_uuid_ext_account_info#:#This is identical to each call, but may allow a direct conclusion about the user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login#:#ILIAS Login combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login_info#:#Sends the login name. This is identical to each call, but may allow a direct conclusion about the ILIAS user.###26 08 2024 new variable
+lti#:#conf_privacy_ident_il_uuid_random#:#Random ID combined with a unique ILIAS platform ID formatted as an E-Mail address###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_random_info#:#For each ILIAS object and ILIAS user a random ID is generated which remains identical for each call. Conclusions about a user are very limited because it is practically impossible to create user profiles across objects.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url#:#Hash combined with the ILIAS Domain formatted as an E-Mail address.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url_info#:#This is identical to each call, with with a maximum of 80 characters significantly shorter than the variant with the ILIAS platform ID and allows only very limited conclusions about the ILIAS user.###04 12 2025 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id#:#ILIAS user id combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id_info#:#Sends the internal numeric user id. This is identical to each call, but may allow conclusions about the ILIAS user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_info#:#Standard is frequently the email address. The unique ILIAS platform id is:###26 08 2024 new variable
@@ -11274,13 +11278,16 @@ lti#:#launched#:#Resource was already launched.###07 02 2020 new variable
 lti#:#learning_progress_options#:#Options for Learning Progress###07 02 2020 new variable
 lti#:#lm_only_one_download_per_type#:#Please note that you can only make one file per type (XML, HTML, SCORM) public accessible.###31 08 2017 new variable
 lti#:#lti13_hints#:#If the tool was created without dynamic registration, the following data must be entered for the tool to run.###26 08 2024 new variable
+lti#:#lti_13_authentication_url#:#Authentication Request URL###04 12 2025 new variable
 lti#:#lti_13_client_id#:#Client-ID###26 08 2024 new variable
 lti#:#lti_13_deployment_id#:#Deployment-ID###26 08 2024 new variable
+lti#:#lti_13_keyset_url#:#Public Keyset URL###04 12 2025 new variable
 lti#:#lti_13_platform_id#:#Platform-ID###26 08 2024 new variable
 lti#:#lti_13_step1#:#Step 1###26 08 2024 new variable
 lti#:#lti_13_step1_info#:#For the initiating platform (consumer), enter the following address for Launch URL, Initiate Login URL, Redirection URI, and Registration URL:###26 08 2024 new variable
 lti#:#lti_13_step2#:#Step 2###26 08 2024 new variable
 lti#:#lti_13_step2_info#:#You will receive information from the initiating platform (Consumer), which you must enter in the following fields. After saving, the LTI 1.3 functionalities are available.###26 08 2024 new variable
+lti#:#lti_13_token_url#:#Access Token URL###04 12 2025 new variable
 lti#:#lti_action_accept_provider_as_global#:#Accept Provider as Global Provider for all Users###07 02 2020 new variable
 lti#:#lti_action_accept_providers_as_global#:#Accept Providers as Global###07 02 2020 new variable
 lti#:#lti_action_delete_providers#:#Delete Providers###07 02 2020 new variable
@@ -11294,6 +11301,8 @@ lti#:#lti_at_least_one_prov_has_usages#:#At least one provider could not be dele
 lti#:#lti_auth_failed_invalid_key#:#Authentication failed, no valid consumer key given.###31 08 2017 new variable
 lti#:#lti_con_content_item#:#Support for Deep Linking###26 08 2024 new variable
 lti#:#lti_con_content_item_url#:#Content URL###26 08 2024 new variable
+lti#:#lti_con_grade_synchronization#:#Assignment and Grade Services###04 12 2025 new variable
+lti#:#lti_con_grade_synchronization_info#:#The LTI tool must offer 'Assignment and Grade Services'.###04 12 2025 new variable
 lti#:#lti_con_initiate_login_url#:#Initiate Login URL###26 08 2024 new variable
 lti#:#lti_con_key_type#:#Public Key Type###26 08 2024 new variable
 lti#:#lti_con_key_type_jwk#:#URL (Json Web Token)###26 08 2024 new variable
@@ -11313,6 +11322,10 @@ lti#:#lti_con_prov_category_info#:#Category to filter entries when LTI Consumer 
 lti#:#lti_con_prov_custom_params#:#Custom Parameters for this specific Provider###07 02 2020 new variable
 lti#:#lti_con_prov_custom_params_info#:#Please enter them in the form param1=value1; param2=value2###07 02 2020 new variable
 lti#:#lti_con_prov_description#:#Description###07 02 2020 new variable
+lti#:#lti_con_prov_dyn_reg_params#:#Optional Parameters###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_params_info#:#Here, for example, references to target objects in the tool can be specified.###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url#:#Registration URL of the Tool###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url_info#:#Note: Not every tool supports dynamic registration.###04 12 2025 new variable
 lti#:#lti_con_prov_external_provider#:#External Provider###07 02 2020 new variable
 lti#:#lti_con_prov_external_provider_info#:#A hint will be shown to users when dealing with an external Provider. An external Provider is characterized by insufficient influence on the Provider by the operator of the ILIAS-installation. This is the case when there are no rights to delete.###07 02 2020 new variable
 lti#:#lti_con_prov_group_options#:#Options to group and filter Providers###07 02 2020 new variable
@@ -11382,12 +11395,13 @@ lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Ad
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable
+lti#:#lti_dynamic_registration#:#Create Own Settings for Tool with Dynamic Registration (LTI 1.3)###04 12 2025
 lti#:#lti_edit_consumer#:#Edit LTI Consumer###31 08 2017 new variable
 lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
-lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_content_selection#:#Përzgjedhja e përmbajtjes
+lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable
@@ -11438,6 +11452,7 @@ lti#:#subtab_certificate#:#Certificate###07 02 2020 new variable
 lti#:#subtab_object_settings#:#Object Settings###07 02 2020 new variable
 lti#:#subtab_provider_settings#:#LTI Provider Settings###07 02 2020 new variable
 lti#:#tab_content#:#Content###07 02 2020 new variable
+lti#:#tab_grade_synchronization#:#Gradebook
 lti#:#tab_info#:#Info###07 02 2020 new variable
 lti#:#tab_scoring#:#Ranking###07 02 2020 new variable
 lti#:#tab_settings#:#Settings###07 02 2020 new variable

--- a/lang/ilias_sq.lang
+++ b/lang/ilias_sq.lang
@@ -11387,6 +11387,7 @@ lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
 lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
+lti#:#lti_form_provider_content_selection#:#Përzgjedhja e përmbajtjes
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable

--- a/lang/ilias_sq.lang
+++ b/lang/ilias_sq.lang
@@ -11378,6 +11378,7 @@ lti#:#lti_create_lti_user_role#:#Create recommended global role for LTI users###
 lti#:#lti_cron_title#:#LTI Outcome Service###07 02 2020 new variable
 lti#:#lti_cron_title_desc#:#Synchronizes the learning progress of LTI users with the LTI consumer, if it supports the outcome service. This cron job is only required to transfer status updates after Learning progress settings updates.###07 02 2020 new variable
 lti#:#lti_custom_new#:#Create Own Provider Settings###07 02 2020 new variable
+lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Administration do not allow content selection
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable

--- a/lang/ilias_sr.lang
+++ b/lang/ilias_sr.lang
@@ -11378,6 +11378,7 @@ lti#:#lti_create_lti_user_role#:#Create recommended global role for LTI users###
 lti#:#lti_cron_title#:#LTI Outcome Service###07 02 2020 new variable
 lti#:#lti_cron_title_desc#:#Synchronizes the learning progress of LTI users with the LTI consumer, if it supports the outcome service. This cron job is only required to transfer status updates after Learning progress settings updates.###07 02 2020 new variable
 lti#:#lti_custom_new#:#Create Own Provider Settings###07 02 2020 new variable
+lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Administration do not allow content selection
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable

--- a/lang/ilias_sr.lang
+++ b/lang/ilias_sr.lang
@@ -1,4 +1,4 @@
-﻿/**
+/**
 * This file is part of ILIAS, a powerful learning management system
 * published by ILIAS open source e-Learning e.V.
 *
@@ -11189,6 +11189,10 @@ lti#:#conf_privacy_ident_il_uuid_ext_account#:#External User ID combined with a 
 lti#:#conf_privacy_ident_il_uuid_ext_account_info#:#This is identical to each call, but may allow a direct conclusion about the user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login#:#ILIAS Login combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login_info#:#Sends the login name. This is identical to each call, but may allow a direct conclusion about the ILIAS user.###26 08 2024 new variable
+lti#:#conf_privacy_ident_il_uuid_random#:#Random ID combined with a unique ILIAS platform ID formatted as an E-Mail address###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_random_info#:#For each ILIAS object and ILIAS user a random ID is generated which remains identical for each call. Conclusions about a user are very limited because it is practically impossible to create user profiles across objects.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url#:#Hash combined with the ILIAS Domain formatted as an E-Mail address.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url_info#:#This is identical to each call, with with a maximum of 80 characters significantly shorter than the variant with the ILIAS platform ID and allows only very limited conclusions about the ILIAS user.###04 12 2025 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id#:#ILIAS user id combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id_info#:#Sends the internal numeric user id. This is identical to each call, but may allow conclusions about the ILIAS user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_info#:#Standard is frequently the email address. The unique ILIAS platform id is:###26 08 2024 new variable
@@ -11274,13 +11278,16 @@ lti#:#launched#:#Resource was already launched.###07 02 2020 new variable
 lti#:#learning_progress_options#:#Options for Learning Progress###07 02 2020 new variable
 lti#:#lm_only_one_download_per_type#:#Please note that you can only make one file per type (XML, HTML, SCORM) public accessible.###31 08 2017 new variable
 lti#:#lti13_hints#:#If the tool was created without dynamic registration, the following data must be entered for the tool to run.###26 08 2024 new variable
+lti#:#lti_13_authentication_url#:#Authentication Request URL###04 12 2025 new variable
 lti#:#lti_13_client_id#:#Client-ID###26 08 2024 new variable
 lti#:#lti_13_deployment_id#:#Deployment-ID###26 08 2024 new variable
+lti#:#lti_13_keyset_url#:#Public Keyset URL###04 12 2025 new variable
 lti#:#lti_13_platform_id#:#Platform-ID###26 08 2024 new variable
 lti#:#lti_13_step1#:#Step 1###26 08 2024 new variable
 lti#:#lti_13_step1_info#:#For the initiating platform (consumer), enter the following address for Launch URL, Initiate Login URL, Redirection URI, and Registration URL:###26 08 2024 new variable
 lti#:#lti_13_step2#:#Step 2###26 08 2024 new variable
 lti#:#lti_13_step2_info#:#You will receive information from the initiating platform (Consumer), which you must enter in the following fields. After saving, the LTI 1.3 functionalities are available.###26 08 2024 new variable
+lti#:#lti_13_token_url#:#Access Token URL###04 12 2025 new variable
 lti#:#lti_action_accept_provider_as_global#:#Accept Provider as Global Provider for all Users###07 02 2020 new variable
 lti#:#lti_action_accept_providers_as_global#:#Accept Providers as Global###07 02 2020 new variable
 lti#:#lti_action_delete_providers#:#Delete Providers###07 02 2020 new variable
@@ -11294,6 +11301,8 @@ lti#:#lti_at_least_one_prov_has_usages#:#At least one provider could not be dele
 lti#:#lti_auth_failed_invalid_key#:#Authentication failed, no valid consumer key given.###31 08 2017 new variable
 lti#:#lti_con_content_item#:#Support for Deep Linking###26 08 2024 new variable
 lti#:#lti_con_content_item_url#:#Content URL###26 08 2024 new variable
+lti#:#lti_con_grade_synchronization#:#Assignment and Grade Services###04 12 2025 new variable
+lti#:#lti_con_grade_synchronization_info#:#The LTI tool must offer 'Assignment and Grade Services'.###04 12 2025 new variable
 lti#:#lti_con_initiate_login_url#:#Initiate Login URL###26 08 2024 new variable
 lti#:#lti_con_key_type#:#Public Key Type###26 08 2024 new variable
 lti#:#lti_con_key_type_jwk#:#URL (Json Web Token)###26 08 2024 new variable
@@ -11313,6 +11322,10 @@ lti#:#lti_con_prov_category_info#:#Category to filter entries when LTI Consumer 
 lti#:#lti_con_prov_custom_params#:#Custom Parameters for this specific Provider###07 02 2020 new variable
 lti#:#lti_con_prov_custom_params_info#:#Please enter them in the form param1=value1; param2=value2###07 02 2020 new variable
 lti#:#lti_con_prov_description#:#Description###07 02 2020 new variable
+lti#:#lti_con_prov_dyn_reg_params#:#Optional Parameters###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_params_info#:#Here, for example, references to target objects in the tool can be specified.###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url#:#Registration URL of the Tool###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url_info#:#Note: Not every tool supports dynamic registration.###04 12 2025 new variable
 lti#:#lti_con_prov_external_provider#:#External Provider###07 02 2020 new variable
 lti#:#lti_con_prov_external_provider_info#:#A hint will be shown to users when dealing with an external Provider. An external Provider is characterized by insufficient influence on the Provider by the operator of the ILIAS-installation. This is the case when there are no rights to delete.###07 02 2020 new variable
 lti#:#lti_con_prov_group_options#:#Options to group and filter Providers###07 02 2020 new variable
@@ -11382,12 +11395,13 @@ lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Ad
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable
+lti#:#lti_dynamic_registration#:#Create Own Settings for Tool with Dynamic Registration (LTI 1.3)###04 12 2025
 lti#:#lti_edit_consumer#:#Edit LTI Consumer###31 08 2017 new variable
 lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
-lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_content_selection#:#Izbor sadržaja
+lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable
@@ -11438,6 +11452,7 @@ lti#:#subtab_certificate#:#Certificate###07 02 2020 new variable
 lti#:#subtab_object_settings#:#Object Settings###07 02 2020 new variable
 lti#:#subtab_provider_settings#:#LTI Provider Settings###07 02 2020 new variable
 lti#:#tab_content#:#Content###07 02 2020 new variable
+lti#:#tab_grade_synchronization#:#Gradebook
 lti#:#tab_info#:#Info###07 02 2020 new variable
 lti#:#tab_scoring#:#Ranking###07 02 2020 new variable
 lti#:#tab_settings#:#Settings###07 02 2020 new variable

--- a/lang/ilias_sr.lang
+++ b/lang/ilias_sr.lang
@@ -11387,6 +11387,7 @@ lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
 lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
+lti#:#lti_form_provider_content_selection#:#Izbor sadržaja
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable

--- a/lang/ilias_sv.lang
+++ b/lang/ilias_sv.lang
@@ -11387,6 +11387,7 @@ lti#:#lti_exit#:#Avsluta LTI-session
 lti#:#lti_exited#:#LTI-sessionen avslutad
 lti#:#lti_exited_info#:#LTI-sessionen slutfördes framgångsrikt.
 lti#:#lti_form_provider_create#:#Skapa inställningar för en leverantör eller ett verktyg
+lti#:#lti_form_provider_content_selection#:#Innehållsval
 lti#:#lti_form_provider_edit#:#Redigera inställningar för leverantören eller verktyget
 lti#:#lti_form_section_appearance#:#Alternativ för lanseringen
 lti#:#lti_global_settings_form#:#Globala inställningar

--- a/lang/ilias_sv.lang
+++ b/lang/ilias_sv.lang
@@ -11378,6 +11378,7 @@ lti#:#lti_create_lti_user_role#:#Skapa rekommenderad global roll för LTI-använ
 lti#:#lti_cron_title#:#LTI Utfallstjänst
 lti#:#lti_cron_title_desc#:#Överför LTI-användarnas inlärningsförlopp till den anropande plattformen. Detta cron-jobb behövs endast i de fall då inlärningsförloppet måste räknas om på grund av ändrade inställningar.
 lti#:#lti_custom_new#:#Skapa din egen leverantör eller verktygsinställningar
+lti#:#lti_deep_linking_not_available_for_admin_objects#:#Konsumenter som skapats i Administration tillåter inte val av innehåll
 lti#:#lti_delete_consume_provider#:#Ta bort leverantör eller verktyg
 lti#:#lti_delete_consume_providers#:#Ta bort leverantör eller verktyg
 lti#:#lti_delete_provider#:#Ta bort leverantör eller verktyg

--- a/lang/ilias_sv.lang
+++ b/lang/ilias_sv.lang
@@ -11189,6 +11189,10 @@ lti#:#conf_privacy_ident_il_uuid_ext_account#:#Externt användar-ID kombinerat m
 lti#:#conf_privacy_ident_il_uuid_ext_account_info#:#Detta är identiskt med varje samtal, men kan göra det möjligt att dra direkta slutsatser om användaren.
 lti#:#conf_privacy_ident_il_uuid_login#:#ILIAS-inloggning som e-postadress, kombinerat med ett unikt ILIAS-plattforms-ID om så krävs.
 lti#:#conf_privacy_ident_il_uuid_login_info#:#Sänder inloggningsnamnet. Detta är identiskt med varje anrop, men kan tillåta direkta slutsatser till ILIAS-användaren.
+lti#:#conf_privacy_ident_il_uuid_random#:#Random ID combined with a unique ILIAS platform ID formatted as an E-Mail address###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_random_info#:#For each ILIAS object and ILIAS user a random ID is generated which remains identical for each call. Conclusions about a user are very limited because it is practically impossible to create user profiles across objects.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url#:#Hash combined with the ILIAS Domain formatted as an E-Mail address.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url_info#:#This is identical to each call, with with a maximum of 80 characters significantly shorter than the variant with the ILIAS platform ID and allows only very limited conclusions about the ILIAS user.###04 12 2025 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id#:#ID för ILIAS-kontot kombinerat med ett unikt ILIAS-plattforms-ID formaterat som en e-postadress.
 lti#:#conf_privacy_ident_il_uuid_user_id_info#:#Sänder det interna numeriska användar-ID:t. Detta är identiskt för varje anrop, men gör det möjligt att dra slutsatser om ILIAS-användaren.
 lti#:#conf_privacy_ident_info#:#Standard är ofta e-postadressen. Det unika ILIAS-plattforms-ID:t är
@@ -11274,13 +11278,16 @@ lti#:#launched#:#Resursen har redan startats.
 lti#:#learning_progress_options#:#Alternativ för lärande framsteg
 lti#:#lm_only_one_download_per_type#:#Endast en fil per typ (XML, HTML, SCORM) kan göras tillgänglig för nedladdning.
 lti#:#lti13_hints#:#Om verktyget skapades utan dynamisk registrering måste följande data anges för att verktyget ska kunna köras.
+lti#:#lti_13_authentication_url#:#Authentication Request URL###04 12 2025 new variable
 lti#:#lti_13_client_id#:#Klient-ID
 lti#:#lti_13_deployment_id#:#ID för utplacering
+lti#:#lti_13_keyset_url#:#Public Keyset URL###04 12 2025 new variable
 lti#:#lti_13_platform_id#:#Platform ID
 lti#:#lti_13_step1#:#Steg 1
 lti#:#lti_13_step1_info#:#För den initierande plattformen (konsumenten), ange följande adress för Launch URL, Initiate Login URL, Redirection URI och Registration URL
 lti#:#lti_13_step2#:#Steg 2
 lti#:#lti_13_step2_info#:#Du kommer att få information från den initierande plattformen (konsumenten) som du måste ange i följande fält. Efter att ha sparat är LTI 1.3-funktionerna tillgängliga.
+lti#:#lti_13_token_url#:#Access Token URL###04 12 2025 new variable
 lti#:#lti_action_accept_provider_as_global#:#Tillämpa leverantören eller verktyget globalt för alla användare.
 lti#:#lti_action_accept_providers_as_global#:#Ta över leverantören eller verktyget som en global leverantör eller ett globalt verktyg.
 lti#:#lti_action_delete_providers#:#Ta bort leverantör eller verktyg
@@ -11294,6 +11301,8 @@ lti#:#lti_at_least_one_prov_has_usages#:#Minst en leverantör eller ett verktyg 
 lti#:#lti_auth_failed_invalid_key#:#Autentisering inte möjlig. Ingen giltig konsumentnyckel överfördes.
 lti#:#lti_con_content_item#:#Stöd för djuplänkning
 lti#:#lti_con_content_item_url#:#URL för innehåll
+lti#:#lti_con_grade_synchronization#:#Assignment and Grade Services###04 12 2025 new variable
+lti#:#lti_con_grade_synchronization_info#:#The LTI tool must offer 'Assignment and Grade Services'.###04 12 2025 new variable
 lti#:#lti_con_initiate_login_url#:#Initiera inloggnings-URL
 lti#:#lti_con_key_type#:#Typ av den offentliga nyckeln
 lti#:#lti_con_key_type_jwk#:#URL (Json Web Token)
@@ -11313,6 +11322,10 @@ lti#:#lti_con_prov_category_info#:#Kategori för att filtrera poster när ett LT
 lti#:#lti_con_prov_custom_params#:#Användardefinierade parametrar för denna specifika leverantör
 lti#:#lti_con_prov_custom_params_info#:#Var god ange dem i formuläret
 lti#:#lti_con_prov_description#:#Beskrivning
+lti#:#lti_con_prov_dyn_reg_params#:#Optional Parameters###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_params_info#:#Here, for example, references to target objects in the tool can be specified.###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url#:#Registration URL of the Tool###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url_info#:#Note: Not every tool supports dynamic registration.###04 12 2025 new variable
 lti#:#lti_con_prov_external_provider#:#Extern leverantör eller externt verktyg
 lti#:#lti_con_prov_external_provider_info#:#När du arbetar med en extern leverantör eller ett externt verktyg visas en notering för användarna. Externa leverantörer eller verktyg kännetecknas av att ILIAS-installatörens inflytande på leverantören eller verktyget är otillräckligt. Detta är fallet o
 lti#:#lti_con_prov_group_options#:#Alternativ för gruppering och filtrering av leverantörer eller verktyg
@@ -11382,12 +11395,13 @@ lti#:#lti_deep_linking_not_available_for_admin_objects#:#Konsumenter som skapats
 lti#:#lti_delete_consume_provider#:#Ta bort leverantör eller verktyg
 lti#:#lti_delete_consume_providers#:#Ta bort leverantör eller verktyg
 lti#:#lti_delete_provider#:#Ta bort leverantör eller verktyg
+lti#:#lti_dynamic_registration#:#Create Own Settings for Tool with Dynamic Registration (LTI 1.3)###04 12 2025
 lti#:#lti_edit_consumer#:#Edit LTI konsument
 lti#:#lti_exit#:#Avsluta LTI-session
 lti#:#lti_exited#:#LTI-sessionen avslutad
 lti#:#lti_exited_info#:#LTI-sessionen slutfördes framgångsrikt.
-lti#:#lti_form_provider_create#:#Skapa inställningar för en leverantör eller ett verktyg
 lti#:#lti_form_provider_content_selection#:#Innehållsval
+lti#:#lti_form_provider_create#:#Skapa inställningar för en leverantör eller ett verktyg
 lti#:#lti_form_provider_edit#:#Redigera inställningar för leverantören eller verktyget
 lti#:#lti_form_section_appearance#:#Alternativ för lanseringen
 lti#:#lti_global_settings_form#:#Globala inställningar
@@ -11438,6 +11452,7 @@ lti#:#subtab_certificate#:#Certifikat
 lti#:#subtab_object_settings#:#Inställningar för objekt
 lti#:#subtab_provider_settings#:#Inställningar för leverantör eller verktyg
 lti#:#tab_content#:#Innehåll
+lti#:#tab_grade_synchronization#:#Gradebook
 lti#:#tab_info#:#Info
 lti#:#tab_scoring#:#Placeringar
 lti#:#tab_settings#:#Inställningar

--- a/lang/ilias_tr.lang
+++ b/lang/ilias_tr.lang
@@ -11189,6 +11189,10 @@ lti#:#conf_privacy_ident_il_uuid_ext_account#:#External User ID combined with a 
 lti#:#conf_privacy_ident_il_uuid_ext_account_info#:#This is identical to each call, but may allow a direct conclusion about the user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login#:#ILIAS Login combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login_info#:#Sends the login name. This is identical to each call, but may allow a direct conclusion about the ILIAS user.###26 08 2024 new variable
+lti#:#conf_privacy_ident_il_uuid_random#:#Random ID combined with a unique ILIAS platform ID formatted as an E-Mail address###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_random_info#:#For each ILIAS object and ILIAS user a random ID is generated which remains identical for each call. Conclusions about a user are very limited because it is practically impossible to create user profiles across objects.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url#:#Hash combined with the ILIAS Domain formatted as an E-Mail address.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url_info#:#This is identical to each call, with with a maximum of 80 characters significantly shorter than the variant with the ILIAS platform ID and allows only very limited conclusions about the ILIAS user.###04 12 2025 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id#:#ILIAS user id combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id_info#:#Sends the internal numeric user id. This is identical to each call, but may allow conclusions about the ILIAS user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_info#:#Standard is frequently the email address. The unique ILIAS platform id is:###26 08 2024 new variable
@@ -11274,13 +11278,16 @@ lti#:#launched#:#Resource was already launched.###07 02 2020 new variable
 lti#:#learning_progress_options#:#Options for Learning Progress###07 02 2020 new variable
 lti#:#lm_only_one_download_per_type#:#Please note that you can only make one file per type (XML, HTML, SCORM) public accessible.###31 08 2017 new variable
 lti#:#lti13_hints#:#If the tool was created without dynamic registration, the following data must be entered for the tool to run.###26 08 2024 new variable
+lti#:#lti_13_authentication_url#:#Authentication Request URL###04 12 2025 new variable
 lti#:#lti_13_client_id#:#Client-ID###26 08 2024 new variable
 lti#:#lti_13_deployment_id#:#Deployment-ID###26 08 2024 new variable
+lti#:#lti_13_keyset_url#:#Public Keyset URL###04 12 2025 new variable
 lti#:#lti_13_platform_id#:#Platform-ID###26 08 2024 new variable
 lti#:#lti_13_step1#:#Step 1###26 08 2024 new variable
 lti#:#lti_13_step1_info#:#For the initiating platform (consumer), enter the following address for Launch URL, Initiate Login URL, Redirection URI, and Registration URL:###26 08 2024 new variable
 lti#:#lti_13_step2#:#Step 2###26 08 2024 new variable
 lti#:#lti_13_step2_info#:#You will receive information from the initiating platform (Consumer), which you must enter in the following fields. After saving, the LTI 1.3 functionalities are available.###26 08 2024 new variable
+lti#:#lti_13_token_url#:#Access Token URL###04 12 2025 new variable
 lti#:#lti_action_accept_provider_as_global#:#Accept Provider as Global Provider for all Users###07 02 2020 new variable
 lti#:#lti_action_accept_providers_as_global#:#Accept Providers as Global###07 02 2020 new variable
 lti#:#lti_action_delete_providers#:#Delete Providers###07 02 2020 new variable
@@ -11294,6 +11301,8 @@ lti#:#lti_at_least_one_prov_has_usages#:#At least one provider could not be dele
 lti#:#lti_auth_failed_invalid_key#:#Authentication failed, no valid consumer key given.###31 08 2017 new variable
 lti#:#lti_con_content_item#:#Support for Deep Linking###26 08 2024 new variable
 lti#:#lti_con_content_item_url#:#Content URL###26 08 2024 new variable
+lti#:#lti_con_grade_synchronization#:#Assignment and Grade Services###04 12 2025 new variable
+lti#:#lti_con_grade_synchronization_info#:#The LTI tool must offer 'Assignment and Grade Services'.###04 12 2025 new variable
 lti#:#lti_con_initiate_login_url#:#Initiate Login URL###26 08 2024 new variable
 lti#:#lti_con_key_type#:#Public Key Type###26 08 2024 new variable
 lti#:#lti_con_key_type_jwk#:#URL (Json Web Token)###26 08 2024 new variable
@@ -11313,6 +11322,10 @@ lti#:#lti_con_prov_category_info#:#Category to filter entries when LTI Consumer 
 lti#:#lti_con_prov_custom_params#:#Custom Parameters for this specific Provider###07 02 2020 new variable
 lti#:#lti_con_prov_custom_params_info#:#Please enter them in the form param1=value1; param2=value2###07 02 2020 new variable
 lti#:#lti_con_prov_description#:#Description###07 02 2020 new variable
+lti#:#lti_con_prov_dyn_reg_params#:#Optional Parameters###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_params_info#:#Here, for example, references to target objects in the tool can be specified.###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url#:#Registration URL of the Tool###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url_info#:#Note: Not every tool supports dynamic registration.###04 12 2025 new variable
 lti#:#lti_con_prov_external_provider#:#External Provider###07 02 2020 new variable
 lti#:#lti_con_prov_external_provider_info#:#A hint will be shown to users when dealing with an external Provider. An external Provider is characterized by insufficient influence on the Provider by the operator of the ILIAS-installation. This is the case when there are no rights to delete.###07 02 2020 new variable
 lti#:#lti_con_prov_group_options#:#Options to group and filter Providers###07 02 2020 new variable
@@ -11382,12 +11395,13 @@ lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Ad
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable
+lti#:#lti_dynamic_registration#:#Create Own Settings for Tool with Dynamic Registration (LTI 1.3)###04 12 2025
 lti#:#lti_edit_consumer#:#Edit LTI Consumer###31 08 2017 new variable
 lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
-lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_content_selection#:#İçerik seçimi
+lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable
@@ -11438,6 +11452,7 @@ lti#:#subtab_certificate#:#Certificate###07 02 2020 new variable
 lti#:#subtab_object_settings#:#Object Settings###07 02 2020 new variable
 lti#:#subtab_provider_settings#:#LTI Provider Settings###07 02 2020 new variable
 lti#:#tab_content#:#Content###07 02 2020 new variable
+lti#:#tab_grade_synchronization#:#Gradebook
 lti#:#tab_info#:#Info###07 02 2020 new variable
 lti#:#tab_scoring#:#Ranking###07 02 2020 new variable
 lti#:#tab_settings#:#Settings###07 02 2020 new variable

--- a/lang/ilias_tr.lang
+++ b/lang/ilias_tr.lang
@@ -11378,6 +11378,7 @@ lti#:#lti_create_lti_user_role#:#Create recommended global role for LTI users###
 lti#:#lti_cron_title#:#LTI Outcome Service###07 02 2020 new variable
 lti#:#lti_cron_title_desc#:#Synchronizes the learning progress of LTI users with the LTI consumer, if it supports the outcome service. This cron job is only required to transfer status updates after Learning progress settings updates.###07 02 2020 new variable
 lti#:#lti_custom_new#:#Create Own Provider Settings###07 02 2020 new variable
+lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Administration do not allow content selection
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable

--- a/lang/ilias_tr.lang
+++ b/lang/ilias_tr.lang
@@ -11387,6 +11387,7 @@ lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
 lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
+lti#:#lti_form_provider_content_selection#:#İçerik seçimi
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable

--- a/lang/ilias_uk.lang
+++ b/lang/ilias_uk.lang
@@ -11189,6 +11189,10 @@ lti#:#conf_privacy_ident_il_uuid_ext_account#:#External User ID combined with a 
 lti#:#conf_privacy_ident_il_uuid_ext_account_info#:#This is identical to each call, but may allow a direct conclusion about the user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login#:#ILIAS Login combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login_info#:#Sends the login name. This is identical to each call, but may allow a direct conclusion about the ILIAS user.###26 08 2024 new variable
+lti#:#conf_privacy_ident_il_uuid_random#:#Random ID combined with a unique ILIAS platform ID formatted as an E-Mail address###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_random_info#:#For each ILIAS object and ILIAS user a random ID is generated which remains identical for each call. Conclusions about a user are very limited because it is practically impossible to create user profiles across objects.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url#:#Hash combined with the ILIAS Domain formatted as an E-Mail address.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url_info#:#This is identical to each call, with with a maximum of 80 characters significantly shorter than the variant with the ILIAS platform ID and allows only very limited conclusions about the ILIAS user.###04 12 2025 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id#:#ILIAS user id combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id_info#:#Sends the internal numeric user id. This is identical to each call, but may allow conclusions about the ILIAS user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_info#:#Standard is frequently the email address. The unique ILIAS platform id is:###26 08 2024 new variable
@@ -11274,13 +11278,16 @@ lti#:#launched#:#Resource was already launched.###07 02 2020 new variable
 lti#:#learning_progress_options#:#Options for Learning Progress###07 02 2020 new variable
 lti#:#lm_only_one_download_per_type#:#Please note that you can only make one file per type (XML, HTML, SCORM) public accessible.###31 08 2017 new variable
 lti#:#lti13_hints#:#If the tool was created without dynamic registration, the following data must be entered for the tool to run.###26 08 2024 new variable
+lti#:#lti_13_authentication_url#:#Authentication Request URL###04 12 2025 new variable
 lti#:#lti_13_client_id#:#Client-ID###26 08 2024 new variable
 lti#:#lti_13_deployment_id#:#Deployment-ID###26 08 2024 new variable
+lti#:#lti_13_keyset_url#:#Public Keyset URL###04 12 2025 new variable
 lti#:#lti_13_platform_id#:#Platform-ID###26 08 2024 new variable
 lti#:#lti_13_step1#:#Step 1###26 08 2024 new variable
 lti#:#lti_13_step1_info#:#For the initiating platform (consumer), enter the following address for Launch URL, Initiate Login URL, Redirection URI, and Registration URL:###26 08 2024 new variable
 lti#:#lti_13_step2#:#Step 2###26 08 2024 new variable
 lti#:#lti_13_step2_info#:#You will receive information from the initiating platform (Consumer), which you must enter in the following fields. After saving, the LTI 1.3 functionalities are available.###26 08 2024 new variable
+lti#:#lti_13_token_url#:#Access Token URL###04 12 2025 new variable
 lti#:#lti_action_accept_provider_as_global#:#Accept Provider as Global Provider for all Users###07 02 2020 new variable
 lti#:#lti_action_accept_providers_as_global#:#Accept Providers as Global###07 02 2020 new variable
 lti#:#lti_action_delete_providers#:#Delete Providers###07 02 2020 new variable
@@ -11294,6 +11301,8 @@ lti#:#lti_at_least_one_prov_has_usages#:#At least one provider could not be dele
 lti#:#lti_auth_failed_invalid_key#:#Authentication failed, no valid consumer key given.###31 08 2017 new variable
 lti#:#lti_con_content_item#:#Support for Deep Linking###26 08 2024 new variable
 lti#:#lti_con_content_item_url#:#Content URL###26 08 2024 new variable
+lti#:#lti_con_grade_synchronization#:#Assignment and Grade Services###04 12 2025 new variable
+lti#:#lti_con_grade_synchronization_info#:#The LTI tool must offer 'Assignment and Grade Services'.###04 12 2025 new variable
 lti#:#lti_con_initiate_login_url#:#Initiate Login URL###26 08 2024 new variable
 lti#:#lti_con_key_type#:#Public Key Type###26 08 2024 new variable
 lti#:#lti_con_key_type_jwk#:#URL (Json Web Token)###26 08 2024 new variable
@@ -11313,6 +11322,10 @@ lti#:#lti_con_prov_category_info#:#Category to filter entries when LTI Consumer 
 lti#:#lti_con_prov_custom_params#:#Custom Parameters for this specific Provider###07 02 2020 new variable
 lti#:#lti_con_prov_custom_params_info#:#Please enter them in the form param1=value1; param2=value2###07 02 2020 new variable
 lti#:#lti_con_prov_description#:#Description###07 02 2020 new variable
+lti#:#lti_con_prov_dyn_reg_params#:#Optional Parameters###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_params_info#:#Here, for example, references to target objects in the tool can be specified.###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url#:#Registration URL of the Tool###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url_info#:#Note: Not every tool supports dynamic registration.###04 12 2025 new variable
 lti#:#lti_con_prov_external_provider#:#External Provider###07 02 2020 new variable
 lti#:#lti_con_prov_external_provider_info#:#A hint will be shown to users when dealing with an external Provider. An external Provider is characterized by insufficient influence on the Provider by the operator of the ILIAS-installation. This is the case when there are no rights to delete.###07 02 2020 new variable
 lti#:#lti_con_prov_group_options#:#Options to group and filter Providers###07 02 2020 new variable
@@ -11382,12 +11395,13 @@ lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Ad
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable
+lti#:#lti_dynamic_registration#:#Create Own Settings for Tool with Dynamic Registration (LTI 1.3)###04 12 2025
 lti#:#lti_edit_consumer#:#Edit LTI Consumer###31 08 2017 new variable
 lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
-lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_content_selection#:#Вибір вмісту
+lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable
@@ -11438,6 +11452,7 @@ lti#:#subtab_certificate#:#Certificate###07 02 2020 new variable
 lti#:#subtab_object_settings#:#Object Settings###07 02 2020 new variable
 lti#:#subtab_provider_settings#:#LTI Provider Settings###07 02 2020 new variable
 lti#:#tab_content#:#Content###07 02 2020 new variable
+lti#:#tab_grade_synchronization#:#Gradebook
 lti#:#tab_info#:#Info###07 02 2020 new variable
 lti#:#tab_scoring#:#Ranking###07 02 2020 new variable
 lti#:#tab_settings#:#Settings###07 02 2020 new variable

--- a/lang/ilias_uk.lang
+++ b/lang/ilias_uk.lang
@@ -11378,6 +11378,7 @@ lti#:#lti_create_lti_user_role#:#Create recommended global role for LTI users###
 lti#:#lti_cron_title#:#LTI Outcome Service###07 02 2020 new variable
 lti#:#lti_cron_title_desc#:#Synchronizes the learning progress of LTI users with the LTI consumer, if it supports the outcome service. This cron job is only required to transfer status updates after Learning progress settings updates.###07 02 2020 new variable
 lti#:#lti_custom_new#:#Create Own Provider Settings###07 02 2020 new variable
+lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Administration do not allow content selection
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable

--- a/lang/ilias_uk.lang
+++ b/lang/ilias_uk.lang
@@ -11387,6 +11387,7 @@ lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
 lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
+lti#:#lti_form_provider_content_selection#:#Вибір вмісту
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable

--- a/lang/ilias_vi.lang
+++ b/lang/ilias_vi.lang
@@ -11191,6 +11191,10 @@ lti#:#conf_privacy_ident_il_uuid_ext_account#:#External User ID combined with a 
 lti#:#conf_privacy_ident_il_uuid_ext_account_info#:#This is identical to each call, but may allow a direct conclusion about the user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login#:#ILIAS Login combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login_info#:#Sends the login name. This is identical to each call, but may allow a direct conclusion about the ILIAS user.###26 08 2024 new variable
+lti#:#conf_privacy_ident_il_uuid_random#:#Random ID combined with a unique ILIAS platform ID formatted as an E-Mail address###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_random_info#:#For each ILIAS object and ILIAS user a random ID is generated which remains identical for each call. Conclusions about a user are very limited because it is practically impossible to create user profiles across objects.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url#:#Hash combined with the ILIAS Domain formatted as an E-Mail address.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url_info#:#This is identical to each call, with with a maximum of 80 characters significantly shorter than the variant with the ILIAS platform ID and allows only very limited conclusions about the ILIAS user.###04 12 2025 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id#:#ILIAS user id combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id_info#:#Sends the internal numeric user id. This is identical to each call, but may allow conclusions about the ILIAS user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_info#:#Standard is frequently the email address. The unique ILIAS platform id is:###26 08 2024 new variable
@@ -11276,13 +11280,16 @@ lti#:#launched#:#Resource was already launched.###07 02 2020 new variable
 lti#:#learning_progress_options#:#Options for Learning Progress###07 02 2020 new variable
 lti#:#lm_only_one_download_per_type#:#Please note that you can only make one file per type (XML, HTML, SCORM) public accessible.###31 08 2017 new variable
 lti#:#lti13_hints#:#If the tool was created without dynamic registration, the following data must be entered for the tool to run.###26 08 2024 new variable
+lti#:#lti_13_authentication_url#:#Authentication Request URL###04 12 2025 new variable
 lti#:#lti_13_client_id#:#Client-ID###26 08 2024 new variable
 lti#:#lti_13_deployment_id#:#Deployment-ID###26 08 2024 new variable
+lti#:#lti_13_keyset_url#:#Public Keyset URL###04 12 2025 new variable
 lti#:#lti_13_platform_id#:#Platform-ID###26 08 2024 new variable
 lti#:#lti_13_step1#:#Step 1###26 08 2024 new variable
 lti#:#lti_13_step1_info#:#For the initiating platform (consumer), enter the following address for Launch URL, Initiate Login URL, Redirection URI, and Registration URL:###26 08 2024 new variable
 lti#:#lti_13_step2#:#Step 2###26 08 2024 new variable
 lti#:#lti_13_step2_info#:#You will receive information from the initiating platform (Consumer), which you must enter in the following fields. After saving, the LTI 1.3 functionalities are available.###26 08 2024 new variable
+lti#:#lti_13_token_url#:#Access Token URL###04 12 2025 new variable
 lti#:#lti_action_accept_provider_as_global#:#Accept Provider as Global Provider for all Users###07 02 2020 new variable
 lti#:#lti_action_accept_providers_as_global#:#Accept Providers as Global###07 02 2020 new variable
 lti#:#lti_action_delete_providers#:#Delete Providers###07 02 2020 new variable
@@ -11296,6 +11303,8 @@ lti#:#lti_at_least_one_prov_has_usages#:#At least one provider could not be dele
 lti#:#lti_auth_failed_invalid_key#:#Authentication failed, no valid consumer key given.###31 08 2017 new variable
 lti#:#lti_con_content_item#:#Support for Deep Linking###26 08 2024 new variable
 lti#:#lti_con_content_item_url#:#Content URL###26 08 2024 new variable
+lti#:#lti_con_grade_synchronization#:#Assignment and Grade Services###04 12 2025 new variable
+lti#:#lti_con_grade_synchronization_info#:#The LTI tool must offer 'Assignment and Grade Services'.###04 12 2025 new variable
 lti#:#lti_con_initiate_login_url#:#Initiate Login URL###26 08 2024 new variable
 lti#:#lti_con_key_type#:#Public Key Type###26 08 2024 new variable
 lti#:#lti_con_key_type_jwk#:#URL (Json Web Token)###26 08 2024 new variable
@@ -11315,6 +11324,10 @@ lti#:#lti_con_prov_category_info#:#Category to filter entries when LTI Consumer 
 lti#:#lti_con_prov_custom_params#:#Custom Parameters for this specific Provider###07 02 2020 new variable
 lti#:#lti_con_prov_custom_params_info#:#Please enter them in the form param1=value1; param2=value2###07 02 2020 new variable
 lti#:#lti_con_prov_description#:#Description###07 02 2020 new variable
+lti#:#lti_con_prov_dyn_reg_params#:#Optional Parameters###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_params_info#:#Here, for example, references to target objects in the tool can be specified.###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url#:#Registration URL of the Tool###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url_info#:#Note: Not every tool supports dynamic registration.###04 12 2025 new variable
 lti#:#lti_con_prov_external_provider#:#External Provider###07 02 2020 new variable
 lti#:#lti_con_prov_external_provider_info#:#A hint will be shown to users when dealing with an external Provider. An external Provider is characterized by insufficient influence on the Provider by the operator of the ILIAS-installation. This is the case when there are no rights to delete.###07 02 2020 new variable
 lti#:#lti_con_prov_group_options#:#Options to group and filter Providers###07 02 2020 new variable
@@ -11384,12 +11397,13 @@ lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Ad
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable
+lti#:#lti_dynamic_registration#:#Create Own Settings for Tool with Dynamic Registration (LTI 1.3)###04 12 2025
 lti#:#lti_edit_consumer#:#Edit LTI Consumer###31 08 2017 new variable
 lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
-lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_content_selection#:#Chọn nội dung
+lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable
@@ -11440,6 +11454,7 @@ lti#:#subtab_certificate#:#Certificate###07 02 2020 new variable
 lti#:#subtab_object_settings#:#Object Settings###07 02 2020 new variable
 lti#:#subtab_provider_settings#:#LTI Provider Settings###07 02 2020 new variable
 lti#:#tab_content#:#Content###07 02 2020 new variable
+lti#:#tab_grade_synchronization#:#Gradebook
 lti#:#tab_info#:#Info###07 02 2020 new variable
 lti#:#tab_scoring#:#Ranking###07 02 2020 new variable
 lti#:#tab_settings#:#Settings###07 02 2020 new variable

--- a/lang/ilias_vi.lang
+++ b/lang/ilias_vi.lang
@@ -11380,6 +11380,7 @@ lti#:#lti_create_lti_user_role#:#Create recommended global role for LTI users###
 lti#:#lti_cron_title#:#LTI Outcome Service###07 02 2020 new variable
 lti#:#lti_cron_title_desc#:#Synchronizes the learning progress of LTI users with the LTI consumer, if it supports the outcome service. This cron job is only required to transfer status updates after Learning progress settings updates.###07 02 2020 new variable
 lti#:#lti_custom_new#:#Create Own Provider Settings###07 02 2020 new variable
+lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Administration do not allow content selection
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable

--- a/lang/ilias_vi.lang
+++ b/lang/ilias_vi.lang
@@ -11389,6 +11389,7 @@ lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
 lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
+lti#:#lti_form_provider_content_selection#:#Chọn nội dung
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable

--- a/lang/ilias_zh.lang
+++ b/lang/ilias_zh.lang
@@ -11188,6 +11188,10 @@ lti#:#conf_privacy_ident_il_uuid_ext_account#:#External User ID combined with a 
 lti#:#conf_privacy_ident_il_uuid_ext_account_info#:#This is identical to each call, but may allow a direct conclusion about the user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login#:#ILIAS Login combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_login_info#:#Sends the login name. This is identical to each call, but may allow a direct conclusion about the ILIAS user.###26 08 2024 new variable
+lti#:#conf_privacy_ident_il_uuid_random#:#Random ID combined with a unique ILIAS platform ID formatted as an E-Mail address###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_random_info#:#For each ILIAS object and ILIAS user a random ID is generated which remains identical for each call. Conclusions about a user are very limited because it is practically impossible to create user profiles across objects.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url#:#Hash combined with the ILIAS Domain formatted as an E-Mail address.###04 12 2025 new variable
+lti#:#conf_privacy_ident_il_uuid_sha256url_info#:#This is identical to each call, with with a maximum of 80 characters significantly shorter than the variant with the ILIAS platform ID and allows only very limited conclusions about the ILIAS user.###04 12 2025 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id#:#ILIAS user id combined with a unique ILIAS platform id formatted as an E-Mail address###26 08 2024 new variable
 lti#:#conf_privacy_ident_il_uuid_user_id_info#:#Sends the internal numeric user id. This is identical to each call, but may allow conclusions about the ILIAS user.###26 08 2024 new variable
 lti#:#conf_privacy_ident_info#:#Standard is frequently the email address. The unique ILIAS platform id is:###26 08 2024 new variable
@@ -11273,13 +11277,16 @@ lti#:#launched#:#Resource was already launched.###07 02 2020 new variable
 lti#:#learning_progress_options#:#Options for Learning Progress###07 02 2020 new variable
 lti#:#lm_only_one_download_per_type#:#Please note that you can only make one file per type (XML, HTML, SCORM) public accessible.###31 08 2017 new variable
 lti#:#lti13_hints#:#If the tool was created without dynamic registration, the following data must be entered for the tool to run.###26 08 2024 new variable
+lti#:#lti_13_authentication_url#:#Authentication Request URL###04 12 2025 new variable
 lti#:#lti_13_client_id#:#Client-ID###26 08 2024 new variable
 lti#:#lti_13_deployment_id#:#Deployment-ID###26 08 2024 new variable
+lti#:#lti_13_keyset_url#:#Public Keyset URL###04 12 2025 new variable
 lti#:#lti_13_platform_id#:#Platform-ID###26 08 2024 new variable
 lti#:#lti_13_step1#:#Step 1###26 08 2024 new variable
 lti#:#lti_13_step1_info#:#For the initiating platform (consumer), enter the following address for Launch URL, Initiate Login URL, Redirection URI, and Registration URL:###26 08 2024 new variable
 lti#:#lti_13_step2#:#Step 2###26 08 2024 new variable
 lti#:#lti_13_step2_info#:#You will receive information from the initiating platform (Consumer), which you must enter in the following fields. After saving, the LTI 1.3 functionalities are available.###26 08 2024 new variable
+lti#:#lti_13_token_url#:#Access Token URL###04 12 2025 new variable
 lti#:#lti_action_accept_provider_as_global#:#Accept Provider as Global Provider for all Users###07 02 2020 new variable
 lti#:#lti_action_accept_providers_as_global#:#Accept Providers as Global###07 02 2020 new variable
 lti#:#lti_action_delete_providers#:#Delete Providers###07 02 2020 new variable
@@ -11293,6 +11300,8 @@ lti#:#lti_at_least_one_prov_has_usages#:#At least one provider could not be dele
 lti#:#lti_auth_failed_invalid_key#:#Authentication failed, no valid consumer key given.###31 08 2017 new variable
 lti#:#lti_con_content_item#:#Support for Deep Linking###26 08 2024 new variable
 lti#:#lti_con_content_item_url#:#Content URL###26 08 2024 new variable
+lti#:#lti_con_grade_synchronization#:#Assignment and Grade Services###04 12 2025 new variable
+lti#:#lti_con_grade_synchronization_info#:#The LTI tool must offer 'Assignment and Grade Services'.###04 12 2025 new variable
 lti#:#lti_con_initiate_login_url#:#Initiate Login URL###26 08 2024 new variable
 lti#:#lti_con_key_type#:#Public Key Type###26 08 2024 new variable
 lti#:#lti_con_key_type_jwk#:#URL (Json Web Token)###26 08 2024 new variable
@@ -11312,6 +11321,10 @@ lti#:#lti_con_prov_category_info#:#Category to filter entries when LTI Consumer 
 lti#:#lti_con_prov_custom_params#:#Custom Parameters for this specific Provider###07 02 2020 new variable
 lti#:#lti_con_prov_custom_params_info#:#Please enter them in the form param1=value1; param2=value2###07 02 2020 new variable
 lti#:#lti_con_prov_description#:#Description###07 02 2020 new variable
+lti#:#lti_con_prov_dyn_reg_params#:#Optional Parameters###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_params_info#:#Here, for example, references to target objects in the tool can be specified.###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url#:#Registration URL of the Tool###04 12 2025 new variable
+lti#:#lti_con_prov_dyn_reg_url_info#:#Note: Not every tool supports dynamic registration.###04 12 2025 new variable
 lti#:#lti_con_prov_external_provider#:#External Provider###07 02 2020 new variable
 lti#:#lti_con_prov_external_provider_info#:#A hint will be shown to users when dealing with an external Provider. An external Provider is characterized by insufficient influence on the Provider by the operator of the ILIAS-installation. This is the case when there are no rights to delete.###07 02 2020 new variable
 lti#:#lti_con_prov_group_options#:#Options to group and filter Providers###07 02 2020 new variable
@@ -11381,12 +11394,13 @@ lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Ad
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable
+lti#:#lti_dynamic_registration#:#Create Own Settings for Tool with Dynamic Registration (LTI 1.3)###04 12 2025
 lti#:#lti_edit_consumer#:#Edit LTI Consumer###31 08 2017 new variable
 lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
-lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_content_selection#:#内容选择
+lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable
@@ -11437,6 +11451,7 @@ lti#:#subtab_certificate#:#Certificate###07 02 2020 new variable
 lti#:#subtab_object_settings#:#Object Settings###07 02 2020 new variable
 lti#:#subtab_provider_settings#:#LTI Provider Settings###07 02 2020 new variable
 lti#:#tab_content#:#Content###07 02 2020 new variable
+lti#:#tab_grade_synchronization#:#Gradebook
 lti#:#tab_info#:#Info###07 02 2020 new variable
 lti#:#tab_scoring#:#Ranking###07 02 2020 new variable
 lti#:#tab_settings#:#Settings###07 02 2020 new variable

--- a/lang/ilias_zh.lang
+++ b/lang/ilias_zh.lang
@@ -11377,6 +11377,7 @@ lti#:#lti_create_lti_user_role#:#Create recommended global role for LTI users###
 lti#:#lti_cron_title#:#LTI Outcome Service###07 02 2020 new variable
 lti#:#lti_cron_title_desc#:#Synchronizes the learning progress of LTI users with the LTI consumer, if it supports the outcome service. This cron job is only required to transfer status updates after Learning progress settings updates.###07 02 2020 new variable
 lti#:#lti_custom_new#:#Create Own Provider Settings###07 02 2020 new variable
+lti#:#lti_deep_linking_not_available_for_admin_objects#:#Consumers created in Administration do not allow content selection
 lti#:#lti_delete_consume_provider#:#Delete Provider###07 02 2020 new variable
 lti#:#lti_delete_consume_providers#:#Delete Providers###07 02 2020 new variable
 lti#:#lti_delete_provider#:#Delete Provider###07 02 2020 new variable

--- a/lang/ilias_zh.lang
+++ b/lang/ilias_zh.lang
@@ -11386,6 +11386,7 @@ lti#:#lti_exit#:#Close LTI Session###31 08 2017 new variable
 lti#:#lti_exited#:#LTI Session closed###31 08 2017 new variable
 lti#:#lti_exited_info#:#LTI Session successfully closed###31 08 2017 new variable
 lti#:#lti_form_provider_create#:#Create Provider Settings###07 02 2020 new variable
+lti#:#lti_form_provider_content_selection#:#内容选择
 lti#:#lti_form_provider_edit#:#Edit Provider Settings###07 02 2020 new variable
 lti#:#lti_form_section_appearance#:#Options for launch###07 02 2020 new variable
 lti#:#lti_global_settings_form#:#Global Settings###07 02 2020 new variable


### PR DESCRIPTION
## Summary

This PR completes the LTI 1.3 consumer-side Assignment and Grade Services (AGS) flow and makes Dynamic Registration / Deep Linking content selection usable from an LTI consumer object.

- Adds AGS Line Items and Results endpoints, persistence for tool-created line items, score maximum support, launch endpoint claims, and database migrations.
- Validates AGS access against the requested token scope and provider client ID; supports RSA and JWK key validation.
- Publishes provider-mode scores, resolves LTI user identifiers consistently, validates score payloads, and maps submitted/fully graded activity states to learning-progress status.
- Enables AGS automatically when requested during Dynamic Registration.
- Adds a Deep Linking selection action for consumer settings, preserves the selected target link URI for subsequent launches, validates redirect URIs, and applies creation permissions to the content-selection flow.
- Adds the required LTI language labels across maintained language files.

## Validation

- git diff --check upstream/release_11...HEAD passes.
- php -l passes for all 22 changed PHP files.
- PHP-CS-Fixer ran across all 86 PHP files in LTI Consumer and LTI Provider; it applied one spacing correction.
- Rebasing onto current release_11 (e33d29e99fe) completed without unresolved conflicts.
- PHPUnit was not run: components/ILIAS/LTIConsumer/phpunit.xml references test/ilModulesLTIConsumerSuite.php, which is absent from this checkout.
- Browser/E2E validation remains required with a configured LTI 1.3 tool (for example Moodle): Dynamic Registration, Deep Linking selection and launch, AGS line-item CRUD, score publication, results retrieval, and learning-progress updates.

## Reviewer Focus

- AGS authorization and client isolation for line items, results, and scores.
- Dynamic Registration scope detection and the database migration for persisted line items.
- Deep Linking redirect validation, selected target-link propagation, and permission checks.

# Related to: #11835 