### PR TITLE
Test: Add Summary Information to Question Tables

### DIFF
--- a/components/ILIAS/Test/classes/class.ilObjTestGUI.php
+++ b/components/ILIAS/Test/classes/class.ilObjTestGUI.php
@@ -1903,12 +1903,15 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
         $this->tabs_manager->activateSubTab(TabsManager::SUBTAB_ID_QST_LIST_VIEW);
 
         $this->tpl->setCurrentBlock('adm_content');
-        $this->tpl->setVariable('ACTION_QUESTION_FORM', $this->ctrl->getFormAction($this));
+        $this->tpl->setVariable('TITLE', $this->lng->txt('list_of_questions'));
+
+        $table = $this->getTable();
         $this->tpl->setVariable(
             'QUESTIONBROWSER',
-            $this->ui_renderer->render(
-                $this->getTable()->getTableComponent()
-            )
+            $this->ui_renderer->render([
+                $table->getSummary(),
+                $table->getTableComponent()
+            ])
         );
         $this->tpl->parseCurrentBlock();
     }

--- a/components/ILIAS/Test/src/Questions/Presentation/QuestionsTable.php
+++ b/components/ILIAS/Test/src/Questions/Presentation/QuestionsTable.php
@@ -25,6 +25,7 @@ use ILIAS\Test\Questions\Properties\Repository as TestQuestionsRepository;
 use ILIAS\Test\Questions\Properties\Properties as TestQuestionProperties;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\UI\Factory as UIFactory;
+use ILIAS\UI\Component\Listing\Descriptive as DescriptiveListing;
 use ILIAS\UI\Component\Table\Ordering;
 use ILIAS\UI\Component\Table\OrderingBinding;
 use ILIAS\UI\Component\Table\OrderingRowBuilder;
@@ -33,6 +34,7 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class QuestionsTable implements OrderingBinding
 {
+    private ?array $records = null;
     /**
      * @param array $data <string, mixed>
      */
@@ -48,10 +50,51 @@ class QuestionsTable implements OrderingBinding
     ) {
     }
 
+    public function getSummary(): DescriptiveListing
+    {
+        $this->loadRecords();
+
+        $info = [
+            $this->lng->txt('tst_num_questions') => $this->refinery->kindlyTo()->string()->transform(
+                $this->test_obj->getQuestionCount()
+            )
+        ];
+
+        if (!$this->test_obj->isRandomTest()) {
+            $info[$this->lng->txt('maximum_points')] = $this->refinery->kindlyTo()->string()->transform(
+                array_reduce(
+                    $this->records,
+                    fn(float $c, TestQuestionProperties $v): float
+                        => $c + $v->getGeneralQuestionProperties()->getAvailablePoints(),
+                    0.0
+                )
+            );
+        }
+
+        $types = array_reduce(
+            $this->records,
+            function (array $c, TestQuestionProperties $v): array {
+                $type = $v->getGeneralQuestionProperties()->getTypeName($this->lng);
+                if (!in_array($type, $c)) {
+                    $c[] = $type;
+                }
+
+                return $c;
+            },
+            []
+        );
+
+        natsort($types);
+
+        $info[$this->lng->txt('contained_question_types')] = implode(', ', $types);
+
+        return $this->ui_factory->listing()->descriptive($info);
+    }
+
     public function getTableComponent(): Ordering
     {
         $table = $this->ui_factory->table()->ordering(
-            $this->lng->txt('list_of_questions'),
+            '',
             $this->getColumns(),
             $this,
             $this->table_actions->getOrderActionUrl()
@@ -59,6 +102,8 @@ class QuestionsTable implements OrderingBinding
         ->withId((string) $this->test_obj->getId())
         ->withActions($this->table_actions->getActions())
         ->withRequest($this->request);
+
+
 
         if ($this->test_obj->isRandomTest()
             || $this->test_obj->evalTotalPersons() !== 0) {
@@ -124,13 +169,20 @@ class QuestionsTable implements OrderingBinding
 
     private function getRecords(): \Generator
     {
-        $records = $this->questionrepository
+        if ($this->records === null) {
+            $this->loadRecords();
+        }
+        yield from $this->records;
+    }
+
+    private function loadRecords(): void
+    {
+        $this->records = $this->questionrepository
             ->getQuestionPropertiesWithAggregatedResultsForTest($this->test_obj);
         usort(
-            $records,
+            $this->records,
             static fn(TestQuestionProperties $a, TestQuestionProperties $b): int =>
                 $a->getSequenceInformation()?->getPlaceInSequence() <=> $b->getSequenceInformation()?->getPlaceInSequence()
         );
-        yield from $records;
     }
 }

--- a/components/ILIAS/Test/templates/default/tpl.il_as_tst_questions.html
+++ b/components/ILIAS/Test/templates/default/tpl.il_as_tst_questions.html
@@ -1,17 +1,5 @@
 <!-- BEGIN pax_info_message -->
 {PAX_INFO_MESSAGE}
 <!-- END pax_info_message -->
-<form name="form_questions" method="POST" action="{ACTION_QUESTION_FORM}">
-<!-- BEGIN move -->
-<input type="hidden" name="move_{MOVE_COUNTER}" value="{MOVE_VALUE}">
-<!-- END move -->
-<!-- BEGIN browser_actions -->
-<p><input type="submit" class="btn btn-default" name="cmd[browseForQuestions]" value="{BUTTON_INSERT_QUESTION}" />&nbsp;{TEXT_CREATE_NEW}&nbsp;
-<select name="question_type">
-<!-- BEGIN QTypes -->
-<option value="{QUESTION_TYPE_ID}"{QUESTION_TYPE_SELECTED}>{QUESTION_TYPE}</option>
-<!-- END QTypes -->
-</select>&nbsp;<input type="submit" class="btn btn-default" name="cmd[createQuestion]" value="{BUTTON_CREATE_QUESTION}" /> {TXT_OR} <input type="submit" class="submit" name="cmd[randomselect]" value="{TEXT_RANDOM_SELECT}" /></p>
-<!-- END browser_actions -->
-</form>
+<h2>{TITLE}</h2>
 {QUESTIONBROWSER}

--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionList.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionList.php
@@ -172,7 +172,7 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         $this->join_obj_data = $a_val;
     }
 
-    private function getParentObjFilterExpression(): ?string
+    protected function getParentObjFilterExpression(): ?string
     {
         if ($this->parentObjId) {
             return "qpl_questions.obj_fi = {$this->db->quote($this->parentObjId, ilDBConstants::T_INTEGER)}";
@@ -514,7 +514,7 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         return "CASE WHEN EXISTS ($tax_subquery) THEN TRUE ELSE FALSE END AS taxonomies";
     }
 
-    private function buildBasicQuery(): string
+    protected function buildBasicQuery(): string
     {
         return "{$this->getSelectFieldsExpression()} FROM qpl_questions {$this->getTableJoinExpression()} WHERE qpl_questions.tstamp > 0";
     }
@@ -676,7 +676,7 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         return $tax_assignment_data;
     }
 
-    private function isActiveQuestionType(array $questionData): bool
+    protected function isActiveQuestionType(array $questionData): bool
     {
         if (!isset($questionData['plugin'])) {
             return false;
@@ -703,7 +703,7 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
             ->isActive();
     }
 
-    private function getQuestionTypeTranslation(array $question_data): string
+    protected function getQuestionTypeTranslation(array $question_data): string
     {
         if (!($question_data['plugin'] ?? false)) {
             return $this->lng->txt($question_data['type_tag']);

--- a/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
@@ -1158,7 +1158,17 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
 
         $this->tpl->setPermanentLink($this->object->getType(), $this->object->getRefId());
         $out[] = $this->getTable();
-        $this->tpl->setContent(implode('', $out));
+        $content_tpl = new ilTemplate(
+            'tpl.il_as_qpl_questions.html',
+            true,
+            true,
+            'components/ILIAS/TestQuestionPool'
+        );
+
+        $content_tpl->setVariable('TITLE', $this->lng->txt('questions'));
+        $content_tpl->setVariable('QUESTIONBROWSER', implode('', $out));
+
+        $this->tpl->setContent($content_tpl->get());
     }
 
     protected function fetchAuthoringQuestionIdParamater(): int
@@ -1871,6 +1881,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
         }
 
         return $r->render([
+            $table->getSummary(),
             $filter,
             $table->getTable()
             ->withRequest($this->request)

--- a/components/ILIAS/TestQuestionPool/src/Questions/Presentation/QuestionTable.php
+++ b/components/ILIAS/TestQuestionPool/src/Questions/Presentation/QuestionTable.php
@@ -26,6 +26,7 @@ use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Data\Range;
 use ILIAS\Data\Order;
 use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\UI\Component\Listing\Descriptive as DescriptiveListing;
 use ILIAS\UI\Component\Table;
 use ILIAS\UI\Component\Input\Container\Filter\Standard as Filter;
 use ILIAS\UI\URLBuilder;
@@ -55,13 +56,54 @@ class QuestionTable extends \ilAssQuestionList implements Table\DataRetrieval
     ) {
         $lng->loadLanguageModule('qpl');
         parent::__construct($db, $lng, $refinery, $component_repository, $notes_service);
+        $this->setParentObjId($this->parent_obj_id);
         $this->setAvailableTaxonomyIds($taxonomy->getUsageOfObject($parent_obj_id));
+    }
+
+    public function getSummary(): DescriptiveListing
+    {
+        $questions = $this->getSummaryInformation();
+
+        $info = [
+            $this->lng->txt('tst_num_questions') => $this->refinery->kindlyTo()->string()->transform(
+                count($questions)
+            )
+        ];
+
+        $info[$this->lng->txt('maximum_points')] = $this->refinery->kindlyTo()->string()->transform(
+            array_reduce(
+                $questions,
+                fn(float $c, array $v): float => $c + $v['points'],
+                0.0
+            )
+        );
+
+        $types = array_reduce(
+            $questions,
+            function (array $c, array $v): array {
+                if (!in_array($v['ttype'], $c)) {
+                    $c[] = $v['ttype'];
+                }
+
+                return $c;
+            },
+            []
+        );
+
+        natsort($types);
+
+        $info[$this->lng->txt('contained_question_types')] = implode(
+            ', ',
+            $types
+        );
+
+        return $this->ui_factory->listing()->descriptive($info);
     }
 
     public function getTable(): Table\Data
     {
         return $this->ui_factory->table()->data(
-            $this->lng->txt('questions'),
+            '',
             $this->getColumns(),
             $this
         )
@@ -310,15 +352,17 @@ class QuestionTable extends \ilAssQuestionList implements Table\DataRetrieval
         ?array $filter_data,
         ?array $additional_parameters
     ): ?int {
-        $this->setParentObjId($this->parent_obj_id);
-        $this->load();
+        if ($this->questions === []) {
+            $this->load();
+        }
         return count($this->getQuestionDataArray());
     }
 
     protected function getData(Order $order, Range $range): array
     {
-        $this->setParentObjId($this->parent_obj_id);
-        $this->load();
+        if ($this->questions === []) {
+            $this->load();
+        }
         $data = $this->postOrder($this->getQuestionDataArray(), $order);
         [$offset, $length] = $range->unpack();
         $length = $length > 0 ? $length : null;
@@ -396,5 +440,38 @@ class QuestionTable extends \ilAssQuestionList implements Table\DataRetrieval
     {
         return $this->notes_service->domain()->commentsActive($this->parent_obj_id)
             || $this->rbac->checkAccess('write', $this->request_ref_id);
+    }
+
+    private function getSummaryInformation(): array
+    {
+        $tags_trafo = $this->refinery->encode()->htmlSpecialCharsAsEntities();
+
+        $questions = [];
+
+        $res = $this->db->query(
+            "{$this->buildBasicQuery()} AND {$this->getParentObjFilterExpression()}"
+        );
+
+        while ($row = $this->db->fetchAssoc($res)) {
+            $row = \ilAssQuestionType::completeMissingPluginName($row);
+
+            if (!$this->isActiveQuestionType($row)) {
+                continue;
+            }
+
+            $row['title'] = $tags_trafo->transform($row['title'] ?? '&nbsp;');
+            $row['ttype'] = $this->getQuestionTypeTranslation($row);
+
+            if (
+                $this->filter_comments === self::QUESTION_COMMENTED_ONLY && $row['comments'] === 0
+                || $this->filter_comments === self::QUESTION_COMMENTED_EXCLUDED && $row['comments'] > 0
+            ) {
+                continue;
+            }
+
+            $questions[$row['question_id']] = $row;
+        }
+
+        return $questions;
     }
 }

--- a/components/ILIAS/TestQuestionPool/templates/default/tpl.il_as_qpl_questions.html
+++ b/components/ILIAS/TestQuestionPool/templates/default/tpl.il_as_qpl_questions.html
@@ -1,0 +1,2 @@
+<h2>{TITLE}</h2>
+{QUESTIONBROWSER}

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -591,6 +591,7 @@ assessment#:#concatenation#:#Verknüpfung
 assessment#:#conf_delete_pass#:#Durchgang wirklich löschen?
 assessment#:#confirm_log_deletion#:#Sind Sie sicher, dass Sie die ausgewählten Protokolleinträge löschen möchten? Die gelöschten Einträge werden unwiderruflich gelöscht.
 assessment#:#confirm_sync_questions#:#Die Frage, die Sie geändert haben, wurde mit dem Einfügen in den Test als Kopie eines Originals angelegt. Wollen Sie Ihre Änderungen jetzt auch auf die Originalfrage anwenden?
+assessment#:#contained_question_types#:#Enthaltene Fragentypen
 assessment#:#coordinates#:#Koordinaten
 assessment#:#copy_and_link_to_questionpool#:#Zu Fragenpool hinzufügen
 assessment#:#copy_no_questions_selected#:#Bitte wählen Sie mindestens eine Frage zum Kopieren aus.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -591,6 +591,7 @@ assessment#:#concatenation#:#Concatenation
 assessment#:#conf_delete_pass#:#Are you sure you want to delete your existing answers?
 assessment#:#confirm_log_deletion#:#Are you sure, you want to delete the selected log entries? You will not be able to recover the deleted entries.
 assessment#:#confirm_sync_questions#:#The question you changed is a copy which has been created for use with the active test. Do you want to change the original of the question too?
+assessment#:#contained_question_types#:#Contained Question Types
 assessment#:#coordinates#:#Coordinates
 assessment#:#copy_and_link_to_questionpool#:#Add to question pool
 assessment#:#copy_no_questions_selected#:#Please select at least one question to copy.
@@ -15094,7 +15095,7 @@ rep#:#rep_fav_intro1#:#You have not yet selected any favourites. To do so, there
 rep#:#rep_fav_intro2#:#Click on '%s' and select a learning object from those available, for example a learning module or a forum.
 rep#:#rep_fav_intro3#:#When you have found something that interests you, you can easily add it to your favourites. Select the desired item in the <i>Actions</i> menu and select "<i>Add to favourites</i>".
 rep#:#rep_favourites#:#Favourites
-rep#:#rep_favourites_info#:#Users can mark individual repository items as favourites. A 'Favourites' list can be activated for the dashboard and the main menu. 
+rep#:#rep_favourites_info#:#Users can mark individual repository items as favourites. A 'Favourites' list can be activated for the dashboard and the main menu.
 rep#:#rep_input_not_empty#:#This field must not be empty, please provide a value.
 rep#:#rep_intro#:#Welcome to the Repository!
 rep#:#rep_intro1#:#In this area you can create learning and working resources for all users. All resources are organised in categories. Categories can reflect the structure of your organisation (e.g. departments), a hierarchy of disciplines, or classes of a school.


### PR DESCRIPTION
Hi all

This is not the most beautiful solution in the world, but I think conceptually this is the soundest way, I could come up with to get the situation here unstuck. Instead of even trying to include the summary information in the table, why not just add it above? The slight inelegance comes from the lack of facilities in the UIComponents to actually address this, a lack that is completely understandable, but cannot be remedied as part of a bugfix.

See: https://mantis.ilias.de/view.php?id=45093

The solution would look like this in the test:
<img width="2677" height="1299" alt="Bildschirmfoto vom 2026-09-09 17-06-43" src="https://github.com/user-attachments/assets/1e86f595-0639-46aa-b345-f034a58dc533" />

and like this in the pool:
<img width="2677" height="1299" alt="Bildschirmfoto vom 2026-09-09 17-07-15" src="https://github.com/user-attachments/assets/d04b89a7-b512-4052-b000-fc1475f52297" />

You also see in the screen shots, that the summary  in the pool does on purpose not take into account any filtering.

I added the information about the contained question types, but this can clearly be removed again. I just thought, as we are creating this summary section, why not add some more useful information. The drawback: It pushes the other information on the screen further down. I've no strict opinion on this and defer it to you.

What do you think @thojou and @dsstrassner ?

Best,
@kergomard 
