### PR TITLE
[FIX] #48258: Fix learning sequence kiosk page renderer undefined method used

### DIFF
--- a/components/ILIAS/LearningSequence/classes/Player/class.ilKioskPageRenderer.php
+++ b/components/ILIAS/LearningSequence/classes/Player/class.ilKioskPageRenderer.php
@@ -97,7 +97,7 @@ class ilKioskPageRenderer
             $this->tpl->setCurrentBlock('obj_desc');
             $this->tpl->setVariable(
                 'OBJECT_DESCRIPTION',
-                nl2br($this->tpl->prepareForOutput($obj_description))
+                nl2br($obj_description)
             );
             $this->tpl->parseCurrentBlock();
         }


### PR DESCRIPTION
Fixes https://mantis.ilias.de/view.php?id=48258

If accepted, should be picked into **release_11** & **trunk**