### PR TITLE
[Fix] Cron #0048287: Hide cron overview tabs when editing a job

### DIFF
--- a/components/ILIAS/Cron/src/class.ilObjCronGUI.php
+++ b/components/ILIAS/Cron/src/class.ilObjCronGUI.php
@@ -176,6 +176,15 @@ final class ilObjCronGUI extends ilObjectGUI
         return implode('_', array_merge(self::TABLE_ACTION_NAMESPACE, [self::TABLE_ACTION_IDENTIFIER_NAME]));
     }
 
+    private function replaceAdminTabsWithBackToOverview(): void
+    {
+        $this->tabs_gui->clearTargets();
+        $this->tabs_gui->setBackTarget(
+            $this->lng->txt('back'),
+            $this->ctrl->getLinkTarget($this, self::VIEW)
+        );
+    }
+
     /**
      * @param mixed $default
      * @return mixed|null
@@ -223,7 +232,7 @@ final class ilObjCronGUI extends ilObjectGUI
 
         switch (strtolower($class)) {
             case strtolower(ilPropertyFormGUI::class):
-                $this->tabs_gui->activateTab(self::VIEW);
+                $this->replaceAdminTabsWithBackToOverview();
                 $entity = $this->cron_repository->getEntityById(
                     ilUtil::stripSlashes(
                         $this->getRequestValue($this->getJobIdParameterName(), $this->refinery->kindlyTo()->string())
@@ -351,6 +360,7 @@ final class ilObjCronGUI extends ilObjectGUI
             $form = $this->buildForm($entity);
         }
 
+        $this->replaceAdminTabsWithBackToOverview();
         $this->tpl->setContent($this->ui_renderer->render($form));
     }
 
@@ -375,6 +385,7 @@ final class ilObjCronGUI extends ilObjectGUI
             $a_form = $this->initLegacyEditForm($entity);
         }
 
+        $this->replaceAdminTabsWithBackToOverview();
         $this->tpl->setContent($a_form->getHTML());
     }
 


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=48287

When editing a cron job, the administration tabs "View" ("Zeigen") and "Permissions" ("Rechte") of the cron overview remain visible. Kitchen Sink forms do not provide a cancel action, so there is no obvious way back to the overview.

This PR replaces those overview tabs with a back target on the job edit screens (KS and legacy forms).

@mjansenDatabay

If approved, please pick this to `trunk` as well.