### PR TITLE
[FIX] 43581: paragraph characteristic is ignored inside lists

### DIFF
--- a/components/ILIAS/COPage/css/content.css
+++ b/components/ILIAS/COPage/css/content.css
@@ -1264,33 +1264,40 @@ ol.ilc_list_o_NumberedListNoStyle {
   counter-reset: section;
 }
 p.ilc_text_block_Book,
+div.ilc_Paragraph.ilc_text_block_Book,
 html.il-no-tiny-bg body#tinymce.ilc_text_block_Book p {
   hyphens: auto;
   text-align: justify;
 }
 p.ilc_text_block_Button:hover,
+div.ilc_Paragraph.ilc_text_block_Button:hover,
 html.il-no-tiny-bg body#tinymce.ilc_text_block_Button:hover p {
   background-color: #5774A0;
 }
 p.ilc_text_block_List,
+div.ilc_Paragraph.ilc_text_block_List,
 html.il-no-tiny-bg body#tinymce.ilc_text_block_List p {
   margin-top: 3px;
   margin-bottom: 3px;
 }
 p.ilc_text_block_Numbers,
+div.ilc_Paragraph.ilc_text_block_Numbers,
 html.il-no-tiny-bg body#tinymce.ilc_text_block_Numbers p {
   text-align: right;
 }
 p.ilc_text_block_Standard,
+div.ilc_Paragraph.ilc_text_block_Standard,
 html.il-no-tiny-bg body#tinymce.ilc_text_block_Standard p {
   margin-bottom: 10px;
   margin-top: 10px;
 }
 p.ilc_text_block_StandardLarge,
+div.ilc_Paragraph.ilc_text_block_StandardLarge,
 html.il-no-tiny-bg body#tinymce.ilc_text_block_StandardLarge p {
   font-size: 1.115rem;
 }
 p.ilc_text_block_TableContent,
+div.ilc_Paragraph.ilc_text_block_TableContent,
 html.il-no-tiny-bg body#tinymce.ilc_text_block_TableContent p {
   line-height: 1.8em;
   padding-bottom: 10px;
@@ -1303,6 +1310,7 @@ html.il-no-tiny-bg body#tinymce.ilc_text_block_TableContent p {
   margin-left: 0px;
 }
 p.ilc_text_block_Verse,
+div.ilc_Paragraph.ilc_text_block_Verse,
 html.il-no-tiny-bg body#tinymce.ilc_text_block_Verse p {
   text-align: center;
 }

--- a/components/ILIAS/COPage/css/content.less
+++ b/components/ILIAS/COPage/css/content.less
@@ -1550,6 +1550,7 @@ ol.ilc_list_o_NumberedListNoStyle
 }
 
 p.ilc_text_block_Book
+,div.ilc_Paragraph.ilc_text_block_Book
 ,html.il-no-tiny-bg body#tinymce.ilc_text_block_Book p
 {
 	hyphens: auto;
@@ -1557,12 +1558,14 @@ p.ilc_text_block_Book
 }
 
 p.ilc_text_block_Button:hover
+,div.ilc_Paragraph.ilc_text_block_Button:hover
 ,html.il-no-tiny-bg body#tinymce.ilc_text_block_Button:hover p
 {
 	background-color: #5774A0;
 }
 
 p.ilc_text_block_List
+,div.ilc_Paragraph.ilc_text_block_List
 ,html.il-no-tiny-bg body#tinymce.ilc_text_block_List p
 {
 	margin-top: 3px;
@@ -1570,12 +1573,14 @@ p.ilc_text_block_List
 }
 
 p.ilc_text_block_Numbers
+,div.ilc_Paragraph.ilc_text_block_Numbers
 ,html.il-no-tiny-bg body#tinymce.ilc_text_block_Numbers p
 {
 	text-align: right;
 }
 
 p.ilc_text_block_Standard
+,div.ilc_Paragraph.ilc_text_block_Standard
 ,html.il-no-tiny-bg body#tinymce.ilc_text_block_Standard p
 {
 	margin-bottom: 10px;
@@ -1583,12 +1588,14 @@ p.ilc_text_block_Standard
 }
 
 p.ilc_text_block_StandardLarge
+,div.ilc_Paragraph.ilc_text_block_StandardLarge
 ,html.il-no-tiny-bg body#tinymce.ilc_text_block_StandardLarge p
 {
 	font-size: 1.115rem;
 }
 
 p.ilc_text_block_TableContent
+,div.ilc_Paragraph.ilc_text_block_TableContent
 ,html.il-no-tiny-bg body#tinymce.ilc_text_block_TableContent p
 {
 	line-height: 1.8em;
@@ -1603,6 +1610,7 @@ p.ilc_text_block_TableContent
 }
 
 p.ilc_text_block_Verse
+,div.ilc_Paragraph.ilc_text_block_Verse
 ,html.il-no-tiny-bg body#tinymce.ilc_text_block_Verse p
 {
 	text-align: center;

--- a/components/ILIAS/Style/Content/Style/CSSBuilder.php
+++ b/components/ILIAS/Style/Content/Style/CSSBuilder.php
@@ -72,6 +72,10 @@ class CSSBuilder
                     $css .= ",span.ilc_text_inline_" . $tag[0]["class"] . "\n";
                 }
                 if ($tag[0]["type"] == "text_block") {
+                    // a paragraph containing a list is rendered as div, not p (page.xsl:929-942),
+                    // so the p selector above would not match it. ilc_Paragraph limits this alias
+                    // to the page editor's paragraph container (page.xsl:990).
+                    $css .= ",div.ilc_Paragraph.ilc_text_block_" . $tag[0]["class"] . "\n";
                     $css .= ",html.il-no-tiny-bg body#tinymce.ilc_text_block_" . $tag[0]["class"] . "\n";
                 }
                 if ($tag[0]["class"] == "VAccordCntr" &&

--- a/components/ILIAS/Style/classes/Setup/class.ilStyleDBUpdateSteps.php
+++ b/components/ILIAS/Style/classes/Setup/class.ilStyleDBUpdateSteps.php
@@ -355,4 +355,21 @@ class ilStyleDBUpdateSteps implements \ilDatabaseUpdateSteps
         );
     }
 
+    /**
+     * Rewrite the cached style.css files, so the div alias for text block
+     * characteristics becomes effective (see CSSBuilder).
+     */
+    public function step_23()
+    {
+        $this->db->update(
+            "style_data",
+            [
+                "uptodate" => ["integer", 0]
+            ],
+            [    // where
+                 "uptodate" => ["integer", 1]
+            ]
+        );
+    }
+
 }


### PR DESCRIPTION
Fixes Mantis 43581: https://mantis.ilias.de/view.php?id=43581

Problem
Applying a bullet or numbered list to a paragraph drops its paragraph
characteristic. The text falls back to the default font, although the editor
still shows the characteristic in its dropdown.

Cause
A paragraph containing a list is rendered as div instead of p (page.xsl:929-942),
since ul inside p is invalid HTML. The class is written correctly onto that div
(page.xsl:990): class="ilc_Paragraph ilc_text_block_StandardLarge".
But the content style only emits p.ilc_text_block_<class> for characteristics of
type text_block (ilObjStyleSheet.php:305, CSSBuilder.php:55), and that selector
does not match a div.

For heading1/2/3 the matching alias already exists (CSSBuilder.php:61-64), which
is why heading characteristics work inside lists since the fix for 41844, while
text block characteristics still do not.

Change
Add the same alias for text_block, plus the eight non-heading classes in the
shipped default style, plus a database update step.

The .ilc_Paragraph part restricts the alias to the paragraph container produced
by the page editor and leaves other divs carrying ilc_text_block_ classes
untouched - notably ilPCDataTableGUI.php:147, where a blanket alias would apply
the padding twice.

The update step is required because style.css is cached per style object
(style_data.uptodate); without it the change has no effect on existing
installations. Same as step_14, step_19 and step_22.

The change applies unmodified to release_11 and trunk; step_23 is free in all
three lines.
