### PR TITLE
Fix: Reorder LSO settings, remove taxonomy provider role, show custom metadata on info screen

### DIFF
--- a/components/ILIAS/LearningSequence/classes/Settings/class.ilObjLearningSequenceSettingsGUI.php
+++ b/components/ILIAS/LearningSequence/classes/Settings/class.ilObjLearningSequenceSettingsGUI.php
@@ -183,16 +183,6 @@ class ilObjLearningSequenceSettingsGUI
                 ])
             );
 
-        $section_additional = $if->field()->section(
-            [
-                self::PROP_GALLERY => $gallery,
-                ilObjectServiceSettingsGUI::CUSTOM_METADATA => $custom_md,
-                ilObjectServiceSettingsGUI::TAXONOMIES => $taxonomies
-            ],
-            $txt('obj_features')
-        );
-        $formElements['additional'] = $section_additional;
-
         // Common properties
         $title_icon = $props->getPropertyTitleAndIconVisibility()->toForm(
             $this->lng,
@@ -224,6 +214,16 @@ class ilObjLearningSequenceSettingsGUI
             $txt('cont_presentation')
         );
         $formElements['common'] = $section_common;
+
+        $section_additional = $if->field()->section(
+            [
+                self::PROP_GALLERY => $gallery,
+                ilObjectServiceSettingsGUI::CUSTOM_METADATA => $custom_md,
+                ilObjectServiceSettingsGUI::TAXONOMIES => $taxonomies
+            ],
+            $txt('obj_features')
+        );
+        $formElements['additional'] = $section_additional;
 
         return $formElements;
     }

--- a/components/ILIAS/LearningSequence/classes/Settings/class.ilObjLearningSequenceSettingsGUI.php
+++ b/components/ILIAS/LearningSequence/classes/Settings/class.ilObjLearningSequenceSettingsGUI.php
@@ -169,20 +169,6 @@ class ilObjLearningSequenceSettingsGUI
                     $this->refinery->always(false)
                 ])
             );
-        //Taxonomies
-        $taxonomies = $if->field()->checkbox($this->lng->txt('obj_tool_setting_taxonomies'))
-            ->withValue((bool) ilContainer::_lookupContainerSetting(
-                $lso->getId(),
-                ilObjectServiceSettingsGUI::TAXONOMIES,
-                '0'
-            ))
-            ->withAdditionalTransformation(
-                $this->refinery->byTrying([
-                    $this->refinery->kindlyTo()->bool(),
-                    $this->refinery->always(false)
-                ])
-            );
-
         // Common properties
         $title_icon = $props->getPropertyTitleAndIconVisibility()->toForm(
             $this->lng,
@@ -218,8 +204,7 @@ class ilObjLearningSequenceSettingsGUI
         $section_additional = $if->field()->section(
             [
                 self::PROP_GALLERY => $gallery,
-                ilObjectServiceSettingsGUI::CUSTOM_METADATA => $custom_md,
-                ilObjectServiceSettingsGUI::TAXONOMIES => $taxonomies
+                ilObjectServiceSettingsGUI::CUSTOM_METADATA => $custom_md
             ],
             $txt('obj_features')
         );
@@ -253,11 +238,6 @@ class ilObjLearningSequenceSettingsGUI
             $lso->getId(),
             ilObjectServiceSettingsGUI::CUSTOM_METADATA,
             ($data['additional'][ilObjectServiceSettingsGUI::CUSTOM_METADATA] ?? false) ? '1' : '0'
-        );
-        ilContainer::_writeContainerSetting(
-            $lso->getId(),
-            ilObjectServiceSettingsGUI::TAXONOMIES,
-            ($data['additional'][ilObjectServiceSettingsGUI::TAXONOMIES] ?? false) ? '1' : '0'
         );
 
         $obj_props->storePropertyIsOnline(

--- a/components/ILIAS/LearningSequence/classes/class.ilLearningSequenceExporter.php
+++ b/components/ILIAS/LearningSequence/classes/class.ilLearningSequenceExporter.php
@@ -124,22 +124,6 @@ class ilLearningSequenceExporter extends ilXmlExporter
                 "entity" => "md",
                 "ids" => $md_ids
             ];
-
-            // taxonomies
-            $tax_ids = [];
-            foreach ($a_ids as $id) {
-                $t_ids = ilObjTaxonomy::getUsageOfObject((int) $id);
-                foreach ($t_ids as $t_id) {
-                    $tax_ids[$t_id] = $t_id;
-                }
-            }
-            if ($tax_ids !== []) {
-                $res[] = [
-                    "component" => "components/ILIAS/Taxonomy",
-                    "entity" => "tax",
-                    "ids" => $tax_ids
-                ];
-            }
         }
 
         // container pages

--- a/components/ILIAS/LearningSequence/classes/class.ilLearningSequenceImporter.php
+++ b/components/ILIAS/LearningSequence/classes/class.ilLearningSequenceImporter.php
@@ -97,20 +97,6 @@ class ilLearningSequenceImporter extends ilXmlImporter
             $new_obj_id = $this->obj->getId();
             ilPageObject::_writeParentId($pg_type, (int) $new_pg_id, (int) $new_obj_id);
         }
-
-        // taxonomy usages
-        $maps = $a_mapping->getMappingsOfEntity("components/ILIAS/LearningSequence", "lso");
-        foreach ($maps as $old => $new) {
-            if ($old !== "new_id" && (int) $old > 0) {
-                $new_tax_ids = $a_mapping->getMapping("components/ILIAS/Taxonomy", "tax_usage_of_obj", (string) $old);
-                if ($new_tax_ids !== "") {
-                    $tax_ids = explode(":", (string) $new_tax_ids);
-                    foreach ($tax_ids as $tid) {
-                        ilObjTaxonomy::saveUsage((int) $tid, (int) $new);
-                    }
-                }
-            }
-        }
     }
 
     public function afterContainerImportProcessing(ilImportMapping $mapping): void

--- a/components/ILIAS/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
+++ b/components/ILIAS/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
@@ -51,11 +51,10 @@ use ILIAS\User\Profile\Data as ProfileData;
  * @ilCtrl_Calls      ilObjLearningSequenceGUI: ilObjSurveyGUI
  * @ilCtrl_Calls      ilObjLearningSequenceGUI: ilObjFileUploadHandlerGUI
  * @ilCtrl_Calls ilObjLearningSequenceGUI: ilObjLearningSequenceEditIntroGUI, ilObjLearningSequenceEditExtroGUI
- * @ilCtrl_Calls ilObjLearningSequenceGUI: ilObjectMetaDataGUI, ilTaxonomySettingsGUI, ilObjTaxonomyGUI
+ * @ilCtrl_Calls ilObjLearningSequenceGUI: ilObjectMetaDataGUI
  */
-class ilObjLearningSequenceGUI extends ilContainerGUI implements ilCtrlBaseClassInterface, \ILIAS\Taxonomy\Settings\ModifierGUIInterface
+class ilObjLearningSequenceGUI extends ilContainerGUI implements ilCtrlBaseClassInterface
 {
-    protected \ILIAS\Taxonomy\Service $taxonomy;
     public const CMD_VIEW = "view";
     public const CMD_LEARNER_VIEW = "learnerView";
     public const CMD_CONTENT = "manageContent";
@@ -230,7 +229,6 @@ class ilObjLearningSequenceGUI extends ilContainerGUI implements ilCtrlBaseClass
         $this->post_wrapper = $DIC->http()->wrapper()->post();
         $this->refinery = $DIC->refinery();
         $this->content_style = $DIC->contentStyle();
-        $this->taxonomy = $DIC->taxonomy();
 
         $this->help->setScreenIdComponent($this->type);
         $this->lng->loadLanguageModule($this->type);
@@ -358,18 +356,6 @@ class ilObjLearningSequenceGUI extends ilContainerGUI implements ilCtrlBaseClass
                 $this->tabs->activateTab("meta_data");
                 $mdgui = new ilObjectMetaDataGUI($this->object);
                 $this->ctrl->forwardCommand($mdgui);
-                break;
-            case "iltaxonomysettingsgui":
-            case "ilobjtaxonomygui":
-                $this->tabs->activateTab(self::TAB_SETTINGS);
-                $this->setEditTabs("taxonomy");
-                $tax_gui = $this->taxonomy->gui()->getSettingsGUI(
-                    $this->object->getId(),
-                    $this->lng->txt("cntr_tax_settings_info"),
-                    true,
-                    $this
-                );
-                $this->ctrl->forwardCommand($tax_gui);
                 break;
             case "ilobjlearningsequenceeditintrogui":
                 $which_page = LSOPageType::INTRO;
@@ -711,7 +697,6 @@ class ilObjLearningSequenceGUI extends ilContainerGUI implements ilCtrlBaseClass
     {
         $subs = [
             ilObjectServiceSettingsGUI::CUSTOM_METADATA,
-            ilObjectServiceSettingsGUI::TAXONOMIES,
             ilObjectServiceSettingsGUI::CALENDAR_CONFIGURATION,
             ilObjectServiceSettingsGUI::TAG_CLOUD,
             ilObjectServiceSettingsGUI::BADGES,
@@ -746,14 +731,6 @@ class ilObjLearningSequenceGUI extends ilContainerGUI implements ilCtrlBaseClass
             $this->lng->txt("general"),
             $this->ctrl->getLinkTargetByClass("ilobjlearningsequencesettingsgui", "settings")
         );
-
-        if (ilContainer::_lookupContainerSetting(
-            $this->object->getId(),
-            ilObjectServiceSettingsGUI::TAXONOMIES,
-            '0'
-        )) {
-            $this->taxonomy->gui()->addSettingsSubTab($this->object->getId());
-        }
 
         $this->tabs->activateTab(self::TAB_SETTINGS);
         $this->tabs->activateSubTab($active_tab);
@@ -875,16 +852,6 @@ class ilObjLearningSequenceGUI extends ilContainerGUI implements ilCtrlBaseClass
             );
         }
         $this->tabs->activateSubTab($active);
-    }
-
-    public function getProperties(int $tax_id): array
-    {
-        return [];
-    }
-
-    public function getActions(int $tax_id): array
-    {
-        return [];
     }
 
     protected function checkAccess(string $which): bool

--- a/components/ILIAS/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
+++ b/components/ILIAS/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
@@ -542,7 +542,23 @@ class ilObjLearningSequenceGUI extends ilContainerGUI implements ilCtrlBaseClass
     {
         $info = new ilInfoScreenGUI($this);
         $info->addMetaDataSections($this->object->getId(), 0, 'lso');
+        $this->addAdvancedMetaDataToInfo($info);
+
         return $info;
+    }
+
+    protected function addAdvancedMetaDataToInfo(ilInfoScreenGUI $info): void
+    {
+        $record_gui = new ilAdvancedMDRecordGUI(
+            ilAdvancedMDRecordGUI::MODE_INFO,
+            'lso',
+            $this->object->getId(),
+            '',
+            0,
+            $this->call_by_reference
+        );
+        $record_gui->setInfoObject($info);
+        $record_gui->parse();
     }
 
     protected function getGUIPermissions(): ilPermissionGUI


### PR DESCRIPTION
## A :  Additional Features out of order

`ilObjLearningSequenceSettingsGUI::buildFormElements()` listed `additional` (Additional
Features) third instead of last, ahead of `common`. ILIAS convention puts Additional Features
at the end of an object's settings. `Form.php` renders sections in insertion order without
re-sorting, so this is purely an array-ordering fix — the `additional` block was moved behind
`common`.

Note for reviewers: the same ordering bug exists unchanged in ILIAS 9, 10 and 11
(and `i9_learnplaces`), predating the taxonomy/metadata work below. It is **not** touched in
this PR — decided to keep this change scoped to trunk/ILIAS 12.

## B:  Taxonomy assignment direction

The LSO recently gained taxonomy support, but as a *provider* (offering its own taxonomy tree
to sub-items, like Category/Glossary/Question Pool), not as *assignable* (being assigned to a
taxonomy node of an ancestor Category, like File/Course/Group/Wiki/...). The advisory board
correctly identified the resulting state but attributed it to a missing capability rather than
an extra one.

**Important for reviewers  verified, not assumed:** LSO objects were already assignable to a
taxonomy node of an ancestor category *before this change, with no code required*. Assignability
in ILIAS is generic, implemented in `ilObjectMetaDataGUI` and
`ilTaxMDGUI::getSelectableTaxonomies()` / `initTaxNodeAssignment()`, and applies to any object
that instantiates `ilObjectMetaDataGUI` and is RBAC-enabled — both already true for the LSO.
This is why `File`, named as the reference, has no taxonomy-specific code at all. We confirmed
it on a running instance against the unmodified code: a category with a taxonomy, an LSO placed
inside it, the assignment made through the metadata tab — and the row landed in
`tax_node_assignment` carrying the exact signature of `ilTaxMDGUI::initTaxNodeAssignment()`
(`component` = object type, `item_type` = `obj`). Anyone re-checking this should query
`tax_node_assignment` and `tax_usage` rather than infer from the absence of dedicated LSO code.

What actually needed fixing: the LSO was **additionally** acting as a taxonomy provider. This
PR removes that role entirely:

- `ModifierGUIInterface` and its implementation in `ilObjLearningSequenceGUI` (interface,
  service property, ilCtrl declaration, forwarding, empty stub methods)
- the `TAXONOMIES` checkbox and its container setting in `ilObjLearningSequenceSettingsGUI`,
  and the Taxonomies settings subtab in `ilObjLearningSequenceGUI`
- provider export handling in `ilLearningSequenceExporter`, and the provider half of the import
  in `ilLearningSequenceImporter`

Deliberately kept, because both belong to the assignment direction or to legacy cleanup:

- the `tax_item` / `tax_item_obj_id` mappings in `ilLearningSequenceImporter` — their
  `lso:obj:<id>` key is the `component:item_type:item_id` pattern of `tax_node_assignment`,
  ten lines away from the provider block that was removed
- `ilObjTaxonomy::deleteUsagesOfObject()` in `ilObjLearningSequence`, which still clears rows
  left by objects created while the provider role existed

Existing provider-role data (a `tax_usage` row for one LSO instance in the trunk dev database)
is **not migrated**. The provider behavior never shipped in a release — ILIAS 12 is still
alpha — so only development instances are affected, and the taxonomy tree simply becomes
unreachable rather than deleted.

Likely root cause, worth reporting to the project as a documentation improvement:
`Taxonomy/README-technical.md` documents only the provider pattern and says nothing about the
assignable direction. The original implementation followed that document.

## C :  Custom metadata missing from info screen

Confirmed report: custom (advanced) metadata values were saved correctly but never rendered on
the LSO's info screen. `ilObjLearningSequenceGUI::getGUIInfo()` only called
`addMetaDataSections()`, which covers standard LOM but not advanced metadata records. Added the
generic `ilAdvancedMDRecordGUI` call in `MODE_INFO`, following the pattern used by
`ilObjFileGUI::buildInfoScreen()` and roughly 25 other components. Verified on the running
instance that a previously saved custom metadata value now appears on the info screen.
