### PR TITLE
Fix: Move LSO Additional Features section to the end of the settings …

### DIFF
--- a/components/ILIAS/LearningSequence/classes/Settings/class.ilObjLearningSequenceSettingsGUI.php
+++ b/components/ILIAS/LearningSequence/classes/Settings/class.ilObjLearningSequenceSettingsGUI.php
@@ -154,14 +154,6 @@ class ilObjLearningSequenceSettingsGUI
                     $this->refinery->always(false)
                 ])
             );
-        $section_additional = $if->field()->section(
-            [
-                self::PROP_GALLERY => $gallery
-            ],
-            $txt('obj_features')
-        );
-        $formElements['additional'] = $section_additional;
-
         // Common properties
         $title_icon = $props->getPropertyTitleAndIconVisibility()->toForm(
             $this->lng,
@@ -193,6 +185,14 @@ class ilObjLearningSequenceSettingsGUI
             $txt('cont_presentation')
         );
         $formElements['common'] = $section_common;
+
+        $section_additional = $if->field()->section(
+            [
+                self::PROP_GALLERY => $gallery
+            ],
+            $txt('obj_features')
+        );
+        $formElements['additional'] = $section_additional;
 
         return $formElements;
     }


### PR DESCRIPTION
…form

ILIAS convention places Additional Features last in an object's settings. In the Learning Sequence it was rendered third, ahead of the presentation settings. Form sections render in insertion order without re-sorting, so moving the array assignment is enough and no logic changes are involved.

The same fix already landed in trunk. This carries it to the release branch, which was left untouched at the time.