### PR TITLE
News 48284: Move Object Type To Item Property

### DIFF
--- a/components/ILIAS/News/classes/class.ilNewsForContextBlockGUI.php
+++ b/components/ILIAS/News/classes/class.ilNewsForContextBlockGUI.php
@@ -142,19 +142,19 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
                 ->withDescription($this->lng->txt('news_sorry_not_accessible_anymore'));
         }
 
-
-        $props = [
-            $this->lng->txt('date') => $info['creation_date'] ?? ''
-        ];
-
         $item = $this->ui->factory()->item()->standard(
             $this->ui->factory()->link()->standard($info['news_title'] ?? '', $info['url'] ?? '')
-        )->withProperties($props);
+        );
+
+        $properties = [];
 
         if ($info['ref_id'] > 0) {
-            $item = $item->withDescription($info['type_txt'] . ': ' . $info['obj_title']);
+            $properties[$info['type_txt']] = $info['obj_title'];
         }
-        return $item;
+
+        $properties[$this->lng->txt('date')] = $info['creation_date'] ?? '';
+
+        return $item->withProperties($properties);
     }
 
     private function getNewsForId(int $news_id): array


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=48284

News items in context blocks showed the object type and title in the item description. They are now rendered as a separate item property for clearer structure.

/cc @thojou @oliversamoila 