### PR TITLE
48210 - Cloze gaps ignore their configured field width

### DIFF
--- a/templates/default/070-components/legacy/Modules/_component_test.scss
+++ b/templates/default/070-components/legacy/Modules/_component_test.scss
@@ -123,5 +123,7 @@ $il-test-working-time-font-weight: $il-font-weight-bold;
 }
 
 .ilc_qanswer_Answer.ilc_answers.answers.ilAssClozeTest p input[type=text] {
-	width: 100%;
+	@media screen and (max-width: $il-grid-float-breakpoint-max) {
+		width: 100%;
+	}
 }

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -15978,8 +15978,10 @@ div.ilc_Page.readonly textarea[disabled] {
   scroll-margin-top: 30px;
 }
 
-.ilc_qanswer_Answer.ilc_answers.answers.ilAssClozeTest p input[type=text] {
-  width: 100%;
+@media screen and (max-width: 991px) {
+  .ilc_qanswer_Answer.ilc_answers.answers.ilAssClozeTest p input[type=text] {
+    width: 100%;
+  }
 }
 
 /* Modules/Wiki */


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=48210

A cloze question lets the author define the width of a text gap, either per gap or for the whole question via the fixed text length. ILIAS still writes this into the markup correctly, the rendered input carries `size="20" maxlength="20"` for a configured length of 20.

In ILIAS 10 the field nevertheless always spans the full width of the line, so the setting has no visible effect. The character limit still works, only the width is ignored.

The cause is a rule that was newly introduced in ILIAS 10, in `templates/default/070-components/legacy/Modules/_component_test.scss`:

```scss
.ilc_qanswer_Answer.ilc_answers.answers.ilAssClozeTest p input[type=text] {
	width: 100%;
}
```

An explicit `width` overrides the `size` attribute of an input element, so every gap is rendered full width regardless of its configuration. ILIAS 9 had no comparable rule, the only styling for these inputs was a `line-height`. The gap templates and the size handling in `assClozeTestGUI` are unchanged between 9 and 10, so the regression is limited to this rule.

Assuming the rule is meant to keep gaps usable on narrow screens, this scopes it to the mobile breakpoint instead of applying it unconditionally. That is the same pattern the neighbouring rule for `.ilc_qinput_TextInput` in `_component_test_legacy.scss` already uses, and it keeps `max-width: 65vw` as the upper bound on wide screens.

The compiled `templates/default/delos.css` is included, since it is committed in the repository. To keep it free of noise from a different sass version, I compiled `delos.scss` before and after the change with the same binary and verified that the only difference is this one rule, then applied exactly that block to the committed file.