### PR TITLE
[FIX] Wiki: Ensure "okayish" Markdown is generated for mails

### DIFF
--- a/components/ILIAS/Wiki/Notification/NotificationGUI.php
+++ b/components/ILIAS/Wiki/Notification/NotificationGUI.php
@@ -29,6 +29,8 @@ use ILIAS\Wiki\InternalDomainService;
  */
 class NotificationGUI
 {
+    private const string MAIL_BLOCK_BORDER = "\n---\n";
+
     protected \ilLogger $log;
     protected InternalGUIService $gui;
     protected InternalDomainService $domain;
@@ -174,9 +176,9 @@ class NotificationGUI
 
                         if ($snippet) {
                             $message .= "\n" . $ulng->txt('content') . "\n" .
-                                "----------------------------------------\n" .
+                                self::MAIL_BLOCK_BORDER . "\n" .
                                 $snippet . "\n" .
-                                "----------------------------------------\n";
+                                self::MAIL_BLOCK_BORDER . "\n";
                         }
 
                         // include comment/note text
@@ -194,9 +196,9 @@ class NotificationGUI
 
                         if ($snippet) {
                             $message .= $ulng->txt('content') . "\n" .
-                                "----------------------------------------\n" .
+                                self::MAIL_BLOCK_BORDER . "\n" .
                                 $snippet . "\n" .
-                                "----------------------------------------\n\n";
+                                self::MAIL_BLOCK_BORDER . "\n\n";
                         }
 
                         $message .= $ulng->txt('wiki_change_notification_link') . ": " . $link;

--- a/components/ILIAS/Wiki/classes/class.ilWikiUtil.php
+++ b/components/ILIAS/Wiki/classes/class.ilWikiUtil.php
@@ -45,6 +45,8 @@ const IL_WIKI_MODE_EXT_COLLECT = "ext_collect";
  */
 class ilWikiUtil
 {
+    private const string MAIL_BLOCK_BORDER = "\n---\n";
+
     /**
      * This one is based on Mediawiki Parser->replaceInternalLinks
      * since we display images in another way, only text links are processed
@@ -587,9 +589,9 @@ class ilWikiUtil
 
                         if ($snippet) {
                             $message .= "\n" . $ulng->txt('content') . "\n" .
-                                "----------------------------------------\n" .
+                                self::MAIL_BLOCK_BORDER . "\n" .
                                 $snippet . "\n" .
-                                "----------------------------------------\n";
+                                self::MAIL_BLOCK_BORDER . "\n";
                         }
 
                         // include comment/note text
@@ -607,9 +609,9 @@ class ilWikiUtil
 
                         if ($snippet) {
                             $message .= $ulng->txt('content') . "\n" .
-                                "----------------------------------------\n" .
+                                self::MAIL_BLOCK_BORDER . "\n" .
                                 $snippet . "\n" .
-                                "----------------------------------------\n\n";
+                                self::MAIL_BLOCK_BORDER . "\n\n";
                         }
 
                         $message .= $ulng->txt('wiki_change_notification_link') . ": " . $link;


### PR DESCRIPTION
This change ensures the generated Markdown (that's what is expected with ILIAS >= 11) looks "okayish" by introducing a new type of block separator for `wiki` mails instead of a hyphen-based line.

See:
- https://github.com/chrisalley/markdown-garden/blob/master/source/guides/headers/setext-headers.md

Mantis Issue: https://mantis.ilias.de/view.php?id=48262

If approved, this has to be picked to `trunk` as well.