### PR TITLE
48309 - Cloze questions: pasted images are dropped in the browser

### DIFF
--- a/components/ILIAS/TestQuestionPool/resources/js/dist/clozeQuestionGapBuilder.js
+++ b/components/ILIAS/TestQuestionPool/resources/js/dist/clozeQuestionGapBuilder.js
@@ -252,8 +252,15 @@ const ClozeQuestionGapBuilder = (function () {
     });
 
     ed.on('paste', (event) => {
+      // gibb: only take the paste over when the clipboard really carries text.
+      // An image has no text/plain representation, so cancelling the event
+      // unconditionally dropped it before TinyMCE ever saw it.
+      const clipboard_data = (event.originalEvent || event).clipboardData;
+      if (!clipboard_data || clipboard_data.getData('text/plain') === '') {
+        return;
+      }
       event.preventDefault();
-      let clipboard_text = (event.originalEvent || event).clipboardData.getData('text/plain');
+      let clipboard_text = clipboard_data.getData('text/plain');
       clipboard_text = clipboard_text.replace(/\[gap[\s\S\d]*?\]/g, '[gap]');
       const text = pro.getTextAreaValue();
       const textBefore = text.substring(0, ClozeGlobals.cursor_pos);
@@ -640,8 +647,15 @@ const ClozeQuestionGapBuilder = (function () {
       return false;
     });
     cloze_text_selector.on('paste', (event) => {
+      // gibb: only take the paste over when the clipboard really carries text.
+      // An image has no text/plain representation, so cancelling the event
+      // unconditionally dropped it before TinyMCE ever saw it.
+      const clipboard_data = (event.originalEvent || event).clipboardData;
+      if (!clipboard_data || clipboard_data.getData('text/plain') === '') {
+        return;
+      }
       event.preventDefault();
-      let clipboard_text = (event.originalEvent || event).clipboardData.getData('text/plain');
+      let clipboard_text = clipboard_data.getData('text/plain');
       clipboard_text = clipboard_text.replace(/\[gap[\s\S\d]*?\]/g, '[gap]');
       const text = pro.getTextAreaValue();
       const textBefore = text.substring(0, ClozeGlobals.cursor_pos);


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=48309

An image cannot be pasted into the cloze text of a gap question — nothing appears in the editor at all. Pasting the very same image into the question text directly above it works, so the two rich text editors on one and the same form behave differently.

The cloze text field registers two of its own paste handlers in `clozeQuestionGapBuilder.js`, one for the TinyMCE instance and one for the plain textarea. Both cancel the event and then read the clipboard as text only:

```js
ed.on('paste', (event) => {
  event.preventDefault();
  let clipboard_text = (event.originalEvent || event).clipboardData.getData('text/plain');
```

An image has no `text/plain` representation, so `clipboard_text` is empty and nothing gets inserted. And because the event was already cancelled, TinyMCE never gets to handle the paste itself. The image is discarded in the browser.

That is also why nothing on the server side is involved: comparing both editors at runtime shows that field configuration, allowed RTE tags, `valid_elements` and the loaded plugins are identical for the question text and the cloze text. The server never receives an image.

The handlers themselves are needed — the cloze text mixes HTML with `[gap]` markers, so a pasted text has to be normalised and the gap structure rebuilt. They just must not apply to a paste that carries no text. This returns early in that case and leaves such a paste to TinyMCE; text pastes keep their current behaviour including the gap handling.

Note the affected file lives under `resources/js/dist` and has no source counterpart in the repository, so the change had to be made in the built file.
