### PR TITLE
Course: Change col `target_group` to type text in table `crs_settings`

### DIFF
--- a/components/ILIAS/Course/Setup/UpdateStepsV12.php
+++ b/components/ILIAS/Course/Setup/UpdateStepsV12.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Course\Setup;
+
+use ilDatabaseUpdateSteps;
+use ilDBInterface;
+use ilDBConstants;
+
+class UpdateStepsV12 implements ilDatabaseUpdateSteps
+{
+    private ilDBInterface $db;
+
+    public function prepare(ilDBInterface $db): void
+    {
+        $this->db = $db;
+    }
+
+    public function step_1(): void
+    {
+        $this->db->modifyTableColumn('crs_settings', 'target_group', [
+            'type' => ilDBConstants::T_CLOB,
+            'length' => 4000,
+        ]);
+    }
+}

--- a/components/ILIAS/Course/Setup/ilCourseSetupAgent.php
+++ b/components/ILIAS/Course/Setup/ilCourseSetupAgent.php
@@ -24,6 +24,8 @@ use ILIAS\Setup\Metrics;
 use ILIAS\Setup\Config;
 use ILIAS\Setup;
 use ILIAS\Refinery\Transformation;
+use ILIAS\Setup\ObjectiveCollection;
+use ILIAS\Course\Setup\UpdateStepsV12;
 
 class ilCourseSetupAgent extends NullAgent
 {
@@ -31,7 +33,12 @@ class ilCourseSetupAgent extends NullAgent
 
     public function getUpdateObjective(?ILIAS\Setup\Config $config = null): Objective
     {
-        return new ilDatabaseUpdateStepsExecutedObjective(new ilCourseDBUpdateSteps());
+        return new ObjectiveCollection(
+            'Update Course component',
+            false,
+            new ilDatabaseUpdateStepsExecutedObjective(new ilCourseDBUpdateSteps()),
+            new ilDatabaseUpdateStepsExecutedObjective(new UpdateStepsV12())
+        );
     }
 
     public function getStatusObjective(Metrics\Storage $storage): Objective


### PR DESCRIPTION
This PR fixes a problem in the `event` table when migrating from `utf8mb3` to `utf8mb4`.

Currently the table cannot be converted to `utf8mb4` because the row size would be to large:
```
Error: query: Row size too large. The maximum row size for the used table type, not counting BLOBs, is 65535. This includes storage overhead, check the manual. You have to change some columns to TEXT or BLOBs
  SQLSTATE: 42000
```

With utf8mb4 4 bytes per char instead 3 are reserved, so each (var-)char field length is multiplied by 4 instead 3.

It is enough to change one `varchar(4000)` field to type `text` to fit into the row size limit.

This PR is in preparation for an upcoming PR to change the Database charset & collation from `utf8mb3` to `utf8mb4`.