### PR TITLE
[Survey] Ilias10 survey incorrect redirect results

### DIFF
--- a/components/ILIAS/Survey/classes/class.ilObjSurveyGUI.php
+++ b/components/ILIAS/Survey/classes/class.ilObjSurveyGUI.php
@@ -796,11 +796,10 @@ class ilObjSurveyGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
                     $DIC->user()->getId(),
                     $appraisee_id
                 );
-                $has_finished_run = true;
-                if ($survey->getMode() === ilObjSurvey::MODE_SELF_EVAL) {
-                    $has_finished_run = $run_manager->hasFinished();
-                } elseif ($domain_service->modeFeatureConfig($survey->getMode())->usesAppraisees()) {
+                if ($domain_service->modeFeatureConfig($survey->getMode())->usesAppraisees()) {
                     $has_finished_run = $appraisee_id > 0 && $run_manager->hasFinished();
+                } else {
+                    $has_finished_run = $run_manager->hasFinished();
                 }
                 if ($am->canAccessEvaluation() && $has_finished_run) {
                     $ctrl->setParameterByClass("ilObjSurveyGUI", "ref_id", $ref_id);

--- a/components/ILIAS/Survey/classes/class.ilObjSurveyGUI.php
+++ b/components/ILIAS/Survey/classes/class.ilObjSurveyGUI.php
@@ -783,15 +783,26 @@ class ilObjSurveyGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
             $ctrl->redirectByClass("ilObjSurveyGUI", "run");
         }
 
-        // read permission, evaluation access and finished run -> evaluation
+        // read permission and evaluation access -> evaluation
         if ($ilAccess->checkAccess("visible", "", $ref_id) ||
             $ilAccess->checkAccess("read", "", $ref_id)) {
             if ($ilAccess->checkAccess("read", "", $ref_id)) {
                 $domain_service = $DIC->survey()->internal()->domain();
                 $am = $domain_service->access($ref_id, $DIC->user()->getId());
                 $survey = new ilObjSurvey($ref_id);
-                $run_manager = $domain_service->execution()->run($survey, $DIC->user()->getId());
-                if ($am->canAccessEvaluation()) {
+                $appraisee_id = $request->getAppraiseeId();
+                $run_manager = $domain_service->execution()->run(
+                    $survey,
+                    $DIC->user()->getId(),
+                    $appraisee_id
+                );
+                $has_finished_run = true;
+                if ($survey->getMode() === ilObjSurvey::MODE_SELF_EVAL) {
+                    $has_finished_run = $run_manager->hasFinished();
+                } elseif ($domain_service->modeFeatureConfig($survey->getMode())->usesAppraisees()) {
+                    $has_finished_run = $appraisee_id > 0 && $run_manager->hasFinished();
+                }
+                if ($am->canAccessEvaluation() && $has_finished_run) {
                     $ctrl->setParameterByClass("ilObjSurveyGUI", "ref_id", $ref_id);
                     $ctrl->redirectByClass(["ilObjSurveyGUI", "ilSurveyEvaluationGUI"], "openEvaluation");
                 }


### PR DESCRIPTION
This PR addresses the issue reported in [Mantis #41610](https://mantis.ilias.de/view.php?id=41610)

When a user clicked on a Survey object (and they have permission to see the Results), they were incorrectly redirected to the **Results** view instead of the main **Survey** view.

This PR fixes the routing behavior so that users are redirected to the appropriate Survey view when opening the object.