### PR TITLE
[FIX] LTI: Preserve embedded session cookie

### DIFF
--- a/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
@@ -710,7 +710,6 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
         $err = $DIC['ilErr'];
         /* @var ilErrorHandling $err */
         $ctrl = $DIC->ctrl();
-        $request = $DIC->http()->request();
         $access = $DIC->access();
         $lng = $DIC->language();
 
@@ -724,6 +723,20 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
         if ($access->checkAccess('read', '', $id)) {
             $ctrl->setTargetScript('ilias.php');
             $ctrl->setParameterByClass(ilObjLTIConsumerGUI::class, 'ref_id', $id);
+            if (session_status() === PHP_SESSION_ACTIVE && session_id() !== '') {
+                $cookie_params = session_get_cookie_params();
+                if ((bool) ($cookie_params['secure'] ?? false)) {
+                    setcookie(session_name(), session_id(), [
+                        'expires' => 0,
+                        'path' => (string) ($cookie_params['path'] ?? '/'),
+                        'domain' => (string) ($cookie_params['domain'] ?? ''),
+                        'secure' => true,
+                        'httponly' => (bool) ($cookie_params['httponly'] ?? true),
+                        'samesite' => 'None'
+                    ]);
+                }
+            }
+
             $ctrl->redirectByClass([ilRepositoryGUI::class, ilObjLTIConsumerGUI::class]);
         } elseif ($access->checkAccess('visible', '', $id)) {
             ilObjectGUI::_gotoRepositoryNode($id, 'infoScreen');

--- a/components/ILIAS/LTIConsumer/resources/ltiauth.php
+++ b/components/ILIAS/LTIConsumer/resources/ltiauth.php
@@ -91,10 +91,47 @@ if ($isContentSelection) {
 } else {
     $url = "../../../goto.php?target=lti_" . $ref_id . "&client_id=" . $il_client_id;
 }
+
+function buildSameSiteNoneSessionCookieHeader(): ?string
+{
+    if (session_status() !== PHP_SESSION_ACTIVE || session_id() === '') {
+        return null;
+    }
+
+    $cookie_params = session_get_cookie_params();
+    if (!(bool) ($cookie_params['secure'] ?? false)) {
+        return null;
+    }
+
+    $cookie_parts = [
+        rawurlencode(session_name()) . '=' . rawurlencode(session_id()),
+        'Path=' . (string) ($cookie_params['path'] ?? '/'),
+        'Secure',
+        'SameSite=None'
+    ];
+
+    $domain = (string) ($cookie_params['domain'] ?? '');
+    if ($domain !== '') {
+        $cookie_parts[] = 'Domain=' . $domain;
+    }
+    if ((bool) ($cookie_params['httponly'] ?? true)) {
+        $cookie_parts[] = 'HttpOnly';
+    }
+
+    return implode('; ', $cookie_parts);
+}
+
+$response = $DIC->http()->response()
+    ->withStatus(302)
+    ->withAddedHeader('Location', $url);
+
+$session_cookie_header = buildSameSiteNoneSessionCookieHeader();
+if ($session_cookie_header !== null) {
+    $response = $response->withAddedHeader('Set-Cookie', $session_cookie_header);
+}
+
 $DIC->http()->saveResponse(
-    $DIC->http()->response()
-        ->withStatus(302)
-        ->withAddedHeader('Location', $url)
+    $response
 );
 try {
     $DIC->http()->sendResponse();


### PR DESCRIPTION
Ensures the LTI session cookie keeps SameSite=None across authentication redirects, preventing embedded launches from falling back to the ILIAS login page in Firefox and Firefox-based browsers.