### PR TITLE
48273 - Fix question hint title in test player

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionHintRequestGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionHintRequestGUI.php
@@ -81,7 +81,7 @@ class ilAssQuestionHintRequestGUI extends ilAssQuestionHintAbstractGUI
             ->exists(ilTestPlayerLayoutProvider::TEST_PLAYER_VIEW_TITLE)) {
             $this->global_screen->tool()->context()->current()->getAdditionalData()->replace(
                 ilTestPlayerLayoutProvider::TEST_PLAYER_VIEW_TITLE,
-                $this->parent_gui->getObject()->getTitleForHTMLOutput() . ' - ' . $this->lng->txt('show_requested_question_hints')
+                $this->question_obj->getTitleForHTMLOutput() . ' - ' . $this->lng->txt('show_requested_question_hints')
             );
         }
 
@@ -115,7 +115,7 @@ class ilAssQuestionHintRequestGUI extends ilAssQuestionHintAbstractGUI
             ->exists(ilTestPlayerLayoutProvider::TEST_PLAYER_VIEW_TITLE)) {
             $this->global_screen->tool()->context()->current()->getAdditionalData()->replace(
                 ilTestPlayerLayoutProvider::TEST_PLAYER_VIEW_TITLE,
-                $this->parent_gui->getObject()->getTitleForHTMLOutput() . ' - ' . sprintf(
+                $this->question_obj->getTitleForHTMLOutput() . ' - ' . sprintf(
                     $this->lng->txt('tst_question_hints_form_header_edit'),
                     $question_hint->getIndex(),
                     $this->request_data_collector->int('sequence') ?? 0

--- a/components/ILIAS/TestQuestionPool/tests/ilAssQuestionHintRequestGUITest.php
+++ b/components/ILIAS/TestQuestionPool/tests/ilAssQuestionHintRequestGUITest.php
@@ -54,4 +54,79 @@ class ilAssQuestionHintRequestGUITest extends assBaseTestCase
     {
         $this->assertInstanceOf(ilAssQuestionHintRequestGUI::class, $this->object);
     }
+
+    public function testShowListUsesQuestionTitleInTestPlayerContext(): void
+    {
+        $parent_gui = $this->createMock(ilTestPlayerAbstractGUI::class);
+        $parent_gui->expects($this->never())->method('getObject');
+
+        $question = $this->createMock(assQuestion::class);
+        $question->expects($this->exactly(2))
+            ->method('getTitleForHTMLOutput')
+            ->willReturn('Question Title');
+
+        $question_gui = $this->createMock(assQuestionGUI::class);
+        $question_gui->method('getObject')->willReturn($question);
+
+        $question_hint_list = $this->createMock(ilAssQuestionHintList::class);
+        $question_hint_list->method('getTableData')->willReturn([]);
+
+        $question_hint_tracking = $this->createMock(ilAssQuestionHintTracking::class);
+        $question_hint_tracking->method('getRequestedHintsList')->willReturn($question_hint_list);
+
+        $ctrl = $this->createMock(ilCtrl::class);
+        $ctrl->method('getCmd')->willReturn(ilAssQuestionHintRequestGUI::CMD_SHOW_LIST);
+        $ctrl->method('getNextClass')->willReturn('');
+        $ctrl->method('getHtml')->willReturn('Hint list');
+
+        $lng = $this->createMock(ilLanguage::class);
+        $lng->method('txt')
+            ->willReturnCallback(static fn(string $key): string => match ($key) {
+                'show_requested_question_hints' => 'Requested Hints',
+                default => $key
+            });
+
+        $this->setGlobalVariable('ilCtrl', $ctrl);
+        $this->setGlobalVariable('lng', $lng);
+
+        $additional_data = $this->createMock(ILIAS\GlobalScreen\ScreenContext\AdditionalData\Collection::class);
+        $additional_data->method('exists')
+            ->with(ilTestPlayerLayoutProvider::TEST_PLAYER_VIEW_TITLE)
+            ->willReturn(true);
+        $additional_data->expects($this->once())
+            ->method('replace')
+            ->with(
+                ilTestPlayerLayoutProvider::TEST_PLAYER_VIEW_TITLE,
+                'Question Title - Requested Hints'
+            );
+
+        $screen_context = $this->createMock(ILIAS\GlobalScreen\ScreenContext\ScreenContext::class);
+        $screen_context->method('getAdditionalData')->willReturn($additional_data);
+
+        $context_services = $this->createMock(ILIAS\GlobalScreen\ScreenContext\ContextServices::class);
+        $context_services->method('current')->willReturn($screen_context);
+
+        $tool_services = $this->createMock(ILIAS\GlobalScreen\Scope\Tool\ToolServices::class);
+        $tool_services->method('context')->willReturn($context_services);
+
+        $global_screen = $this->createMock(ILIAS\GlobalScreen\Services::class);
+        $global_screen->method('tool')->willReturn($tool_services);
+
+        $tpl = $this->createMock(ilGlobalTemplateInterface::class);
+        $tpl->expects($this->once())->method('setContent')->with('Hint list');
+
+        $object = new ilAssQuestionHintRequestGUI(
+            $parent_gui,
+            '',
+            $question_gui,
+            $question_hint_tracking,
+            $ctrl,
+            $lng,
+            $tpl,
+            $this->createMock(ilTabsGUI::class),
+            $global_screen
+        );
+
+        $object->executeCommand();
+    }
 }


### PR DESCRIPTION
## Description

Uses the question object already held by `ilAssQuestionHintRequestGUI` when rendering hint page titles.

In the test player, the parent GUI returns an `ilObjTest`. Calling `getTitleForHTMLOutput()` on that object causes a fatal error. The hint GUI already has the corresponding question object, which provides the required HTML-safe title.

Mantis: https://mantis.ilias.de/view.php?id=48273

## Tests

- Added regression coverage for `showListCmd()` and `showHintCmd()` in test-player context.
- `ilAssQuestionHintRequestGUITest`: 2 tests, 5 assertions.
- TestQuestionPool suite: 472 tests, 514 assertions, 9 existing skips.
- PHP 8.2 syntax check passed.
- ILIAS PHP-CS-Fixer check passed.