### PR TITLE
ItemGroup 31861-4, 48043 & 48101: Fix itgr_data Column Defaults 10 & 11

### DIFF
--- a/components/ILIAS/ItemGroup/classes/Setup/class.ilItemGroupDBUpdateSteps.php
+++ b/components/ILIAS/ItemGroup/classes/Setup/class.ilItemGroupDBUpdateSteps.php
@@ -75,4 +75,19 @@ class ilItemGroupDBUpdateSteps implements \ilDatabaseUpdateSteps
             ]);
         }
     }
+
+    public function step_4(): void
+    {
+        if ($this->db->tableColumnExists('itgr_data', 'hide_title')) {
+            $this->db->modifyTableColumn('itgr_data', 'hide_title', [
+                'default' => ilItemGroupDisplayMigration::MIGRATED_MARKER,
+            ]);
+        }
+
+        if ($this->db->tableColumnExists('itgr_data', 'behaviour')) {
+            $this->db->modifyTableColumn('itgr_data', 'behaviour', [
+                'default' => ilItemGroupDisplayMigration::MIGRATED_MARKER,
+            ]);
+        }
+    }
 }

--- a/components/ILIAS/ItemGroup/classes/Setup/class.ilItemGroupDisplayMigration.php
+++ b/components/ILIAS/ItemGroup/classes/Setup/class.ilItemGroupDisplayMigration.php
@@ -30,7 +30,7 @@ use ILIAS\Setup\Migration;
 
 class ilItemGroupDisplayMigration implements Migration
 {
-    private const MIGRATED_MARKER = -1;
+    public const MIGRATED_MARKER = -1;
 
     private ilDBInterface $db;
 


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=31861
    
See: https://mantis.ilias.de/view.php?id=48043
    
See: https://mantis.ilias.de/view.php?id=48101

After the item group display migration, `hide_title` and `behaviour` in `itgr_data` need a default of `MIGRATED_MARKER` (-1). Setup step 4 now sets these column defaults and exposes the marker constant for reuse.

/cc @thojou 