### PR TITLE
[FIX] Calendar: drop the self-assignments in parsePartsToDate

### DIFF
--- a/components/ILIAS/Calendar/classes/class.ilDateTime.php
+++ b/components/ILIAS/Calendar/classes/class.ilDateTime.php
@@ -328,10 +328,6 @@ class ilDateTime
         ?int $a_sec = null,
         ?string $a_timezone = null
     ): ?DateTime {
-        $a_year = $a_year;
-        $a_month = $a_month;
-        $a_day = $a_day;
-
         if (!$a_year) {
             return null;
         }


### PR DESCRIPTION
`parsePartsToDate()` opens by assigning `$a_year`, `$a_month` and `$a_day` to themselves. All three are already typed `int` in the signature, so the lines do nothing at all.

They read like casts that lost their `(int)` when the signature picked up types: the three nullable parameters below them still get `$a_hour = (int) $a_hour;` and friends inside the try block, which is the same idea done where it is still needed.
