### PR TITLE
[FIX] #48285 CmiXapi: Handle xAPI document resource preconditions in the proxy

### DIFF
--- a/components/ILIAS/CmiXapi/classes/XapiProxy/XapiProxyRequest.php
+++ b/components/ILIAS/CmiXapi/classes/XapiProxy/XapiProxyRequest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace XapiProxy;
 
@@ -37,6 +37,20 @@ class XapiProxyRequest
 
     private string $cmdPart2plus = "";
     private bool $checkGetStatements = true;
+
+    /**
+     * The xAPI document resources are mutable, so the specification guards them with optimistic
+     * concurrency (xAPI 1.0.3, "Concurrency"): a content player announces the document revision
+     * it expects, and an LRS must reject a PUT on an already existing document that carries
+     * neither of these headers with 409 Conflict.
+     * @var list<string>
+     */
+    private const CONDITIONAL_REQUEST_HEADERS = ['If-Match', 'If-None-Match'];
+
+    /**
+     * @var list<string>
+     */
+    private const DOCUMENT_RESOURCES = ['activities/state', 'activities/profile', 'agents/profile'];
 
     public function __construct(XapiProxy $xapiproxy)
     {
@@ -279,6 +293,25 @@ class XapiProxyRequest
                 $this->xapiproxy->log()->error($this->msg($e->getMessage()));
             }
 
+            $responses['default'] = $this->repeatDocumentWriteWithPrecondition(
+                $httpclient,
+                $request,
+                $responses['default'],
+                $uriDefault,
+                $authDefault,
+                $body,
+                $req_opts
+            );
+            $responses['fallback'] = $this->repeatDocumentWriteWithPrecondition(
+                $httpclient,
+                $request,
+                $responses['fallback'],
+                $uriFallback,
+                $authFallback,
+                $body,
+                $req_opts
+            );
+
             $defaultOk = $this->xapiProxyResponse->checkResponse($responses['default'], $endpointDefault);
             $fallbackOk = $this->xapiProxyResponse->checkResponse($responses['fallback'], $endpointFallback);
 
@@ -318,6 +351,16 @@ class XapiProxyRequest
             } catch (\Exception $e) {
                 $this->xapiproxy->log()->error($this->msg($e->getMessage()));
             }
+            $responses['default'] = $this->repeatDocumentWriteWithPrecondition(
+                $httpclient,
+                $request,
+                $responses['default'],
+                $uriDefault,
+                $authDefault,
+                $body,
+                $req_opts
+            );
+
             if ($this->xapiProxyResponse->checkResponse($responses['default'], $endpointDefault)) {
                 try {
                     $this->xapiProxyResponse->handleResponse(
@@ -372,10 +415,98 @@ class XapiProxyRequest
             $headers['Connection'] = $request->getHeader('Connection');
         }
 
+        foreach (self::CONDITIONAL_REQUEST_HEADERS as $conditionalHeader) {
+            if ($request->hasHeader($conditionalHeader)) {
+                $headers[$conditionalHeader] = $request->getHeader($conditionalHeader);
+            }
+        }
+
         //$this->xapiproxy->log()->debug($this->msg($body));
 
         $req = new Request(strtoupper($request->getMethod()), $uri, $headers, $body);
 
         return $req;
+    }
+
+    /**
+     * TinCanJS, which is bundled with common content players, only sends If-Match on a state
+     * write when the caller supplied the SHA1 of the document it read before, and no precondition
+     * at all otherwise. A specification compliant LRS answers such a write with 409 Conflict. In
+     * that case the current ETag is looked up and the write is repeated once with an If-Match
+     * built from it. An LRS that does not demand a precondition never answers 409 and therefore
+     * never causes the additional roundtrip.
+     * @param array{state: string, value?: \GuzzleHttp\Psr7\Response, reason?: mixed} $response
+     * @param array<string, mixed> $req_opts
+     * @return array{state: string, value?: \GuzzleHttp\Psr7\Response, reason?: mixed}
+     */
+    private function repeatDocumentWriteWithPrecondition(
+        Client $httpclient,
+        \Psr\Http\Message\RequestInterface $request,
+        array $response,
+        Uri $uri,
+        string $auth,
+        string $body,
+        array $req_opts
+    ): array {
+        if ($response['state'] !== 'fulfilled' || $response['value']->getStatusCode() !== 409) {
+            return $response;
+        }
+        if (!$this->requiresSynthesizedPrecondition($request)) {
+            return $response;
+        }
+        $etag = $this->fetchDocumentEtag($httpclient, $request, $uri, $auth, $req_opts);
+        if ($etag === '') {
+            return $response;
+        }
+
+        $this->xapiproxy->log()->debug($this->msg('lrs requires a precondition for ' . $uri . ', repeating request with If-Match: ' . $etag));
+
+        try {
+            /** @var \GuzzleHttp\Psr7\Response $repeated */
+            $repeated = $httpclient->send(
+                $this->createProxyRequest($request, $uri, $auth, $body)->withHeader('If-Match', $etag),
+                $req_opts
+            );
+        } catch (\Exception $e) {
+            $this->xapiproxy->log()->error($this->msg($e->getMessage()));
+            return $response;
+        }
+
+        return ['state' => 'fulfilled', 'value' => $repeated];
+    }
+
+    private function requiresSynthesizedPrecondition(\Psr\Http\Message\RequestInterface $request): bool
+    {
+        return strtoupper($request->getMethod()) === 'PUT'
+            && in_array($this->xapiproxy->cmdParts()[3] ?? '', self::DOCUMENT_RESOURCES, true)
+            && !$request->hasHeader('If-Match')
+            && !$request->hasHeader('If-None-Match');
+    }
+
+    /**
+     * Returns the current ETag of an xAPI document, or an empty string if it does not exist.
+     * Some LRS send an ETag along with the 404 of a missing document, so only a 200 is trusted.
+     * @param array<string, mixed> $req_opts
+     */
+    private function fetchDocumentEtag(
+        Client $httpclient,
+        \Psr\Http\Message\RequestInterface $request,
+        Uri $uri,
+        string $auth,
+        array $req_opts
+    ): string {
+        $headers = ['Authorization' => $auth];
+        if ($request->hasHeader('X-Experience-API-Version')) {
+            $headers['X-Experience-API-Version'] = $request->getHeader('X-Experience-API-Version');
+        }
+
+        try {
+            $probe = $httpclient->send(new Request('GET', $uri, $headers), $req_opts);
+        } catch (\Exception $e) {
+            $this->xapiproxy->log()->error($this->msg($e->getMessage()));
+            return '';
+        }
+
+        return $probe->getStatusCode() === 200 ? $probe->getHeaderLine('ETag') : '';
     }
 }

--- a/components/ILIAS/CmiXapi/classes/XapiProxy/XapiProxyResponse.php
+++ b/components/ILIAS/CmiXapi/classes/XapiProxy/XapiProxyResponse.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +16,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace XapiProxy;
 
 use Psr\Http\Message\ServerRequestInterface;
@@ -26,6 +27,14 @@ use GuzzleHttp\Psr7\Request;
 
 class XapiProxyResponse
 {
+    /**
+     * 304, 409 and 412 are the conditional answers of the xAPI document resources. They are
+     * regular protocol answers which the content has to evaluate on its own, so they are
+     * relayed unchanged instead of being replaced by a generic proxy error.
+     * @var list<int>
+     */
+    private const RELAYED_STATUS_CODES = [200, 204, 304, 404, 409, 412];
+
     //        private $dic;
     private XapiProxy $xapiproxy;
     //private $xapiProxyRequest;
@@ -40,7 +49,7 @@ class XapiProxyResponse
     {
         if ($response['state'] == 'fulfilled') {
             $status = $response['value']->getStatusCode();
-            if ($status === 200 || $status === 204 || $status === 404) {
+            if (in_array($status, self::RELAYED_STATUS_CODES, true)) {
                 return true;
             } else {
                 $this->xapiproxy->log()->error("LRS error {$endpoint}: " . $response['value']->getBody());
@@ -240,6 +249,9 @@ class XapiProxyResponse
                 $first = false;
             }
         }
+
+        // the content may only read the relayed ETag of a document if it is exposed
+        header('Access-Control-Expose-Headers: ETag, Last-Modified, X-Experience-API-Version', true, $statusCode);
 
         // statusline
         header(sprintf(

--- a/components/ILIAS/CmiXapi/resources/xapiproxy.php
+++ b/components/ILIAS/CmiXapi/resources/xapiproxy.php
@@ -35,7 +35,7 @@ if (strtoupper($_SERVER["REQUEST_METHOD"]) == "OPTIONS") {
     header('Access-Control-Allow-Origin: ' . $_SERVER["HTTP_ORIGIN"]);
     header('Access-Control-Allow-Credentials: true');
     header('Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS');
-    header('Access-Control-Allow-Headers: X-Experience-API-Version,Accept,Authorization,Etag,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Mx-ReqToken,X-Requested-With');
+    header('Access-Control-Allow-Headers: X-Experience-API-Version,Accept,Authorization,Etag,Cache-Control,Content-Type,DNT,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Origin,User-Agent,X-Mx-ReqToken,X-Requested-With');
     exit;
 }
 
@@ -54,7 +54,7 @@ if (!empty($_SERVER['PHP_AUTH_USER']) && !empty($_SERVER['PHP_AUTH_PW'])) {
     header('Access-Control-Allow-Origin: ' . $_SERVER["HTTP_ORIGIN"]);
     header('Access-Control-Allow-Credentials: true');
     header('Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS');
-    header('Access-Control-Allow-Headers: X-Experience-API-Version,Accept,Authorization,Etag,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Mx-ReqToken,X-Requested-With');
+    header('Access-Control-Allow-Headers: X-Experience-API-Version,Accept,Authorization,Etag,Cache-Control,Content-Type,DNT,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Origin,User-Agent,X-Mx-ReqToken,X-Requested-With');
     exit;
 }
 

--- a/components/ILIAS/CmiXapi/tests/XapiProxyRequestTest.php
+++ b/components/ILIAS/CmiXapi/tests/XapiProxyRequestTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use GuzzleHttp\Psr7\Request;
+use ILIAS\DI\Container;
+use PHPUnit\Framework\TestCase;
+use XapiProxy\XapiProxy;
+use XapiProxy\XapiProxyRequest;
+
+class XapiProxyRequestTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['DIC'] = new Container();
+    }
+
+    /**
+     * @param array<string, string> $headers
+     * @dataProvider preconditionCases
+     */
+    public function testPreconditionIsOnlySynthesizedForUnconditionalDocumentWrites(
+        string $method,
+        string $resource,
+        array $headers,
+        bool $expected
+    ): void {
+        // XapiProxy declares its own method(), so the stub is configured through expects()
+        $proxy = $this->createMock(XapiProxy::class);
+        $proxy->expects($this->any())->method('cmdParts')->willReturn(['', '', '', $resource, '']);
+
+        $method_under_test = new ReflectionMethod(XapiProxyRequest::class, 'requiresSynthesizedPrecondition');
+        $method_under_test->setAccessible(true);
+
+        $this->assertSame(
+            $expected,
+            $method_under_test->invoke(
+                new XapiProxyRequest($proxy),
+                new Request($method, 'https://ilias.example.org/xapiproxy.php/' . $resource, $headers)
+            )
+        );
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string, 2: array<string, string>, 3: bool}>
+     */
+    public static function preconditionCases(): array
+    {
+        return [
+            'unconditional state write' => ['PUT', 'activities/state', [], true],
+            'unconditional activity profile write' => ['PUT', 'activities/profile', [], true],
+            'unconditional agent profile write' => ['PUT', 'agents/profile', [], true],
+            'client sends If-Match' => ['PUT', 'activities/state', ['If-Match' => '"abc"'], false],
+            'client sends If-None-Match' => ['PUT', 'activities/state', ['If-None-Match' => '*'], false],
+            'merging POST is not guarded' => ['POST', 'activities/state', [], false],
+            'document read is not guarded' => ['GET', 'activities/state', [], false],
+            'document delete is not guarded' => ['DELETE', 'activities/state', [], false],
+            'statements are immutable' => ['PUT', 'statements', [], false],
+        ];
+    }
+}

--- a/components/ILIAS/CmiXapi/tests/XapiProxyResponseTest.php
+++ b/components/ILIAS/CmiXapi/tests/XapiProxyResponseTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use XapiProxy\XapiProxy;
+use XapiProxy\XapiProxyResponse;
+
+class XapiProxyResponseTest extends TestCase
+{
+    /**
+     * @dataProvider statusCodes
+     */
+    public function testConditionalAnswersAreRelayedInsteadOfBeingReplacedByAProxyError(
+        int $status,
+        bool $expected
+    ): void {
+        // XapiProxy declares its own method(), so the stub is configured through expects()
+        $proxy = $this->createMock(XapiProxy::class);
+        $proxy->expects($this->any())->method('log')->willReturn($this->createMock(ilLogger::class));
+
+        $this->assertSame(
+            $expected,
+            (new XapiProxyResponse($proxy))->checkResponse(
+                ['state' => 'fulfilled', 'value' => new Response($status)],
+                'https://lrs.example.org/xapi'
+            )
+        );
+    }
+
+    /**
+     * @return array<string, array{0: int, 1: bool}>
+     */
+    public static function statusCodes(): array
+    {
+        return [
+            'ok' => [200, true],
+            'no content' => [204, true],
+            'not modified' => [304, true],
+            'document does not exist' => [404, true],
+            'precondition required by the lrs' => [409, true],
+            'precondition failed' => [412, true],
+            'bad request' => [400, false],
+            'server error' => [500, false],
+        ];
+    }
+
+    public function testConnectionErrorsRemainAnError(): void
+    {
+        $proxy = $this->createMock(XapiProxy::class);
+        $proxy->expects($this->any())->method('log')->willReturn($this->createMock(ilLogger::class));
+
+        $this->assertFalse(
+            (new XapiProxyResponse($proxy))->checkResponse(
+                ['state' => 'rejected', 'reason' => new Exception('connection refused')],
+                'https://lrs.example.org/xapi'
+            )
+        );
+    }
+}


### PR DESCRIPTION
Mantis Issue: https://mantis.ilias.de/view.php?id=48285

## Problem

The xAPI proxy does not forward the `If-Match` and `If-None-Match` request headers to the LRS. Both are missing from the allowlist in `XapiProxyRequest::createProxyRequest()`. It also never relays the `ETag` of a document back to the content.

For the xAPI document resources (`activities/state`, `activities/profile`, `agents/profile`) the specification (xAPI 1.0.3, "Concurrency") requires an LRS to reject a `PUT` on an already existing document that carries neither header with 409 Conflict. `XapiProxyResponse::checkResponse()` accepts only 200, 204 and 404, and replaces everything else with a fabricated `HTTP/1.1 412 Wrong Response`.

Against an LRS that follows the specification, every rewrite of a state document is therefore rejected, the learning progress is lost, and the content never learns why. For a learner the module simply restarts from the beginning. Learning Locker ignores both headers, so the defect does not surface there.

TinCanJS, which is bundled with common content players, treats the resources differently. `saveActivityProfile()` and `saveAgentProfile()` fall back to `If-None-Match: "*"` when they know no revision, but the state write does not:

```js
if (typeof cfg.lastSHA1 !== "undefined" && cfg.lastSHA1 !== null) {
    requestCfg.headers["If-Match"] = cfg.lastSHA1;
}
return this.sendRequest(requestCfg);
```

Without a `lastSHA1` it sends no precondition at all, and the state resource is exactly the one carrying the learning progress. A player can only supply `lastSHA1` if it received the document ETag beforehand, which the proxy does not relay either. Both halves of the defect reinforce each other.

## What this changes

1. `If-Match` and `If-None-Match` are relayed to the LRS, and allowed in the CORS preflight.
2. The `ETag` of a document response is exposed to the content via `Access-Control-Expose-Headers`.
3. The status codes 304, 409 and 412 reach the content unchanged instead of being replaced by a generic proxy error.
4. A document write that an LRS rejected with 409 for a missing precondition is repeated once, with an `If-Match` built from the current ETag.

An LRS that does not demand a precondition never answers 409, so point 4 causes no additional request there.

## Testing

Verified end to end through a running ILIAS 10.10 against two real LRS, Yet Analytics lrsql and Learning Locker (`xapi-service` 2.1.10), with a real Articulate Storyline module, by clicking through the module, leaving it and resuming.

| | lrsql | Learning Locker |
|---|---|---|
| state write, document exists | 204 | 204 |
| progress restored on resume | yes | yes |
| before the fix | 412, write lost | unaffected |

Plus 18 unit tests. PHPStan reports no new findings, PHP-CS-Fixer is clean on all changed files.

## Affected branches

The defect is present in release_9, release_10 (10.10), release_11 (11.3) and trunk. None of them forwards the headers or evaluates the ETag, and `checkResponse()` masks the status identically. The proxy implementation differs considerably between branches though. Guzzle is used in 9 and 10, cURL from 11 onwards, and in trunk `sendCurlRequest()` no longer receives the request object at all. So this cannot be cherry picked and has to be ported per branch.

The copyright header of the two changed classes had `declare(strict_types=1);` above the license block, which the Copyright-Checker rejects for any file in a diff. The header is now in the order the checker expects. That is the only change beyond the fix itself.

Transparency note: this patch was written with AI assistance. The analysis and all testing against both LRS were carried out and verified manually by me.

