### PR TITLE
Repair old .html static links in ILIAS 11

### DIFF
--- a/components/ILIAS/StaticURL/src/Request/ShortlinkRequestBuilder.php
+++ b/components/ILIAS/StaticURL/src/Request/ShortlinkRequestBuilder.php
@@ -38,6 +38,7 @@ class ShortlinkRequestBuilder implements RequestBuilder
             str_contains($requested_url, StandardURIBuilder::SHORT)
             || str_contains($requested_url, StandardURIBuilder::LONG)
             || str_contains($requested_url, rtrim(StandardURIBuilder::LONG, '/'))
+            || str_contains($requested_url, '.html')
         ) {
             return null;
         }


### PR DESCRIPTION
Add links containing `.html` to the exceptions of the `ShortlinkRequestBuilder`, so it switches to another Request implementation