### PR TITLE
[Quickfix] fix Cloze question gap width

### DIFF
--- a/templates/default/070-components/legacy/Modules/_component_test.scss
+++ b/templates/default/070-components/legacy/Modules/_component_test.scss
@@ -123,5 +123,6 @@ $il-test-working-time-font-weight: $il-font-weight-bold;
 }
 
 .ilc_qanswer_Answer.ilc_answers.answers.ilAssClozeTest p input[type=text] {
-	width: 100%;
+	width: auto;
+	max-width: min(65vw, 100%);
 }

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -15979,7 +15979,8 @@ div.ilc_Page.readonly textarea[disabled] {
 }
 
 .ilc_qanswer_Answer.ilc_answers.answers.ilAssClozeTest p input[type=text] {
-  width: 100%;
+  width: auto;
+  max-width: min(65vw, 100%);
 }
 
 /* Modules/Wiki */


### PR DESCRIPTION
This fixes Mantis [#48000 ](https://mantis.ilias.de/view.php?id=48000)by restoring the configured Cloze text gap width instead of forcing all text inputs to width: 100%.

The change should keep large fields bounded so the overflow protection from Mantis [#47413 ](https://mantis.ilias.de/view.php?id=47413)remains intact.
