### PR TITLE
[Fix] FileDelivery: Correct typo breaking file save logic

### DIFF
--- a/components/ILIAS/FileDelivery/src/Delivery/LegacyDelivery.php
+++ b/components/ILIAS/FileDelivery/src/Delivery/LegacyDelivery.php
@@ -78,6 +78,6 @@ final class LegacyDelivery extends BaseDelivery
             $r,
             Streams::ofResource(fopen($path_to_file, 'rb'))
         );
-        $this - $this->saveAndClose($r, $delete_file ? $path_to_file : null);
+        $this->saveAndClose($r, $delete_file ? $path_to_file : null);
     }
 }


### PR DESCRIPTION
This PR removes `$this -` before calling `saveAndClose`, which seems accidentally been added in the past.

This was a finding while analysing https://mantis.ilias.de/view.php?id=48312