### PR TITLE
[Survey] fix: Add url permalink

### DIFF
--- a/components/ILIAS/Survey/Execution/class.LaunchGUI.php
+++ b/components/ILIAS/Survey/Execution/class.LaunchGUI.php
@@ -95,6 +95,7 @@ class LaunchGUI
         $r = $this->gui->ui()->renderer();
         $ctrl = $this->gui->ctrl();
         $main_tpl = $this->gui->ui()->mainTemplate();
+        $main_tpl->setPermanentLink($this->survey->getType(), $this->survey->getRefId());
         $lng = $this->domain->lng();
 
         // init session


### PR DESCRIPTION
This PR addresses the missing **permalink button** on the Survey main page, as reported in [[Mantis issue #48242](https://mantis.ilias.de/view.php?id=48242)].

It restores the expected permalink functionality and ensures consistent behavior on the Survey main page.