### PR TITLE
[FIX] #48017 UI: skip `isClientSideValueOk()` for `null`

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Input/Group.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Group.php
@@ -142,6 +142,10 @@ trait Group
             if (!array_key_exists($key, $value)) {
                 return false;
             }
+            /** this is currently entangled to {@see Input::withValue()} */
+            if (null === $value[$key]) {
+                continue;
+            }
             if (!$input->isClientSideValueOk($value[$key])) {
                 return false;
             }

--- a/components/ILIAS/UI/tests/Component/Input/Field/GroupInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/GroupInputTest.php
@@ -171,6 +171,35 @@ class GroupInputTest extends ILIAS_UI_TestBase
         $this->assertNotSame($this->group, $new_group);
     }
 
+    public function testGroupForwardsNullWithoutValidationOnWithValue(): void
+    {
+        $this->child1
+            ->expects($this->once())
+            ->method("withValue")
+            ->with(1)
+            ->willReturn($this->child2);
+        $this->child1
+            ->expects($this->once())
+            ->method("isClientSideValueOk")
+            ->with(1)
+            ->willReturn(true);
+        $this->child2
+            ->expects($this->once())
+            ->method("withValue")
+            ->with(null)
+            ->willReturn($this->child1);
+        $this->child2
+            ->expects($this->never())
+            ->method("isClientSideValueOk")
+            ->with(null)
+            ->willReturn(true);
+
+        $new_group = $this->group->withValue([1, null]);
+
+        $this->assertEquals([$this->child2, $this->child1], $new_group->getInputs());
+        $this->assertNotSame($this->group, $new_group);
+    }
+
     public function testWithValuePreservesKeys(): void
     {
         $this->assertNotSame($this->child1, $this->child2);


### PR DESCRIPTION
Hi @iszmais,

This should probably address https://mantis.ilias.de/view.php?id=48017, can you verify?

I will think about possible side-effects in the meantime.

Thx and kind regards,
@thibsy 