### PR TITLE
[FIX] UICore: encode cmd- and base-class parameters

### DIFF
--- a/components/ILIAS/UICore/classes/class.ilCtrl.php
+++ b/components/ILIAS/UICore/classes/class.ilCtrl.php
@@ -34,6 +34,8 @@ use GuzzleHttp\Psr7\Response;
  */
 class ilCtrl implements ilCtrlInterface
 {
+    use ilCtrlNamespaceEncoding;
+
     protected ?object $exec_object = null;
     protected ?string $command = null;
 
@@ -868,7 +870,7 @@ class ilCtrl implements ilCtrlInterface
         $target_url = $this->appendParameterString(
             $target_url,
             self::PARAM_BASE_CLASS,
-            urlencode($base_class), // encode in case of namespaced classes
+            $this->encodeNamespaceForUrl($base_class), // encode in case of namespaced classes
             $is_escaped
         );
 
@@ -889,7 +891,7 @@ class ilCtrl implements ilCtrlInterface
             $target_url = $this->appendParameterString(
                 $target_url,
                 self::PARAM_CMD_CLASS,
-                urlencode($cmd_class), // encode in case of namespaced classes
+                $this->encodeNamespaceForUrl($cmd_class), // encode in case of namespaced classes
                 $is_escaped
             );
         }

--- a/components/ILIAS/UICore/classes/class.ilCtrlContext.php
+++ b/components/ILIAS/UICore/classes/class.ilCtrlContext.php
@@ -30,6 +30,8 @@ use ILIAS\HTTP\Wrapper\RequestWrapper;
  */
 class ilCtrlContext implements ilCtrlContextInterface
 {
+    use ilCtrlNamespaceEncoding;
+
     /**
      * @var ilCtrlPathFactory
      */
@@ -305,14 +307,14 @@ class ilCtrlContext implements ilCtrlContextInterface
         // previously set existing path.
         $base_class = $this->getQueryParam(ilCtrlInterface::PARAM_BASE_CLASS);
         if (null !== $base_class) {
-            $this->setBaseClass($base_class);
+            $this->setBaseClass($this->decodeNamespaceFromUrl($base_class));
         }
 
         // set or append the provided command class, which might
         // override the previously set path again.
         $cmd_class = $this->getQueryParam(ilCtrlInterface::PARAM_CMD_CLASS);
         if (null !== $cmd_class) {
-            $this->setCmdClass($cmd_class);
+            $this->setCmdClass($this->decodeNamespaceFromUrl($cmd_class));
         }
     }
 

--- a/components/ILIAS/UICore/classes/trait.ilCtrlNamespaceEncoding.php
+++ b/components/ILIAS/UICore/classes/trait.ilCtrlNamespaceEncoding.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+/**
+ * This absolute monstrosity of an encoding/decoding trait exists because
+ * ILIAS strips `\` from request URLs. This prevents ilCtrl from using
+ * PSR-4 namespaced command- and base-classes until we either work around
+ * this issue or drop these as arguments from the URL – which we could, but
+ * decide not to pursue, because we should focus on migrating towards a
+ * real routing component (see https://docu.ilias.de/go/wiki/wpage_8780_1357).
+ *
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ *
+ * @noinspection AutoloadingIssuesInspection
+ */
+trait ilCtrlNamespaceEncoding
+{
+    private static string $psr4_namespace_delimiter = '\\';
+    private static string $ilctrl_namespace_delimiter = '.';
+
+    public function encodeNamespaceForUrl(string $psr4_namespace): string
+    {
+        return str_replace(self::$psr4_namespace_delimiter, self::$ilctrl_namespace_delimiter, $psr4_namespace);
+    }
+
+    public function decodeNamespaceFromUrl(string $ilctrl_namespace): string
+    {
+        return str_replace(self::$ilctrl_namespace_delimiter, self::$psr4_namespace_delimiter, $ilctrl_namespace);
+    }
+}


### PR DESCRIPTION
This works around the fact the Init component strips some
characters from the request URL for security reasons. It
uses a very hideous way to replace `\` of PSR-4 namespaces
to ensure we can still use them with `ilCtrl`.
