### PR TITLE
Give the login form a minimum width so its labels are not hyphenated

### DIFF
--- a/templates/default/070-components/legacy/Services/_component_init.scss
+++ b/templates/default/070-components/legacy/Services/_component_init.scss
@@ -23,6 +23,10 @@ div.ilStartupFrame {
 	width: fit-content;
 	margin-left: auto;
 	margin-right: auto;
+
+	> .c-form {
+		min-width: 34rem;
+	}
 	@media only screen and (max-width: $il-grid-float-breakpoint-max) {
       padding-top: 15px;
 
@@ -33,6 +37,10 @@ div.ilStartupFrame {
         & + div {
           width: 100%;
         }
+      }
+
+      > .c-form {
+        min-width: 0;
       }
     }
 }

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -18712,6 +18712,9 @@ a#ilHelpClose {
   margin-left: auto;
   margin-right: auto;
 }
+.ilStartupSection > .c-form {
+  min-width: 34rem;
+}
 @media only screen and (max-width: 991px) {
   .ilStartupSection {
     padding-top: 15px;
@@ -18722,6 +18725,9 @@ a#ilHelpClose {
   }
   .ilStartupSection .control-label + div {
     width: 100%;
+  }
+  .ilStartupSection > .c-form {
+    min-width: 0;
   }
 }
 


### PR DESCRIPTION
### What this fixes

The login form takes its width from whatever happens to sit next to it, not from its own needs.

`.ilStartupSection` in `_component_init.scss` uses `width: fit-content` with no lower bound, so its width is that of the widest child — and that child is not the form. On an installation where self registration and the "forgot your password" links are enabled, the row of those links is the widest element and stretches the container to a comfortable width. Where those links are switched off, nothing stretches it and the form collapses to its own intrinsic width. The label column, at 25% of that, becomes too narrow for its own text: in German the login name label renders as "Anmel-dena-me" across three lines.

Measured on two of our installations at an identical viewport width of 1600px, both ILIAS 10.10:

| | links enabled | links disabled |
|---|---|---|
| link row | 432px | 159px |
| `.ilStartupSection` | 432px | **274px** |
| label column (25%) | 108px | **68px** |

Grid definition, fonts and stylesheets are identical in both cases, so the difference is purely the missing sibling content.

### Why it is done this way

Two variants do not work, both verified in the browser:

- **A lower bound on the section** stretches the nested `.ilStartupSection` elements that hold the link rows as well. Their left-aligned links then sit in a box that is too wide and no longer look centred under the form (measured: 15px gap left, 112px right).
- **A percentage** in the form's `min-width` collapses to zero, because it cannot be resolved against a `fit-content` parent. The section stayed at 432px instead of growing.

So the bound goes on the form as a plain value, with a reset inside the media query that already switches the section to `width: auto` on narrow screens.

### Verified

- 1600px: section 544px and centred, nested link row still 432px and centred, label on one line.
- 375px: section 345px, no horizontal overflow.

### Notes

The compiled `templates/default/delos.css` is included since it is committed in the repository. To keep it free of noise from a different sass version, I compiled `delos.scss` before and after the change with the same binary, verified that the only differences are these two rules, and applied exactly those blocks to the committed file.

There is no Mantis entry for this yet — happy to create one and add the number to the title if you would rather have it tracked as a bugfix.