### PR TITLE
LSO kiosk player: finish on last step, show sequence title and item description

### DIFF
--- a/components/ILIAS/LearningSequence/classes/GlobalScreen/class.ilLSViewLayoutProvider.php
+++ b/components/ILIAS/LearningSequence/classes/GlobalScreen/class.ilLSViewLayoutProvider.php
@@ -139,7 +139,9 @@ class ilLSViewLayoutProvider extends AbstractModificationProvider implements Mod
         }
 
         $exit = $this->data_collection->get(\ilLSPlayer::GS_DATA_LS_METABARCONTROLS)['exit'];
-        $label = $this->dic['lng']->txt('lso_player_viewmodelabel');
+
+        $label = $this->data_collection->get(\ilLSPlayer::GS_DATA_LS_TITLE)
+            ?? $this->dic['lng']->txt('lso_player_viewmodelabel');
 
         $lnk = new URI($exit->getAction());
 

--- a/components/ILIAS/LearningSequence/classes/Player/LSControlBuilder.php
+++ b/components/ILIAS/LearningSequence/classes/Player/LSControlBuilder.php
@@ -156,6 +156,9 @@ class LSControlBuilder implements ControlBuilder
             throw new \LogicException("Only one next-control per view...", 1);
         }
         $label = $this->lng->txt('lso_player_next');
+        if ($command === ilLSPlayer::LSO_CMD_FINISH) {
+            $label = $this->lng->txt('lso_player_finish');
+        }
         $cmd = $this->url_builder->getHref($command, $parameter);
         $btn = $this->ui_factory->button()->standard($label, $cmd);
         if ($command === '') {

--- a/components/ILIAS/LearningSequence/classes/Player/class.ilKioskPageRenderer.php
+++ b/components/ILIAS/LearningSequence/classes/Player/class.ilKioskPageRenderer.php
@@ -84,6 +84,7 @@ class ilKioskPageRenderer
     public function render(
         LSControlBuilder $control_builder,
         string $obj_title,
+        string $obj_description,
         Component $icon,
         array $content
     ): string {
@@ -92,6 +93,14 @@ class ilKioskPageRenderer
             $this->ui_renderer->render($icon)
         );
         $this->tpl->setVariable("OBJECT_TITLE", $obj_title);
+        if (trim($obj_description) !== '') {
+            $this->tpl->setCurrentBlock('obj_desc');
+            $this->tpl->setVariable(
+                'OBJECT_DESCRIPTION',
+                nl2br($this->tpl->prepareForOutput($obj_description))
+            );
+            $this->tpl->parseCurrentBlock();
+        }
 
         $this->tpl->setVariable(
             "PLAYER_NAVIGATION",

--- a/components/ILIAS/LearningSequence/classes/Player/class.ilLSCurriculumBuilder.php
+++ b/components/ILIAS/LearningSequence/classes/Player/class.ilLSCurriculumBuilder.php
@@ -45,8 +45,10 @@ class ilLSCurriculumBuilder
         $this->url_builder = $url_builder;
     }
 
-    public function getLearnerCurriculum(bool $with_action = false): ILIAS\UI\Component\Listing\Workflow\Linear
-    {
+    public function getLearnerCurriculum(
+        bool $with_action = false,
+        ?string $title = null
+    ): ILIAS\UI\Component\Listing\Workflow\Linear {
         $steps = [];
         $items = $this->ls_items->getItems();
         foreach ($items as $item) {
@@ -69,7 +71,7 @@ class ilLSCurriculumBuilder
         }
 
         $workflow = $this->ui_factory->listing()->workflow()->linear(
-            $this->lng->txt('curriculum'),
+            $title ?? $this->lng->txt('curriculum'),
             $steps
         );
 

--- a/components/ILIAS/LearningSequence/classes/Player/class.ilLSLearnerItemsQueries.php
+++ b/components/ILIAS/LearningSequence/classes/Player/class.ilLSLearnerItemsQueries.php
@@ -43,7 +43,7 @@ class ilLSLearnerItemsQueries
         $this->usr_id = $usr_id;
     }
 
-    public function hasItems() : bool
+    public function hasItems(): bool
     {
         return count($this->getItems()) > 0;
     }
@@ -54,6 +54,11 @@ class ilLSLearnerItemsQueries
     public function getItems(): array
     {
         return $this->progress_db->getLearnerItems($this->usr_id, $this->ls_ref_id);
+    }
+
+    public function getLearningSequenceRefId(): int
+    {
+        return $this->ls_ref_id;
     }
 
     public function getCurrentItemRefId(): int

--- a/components/ILIAS/LearningSequence/classes/Player/class.ilLSPlayer.php
+++ b/components/ILIAS/LearningSequence/classes/Player/class.ilLSPlayer.php
@@ -41,6 +41,7 @@ class ilLSPlayer
 
     public const GS_DATA_LS_KIOSK_MODE = 'ls_kiosk_mode';
     public const GS_DATA_LS_CONTENT = 'ls_content';
+    public const GS_DATA_LS_TITLE = 'ls_title';
     public const GS_DATA_LS_MAINBARCONTROLS = 'ls_mainbar_controls';
     public const GS_DATA_LS_METABARCONTROLS = 'ls_metabar_controls';
 
@@ -115,6 +116,8 @@ class ilLSPlayer
 
         //content
         $obj_title = $next_item->getTitle();
+        $obj_description = $next_item->getDescription();
+        $ls_title = ilObject::_lookupTitle(ilObject::_lookupObjId($this->ls_items->getLearningSequenceRefId()));
         $icon = $this->ui_factory->symbol()->icon()->standard(
             $next_item->getType(),
             $next_item->getType(),
@@ -144,6 +147,7 @@ class ilLSPlayer
         $rendered_body = $this->page_renderer->render(
             $control_builder,
             $obj_title,
+            $obj_description,
             $icon,
             $content
         );
@@ -154,7 +158,7 @@ class ilLSPlayer
 
         $curriculum_slate = $this->page_renderer->buildCurriculumSlate(
             $this->curriculum_builder
-                ->getLearnerCurriculum(true)
+                ->getLearnerCurriculum(true, $ls_title)
                 ->withActive($item_position)
         );
         $mainbar_controls = [
@@ -169,6 +173,7 @@ class ilLSPlayer
 
         $cc = $this->current_context;
         $cc->addAdditionalData(self::GS_DATA_LS_KIOSK_MODE, true);
+        $cc->addAdditionalData(self::GS_DATA_LS_TITLE, $ls_title);
         $cc->addAdditionalData(self::GS_DATA_LS_METABARCONTROLS, $metabar_controls);
         $cc->addAdditionalData(self::GS_DATA_LS_MAINBARCONTROLS, $mainbar_controls);
         $cc->addAdditionalData(self::GS_DATA_LS_CONTENT, $rendered_body);
@@ -299,7 +304,10 @@ class ilLSPlayer
         if (!$control_builder->getNextControl()) {
             $direction_next = 1;
             $cmd = '';
-            if (!$is_last) {
+            if ($is_last) {
+                $cmd = self::LSO_CMD_FINISH;
+                $direction_next = null;
+            } else {
                 $available = $this->getNextItem($items, $item, $direction_next)
                     ->getAvailability() === Step::AVAILABLE;
 

--- a/components/ILIAS/LearningSequence/templates/default/tpl.kioskpage.html
+++ b/components/ILIAS/LearningSequence/templates/default/tpl.kioskpage.html
@@ -8,6 +8,9 @@
 			<h1 class="il-page-content-header media-heading ilHeader">
 					{OBJECT_TITLE}
 			</h1>
+			<!-- BEGIN obj_desc -->
+			<div class="il_Description">{OBJECT_DESCRIPTION}</div>
+			<!-- END obj_desc -->
 		</div>
 	</div>
 


### PR DESCRIPTION
 ### Summary                                                                                                                             
     - Shows the learning sequence title in the kiosk player context/curriculum instead of the generic curriculum label.                     
     - Displays the current item's description on the kiosk page when available.                                                             
     - Changes the final navigation step so the player offers `Finish` on the last item instead of continuing with `Next`.                   
### Related Issues                                                                                                                      
     - https://mantis.ilias.de/view.php?id=46242                                                                                             
     - https://mantis.ilias.de/view.php?id=34620                                                                                             
                                                    