### PR TITLE
48255 - Route hint requests in question preview

### DIFF
--- a/components/ILIAS/Test/classes/class.ilObjTestGUI.php
+++ b/components/ILIAS/Test/classes/class.ilObjTestGUI.php
@@ -1076,6 +1076,18 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
             $this->ctrl->getLinkTargetByClass(self::class, self::SHOW_QUESTIONS_CMD)
         );
         $this->ctrl->saveParameterByClass(self::class, 'q_id');
+        $this->dispatchQuestionPreviewCommand($gui, $cmd);
+    }
+
+    protected function dispatchQuestionPreviewCommand(
+        ilAssQuestionPreviewGUI $gui,
+        string $cmd
+    ): void {
+        if ($this->ctrl->getNextClass($gui) !== '') {
+            $this->ctrl->forwardCommand($gui);
+            return;
+        }
+
         $gui->{$cmd . 'Cmd'}();
     }
 

--- a/components/ILIAS/Test/tests/ilObjTestGUITest.php
+++ b/components/ILIAS/Test/tests/ilObjTestGUITest.php
@@ -134,4 +134,63 @@ class ilObjTestGUITest extends ilTestBaseTestCase
         ;
         $testObj->cancelCreateQuestionObject();
     }
+
+    public function testDispatchQuestionPreviewCommandDirectly(): void
+    {
+        $ctrl_mock = $this->createMock(ilCtrl::class);
+        $this->setGlobalVariable('ilCtrl', $ctrl_mock);
+        $testObj = $this->getNewTestGUI();
+        $preview_gui = $this->getMockBuilder(ilAssQuestionPreviewGUI::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['showCmd'])
+            ->getMock();
+
+        $ctrl_mock
+            ->expects($this->once())
+            ->method('getNextClass')
+            ->with($preview_gui)
+            ->willReturn('');
+        $ctrl_mock
+            ->expects($this->never())
+            ->method('forwardCommand');
+        $preview_gui
+            ->expects($this->once())
+            ->method('showCmd');
+
+        self::callMethod(
+            $testObj,
+            'dispatchQuestionPreviewCommand',
+            [$preview_gui, ilAssQuestionPreviewGUI::CMD_SHOW]
+        );
+    }
+
+    public function testDispatchQuestionPreviewCommandToChildGui(): void
+    {
+        $ctrl_mock = $this->createMock(ilCtrl::class);
+        $this->setGlobalVariable('ilCtrl', $ctrl_mock);
+        $testObj = $this->getNewTestGUI();
+        $preview_gui = $this->getMockBuilder(ilAssQuestionPreviewGUI::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['showCmd'])
+            ->getMock();
+
+        $ctrl_mock
+            ->expects($this->once())
+            ->method('getNextClass')
+            ->with($preview_gui)
+            ->willReturn(strtolower(ilAssQuestionHintRequestGUI::class));
+        $ctrl_mock
+            ->expects($this->once())
+            ->method('forwardCommand')
+            ->with($preview_gui);
+        $preview_gui
+            ->expects($this->never())
+            ->method('showCmd');
+
+        self::callMethod(
+            $testObj,
+            'dispatchQuestionPreviewCommand',
+            [$preview_gui, ilAssQuestionPreviewGUI::CMD_SHOW]
+        );
+    }
 }


### PR DESCRIPTION
## Description

Routes commands for question hint sub-GUIs through `ilCtrl::forwardCommand()` while preserving the existing direct dispatch for commands handled by `ilAssQuestionPreviewGUI` itself.

Without this distinction, requesting a hint in question preview calls `confirmRequestCmd()` on `ilAssQuestionPreviewGUI`, where that method does not exist.

Mantis: https://mantis.ilias.de/view.php?id=48255

## Tests

- Added regression tests for direct preview commands and child-GUI dispatch.
- `ilObjTestGUITest`: 6 tests, 8 assertions.
- PHP 8.2 syntax check passed.
- ILIAS PHP-CS-Fixer check passed.