### PR TITLE
Add tracking export tail dependency and mapping to multiple components

### DIFF
--- a/components/ILIAS/CmiXapi/classes/class.ilCmiXapiExporter.php
+++ b/components/ILIAS/CmiXapi/classes/class.ilCmiXapiExporter.php
@@ -74,7 +74,11 @@ class ilCmiXapiExporter extends ilXmlExporter
                 "ids" => $md_ids
             ];
         }
-
+        $dependencies[] = [
+            "component" => "components/ILIAS/Tracking",
+            "entity" => "lpsettings",
+            "ids" => $a_ids
+        ];
         return $dependencies;
     }
 

--- a/components/ILIAS/CmiXapi/classes/class.ilCmiXapiImporter.php
+++ b/components/ILIAS/CmiXapi/classes/class.ilCmiXapiImporter.php
@@ -95,6 +95,7 @@ class ilCmiXapiImporter extends ilXmlImporter
         $this->prepareLocalSourceStorage();
         $this->parseXmlFileProperties();
         $this->updateNewObj();
+        $a_mapping->addMapping("components/ILIAS/Tracking", "obj", $a_id, (string) $this->_cmixObj->getId());
     }
 
     /**

--- a/components/ILIAS/ContainerReference/classes/class.ilContainerReferenceExporter.php
+++ b/components/ILIAS/ContainerReference/classes/class.ilContainerReferenceExporter.php
@@ -51,6 +51,16 @@ abstract class ilContainerReferenceExporter extends ilXmlExporter
         return [];
     }
 
+    public function getXmlExportTailDependencies(string $a_entity, string $a_target_release, array $a_ids): array
+    {
+        $dependencies[] = [
+            "component" => "components/ILIAS/Tracking",
+            "entity" => "lpsettings",
+            "ids" => $a_ids
+        ];
+        return $dependencies;
+    }
+
     abstract protected function initWriter(ilContainerReference $ref): ilContainerReferenceXmlWriter;
 
     public function getXmlRepresentation(string $a_entity, string $a_schema_version, string $a_id): string

--- a/components/ILIAS/ContainerReference/classes/class.ilContainerReferenceImporter.php
+++ b/components/ILIAS/ContainerReference/classes/class.ilContainerReferenceImporter.php
@@ -87,6 +87,12 @@ abstract class ilContainerReferenceImporter extends ilXmlImporter
                 $a_id,
                 (string) $this->getReference()->getId()
             );
+            $a_mapping->addMapping(
+                "components/ILIAS/Tracking",
+                "obj",
+                $a_id,
+                (string) $this->getReference()->getId()
+            );
         } catch (ilSaxParserException | Exception $e) {
             $log->error(__METHOD__ . ': Parsing failed with message, "' . $e->getMessage() . '".');
         }

--- a/components/ILIAS/ContentPage/classes/class.ilContentPageDataSet.php
+++ b/components/ILIAS/ContentPage/classes/class.ilContentPageDataSet.php
@@ -161,6 +161,12 @@ class ilContentPageDataSet extends ilDataSet implements ilContentPageObjectConst
                     $newObject->getId() . ':0:' . self::OBJ_TYPE
                 );
                 $a_mapping->addMapping(
+                    "components/ILIAS/Tracking",
+                    "obj",
+                    $a_rec['id'],
+                    (string) $newObject->getId()
+                );
+                $a_mapping->addMapping(
                     "components/ILIAS/ILIASObject",
                     "obj",
                     $a_rec["id"],

--- a/components/ILIAS/ContentPage/classes/class.ilContentPageExporter.php
+++ b/components/ILIAS/ContentPage/classes/class.ilContentPageExporter.php
@@ -117,6 +117,12 @@ class ilContentPageExporter extends ilXmlExporter implements ilContentPageObject
             ];
         }
 
+        $deps[] = [
+            "component" => "components/ILIAS/Tracking",
+            "entity" => "lpsettings",
+            "ids" => $a_ids
+        ];
+
         return $deps;
     }
 }

--- a/components/ILIAS/Course/classes/class.ilCourseExporter.php
+++ b/components/ILIAS/Course/classes/class.ilCourseExporter.php
@@ -141,6 +141,11 @@ class ilCourseExporter extends ilXmlExporter
                     "ids" => $md_ids
             ];
         }
+        $dependencies[] = [
+            "component" => "components/ILIAS/Tracking",
+            "entity" => "lpsettings",
+            "ids" => $a_ids
+        ];
         return $dependencies;
     }
 

--- a/components/ILIAS/Course/classes/class.ilCourseImporter.php
+++ b/components/ILIAS/Course/classes/class.ilCourseImporter.php
@@ -96,6 +96,12 @@ class ilCourseImporter extends ilXmlImporter
                 $a_id . ':0:crs',
                 $this->course->getId() . ':0:crs'
             );
+            $a_mapping->addMapping(
+                "components/ILIAS/Tracking",
+                "obj",
+                $a_id,
+                (string) $this->course->getId()
+            );
         } catch (ilSaxParserException|Exception $e) {
             $this->logger->error('Parsing failed with message, "' . $e->getMessage() . '".');
         }

--- a/components/ILIAS/Exercise/classes/class.ilExerciseDataSet.php
+++ b/components/ILIAS/Exercise/classes/class.ilExerciseDataSet.php
@@ -613,6 +613,12 @@ class ilExerciseDataSet extends ilDataSet
                     $a_rec["Id"] . ":0:exc",
                     $newObj->getId() . ":0:exc"
                 );
+                $a_mapping->addMapping(
+                    "components/ILIAS/Tracking",
+                    "obj",
+                    (string) $a_rec["Id"],
+                    (string) $newObj->getId()
+                );
                 break;
 
             case "exc_assignment":

--- a/components/ILIAS/Exercise/classes/class.ilExerciseExporter.php
+++ b/components/ILIAS/Exercise/classes/class.ilExerciseExporter.php
@@ -147,6 +147,12 @@ class ilExerciseExporter extends ilXmlExporter
             );
         }
 
+        $deps[] = [
+            "component" => "components/ILIAS/Tracking",
+            "entity" => "lpsettings",
+            "ids" => $a_ids
+        ];
+
         return $deps;
     }
 

--- a/components/ILIAS/File/classes/class.ilFileExporter.php
+++ b/components/ILIAS/File/classes/class.ilFileExporter.php
@@ -59,6 +59,11 @@ class ilFileExporter extends ilXmlExporter
                 "component" => "components/ILIAS/ILIASObject",
                 "entity" => "common",
                 "ids" => $a_ids
+            ],
+            [
+                "component" => "components/ILIAS/Tracking",
+                "entity" => "lpsettings",
+                "ids" => $a_ids
             ]
         ];
     }

--- a/components/ILIAS/File/classes/class.ilFileImporter.php
+++ b/components/ILIAS/File/classes/class.ilFileImporter.php
@@ -67,5 +67,11 @@ class ilFileImporter extends ilXmlImporter
             $a_id . ":0:file",
             $newObj->getId() . ":0:file"
         );
+        $a_mapping->addMapping(
+            "components/ILIAS/Tracking",
+            "obj",
+            $a_id,
+            (string) $newObj->getId()
+        );
     }
 }

--- a/components/ILIAS/Folder/classes/class.ilFolderExporter.php
+++ b/components/ILIAS/Folder/classes/class.ilFolderExporter.php
@@ -28,6 +28,17 @@ class ilFolderExporter extends ilXmlExporter
     {
     }
 
+    public function getXmlExportTailDependencies(string $a_entity, string $a_target_release, array $a_ids): array
+    {
+        return [
+            [
+                "component" => "components/ILIAS/Tracking",
+                "entity" => "lpsettings",
+                "ids" => $a_ids
+            ]
+        ];
+    }
+
     public function getXmlExportHeadDependencies(string $a_entity, string $a_target_release, array $a_ids): array
     {
         // always trigger container because of co-page(s)

--- a/components/ILIAS/Folder/classes/class.ilFolderImporter.php
+++ b/components/ILIAS/Folder/classes/class.ilFolderImporter.php
@@ -47,6 +47,12 @@ class ilFolderImporter extends ilXmlImporter
             $parser = new ilFolderXmlParser($this->folder, $a_xml);
             $parser->start();
             $a_mapping->addMapping('components/ILIAS/Folder', 'fold', $a_id, (string) $this->folder->getId());
+            $a_mapping->addMapping(
+                "components/ILIAS/Tracking",
+                "obj",
+                $a_id,
+                (string) $this->folder->getId()
+            );
         } catch (ilSaxParserException $e) {
             $GLOBALS['ilLog']->write(__METHOD__ . ': Parsing failed with message, "' . $e->getMessage() . '".');
         }

--- a/components/ILIAS/Forum/classes/class.ilForumExporter.php
+++ b/components/ILIAS/Forum/classes/class.ilForumExporter.php
@@ -112,6 +112,12 @@ class ilForumExporter extends ilXmlExporter implements ilForumObjectConstants
             ];
         }
 
+        $deps[] = [
+            "component" => "components/ILIAS/Tracking",
+            "entity" => "lpsettings",
+            "ids" => $a_ids
+        ];
+
         return $deps;
     }
 

--- a/components/ILIAS/Forum/classes/class.ilForumImporter.php
+++ b/components/ILIAS/Forum/classes/class.ilForumImporter.php
@@ -49,6 +49,12 @@ class ilForumImporter extends ilXmlImporter implements ilForumObjectConstants
         $parser->startParsing();
 
         $a_mapping->addMapping('components/ILIAS/Forum', 'frm', $a_id, (string) $newObj->getId());
+        $a_mapping->addMapping(
+            "components/ILIAS/Tracking",
+            "obj",
+            $a_id,
+            (string) $newObj->getId()
+        );
     }
 
     public function finalProcessing(ilImportMapping $a_mapping): void

--- a/components/ILIAS/Group/classes/class.ilGroupImporter.php
+++ b/components/ILIAS/Group/classes/class.ilGroupImporter.php
@@ -72,7 +72,12 @@ class ilGroupImporter extends ilXmlImporter
                 $a_id . ':0:grp',
                 $this->group->getId() . ':0:grp'
             );
-
+            $a_mapping->addMapping(
+                "components/ILIAS/Tracking",
+                "obj",
+                $a_id,
+                (string) $this->group->getId()
+            );
         } catch (ilSaxParserException | ilWebLinkXmlParserException $e) {
             $GLOBALS['DIC']->logger()->grp()->warning('Parsing failed with message, "' . $e->getMessage() . '".');
         }

--- a/components/ILIAS/HTMLLearningModule/classes/class.ilHTMLLearningModuleDataSet.php
+++ b/components/ILIAS/HTMLLearningModule/classes/class.ilHTMLLearningModuleDataSet.php
@@ -150,6 +150,12 @@ class ilHTMLLearningModuleDataSet extends ilDataSet
                     $a_rec["Id"] . ":0:htlm",
                     $newObj->getId() . ":0:htlm"
                 );
+                $a_mapping->addMapping(
+                    "components/ILIAS/Tracking",
+                    "obj",
+                    (string) $a_rec["Id"],
+                    (string) $newObj->getId()
+                );
                 break;
         }
     }

--- a/components/ILIAS/HTMLLearningModule/classes/class.ilHTMLLearningModuleExporter.php
+++ b/components/ILIAS/HTMLLearningModule/classes/class.ilHTMLLearningModuleExporter.php
@@ -52,6 +52,11 @@ class ilHTMLLearningModuleExporter extends ilXmlExporter
             "ids" => $a_ids
         ];
 
+        $deps[] = [
+            "component" => "components/ILIAS/Tracking",
+            "entity" => "lpsettings",
+            "ids" => $a_ids
+        ];
         return $deps;
     }
 

--- a/components/ILIAS/IndividualAssessment/classes/class.ilIndividualAssessmentDataSet.php
+++ b/components/ILIAS/IndividualAssessment/classes/class.ilIndividualAssessmentDataSet.php
@@ -160,6 +160,12 @@ class ilIndividualAssessmentDataSet extends ilDataSet
             $newObj->update();
             $newObj->updateInfo();
             $a_mapping->addMapping("components/ILIAS/IndividualAssessment", "iass", $a_rec["id"], (string) $newObj->getId());
+            $a_mapping->addMapping(
+                "components/ILIAS/Tracking",
+                "obj",
+                (string) $a_rec["id"],
+                (string) $newObj->getId()
+            );
         }
     }
 }

--- a/components/ILIAS/IndividualAssessment/classes/class.ilIndividualAssessmentExporter.php
+++ b/components/ILIAS/IndividualAssessment/classes/class.ilIndividualAssessmentExporter.php
@@ -59,8 +59,12 @@ class ilIndividualAssessmentExporter extends ilXmlExporter
                 "entity" => "common",
                 "ids" => $a_ids
             ];
+            $res[] = [
+                "component" => "components/ILIAS/Tracking",
+                "entity" => "lpsettings",
+                "ids" => $a_ids
+            ];
         }
-
         return $res;
     }
 

--- a/components/ILIAS/IndividualAssessment/tests/ilIndividualAssessmentExporterTest.php
+++ b/components/ILIAS/IndividualAssessment/tests/ilIndividualAssessmentExporterTest.php
@@ -44,6 +44,11 @@ class ilIndividualAssessmentExporterTest extends TestCase
             "entity" => "common",
             "ids" => [12,13]
         ];
+        $expected[] = [
+            "component" => "components/ILIAS/Tracking",
+            "entity" => "lpsettings",
+            "ids" => [12,13]
+        ];
 
         $obj = new ilIndividualAssessmentExporter();
         $result = $obj->getXmlExportTailDependencies("iass", "", [12,13]);

--- a/components/ILIAS/LearningModule/Export/class.ilLearningModuleExporter.php
+++ b/components/ILIAS/LearningModule/Export/class.ilLearningModuleExporter.php
@@ -133,6 +133,11 @@ class ilLearningModuleExporter extends ilXmlExporter
                     "ids" => $style_id
                 );
             }
+            $deps[] = [
+                "component" => "components/ILIAS/Tracking",
+                "entity" => "lpsettings",
+                "ids" => $a_ids
+            ];
         }
 
         return $deps;

--- a/components/ILIAS/LearningModule/classes/class.ilLearningModuleDataSet.php
+++ b/components/ILIAS/LearningModule/classes/class.ilLearningModuleDataSet.php
@@ -594,6 +594,12 @@ class ilLearningModuleDataSet extends ilDataSet
                     $a_rec["Id"] . ":0:lm",
                     $newObj->getId() . ":0:lm"
                 );
+                $a_mapping->addMapping(
+                    "components/ILIAS/Tracking",
+                    "obj",
+                    (string) $a_rec["Id"],
+                    (string) $newObj->getId()
+                );
                 break;
 
             case "lm_tree":

--- a/components/ILIAS/LearningSequence/classes/class.ilLearningSequenceExporter.php
+++ b/components/ILIAS/LearningSequence/classes/class.ilLearningSequenceExporter.php
@@ -161,6 +161,12 @@ class ilLearningSequenceExporter extends ilXmlExporter
             }
         }
 
+        $res[] = [
+            "component" => "components/ILIAS/Tracking",
+            "entity" => "lpsettings",
+            "ids" => $a_ids
+        ];
+
         return $res;
     }
 

--- a/components/ILIAS/LearningSequence/classes/class.ilLearningSequenceImporter.php
+++ b/components/ILIAS/LearningSequence/classes/class.ilLearningSequenceImporter.php
@@ -79,6 +79,12 @@ class ilLearningSequenceImporter extends ilXmlImporter
             "lso:obj:" . $a_id,
             (string) $this->obj->getId()
         );
+        $a_mapping->addMapping(
+            "components/ILIAS/Tracking",
+            "obj",
+            (string) $a_id,
+            (string) $this->obj->getId()
+        );
     }
 
     public function finalProcessing(ilImportMapping $a_mapping): void

--- a/components/ILIAS/MediaCast/classes/class.ilMediaCastDataSet.php
+++ b/components/ILIAS/MediaCast/classes/class.ilMediaCastDataSet.php
@@ -244,6 +244,12 @@ class ilMediaCastDataSet extends ilDataSet
                     $a_rec["Id"] . ":0:mcst",
                     $newObj->getId() . ":0:mcst"
                 );
+                $a_mapping->addMapping(
+                    "components/ILIAS/Tracking",
+                    "obj",
+                    (string) $a_rec["Id"],
+                    (string) $newObj->getId()
+                );
                 break;
         }
     }

--- a/components/ILIAS/MediaCast/classes/class.ilMediaCastExporter.php
+++ b/components/ILIAS/MediaCast/classes/class.ilMediaCastExporter.php
@@ -79,6 +79,11 @@ class ilMediaCastExporter extends ilXmlExporter
             "ids" => $a_ids
         ];
 
+        $deps[] = [
+            "component" => "components/ILIAS/Tracking",
+            "entity" => "lpsettings",
+            "ids" => $a_ids
+        ];
 
         return $deps;
     }

--- a/components/ILIAS/Session/classes/class.ilSessionDataSet.php
+++ b/components/ILIAS/Session/classes/class.ilSessionDataSet.php
@@ -409,6 +409,12 @@ class ilSessionDataSet extends ilDataSet
                     $a_rec["Id"] . ":0:sess",
                     $newObj->getId() . ":0:sess"
                 );
+                $a_mapping->addMapping(
+                    "components/ILIAS/Tracking",
+                    "obj",
+                    (string) $a_rec["Id"],
+                    (string) $newObj->getId()
+                );
                 break;
 
             case "sess_item":

--- a/components/ILIAS/Session/classes/class.ilSessionExporter.php
+++ b/components/ILIAS/Session/classes/class.ilSessionExporter.php
@@ -82,6 +82,11 @@ class ilSessionExporter extends ilXmlExporter
             "entity" => "tile",
             "ids" => $a_ids);
 
+        $deps[] = [
+            "component" => "components/ILIAS/Tracking",
+            "entity" => "lpsettings",
+            "ids" => $a_ids
+        ];
         return $deps;
     }
 

--- a/components/ILIAS/Survey/Export/class.ilSurveyExporter.php
+++ b/components/ILIAS/Survey/Export/class.ilSurveyExporter.php
@@ -104,6 +104,12 @@ class ilSurveyExporter extends ilXmlExporter
                     "ids" => $md_ids
                 ];
             }
+
+            $dependencies[] = [
+                "component" => "components/ILIAS/Tracking",
+                "entity" => "lpsettings",
+                "ids" => $a_ids
+            ];
             return $dependencies;
         }
         return array();

--- a/components/ILIAS/Survey/Export/class.ilSurveyImporter.php
+++ b/components/ILIAS/Survey/Export/class.ilSurveyImporter.php
@@ -91,6 +91,12 @@ class ilSurveyImporter extends ilXmlImporter
                 $newObj->create(true);
             }
             $a_mapping->addMapping('components/ILIAS/Survey', 'svy', $a_id, (string) $newObj->getId());
+            $a_mapping->addMapping(
+                "components/ILIAS/Tracking",
+                "obj",
+                $a_id,
+                (string) $newObj->getId()
+            );
             $this->setSurvey($newObj);
 
 

--- a/components/ILIAS/Test/classes/class.ilTestExporter.php
+++ b/components/ILIAS/Test/classes/class.ilTestExporter.php
@@ -158,6 +158,12 @@ class ilTestExporter extends ilXmlExporter
                 ];
             }
 
+            $deps[] = [
+                "component" => "components/ILIAS/Tracking",
+                "entity" => "lpsettings",
+                "ids" => $a_ids
+            ];
+
             return $deps;
         }
 

--- a/components/ILIAS/Test/classes/class.ilTestImporter.php
+++ b/components/ILIAS/Test/classes/class.ilTestImporter.php
@@ -144,6 +144,12 @@ class ilTestImporter extends ilXmlImporter
             $a_id . ":0:tst",
             $new_obj->getId() . ":0:tst"
         );
+        $a_mapping->addMapping(
+            "components/ILIAS/Tracking",
+            "obj",
+            $a_id,
+            (string) $new_obj->getId()
+        );
     }
 
     public function addTaxonomyAndQuestionsMapping(


### PR DESCRIPTION
This PR adds a new tail dependency as well as a new mapping to components with exportable learning progress settings.

These changes are required to export learning progress settings, see also #11976.

Please take a look at the changes.

[Feature Wiki Article](https://docu.ilias.de/go/wiki/wpage_8357_1357)