### PR TITLE
48208 - Test question list no longer shows the total points of the question set

### DIFF
--- a/components/ILIAS/Test/src/Questions/Presentation/QuestionsTable.php
+++ b/components/ILIAS/Test/src/Questions/Presentation/QuestionsTable.php
@@ -100,7 +100,12 @@ class QuestionsTable implements OrderingBinding
                 $f->symbol()->icon()->custom('assets/images/standard/icon_alert.svg', '', 'small')
             ),
             'type_tag' => $f->table()->column()->text($this->lng->txt('tst_question_type')),
-            'points' => $f->table()->column()->text($this->lng->txt('points')),
+            'points' => $f->table()->column()->text(
+                $this->test_obj->isFixedTest()
+                    ? $this->lng->txt('points') . ' (' . $this->lng->txt('total') . ': '
+                        . $this->test_obj->getFixedQuestionSetTotalPoints() . ')'
+                    : $this->lng->txt('points')
+            ),
             'author' => $f->table()->column()->text($this->lng->txt('author'))
                 ->withIsOptional(true, false),
             'lifecycle' => $f->table()->column()->text($this->lng->txt('qst_lifecycle'))


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=48208

In ILIAS 9 the questions list of a test showed the total points of the fixed question set in the header of the Points column. `ilTestQuestionsTableGUI` kept the sum and appended it to the column title. After the migration to the new UI table framework the total is no longer displayed anywhere in the list view; it only survives in the print view (`Printer.php`).

That makes editing a test harder than before, because the achievable total is exactly the number an author needs while adding, removing or re-weighting questions.

The summation logic still exists and is unchanged (`ilObjTest::getFixedQuestionSetTotalPoints()`), it is simply no longer called. This uses it again when building the column header, limited to fixed question sets since the sum is not meaningful for random tests.

The number is labelled with the existing language variable `total`, so the header reads `Points (Total: 42)` rather than showing a bare number in parentheses as ILIAS 9 did. Since the label is part of the column header text, it is announced by screen readers as well.