### PR TITLE
48278 - Scoring adjustment crashes with a TypeError when a participant has no pass result

### DIFF
--- a/components/ILIAS/Test/classes/Evaluation/class.ilTestEvaluationFactory.php
+++ b/components/ILIAS/Test/classes/Evaluation/class.ilTestEvaluationFactory.php
@@ -134,7 +134,7 @@ class ilTestEvaluationFactory
         $current_attempt = null;
 
         foreach ($eval_data_rows as $row) {
-            if($row['pass'] === null) {
+            if ($row['pass'] === null) {
                 continue;
             }
 

--- a/components/ILIAS/Test/classes/Evaluation/class.ilTestEvaluationFactory.php
+++ b/components/ILIAS/Test/classes/Evaluation/class.ilTestEvaluationFactory.php
@@ -101,6 +101,10 @@ class ilTestEvaluationFactory
         $current_attempt = null;
 
         foreach ($this->retrieveEvaluationData($this->getAccessFilteredActiveIds()) as $row) {
+            if ($row['pass'] === null) {
+                continue;
+            }
+
             $active_id = $row['active_id'];
             $pass = $row['pass'];
 


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=48278

Saving a change in the scoring adjustment of a question aborts with a TypeError:

```
ilTestEvaluationUserData::addPass(): Argument #1 ($pass_nr) must be of type int, null given,
called in class.ilTestEvaluationFactory.php on line 119
```

The query behind this data selects `FROM tst_active` and joins `tst_pass_result` with a `LEFT JOIN`, so a participant who has an active id but no pass result produces a row where `pass` is `NULL`. `getCorrectionsEvaluationData()` passes that straight into `addPass(int $pass_nr, ...)`.

The sibling method `getEvaluationData()` in the same class already guards against exactly this. This adds the same guard, so both methods behave consistently.

Effect: the scoring adjustment is unusable in any test that contains a participant without a finished attempt, which is common right after an exam.