### PR TITLE
Session: Change col `details` to type text in table `event`

### DIFF
--- a/components/ILIAS/Session/classes/Setup/UpdateStepsV12.php
+++ b/components/ILIAS/Session/classes/Setup/UpdateStepsV12.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Session\Setup;
+
+use ilDatabaseUpdateSteps;
+use ilDBInterface;
+use ilDBConstants;
+
+class UpdateStepsV12 implements ilDatabaseUpdateSteps
+{
+    private ilDBInterface $db;
+
+    public function prepare(ilDBInterface $db): void
+    {
+        $this->db = $db;
+    }
+
+    public function step_1(): void
+    {
+        $this->db->modifyTableColumn('event', 'details', [
+            'type' => ilDBConstants::T_CLOB,
+            'length' => 4000,
+        ]);
+    }
+}

--- a/components/ILIAS/Session/classes/Setup/class.ilSessionSetupAgent.php
+++ b/components/ILIAS/Session/classes/Setup/class.ilSessionSetupAgent.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 use ILIAS\Setup;
 use ILIAS\Setup\Config;
+use ILIAS\Session\Setup\UpdateStepsV12;
 
 /**
  * @author  Tim Schmitz <schmitz@leifos.de>
@@ -28,7 +29,12 @@ class ilSessionSetupAgent extends Setup\Agent\NullAgent
 {
     public function getUpdateObjective(?Setup\Config $config = null): Setup\Objective
     {
-        return new ilDatabaseUpdateStepsExecutedObjective(new ilSessionDBUpdateSteps9());
+        return new Setup\ObjectiveCollection(
+            'Update Session component',
+            false,
+            new ilDatabaseUpdateStepsExecutedObjective(new ilSessionDBUpdateSteps9()),
+            new ilDatabaseUpdateStepsExecutedObjective(new UpdateStepsV12())
+        );
     }
 
     public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective


### PR DESCRIPTION
This PR fixes a problem in the `event` table when migrating from `utf8mb3` to `utf8mb4`.

Currently the table cannot be converted to `utf8mb4` because the row size would be to large:
```
Error: query: Row size too large. The maximum row size for the used table type, not counting BLOBs, is 65535. This includes storage overhead, check the manual. You have to change some columns to TEXT or BLOBs
  SQLSTATE: 42000
```

With utf8mb4 4 bytes per char instead 3 are reserved, so each (var-)char field length is multiplied by 4 instead 3.

It is enough to change one `varchar(4000)` field to type `text` to fit into the row size limit.

This PR is in preparation for an upcoming PR to change the Database charset & collation from `utf8mb3` to `utf8mb4`.