### PR TITLE
48209 - Participants tab of a test no longer shows the number of participants

### DIFF
--- a/components/ILIAS/Test/src/Participants/ParticipantTable.php
+++ b/components/ILIAS/Test/src/Participants/ParticipantTable.php
@@ -40,6 +40,8 @@ class ParticipantTable implements DataRetrieval
 {
     private const ID = 'pt';
     private ?iterable $records = null;
+    /** @var array<string, int> */
+    private array $participant_counts = [];
 
     public function __construct(
         private readonly UIFactory $ui_factory,
@@ -81,7 +83,17 @@ class ParticipantTable implements DataRetrieval
 
     public function getTotalRowCount(?array $filter_data, ?array $additional_parameters): ?int
     {
-        return $this->repository->countParticipants($this->test_object->getTestId(), $filter_data);
+        return $this->countParticipants($filter_data);
+    }
+
+    /**
+     * The renderer asks for the total row count anyway; memoize the result so
+     * that also showing the number in the table title costs no second query.
+     */
+    private function countParticipants(?array $filter_data): int
+    {
+        return $this->participant_counts[serialize($filter_data ?? [])] ??= $this->repository
+            ->countParticipants($this->test_object->getTestId(), $filter_data);
     }
 
     public function getRows(
@@ -327,7 +339,8 @@ class ParticipantTable implements DataRetrieval
         return $this->ui_factory
             ->table()
             ->data(
-                $this->lng->txt('list_of_participants'),
+                $this->lng->txt('list_of_participants') . ' (' . $this->lng->txt('total') . ': '
+                    . $this->countParticipants($filter ?? []) . ')',
                 $this->getColumns(),
                 $this
             )


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=48209

In ILIAS 9 the participants table was based on `ilTable2GUI`, which displays the number of records by default, so the number of participants was visible on the Participants tab. After the migration to the new UI data table the count is no longer surfaced anywhere. For an exam that is a number one wants to see at a glance.

This appends it to the table title, `Participants (Total: 12)`.

Two things this deliberately gets right:

- **No additional database roundtrip.** The renderer asks the data retrieval for the total row count anyway via `getTotalRowCount()`. Both that call and the title now go through a small memoization keyed by the filter data, and the title passes the same filter the renderer does (`getFilter() ?? []`), so the participants are counted once per request instead of twice. As a side effect the displayed number follows an active filter, which matches what the table shows.
- **The number is labelled** with the existing language variable `total` instead of standing bare in parentheses, so it is clear what it denotes, visually and, since it is part of the table title, for screen readers.