### PR TITLE
48279 - Participants tab fails to render when the percentage column is enabled

### DIFF
--- a/components/ILIAS/Test/src/Participants/ParticipantTable.php
+++ b/components/ILIAS/Test/src/Participants/ParticipantTable.php
@@ -142,7 +142,7 @@ class ParticipantTable implements DataRetrieval
                     $record->getAttemptOverviewInformation()?->getNrOfAnsweredQuestions(),
                     $record->getAttemptOverviewInformation()?->getNrOfTotalQuestions()
                 );
-                $row['percent_of_available_points'] = $record->getAttemptOverviewInformation()?->getReachedPointsInPercent();
+                $row['percent_of_available_points'] = $record->getAttemptOverviewInformation()?->getReachedPointsInPercent() ?? 0;
             }
 
             if ($status_of_attempt->isFinished()) {


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=48279

As soon as the optional column for the achieved percentage is switched on in the participants table of a test, the whole tab stops rendering:

```
number_format(): Argument #1 ($num) must be of type int|float, null given
in UI/src/Implementation/Component/Table/Column/Number.php:68
```

`percent_of_available_points` is a `number()` column, but the row value is built with the null-safe operator and no fallback, so a participant without an attempt yields `null`. The renderer then hands that `null` to `number_format()` and the whole table fails, not just the affected cell.

The neighbouring values in the same method all do provide a fallback (`total_attempts ?? 0`, `test_passed ?? false`, `total_time_on_task ?? ''`); only the percentage lacks one. This adds `?? 0` accordingly.

If an empty cell is preferred over a zero for participants without an attempt, letting the number column render `null` would be the alternative, but the fallback is the smaller and more consistent change.