### PR TITLE
UI: Improve Displaying of Duration in Filter

### DIFF
--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -15094,7 +15094,7 @@ rep#:#rep_fav_intro1#:#You have not yet selected any favourites. To do so, there
 rep#:#rep_fav_intro2#:#Click on '%s' and select a learning object from those available, for example a learning module or a forum.
 rep#:#rep_fav_intro3#:#When you have found something that interests you, you can easily add it to your favourites. Select the desired item in the <i>Actions</i> menu and select "<i>Add to favourites</i>".
 rep#:#rep_favourites#:#Favourites
-rep#:#rep_favourites_info#:#Users can mark individual repository items as favourites. A 'Favourites' list can be activated for the dashboard and the main menu. 
+rep#:#rep_favourites_info#:#Users can mark individual repository items as favourites. A 'Favourites' list can be activated for the dashboard and the main menu.
 rep#:#rep_input_not_empty#:#This field must not be empty, please provide a value.
 rep#:#rep_intro#:#Welcome to the Repository!
 rep#:#rep_intro1#:#In this area you can create learning and working resources for all users. All resources are organised in categories. Categories can reflect the structure of your organisation (e.g. departments), a hierarchy of disciplines, or classes of a school.
@@ -17402,8 +17402,8 @@ ui#:#datatable_multiactionmodal_listentry#:#Actions for Entire Table
 ui#:#datatable_multiactionmodal_msg#:#Selected action will affect all entries in this table.
 ui#:#datatable_multiactionmodal_title#:#Actions for Entire Table
 ui#:#drilldown_no_items#:#No Matching Elements
-ui#:#duration_default_label_end#:#end
-ui#:#duration_default_label_start#:#start
+ui#:#duration_default_label_end#:#End
+ui#:#duration_default_label_start#:#Start
 ui#:#duration_end_must_not_be_earlier_than_start#:#Start must not be later than end.
 ui#:#filter_nodes_in#:#Filter Nodes in %s
 ui#:#footer_icons#:#Footer Icons

--- a/templates/default/070-components/UI-framework/Input/_ui-component_filter.scss
+++ b/templates/default/070-components/UI-framework/Input/_ui-component_filter.scss
@@ -115,6 +115,7 @@ $il-standard-filter-add-input-popover-list-button-width: 100%;
 	}
 
 	ul.c-field-multiselect,
+    div.c-field-duration,
 	.il-filter-add-list ul{
 		list-style: none;
 		margin: $il-standard-filter-add-input-popover-list-margin;
@@ -134,6 +135,11 @@ $il-standard-filter-add-input-popover-list-button-width: 100%;
 			width: $il-standard-filter-add-input-popover-list-button-width;
 		}
 	}
+
+    div.c-field-duration > fieldset > label {
+        margin-bottom: auto;
+        margin-top: auto;
+    }
 
 	span[data-collapse-glyph-visibility="1"] {
 		display: inline;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -4898,6 +4898,7 @@ hr.il-divider-with-label {
   padding-left: 9px;
 }
 .il-filter ul.c-field-multiselect,
+.il-filter div.c-field-duration,
 .il-filter .il-filter-add-list ul {
   list-style: none;
   margin: 0;
@@ -4910,6 +4911,10 @@ hr.il-divider-with-label {
   padding: 6px 9px;
   display: block;
   width: 100%;
+}
+.il-filter div.c-field-duration > fieldset > label {
+  margin-bottom: auto;
+  margin-top: auto;
 }
 .il-filter span[data-collapse-glyph-visibility="1"] {
   display: inline;


### PR DESCRIPTION
Ok, this is a very small improvement and just straightens the display of the duration-input in filters. It also  changes the language variable to use an upper case, as the places this will be used require a title case as far as I can see. The unrelated change in the language file just concerns a trailing space that was automatically cleaned.

I do not fix the issue that only pressing "Enter/Return" (or clicking outside of the popup) will close it and set the values. This is, as far as I can see, expected behavior and any way it would be part of a bigger issue, as e.g. the multiselect-inputs can not be entered at all via keyboard (at least I didn't find a way).

See: https://mantis.ilias.de/view.php?id=43967

Before:
<img width="1440" height="810" alt="image" src="https://github.com/user-attachments/assets/66c9f0bb-b69a-4287-83e3-5c49eb4295df" />

After:
<img width="1440" height="810" alt="image" src="https://github.com/user-attachments/assets/7c0b94b0-3baa-43d9-b9fb-f826690cf2f4" />

Best,
@kergomard 
