### PR TITLE
[FIX] Container: Show items when filter is off

### DIFF
--- a/components/ILIAS/Container/Content/Filter/class.FilterManager.php
+++ b/components/ILIAS/Container/Content/Filter/class.FilterManager.php
@@ -62,7 +62,7 @@ class FilterManager
         $obj_repo = $this->repo_service->filter()->object();
         $member_repo = $this->repo_service->filter()->member();
 
-        if (is_null($container_user_filter)) {
+        if (is_null($container_user_filter) || !$container_user_filter->isActivated()) {
             return $this->objects;
         }
 

--- a/components/ILIAS/Container/Filter/classes/class.ilContainerUserFilter.php
+++ b/components/ILIAS/Container/Filter/classes/class.ilContainerUserFilter.php
@@ -38,6 +38,17 @@ class ilContainerUserFilter
         return $this->data;
     }
 
+    /**
+     * Whether the UI filter is currently applied.
+     *
+     * `ilUIFilterService::getData()` returns null when the filter toggle is off.
+     * That is distinct from an activated filter whose fields are all empty.
+     */
+    public function isActivated(): bool
+    {
+        return is_array($this->data);
+    }
+
     public function isEmpty(): bool
     {
         $empty = true;

--- a/components/ILIAS/Container/classes/class.ilContainerGUI.php
+++ b/components/ILIAS/Container/classes/class.ilContainerGUI.php
@@ -2709,11 +2709,13 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 
             $main_tpl = $this->tpl;
             $main_tpl->setFilter($renderer->render($this->ui_filter));
-            if ($this->container_user_filter->isEmpty() && !ilContainer::_lookupContainerSetting(
-                $this->object->getId(),
-                "filter_show_empty",
-                '0'
-            )) {
+            if ($this->container_user_filter->isActivated() &&
+                $this->container_user_filter->isEmpty() &&
+                !ilContainer::_lookupContainerSetting(
+                    $this->object->getId(),
+                    "filter_show_empty",
+                    '0'
+                )) {
                 $this->tpl->setOnScreenMessage('info', $this->lng->txt("cont_filter_empty"));
             }
         }


### PR DESCRIPTION
A deactivated category filter was treated as an empty active filter. With "show all items if the filter is empty" disabled, that hid every object even though the KS toggle was off.

Mantis Issue: https://mantis.ilias.de/view.php?id=48320