### PR TITLE
[FIX] LTI: Align auth mode filter with external consumers

### DIFF
--- a/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilAuthProviderLTI.php
+++ b/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilAuthProviderLTI.php
@@ -122,7 +122,10 @@ class ilAuthProviderLTI extends \ilAuthProvider implements \ilAuthProviderInterf
     {
         $connector = new ilLTIDataConnector();
         $consumer = ilLTIPlatform::fromRecordId($a_sid, $connector);
-        return $consumer->getTitle();
+
+        $object_ref = $consumer->getRefId();
+        $object_title = ilObject2::_lookupTitle(ilObject2::_lookupObjectId($object_ref));
+        return $consumer->getTitle() . " / " . $object_title;
     }
 
     /**

--- a/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilAuthProviderLTI.php
+++ b/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilAuthProviderLTI.php
@@ -82,14 +82,17 @@ class ilAuthProviderLTI extends \ilAuthProvider implements \ilAuthProviderInterf
     {
         global $ilDB;
 
-        // move to connector
+        // Users store the external LTI consumer id in usr_data.auth_mode (lti_<id>).
         $query = /** @lang text */
-            'SELECT consumer_pk from lti2_consumer where enabled = ' . $ilDB->quote(1, 'integer');
+            'SELECT DISTINCT ec.id FROM lti_ext_consumer ec ' .
+            'JOIN lti2_consumer c ON c.ext_consumer_id = ec.id ' .
+            'WHERE ec.active = ' . $ilDB->quote(1, 'integer') . ' ' .
+            'AND c.enabled = ' . $ilDB->quote(1, 'integer');
         $res = $ilDB->query($query);
 
         $sids = array();
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            $sids[] = $row->consumer_pk;
+            $sids[] = $row->id;
         }
         return $sids;
     }
@@ -101,14 +104,15 @@ class ilAuthProviderLTI extends \ilAuthProvider implements \ilAuthProviderInterf
     {
         global $ilDB;
 
-        // move to connector
+        // Users store the external LTI consumer id in usr_data.auth_mode (lti_<id>).
         $query = /** @lang text */
-            'SELECT distinct(consumer_pk) consumer_pk from lti2_consumer';
+            'SELECT DISTINCT ec.id FROM lti_ext_consumer ec ' .
+            'JOIN lti2_consumer c ON c.ext_consumer_id = ec.id';
         $res = $ilDB->query($query);
 
         $sids = array();
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            $sids[] = $row->consumer_pk;
+            $sids[] = $row->id;
         }
         return $sids;
     }
@@ -121,11 +125,9 @@ class ilAuthProviderLTI extends \ilAuthProvider implements \ilAuthProviderInterf
     public static function lookupConsumer(int $a_sid): string
     {
         $connector = new ilLTIDataConnector();
-        $consumer = ilLTIPlatform::fromRecordId($a_sid, $connector);
+        $consumer = ilLTIPlatform::fromExternalConsumerId($a_sid, $connector);
 
-        $object_ref = $consumer->getRefId();
-        $object_title = ilObject2::_lookupTitle(ilObject2::_lookupObjectId($object_ref));
-        return $consumer->getTitle() . " / " . $object_title;
+        return $consumer->getTitle() . ' (ID ' . $a_sid . ')';
     }
 
     /**


### PR DESCRIPTION
Ports the auth_mode fix from release_11 to release_10, where auth_mode was still resolved inconsistently between user creation (ext_consumer_id) and the authentication mode filter/UI (consumer_pk), causing wrong or indistinguishable provider labels once multiple external consumers existed.

Cherry-picked from release_11:
- 415eabd2 — Improve LTI consumer label in authentication mode filter
- 4b4d2923 — Align auth mode filter with external consumers

Both commits applied cleanly with no conflicts. Verified live on lti.ilias10.com (release_10): the Authentication Mode filter in Administration > User Management now shows each LTI provider with a distinguishing ID suffix instead of duplicate/ambiguous titles.